### PR TITLE
chore(mantle): stop publishing source maps

### DIFF
--- a/.changeset/drop-published-sourcemaps.md
+++ b/.changeset/drop-published-sourcemaps.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+Stop publishing source maps. The `.js.map` files were ~58% of the package's unpacked size (and compressed tarball) and embedded the full original source via `sourcesContent`, despite `src/` not being shipped. The published tarball drops from ~431 KB to ~178 KB.
+
+This affects nothing consumers import at runtime. The typed `.d.ts` surface (with its JSDoc and `@example` blocks) and the agent-discovery artifacts (`dist/agent.json`, `dist/llms.txt`) are unchanged; only stepping into mantle's original source in a debugger is no longer possible.

--- a/.changeset/drop-published-sourcemaps.md
+++ b/.changeset/drop-published-sourcemaps.md
@@ -2,6 +2,6 @@
 "@ngrok/mantle": patch
 ---
 
-Stop publishing source maps. The `.js.map` files were ~58% of the package's unpacked size (and compressed tarball) and embedded the full original source via `sourcesContent`, despite `src/` not being shipped. The published tarball drops from ~431 KB to ~178 KB.
+Stop publishing source maps. The `.js.map` files were ~58% of the package's unpacked size (and compressed tarball) and embedded the full original source via `sourcesContent`, despite `src/` not being shipped. Dropping them more than halves the published package.
 
-This affects nothing consumers import at runtime. The typed `.d.ts` surface (with its JSDoc and `@example` blocks) and the agent-discovery artifacts (`dist/agent.json`, `dist/llms.txt`) are unchanged; only stepping into mantle's original source in a debugger is no longer possible.
+This affects nothing consumers import at runtime. The typed `.d.ts` surface (with its JSDoc and `@example` blocks) and the bundled agent-discovery artifacts (`dist/agent.json`, `dist/llms.txt`) are unchanged; only stepping into mantle's original source in a debugger is no longer possible.

--- a/packages/mantle/tsdown.config.ts
+++ b/packages/mantle/tsdown.config.ts
@@ -140,7 +140,11 @@ export default defineConfig((options) => [
 		// for one of the builds. rm -rf dist is run as a "prebuild" script to avoid this issue
 		clean: false,
 		minify: true,
-		sourcemap: true,
+		// Don't ship source maps: they were ~58% of the published package and
+		// embed the full source via `sourcesContent`. Consumers debug against
+		// the minified bundle; agents read the typed `.d.ts` surface and the
+		// docs site (dist/agent.json, dist/llms.txt) — not decoded map JSON.
+		sourcemap: false,
 		target: "ES2025",
 		tsconfig: "tsconfig.build.json",
 		fixedExtension: false,

--- a/packages/mantle/tsdown.config.ts
+++ b/packages/mantle/tsdown.config.ts
@@ -141,9 +141,10 @@ export default defineConfig((options) => [
 		clean: false,
 		minify: true,
 		// Don't ship source maps: they were ~58% of the published package and
-		// embed the full source via `sourcesContent`. Consumers debug against
-		// the minified bundle; agents read the typed `.d.ts` surface and the
-		// docs site (dist/agent.json, dist/llms.txt) — not decoded map JSON.
+		// embed the full source via `sourcesContent`, despite `src/` not being
+		// published. Consumers debug against the minified bundle; agents read the
+		// typed `.d.ts` surface and the bundled offline discovery artifacts
+		// (dist/agent.json, dist/llms.txt) — not decoded map JSON.
 		sourcemap: false,
 		target: "ES2025",
 		tsconfig: "tsconfig.build.json",


### PR DESCRIPTION
The .js.map files were ~58% of the published package's unpacked size and embedded the full original source via sourcesContent, despite src/ not being shipped. Tarball drops ~420 KB -> ~168 KB; nothing consumers import at runtime changes (the typed .d.ts surface and agent artifacts are untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Source maps are no longer published with the package. Type definitions and documentation tools remain available for debugging and discovery purposes. Runtime imports are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->