### PR TITLE
feat(mantle): default Button and IconButton type to "button"

### DIFF
--- a/.changeset/default-button-type-button.md
+++ b/.changeset/default-button-type-button.md
@@ -1,0 +1,11 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Button` and `IconButton` now default `type` to `"button"` instead of requiring it.
+
+The `type` prop is relaxed from required to optional on both components; when omitted it renders `type="button"`, matching the wider React ecosystem (Radix, shadcn, MUI, …) and neutralizing the native `<button>` accidental-form-submit footgun. This is backward compatible — every existing call site already passes `type`, so nothing changes for them; omitting `type` simply stops being a compile error.
+
+Forms note: because the default is now `"button"`, a `Button`/`IconButton` that relies on **native** form submission must opt in with `type="submit"`.
+
+When `asChild` is used, `type` continues to have no effect and is not forwarded to the child.

--- a/apps/www/app/docs/components/button.mdx
+++ b/apps/www/app/docs/components/button.mdx
@@ -16,16 +16,16 @@ Initiates an action, such as completing a task or submitting information.
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">Default</p>
 		<div className="flex items-center gap-2">
-			<Button type="button" appearance="ghost" priority="default">
+			<Button appearance="ghost" priority="default">
 				Ghost
 			</Button>
-			<Button type="button" appearance="filled" priority="default">
+			<Button appearance="filled" priority="default">
 				Filled
 			</Button>
-			<Button type="button" appearance="outlined" priority="default">
+			<Button appearance="outlined" priority="default">
 				Outlined
 			</Button>
-			<Button type="button" appearance="link" priority="default">
+			<Button appearance="link" priority="default">
 				Link
 			</Button>
 		</div>
@@ -33,16 +33,16 @@ Initiates an action, such as completing a task or submitting information.
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">Neutral</p>
 		<div className="flex items-center gap-2">
-			<Button type="button" appearance="ghost" priority="neutral">
+			<Button appearance="ghost" priority="neutral">
 				Ghost
 			</Button>
-			<Button type="button" appearance="filled" priority="neutral">
+			<Button appearance="filled" priority="neutral">
 				Filled
 			</Button>
-			<Button type="button" appearance="outlined" priority="neutral">
+			<Button appearance="outlined" priority="neutral">
 				Outlined
 			</Button>
-			<Button type="button" appearance="link" priority="neutral">
+			<Button appearance="link" priority="neutral">
 				Link
 			</Button>
 		</div>
@@ -50,16 +50,16 @@ Initiates an action, such as completing a task or submitting information.
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">Danger</p>
 		<div className="flex items-center gap-2">
-			<Button type="button" appearance="ghost" priority="danger">
+			<Button appearance="ghost" priority="danger">
 				Ghost
 			</Button>
-			<Button type="button" appearance="filled" priority="danger">
+			<Button appearance="filled" priority="danger">
 				Filled
 			</Button>
-			<Button type="button" appearance="outlined" priority="danger">
+			<Button appearance="outlined" priority="danger">
 				Outlined
 			</Button>
-			<Button type="button" appearance="link" priority="danger">
+			<Button appearance="link" priority="danger">
 				Link
 			</Button>
 		</div>
@@ -69,21 +69,37 @@ Initiates an action, such as completing a task or submitting information.
 ```tsx
 import { Button } from "@ngrok/mantle/button";
 
-<Button type="button">Outlined</Button>
-<Button type="button" appearance="filled">Filled</Button>
-<Button type="button" appearance="ghost">Ghost</Button>
-<Button type="button" appearance="link">Link</Button>
+<Button>Outlined</Button>
+<Button appearance="filled">Filled</Button>
+<Button appearance="ghost">Ghost</Button>
+<Button appearance="link">Link</Button>
 
-<Button type="button" priority="neutral">Outlined</Button>
-<Button type="button" priority="neutral" appearance="filled">Filled</Button>
-<Button type="button" priority="neutral" appearance="ghost">Ghost</Button>
-<Button type="button" priority="neutral" appearance="link">Link</Button>
+<Button priority="neutral">Outlined</Button>
+<Button priority="neutral" appearance="filled">Filled</Button>
+<Button priority="neutral" appearance="ghost">Ghost</Button>
+<Button priority="neutral" appearance="link">Link</Button>
 
-<Button type="button" priority="danger">Outlined</Button>
-<Button type="button" priority="danger" appearance="filled">Filled</Button>
-<Button type="button" priority="danger" appearance="ghost">Ghost</Button>
-<Button type="button" priority="danger" appearance="link">Link</Button>
+<Button priority="danger">Outlined</Button>
+<Button priority="danger" appearance="filled">Filled</Button>
+<Button priority="danger" appearance="ghost">Ghost</Button>
+<Button priority="danger" appearance="link">Link</Button>
 ```
+
+## Type
+
+Unlike the native `<button>` element — which defaults to `type="submit"` — a mantle `Button` defaults to **`type="button"`**. This matches the wider React ecosystem (Radix, shadcn, MUI, …) and stops a button from accidentally submitting a surrounding `<form>` when all you wanted was an `onClick`.
+
+The tradeoff: a button that _should_ submit a form has to opt in with `type="submit"` (or `type="reset"` to reset it). A plain `<Button>` that relies on native form submission will silently do nothing.
+
+```tsx
+// ✅ Opts in — submits the form
+<Button type="submit" appearance="filled">Save</Button>
+
+// ❌ Defaults to type="button" — native form submission never fires
+<Button appearance="filled">Save</Button>
+```
+
+When `asChild` is used, `type` has no effect and is not forwarded to the child, so a wrapped anchor never inherits a `button` `type`.
 
 ## Icon and Positioning
 
@@ -91,10 +107,8 @@ Use the `icon` prop to add an icon to the button. By default, it will render on 
 
 <Example>
 	<div className="flex items-center gap-2">
-		<Button type="button" icon={<FireIcon weight="fill" />}>
-			Icon Start
-		</Button>
-		<Button type="button" icon={<FireIcon weight="fill" />} iconPlacement="end">
+		<Button icon={<FireIcon weight="fill" />}>Icon Start</Button>
+		<Button icon={<FireIcon weight="fill" />} iconPlacement="end">
 			Icon End
 		</Button>
 	</div>
@@ -104,8 +118,8 @@ Use the `icon` prop to add an icon to the button. By default, it will render on 
 import { Button } from "@ngrok/mantle/button";
 import { FireIcon } from "@phosphor-icons/react/Fire";
 
-<Button type="button" icon={<FireIcon weight="fill" />}>Icon Start</Button>
-<Button type="button" icon={<FireIcon weight="fill" />} iconPlacement="end">
+<Button icon={<FireIcon weight="fill" />}>Icon Start</Button>
+<Button icon={<FireIcon weight="fill" />} iconPlacement="end">
 	Icon End
 </Button>
 ```
@@ -118,11 +132,9 @@ import { FireIcon } from "@phosphor-icons/react/Fire";
 	<div className="space-y-2">
 		<p className="mb-2 text-center font-mono text-xs">Idle</p>
 		<div className="flex flex-wrap items-center justify-center gap-2">
-			<Button type="button">No Icon + Idle</Button>
-			<Button type="button" icon={<FireIcon weight="fill" />}>
-				Icon Start + Idle
-			</Button>
-			<Button type="button" icon={<FireIcon weight="fill" />} iconPlacement="end">
+			<Button>No Icon + Idle</Button>
+			<Button icon={<FireIcon weight="fill" />}>Icon Start + Idle</Button>
+			<Button icon={<FireIcon weight="fill" />} iconPlacement="end">
 				Icon End + Idle
 			</Button>
 		</div>
@@ -130,13 +142,11 @@ import { FireIcon } from "@phosphor-icons/react/Fire";
 	<div className="space-y-2">
 		<p className="mb-2 text-center font-mono text-xs">isLoading</p>
 		<div className="flex flex-wrap items-center justify-center gap-2">
-			<Button type="button" isLoading>
-				No Icon + isLoading
-			</Button>
-			<Button type="button" icon={<FireIcon weight="fill" />} isLoading>
+			<Button isLoading>No Icon + isLoading</Button>
+			<Button icon={<FireIcon weight="fill" />} isLoading>
 				Icon Start + isLoading
 			</Button>
-			<Button type="button" icon={<FireIcon weight="fill" />} iconPlacement="end" isLoading>
+			<Button icon={<FireIcon weight="fill" />} iconPlacement="end" isLoading>
 				Icon End + isLoading
 			</Button>
 		</div>
@@ -147,16 +157,16 @@ import { FireIcon } from "@phosphor-icons/react/Fire";
 import { Button } from "@ngrok/mantle/button";
 import { FireIcon } from "@phosphor-icons/react/Fire";
 
-<Button type="button">No Icon + Idle</Button>
-<Button type="button" icon={<FireIcon weight="fill" />}>Icon Start + Idle</Button>
-<Button type="button" icon={<FireIcon weight="fill" />} iconPlacement="end">
+<Button>No Icon + Idle</Button>
+<Button icon={<FireIcon weight="fill" />}>Icon Start + Idle</Button>
+<Button icon={<FireIcon weight="fill" />} iconPlacement="end">
 	Icon End + Idle
 </Button>
-<Button type="button" isLoading>No Icon + isLoading</Button>
-<Button type="button" icon={<FireIcon weight="fill" />} isLoading>
+<Button isLoading>No Icon + isLoading</Button>
+<Button icon={<FireIcon weight="fill" />} isLoading>
 	Icon Start + isLoading
 </Button>
-<Button type="button" icon={<FireIcon weight="fill" />} iconPlacement="end" isLoading>
+<Button icon={<FireIcon weight="fill" />} iconPlacement="end" isLoading>
 	Icon End + isLoading
 </Button>
 ```
@@ -187,12 +197,12 @@ import { Link, href } from "react-router";
 
 All props from [button](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attributes), plus:
 
-| Prop             | Type                                                | Default      | Description                                                                                                                                                                                                                                                                      |
-| ---------------- | --------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `appearance?`    | `"ghost"` \| `"filled"` \| `"outlined"` \| `"link"` | `"outlined"` | Defines the visual style of the `Button`.                                                                                                                                                                                                                                        |
-| `asChild?`       | `boolean`                                           | `false`      | Use the `asChild` prop to compose the `Button` styling onto alternative element types or your own React components.                                                                                                                                                              |
-| `icon?`          | `ReactNode`                                         |              | An icon to render inside the button. When `isLoading` is `true`, the icon will automatically be replaced with a spinner.                                                                                                                                                         |
-| `iconPlacement?` | `"start"` \| `"end"`                                | `"start"`    | The side that the icon will render on, if one is present. When `isLoading` is `true`, the loading spinner will also render on this side.                                                                                                                                         |
-| `isLoading?`     | `boolean`                                           | `false`      | Determines whether or not the button is in a loading state. Setting `isLoading` will replace any `icon` with a spinner, or add one if an icon wasn't given. It will also disable user interaction with the button and set `aria-disabled`.                                       |
-| `priority?`      | `"default"` \| `"danger"` \| `"neutral"`            | `"default"`  | Indicates the importance or impact level of the button, affecting its color and styling to communicate its purpose to the user.                                                                                                                                                  |
-| `type`           | `"button"` \| `"reset"` \| `"submit"`               |              | The default behavior of the `Button`. Unlike the native `button` element, unless you use the `asChild` prop, **this prop is required and has no default value**. See [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type) for more information. |
+| Prop             | Type                                                | Default      | Description                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------- | --------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appearance?`    | `"ghost"` \| `"filled"` \| `"outlined"` \| `"link"` | `"outlined"` | Defines the visual style of the `Button`.                                                                                                                                                                                                                                                                                                                              |
+| `asChild?`       | `boolean`                                           | `false`      | Use the `asChild` prop to compose the `Button` styling onto alternative element types or your own React components.                                                                                                                                                                                                                                                    |
+| `icon?`          | `ReactNode`                                         |              | An icon to render inside the button. When `isLoading` is `true`, the icon will automatically be replaced with a spinner.                                                                                                                                                                                                                                               |
+| `iconPlacement?` | `"start"` \| `"end"`                                | `"start"`    | The side that the icon will render on, if one is present. When `isLoading` is `true`, the loading spinner will also render on this side.                                                                                                                                                                                                                               |
+| `isLoading?`     | `boolean`                                           | `false`      | Determines whether or not the button is in a loading state. Setting `isLoading` will replace any `icon` with a spinner, or add one if an icon wasn't given. It will also disable user interaction with the button and set `aria-disabled`.                                                                                                                             |
+| `priority?`      | `"default"` \| `"danger"` \| `"neutral"`            | `"default"`  | Indicates the importance or impact level of the button, affecting its color and styling to communicate its purpose to the user.                                                                                                                                                                                                                                        |
+| `type?`          | `"button"` \| `"reset"` \| `"submit"`               | `"button"`   | The behavior of the `Button` when activated. Defaults to `"button"`, so a `Button` inside a `<form>` will **not** submit it — pass `type="submit"` to submit the form. When `asChild` is used, `type` has no effect and is not forwarded to the child. See [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type) for more information. |

--- a/apps/www/app/docs/components/icon-button.mdx
+++ b/apps/www/app/docs/components/icon-button.mdx
@@ -17,56 +17,22 @@ Initiates an action, such as completing a task or submitting information. Render
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">Size xs</p>
 		<div className="flex items-center gap-2">
-			<IconButton
-				type="button"
-				appearance="ghost"
-				label="prestige worldwide"
-				size="xs"
-				icon={<GlobeIcon />}
-			/>
-			<IconButton
-				type="button"
-				appearance="outlined"
-				label="prestige worldwide"
-				size="xs"
-				icon={<GlobeIcon />}
-			/>
+			<IconButton appearance="ghost" label="prestige worldwide" size="xs" icon={<GlobeIcon />} />
+			<IconButton appearance="outlined" label="prestige worldwide" size="xs" icon={<GlobeIcon />} />
 		</div>
 	</div>
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">Size sm</p>
 		<div className="flex items-center gap-2">
-			<IconButton
-				type="button"
-				appearance="ghost"
-				label="prestige worldwide"
-				size="sm"
-				icon={<GlobeIcon />}
-			/>
-			<IconButton
-				type="button"
-				appearance="outlined"
-				label="prestige worldwide"
-				size="sm"
-				icon={<GlobeIcon />}
-			/>
+			<IconButton appearance="ghost" label="prestige worldwide" size="sm" icon={<GlobeIcon />} />
+			<IconButton appearance="outlined" label="prestige worldwide" size="sm" icon={<GlobeIcon />} />
 		</div>
 	</div>
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">Size md</p>
 		<div className="flex items-center gap-2">
-			<IconButton
-				type="button"
-				appearance="ghost"
-				label="prestige worldwide"
-				icon={<GlobeIcon />}
-			/>
-			<IconButton
-				type="button"
-				appearance="outlined"
-				label="prestige worldwide"
-				icon={<GlobeIcon />}
-			/>
+			<IconButton appearance="ghost" label="prestige worldwide" icon={<GlobeIcon />} />
+			<IconButton appearance="outlined" label="prestige worldwide" icon={<GlobeIcon />} />
 		</div>
 	</div>
 	<div>
@@ -74,13 +40,7 @@ Initiates an action, such as completing a task or submitting information. Render
 		<div className="flex items-center gap-2">
 			<Tooltip.Root>
 				<Tooltip.Trigger asChild>
-					<IconButton
-						disabled
-						type="button"
-						appearance="ghost"
-						label="prestige worldwide"
-						icon={<GlobeIcon />}
-					/>
+					<IconButton disabled appearance="ghost" label="prestige worldwide" icon={<GlobeIcon />} />
 				</Tooltip.Trigger>
 				<Tooltip.Content>Tooltips work on disabled buttons!</Tooltip.Content>
 			</Tooltip.Root>
@@ -88,7 +48,6 @@ Initiates an action, such as completing a task or submitting information. Render
 				<Tooltip.Trigger asChild>
 					<IconButton
 						disabled
-						type="button"
 						appearance="outlined"
 						label="prestige worldwide"
 						icon={<GlobeIcon />}
@@ -104,15 +63,19 @@ Initiates an action, such as completing a task or submitting information. Render
 import { IconButton } from "@ngrok/mantle/button";
 import { GlobeIcon } from "@phosphor-icons/react/Globe";
 
-<IconButton type="button" appearance="ghost" label="prestige worldwide" size="xs" icon={<GlobeIcon />} />
-<IconButton type="button" appearance="outlined" label="prestige worldwide" size="xs" icon={<GlobeIcon />} />
+<IconButton appearance="ghost" label="prestige worldwide" size="xs" icon={<GlobeIcon />} />
+<IconButton appearance="outlined" label="prestige worldwide" size="xs" icon={<GlobeIcon />} />
 
-<IconButton type="button" appearance="ghost" label="prestige worldwide" size="sm" icon={<GlobeIcon />} />
-<IconButton type="button" appearance="outlined" label="prestige worldwide" size="sm" icon={<GlobeIcon />} />
+<IconButton appearance="ghost" label="prestige worldwide" size="sm" icon={<GlobeIcon />} />
+<IconButton appearance="outlined" label="prestige worldwide" size="sm" icon={<GlobeIcon />} />
 
-<IconButton type="button" appearance="ghost" label="prestige worldwide" size="md" icon={<GlobeIcon />} />
-<IconButton type="button" appearance="outlined" label="prestige worldwide" size="md" icon={<GlobeIcon />} />
+<IconButton appearance="ghost" label="prestige worldwide" size="md" icon={<GlobeIcon />} />
+<IconButton appearance="outlined" label="prestige worldwide" size="md" icon={<GlobeIcon />} />
 ```
+
+## Type
+
+Like [`Button`](/components/button#type), `IconButton` defaults to **`type="button"`** rather than the native `submit`, so it never accidentally submits a surrounding `<form>`. Opt in with `type="submit"` (or `type="reset"`) when the button should submit or reset a form. When `asChild` is used, `type` has no effect and is not forwarded to the child.
 
 ## isLoading
 
@@ -122,37 +85,15 @@ import { GlobeIcon } from "@phosphor-icons/react/Globe";
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">idle</p>
 		<div className="flex items-center gap-2">
-			<IconButton
-				type="button"
-				appearance="ghost"
-				label="prestige worldwide"
-				icon={<GlobeIcon />}
-			/>
-			<IconButton
-				type="button"
-				appearance="outlined"
-				label="prestige worldwide"
-				icon={<GlobeIcon />}
-			/>
+			<IconButton appearance="ghost" label="prestige worldwide" icon={<GlobeIcon />} />
+			<IconButton appearance="outlined" label="prestige worldwide" icon={<GlobeIcon />} />
 		</div>
 	</div>
 	<div>
 		<p className="mb-2 text-center font-mono text-xs">isLoading</p>
 		<div className="flex items-center gap-2">
-			<IconButton
-				type="button"
-				appearance="ghost"
-				label="prestige worldwide"
-				isLoading
-				icon={<GlobeIcon />}
-			/>
-			<IconButton
-				type="button"
-				appearance="outlined"
-				label="prestige worldwide"
-				isLoading
-				icon={<GlobeIcon />}
-			/>
+			<IconButton appearance="ghost" label="prestige worldwide" isLoading icon={<GlobeIcon />} />
+			<IconButton appearance="outlined" label="prestige worldwide" isLoading icon={<GlobeIcon />} />
 		</div>
 	</div>
 </Example>
@@ -161,11 +102,11 @@ import { GlobeIcon } from "@phosphor-icons/react/Globe";
 import { IconButton } from "@ngrok/mantle/button";
 import { GlobeIcon } from "@phosphor-icons/react/Globe";
 
-<IconButton type="button" appearance="ghost" label="prestige worldwide" icon={<GlobeIcon />} />
-<IconButton type="button" appearance="outlined" label="prestige worldwide" icon={<GlobeIcon />} />
+<IconButton appearance="ghost" label="prestige worldwide" icon={<GlobeIcon />} />
+<IconButton appearance="outlined" label="prestige worldwide" icon={<GlobeIcon />} />
 
-<IconButton type="button" appearance="ghost" label="prestige worldwide" isLoading icon={<GlobeIcon />} />
-<IconButton type="button" appearance="outlined" label="prestige worldwide" isLoading icon={<GlobeIcon />} />
+<IconButton appearance="ghost" label="prestige worldwide" isLoading icon={<GlobeIcon />} />
+<IconButton appearance="outlined" label="prestige worldwide" isLoading icon={<GlobeIcon />} />
 ```
 
 ## Polymorphism
@@ -192,12 +133,12 @@ import { Link, href } from "react-router";
 
 The `IconButton` accepts the following props in addition to the [standard HTML button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Prop         | Type                                  | Default      | Description                                                                                                                                                                                               |
-| ------------ | ------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `appearance` | `"ghost"` \| `"outlined"`             | `"outlined"` | Defines the visual style of the `IconButton`.                                                                                                                                                             |
-| `asChild`    | `boolean`                             | `false`      | Use the `asChild` prop to compose the `IconButton` styling and functionality onto alternative element types or your own React components.                                                                 |
-| `icon`       | `ReactNode`                           |              | The icon to render inside the button. When `isLoading` is `true`, the icon is automatically replaced with a spinner.                                                                                      |
-| `isLoading`  | `boolean`                             | `false`      | Determines whether or not the icon button is in a loading state. Setting `isLoading` will replace the icon with a spinner. It will also disable user interaction with the button and set `aria-disabled`. |
-| `label`      | `string`                              |              | The accessible label for the icon. This label will be visually hidden but announced to screen reader users, similar to alt text for img tags.                                                             |
-| `size`       | `"xs"` \| `"sm"` \| `"md"`            | `"md"`       | The size of the `IconButton`.                                                                                                                                                                             |
-| `type`       | `"button"` \| `"reset"` \| `"submit"` |              | The default behavior of the `IconButton`. Unlike the native `button` element, unless you use the `asChild` prop, this prop is required and has no default value.                                          |
+| Prop         | Type                                  | Default      | Description                                                                                                                                                                                                                                                     |
+| ------------ | ------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appearance` | `"ghost"` \| `"outlined"`             | `"outlined"` | Defines the visual style of the `IconButton`.                                                                                                                                                                                                                   |
+| `asChild`    | `boolean`                             | `false`      | Use the `asChild` prop to compose the `IconButton` styling and functionality onto alternative element types or your own React components.                                                                                                                       |
+| `icon`       | `ReactNode`                           |              | The icon to render inside the button. When `isLoading` is `true`, the icon is automatically replaced with a spinner.                                                                                                                                            |
+| `isLoading`  | `boolean`                             | `false`      | Determines whether or not the icon button is in a loading state. Setting `isLoading` will replace the icon with a spinner. It will also disable user interaction with the button and set `aria-disabled`.                                                       |
+| `label`      | `string`                              |              | The accessible label for the icon. This label will be visually hidden but announced to screen reader users, similar to alt text for img tags.                                                                                                                   |
+| `size`       | `"xs"` \| `"sm"` \| `"md"`            | `"md"`       | The size of the `IconButton`.                                                                                                                                                                                                                                   |
+| `type`       | `"button"` \| `"reset"` \| `"submit"` | `"button"`   | The behavior of the `IconButton` when activated. Defaults to `"button"`, so an `IconButton` inside a `<form>` will **not** submit it — pass `type="submit"` to submit the form. When `asChild` is used, `type` has no effect and is not forwarded to the child. |

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -76,7 +76,8 @@
     "summary": "Initiates an action, such as completing a task or submitting information.",
     "jsdoc": "Renders a button or a component that looks like a button, an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology.",
     "examples": [
-      "```tsx\n<Button type=\"button\" appearance=\"filled\" priority=\"default\">\n  Click me\n</Button>\n```"
+      "```tsx\n<Button appearance=\"filled\" onClick={handleClick}>\n  Click me\n</Button>\n```",
+      "Submit a form — opt in with `type=\"submit\"` (the default `\"button\"` does not submit):\n```tsx\n<Button type=\"submit\" appearance=\"filled\">\n  Save\n</Button>\n```"
     ]
   },
   {
@@ -277,7 +278,8 @@
     "summary": "Initiates an action, such as completing a task or submitting information. Renders only a single icon as children with an accessible, screen-reader-only label.",
     "jsdoc": "Renders a button or a component that looks like a button, an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology.",
     "examples": [
-      "```tsx\n<IconButton\n  type=\"button\"\n  icon={<TrashIcon />}\n  label=\"Delete item\"\n  appearance=\"ghost\"\n  size=\"sm\"\n/>\n```"
+      "```tsx\n<IconButton\n  icon={<TrashIcon />}\n  label=\"Delete item\"\n  appearance=\"ghost\"\n  size=\"sm\"\n  onClick={handleDelete}\n/>\n```",
+      "Submit a form — opt in with `type=\"submit\"` (the default `\"button\"` does not submit):\n```tsx\n<IconButton type=\"submit\" icon={<MagnifyingGlassIcon />} label=\"Search\" />\n```"
     ]
   },
   {

--- a/decisions/2026-06-17-default-button-type-button.md
+++ b/decisions/2026-06-17-default-button-type-button.md
@@ -1,0 +1,141 @@
+# Default `Button` and `IconButton` to `type="button"`
+
+## Status
+
+Accepted — 2026-06-17. Implemented. Shipped as a `patch` (see [Changeset](#implementation-plan) note);
+the `asChild` discriminated union was collapsed to a single flat shape since `type` was the only
+prop it gated.
+
+## Context
+
+Today `Button` (`packages/mantle/src/components/button/button.tsx`) and `IconButton`
+(`.../icon-button.tsx`) make `type` a **required** prop. The props are modeled as a
+discriminated union on `asChild`:
+
+- `asChild: true` → `type?: …` (optional, and intentionally **not** forwarded to the
+  cloned child — see the `Slot` branch, which spreads `buttonProps` _without_ `type`).
+- `asChild?: false | undefined` → `type: Exclude<ComponentProps<"button">["type"], undefined>`
+  (**required**, no default).
+
+The native render path is `<button {...buttonProps} type={type}>`. There is already an
+`oxlint-disable react/button-has-type` comment claiming `type` is _"defaulted to 'button'"_
+— which is **not true today** (it is required, and the destructure has no default). That
+comment is stale/aspirational.
+
+Why this is worth changing:
+
+- **It diverges from the whole ecosystem.** Radix, shadcn, MUI, Chakra, Ant, and most
+  hand-rolled buttons default to `type="button"`. mantle requiring it is surprising and is
+  a hard TypeScript error on the overwhelmingly common case (`<Button onClick={…}>Save</Button>`).
+- **Agent-facing friction.** The source JSDoc `@example` blocks feed the `.d.ts`, `llms.txt`,
+  and the `/api/components.json` agent manifest (see
+  [#1239](https://github.com/ngrok-oss/mantle/pull/1239), and the
+  [2026-06-16 DataTable recipes decision](./2026-06-16-data-table-empty-and-pagination-recipes.md)),
+  so examples are normative — agents reproduce them. A required `type` means every generated
+  button must spell out `type="button"` or fail to compile; agents trained on the ecosystem
+  norm will routinely omit it and round-trip on the diagnostic.
+- **The native default (`submit`) is the real footgun.** Native `<button>` inside a `<form>`
+  submits on click. Defaulting to `"button"` neutralizes the accidental-submit footgun for
+  the common case while still allowing `type="submit"` opt-in.
+
+This relaxes a **required** prop to **optional** with a safe default — backward compatible.
+All ~311 existing `<Button>`/`<IconButton>` call sites already pass `type` explicitly (they
+had to), so nothing breaks; the change is purely additive.
+
+## Decision
+
+Default `type` to `"button"` on both `Button` and `IconButton`, making the prop optional in
+the non-`asChild` arm. `asChild` behavior is unchanged (`type` still has no effect and is not
+forwarded to the child, so a wrapped anchor never inherits a `button` `type`).
+
+### The one real tradeoff (reverse footgun)
+
+The current required-prop design is the _only_ option that is un-footgunnable in **both**
+directions: you cannot accidentally submit, and you cannot accidentally fail to submit,
+because you are forced to choose. Defaulting to `"button"` trades the loud, obvious
+accidental-submit footgun for a quiet one: a form whose submit button is written
+`<Button>Submit</Button>` and relies on **native** form submission will silently not submit —
+with no compile error, just wrong runtime behavior.
+
+This is low-risk in practice because most form code uses an explicit `onClick`/`onSubmit`
+handler rather than native submission, but it is the reason this is a real decision and not a
+pure win. Mitigation is documentation (see below): make `type="submit"` prominent wherever
+forms are shown.
+
+## Implementation plan
+
+1. **`button.tsx` — relax the type and apply the default.**
+   - In the `asChild?: false | undefined` arm, change
+     `type: Exclude<ComponentProps<"button">["type"], undefined>` →
+     `type?: ComponentProps<"button">["type"]`.
+   - Apply the default at the point of use on the native branch only, to preserve the
+     `asChild` "not forwarded" semantics:
+     `<button {...buttonProps} type={type ?? "button"}>`.
+     (Do **not** default in the destructure — that would risk leaking `type` toward the
+     `asChild`/`Slot` path. Keeping the default at the `<button>` also makes the existing
+     `react/button-has-type` lint-disable comment finally accurate.)
+   - Re-evaluate whether the `asChild` discriminated union is still needed for `type`. If the
+     two arms now differ only by the `asChild` literal and JSDoc, simplify toward a single
+     shape with `asChild?: boolean` + optional `type` — **only if** nothing else depends on
+     the discriminant. Verify by typechecking; do not force a simplification that changes
+     other props.
+
+2. **`icon-button.tsx` — same change.** Identical union shape (lines ~102/120) and render
+   path; apply the same relaxation + `?? "button"` default.
+
+3. **JSDoc rewrite (both files).** Replace the multi-paragraph "unlike native `<button>`,
+   this prop is required" language with a concise contract: `@default "button"`, keep the
+   `@enum` values, and keep the `asChild` "has no effect / not merged with a child anchor's
+   `type`" note. Update the `@example` on `Button`/`IconButton` to omit `type` for the common
+   case (showing the new ergonomic default) while keeping one `type="submit"` example.
+
+4. **`split-button.tsx` — keep in lockstep.** `SplitButton` forwards `type` to `Button` at
+   lines 43 and 75. If its own `type` prop is modeled as required, relax it to optional in the
+   same change so `SplitButton` doesn't keep forcing `type` after `Button` stops. (Confirm its
+   current modeling; if it just passes through `...props`, no change is needed.)
+
+5. **Tests (`button.test.tsx`, `icon-button.test.tsx`) — regression coverage.**
+   - Omitted `type` renders `type="button"` (the new default) for both components.
+   - Explicit `type="submit"` / `type="reset"` still render through unchanged.
+   - `asChild` with an `<a>` child renders **no** `type` attribute on the anchor.
+   - (These are DOM-attribute assertions — happy-dom is sufficient, no browser mode.)
+
+6. **Docs site.**
+   - `apps/www/app/docs/components/button.mdx`, `icon-button.mdx`, `split-button.mdx`: drop
+     any "type is required" wording; show the defaulted common case.
+   - Ensure the Field/form docs and any form example prominently use `type="submit"` to
+     counter the reverse footgun.
+   - Regenerate the agent surface snapshot
+     (`apps/www/app/utilities/__snapshots__/components-surface.json`) — it derives from the
+     JSDoc and will pick up the new `@default`/examples.
+
+7. **Changeset — `patch`.** The public type contract changes (required → optional) and a new
+   runtime default is introduced; both are backward compatible and additive. We shipped this as a
+   `patch`: every existing call site already passes `type`, so no published behavior changes for
+   current consumers — the relaxation only removes a compile error from previously-invalid code.
+   (`minor` is defensible too, treating the new optional-usage capability as a feature.)
+
+## Optional follow-up (separate PR)
+
+Internal call sites that pass a now-redundant `type="button"` could be cleaned up, but that is
+churn across ~300 sites and unrelated to the API change. Keep it out of this PR; do it
+separately if desired.
+
+## Consequences
+
+- `<Button>` / `<IconButton>` compile and work without `type`; ergonomics match the ecosystem
+  and the agent-generated common case stops erroring.
+- The stale `react/button-has-type` lint-disable comment becomes accurate.
+- New responsibility on docs: native form-submit buttons must opt in with `type="submit"`,
+  since the default no longer submits.
+- No change for any existing call site (all already pass `type`).
+
+## Resolved
+
+- `minor` vs `patch` — **shipped as `patch`.** Existing explicit usage is unchanged and no
+  published runtime behavior changes for current consumers; the relaxation only removes a
+  compile error from previously-invalid code.
+- Simplify the `asChild` discriminated union — **yes, simplified.** Once `type` was relaxed to
+  optional in both arms, the discriminant gated nothing else, so both `Button` and `IconButton`
+  now use a single flat `WithAsChild`-based shape. `split-button.tsx` dropped its now-redundant
+  `Pick<…, "type">` and `type="button"` defaults, deferring to the components' default.

--- a/packages/mantle/src/components/button/button.test.tsx
+++ b/packages/mantle/src/components/button/button.test.tsx
@@ -56,6 +56,15 @@ describe("Button", () => {
 			);
 			expect(screen.getByRole("link")).not.toHaveAttribute("type");
 		});
+
+		test("does not forward an explicit `type` to an `asChild` anchor", () => {
+			render(
+				<Button type="submit" asChild>
+					<a href="#yolo">click me</a>
+				</Button>,
+			);
+			expect(screen.getByRole("link")).not.toHaveAttribute("type");
+		});
 	});
 
 	test("when isLoading={false}, allows click and submit events to propagate", async () => {

--- a/packages/mantle/src/components/button/button.test.tsx
+++ b/packages/mantle/src/components/button/button.test.tsx
@@ -32,6 +32,32 @@ describe("Button", () => {
 		expect(screen.getByRole("link")).not.toHaveAttribute("type");
 	});
 
+	describe("type", () => {
+		test(`defaults to type="button" when \`type\` is omitted`, () => {
+			render(<Button>click me</Button>);
+			expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+		});
+
+		test(`renders an explicit type="submit"`, () => {
+			render(<Button type="submit">submit</Button>);
+			expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+		});
+
+		test(`renders an explicit type="reset"`, () => {
+			render(<Button type="reset">reset</Button>);
+			expect(screen.getByRole("button")).toHaveAttribute("type", "reset");
+		});
+
+		test("does not leak the default `type` onto an `asChild` anchor", () => {
+			render(
+				<Button asChild>
+					<a href="#yolo">click me</a>
+				</Button>,
+			);
+			expect(screen.getByRole("link")).not.toHaveAttribute("type");
+		});
+	});
+
 	test("when isLoading={false}, allows click and submit events to propagate", async () => {
 		const Subject = () => {
 			const [submitState, setSubmitState] = useState<"submitting" | "idle">("idle");

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -5,6 +5,7 @@ import type { ComponentProps, ReactNode } from "react";
 import { Children, cloneElement, forwardRef, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import { parseBooleanish } from "../../types/index.js";
+import type { WithAsChild } from "../../types/index.js";
 import type { VariantProps } from "../../types/variant-props.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Icon } from "../icon/index.js";
@@ -107,7 +108,8 @@ type ButtonPriority = Pick<ButtonVariants, "priority">["priority"];
  * The props for the `Button` component.
  */
 type ButtonProps = ComponentProps<"button"> &
-	ButtonVariants & {
+	ButtonVariants &
+	WithAsChild & {
 		/**
 		 * An icon to render inside the button. If the `state` is `"pending"`, then
 		 * the icon will automatically be replaced with a spinner.
@@ -119,57 +121,25 @@ type ButtonProps = ComponentProps<"button"> &
 		 * @default "start"
 		 */
 		iconPlacement?: "start" | "end";
-	} & (
-		| {
-				/**
-				 * Use the `asChild` prop to compose Radix's functionality onto alternative
-				 * element types or your own React components.
-				 *
-				 * When `asChild` is set to `true`, mantle will not render a default DOM
-				 * element, instead cloning the component's child and passing it the props and
-				 * behavior required to make it functional.
-				 *
-				 * asChild can be used as deeply as you need to. This means it is a great way
-				 * to compose multiple primitive's behavior together.
-				 *
-				 * @see https://www.radix-ui.com/docs/primitives/guides/composition#composition
-				 */
-				asChild: true;
-				/**
-				 * The default behavior of the button. Possible values are: `"button"`, `"submit"`, and `"reset"`.
-				 *
-				 * if `asChild` is NOT used: Unlike the native `<button>` element, this prop is required and has no default value.
-				 *
-				 * If `asChild` IS used: This prop HAS NO EFFECT, is REMOVED, and has no default value. This is because we do not want the `button` `type` to automatically merge with any child anchor `type` attribute because the `anchor` `type` is _strictly different_ than the `button` type, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#type
-				 *
-				 * @enum
-				 * - `"button"`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
-				 * - `"reset"`: The button resets all the controls to their initial values.
-				 * - `"submit"`: The button submits the form data to the server.
-				 *
-				 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
-				 */
-				type?: ComponentProps<"button">["type"];
-		  }
-		| {
-				asChild?: false | undefined;
-				/**
-				 * The default behavior of the button. Possible values are: `"button"`, `"submit"`, and `"reset"`.
-				 *
-				 * if `asChild` is NOT used: Unlike the native `<button>` element, this prop is required and has no default value.
-				 *
-				 * If `asChild` IS used: This prop HAS NO EFFECT, is REMOVED, and has no default value. This is because we do not want the `button` `type` to automatically merge with any child anchor `type` attribute because the `anchor` `type` is _strictly different_ than the `button` type, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#type
-				 *
-				 * @enum
-				 * - `"button"`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
-				 * - `"reset"`: The button resets all the controls to their initial values.
-				 * - `"submit"`: The button submits the form data to the server.
-				 *
-				 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
-				 */
-				type: Exclude<ComponentProps<"button">["type"], undefined>;
-		  }
-	);
+		/**
+		 * The behavior of the button when activated. Defaults to `"button"`, so the
+		 * button does not accidentally submit a surrounding `<form>` — pass
+		 * `type="submit"` to submit a form, or `type="reset"` to reset it.
+		 *
+		 * When `asChild` is used, `type` has no effect and is not forwarded to the
+		 * child, so a wrapped anchor never inherits a `button` `type`. See:
+		 * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#type
+		 *
+		 * @default "button"
+		 * @enum
+		 * - `"button"`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
+		 * - `"reset"`: The button resets all the controls to their initial values.
+		 * - `"submit"`: The button submits the form data to the server.
+		 *
+		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
+		 */
+		type?: ComponentProps<"button">["type"];
+	};
 
 /**
  * Renders a button or a component that looks like a button, an interactive
@@ -181,8 +151,16 @@ type ButtonProps = ComponentProps<"button"> &
  *
  * @example
  * ```tsx
- * <Button type="button" appearance="filled" priority="default">
+ * <Button appearance="filled" onClick={handleClick}>
  *   Click me
+ * </Button>
+ * ```
+ *
+ * @example
+ * Submit a form — opt in with `type="submit"` (the default `"button"` does not submit):
+ * ```tsx
+ * <Button type="submit" appearance="filled">
+ *   Save
  * </Button>
  * ```
  */
@@ -258,8 +236,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		}
 
 		return (
-			// oxlint-disable-next-line react/button-has-type -- `type` is resolved at runtime from the `type` prop (defaulted to "button"); the static analyzer can't see that.
-			<button {...buttonProps} type={type}>
+			// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
+			<button {...buttonProps} type={type ?? "button"}>
 				{icon && <Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />}
 				{children}
 			</button>

--- a/packages/mantle/src/components/button/icon-button.test.tsx
+++ b/packages/mantle/src/components/button/icon-button.test.tsx
@@ -35,5 +35,14 @@ describe("IconButton", () => {
 			expect(link).toHaveAccessibleName("home");
 			expect(link).not.toHaveAttribute("type");
 		});
+
+		test("does not forward an explicit `type` to an `asChild` anchor", () => {
+			render(
+				<IconButton type="submit" asChild label="home" icon={<GlobeIcon />}>
+					<a href="#yolo" />
+				</IconButton>,
+			);
+			expect(screen.getByRole("link")).not.toHaveAttribute("type");
+		});
 	});
 });

--- a/packages/mantle/src/components/button/icon-button.test.tsx
+++ b/packages/mantle/src/components/button/icon-button.test.tsx
@@ -1,0 +1,39 @@
+import { GlobeIcon } from "@phosphor-icons/react/Globe";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { IconButton } from "./icon-button.js";
+
+describe("IconButton", () => {
+	test("renders a button with an accessible label", () => {
+		render(<IconButton label="globe" icon={<GlobeIcon />} />);
+		expect(screen.getByRole("button", { name: "globe" })).toBeInTheDocument();
+	});
+
+	describe("type", () => {
+		test(`defaults to type="button" when \`type\` is omitted`, () => {
+			render(<IconButton label="globe" icon={<GlobeIcon />} />);
+			expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+		});
+
+		test(`renders an explicit type="submit"`, () => {
+			render(<IconButton type="submit" label="search" icon={<GlobeIcon />} />);
+			expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+		});
+
+		test(`renders an explicit type="reset"`, () => {
+			render(<IconButton type="reset" label="reset" icon={<GlobeIcon />} />);
+			expect(screen.getByRole("button")).toHaveAttribute("type", "reset");
+		});
+
+		test("does not leak the default `type` onto an `asChild` anchor", () => {
+			render(
+				<IconButton asChild label="home" icon={<GlobeIcon />}>
+					<a href="#yolo" />
+				</IconButton>,
+			);
+			const link = screen.getByRole("link");
+			expect(link).toHaveAccessibleName("home");
+			expect(link).not.toHaveAttribute("type");
+		});
+	});
+});

--- a/packages/mantle/src/components/button/icon-button.tsx
+++ b/packages/mantle/src/components/button/icon-button.tsx
@@ -96,7 +96,7 @@ type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
  * as submitting a form or opening a dialog.
  * Renders only a single icon as children with an accessible, screen-reader-only label.
  *
- * @see https://mantle.ngrok.com/components/button
+ * @see https://mantle.ngrok.com/components/icon-button
  *
  * @example
  * ```tsx

--- a/packages/mantle/src/components/button/icon-button.tsx
+++ b/packages/mantle/src/components/button/icon-button.tsx
@@ -55,7 +55,7 @@ const iconButtonVariants = cva(baseIconButtonClasses, {
 type IconButtonVariants = VariantProps<typeof iconButtonVariants>;
 
 /**
- * The props for the `Button` component.
+ * The props for the `IconButton` component.
  */
 type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 	WithAsChild &
@@ -69,57 +69,25 @@ type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 		 * the icon will automatically be replaced with a spinner.
 		 */
 		icon: ReactNode;
-	} & (
-		| {
-				/**
-				 * Use the `asChild` prop to compose Radix's functionality onto alternative
-				 * element types or your own React components.
-				 *
-				 * When `asChild` is set to `true`, mantle will not render a default DOM
-				 * element, instead cloning the component's child and passing it the props and
-				 * behavior required to make it functional.
-				 *
-				 * asChild can be used as deeply as you need to. This means it is a great way
-				 * to compose multiple primitive's behavior together.
-				 *
-				 * @see https://www.radix-ui.com/docs/primitives/guides/composition#composition
-				 */
-				asChild: true;
-				/**
-				 * The default behavior of the button. Possible values are: `"button"`, `"submit"`, and `"reset"`.
-				 *
-				 * if `asChild` is NOT used: Unlike the native `<button>` element, this prop is required and has no default value.
-				 *
-				 * If `asChild` IS used: This prop HAS NO EFFECT, is REMOVED, and has no default value. This is because we do not want the `button` `type` to automatically merge with any child anchor `type` attribute because the `anchor` `type` is _strictly different_ than the `button` type, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#type
-				 *
-				 * @enum
-				 * - `"button"`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
-				 * - `"reset"`: The button resets all the controls to their initial values.
-				 * - `"submit"`: The button submits the form data to the server.
-				 *
-				 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
-				 */
-				type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
-		  }
-		| {
-				asChild?: false | undefined;
-				/**
-				 * The default behavior of the button. Possible values are: `"button"`, `"submit"`, and `"reset"`.
-				 *
-				 * if `asChild` is NOT used: Unlike the native `<button>` element, this prop is required and has no default value.
-				 *
-				 * If `asChild` IS used: This prop HAS NO EFFECT, is REMOVED, and has no default value. This is because we do not want the `button` `type` to automatically merge with any child anchor `type` attribute because the `anchor` `type` is _strictly different_ than the `button` type, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#type
-				 *
-				 * @enum
-				 * - `"button"`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
-				 * - `"reset"`: The button resets all the controls to their initial values.
-				 * - `"submit"`: The button submits the form data to the server.
-				 *
-				 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
-				 */
-				type: Exclude<ButtonHTMLAttributes<HTMLButtonElement>["type"], undefined>;
-		  }
-	);
+		/**
+		 * The behavior of the button when activated. Defaults to `"button"`, so the
+		 * button does not accidentally submit a surrounding `<form>` — pass
+		 * `type="submit"` to submit a form, or `type="reset"` to reset it.
+		 *
+		 * When `asChild` is used, `type` has no effect and is not forwarded to the
+		 * child, so a wrapped anchor never inherits a `button` `type`. See:
+		 * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#type
+		 *
+		 * @default "button"
+		 * @enum
+		 * - `"button"`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
+		 * - `"reset"`: The button resets all the controls to their initial values.
+		 * - `"submit"`: The button submits the form data to the server.
+		 *
+		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
+		 */
+		type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
+	};
 
 /**
  * Renders a button or a component that looks like a button, an interactive
@@ -133,12 +101,18 @@ type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
  * @example
  * ```tsx
  * <IconButton
- *   type="button"
  *   icon={<TrashIcon />}
  *   label="Delete item"
  *   appearance="ghost"
  *   size="sm"
+ *   onClick={handleDelete}
  * />
+ * ```
+ *
+ * @example
+ * Submit a form — opt in with `type="submit"` (the default `"button"` does not submit):
+ * ```tsx
+ * <IconButton type="submit" icon={<MagnifyingGlassIcon />} label="Search" />
  * ```
  */
 const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
@@ -193,8 +167,8 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
 		}
 
 		return (
-			// oxlint-disable-next-line react/button-has-type -- `type` is resolved at runtime from the `type` prop (defaulted to "button"); the static analyzer can't see that.
-			<button {...buttonProps} type={type}>
+			// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
+			<button {...buttonProps} type={type ?? "button"}>
 				{innerChildren}
 			</button>
 		);

--- a/packages/mantle/src/components/split-button/split-button.tsx
+++ b/packages/mantle/src/components/split-button/split-button.tsx
@@ -35,26 +35,23 @@ const Root = forwardRef<ComponentRef<"div">, RootProps>(
 );
 Root.displayName = "SplitButton";
 
-type PrimaryActionProps = Omit<ComponentProps<typeof Button>, "appearance" | "type" | "priority"> &
-	Pick<ComponentProps<"button">, "type">;
+type PrimaryActionProps = Omit<ComponentProps<typeof Button>, "appearance" | "priority">;
 
-const PrimaryAction = forwardRef<ComponentRef<"button">, PrimaryActionProps>(
-	({ type = "button", ...props }, ref) => {
-		return <Button appearance="outlined" priority="neutral" ref={ref} type={type} {...props} />;
-	},
-);
+const PrimaryAction = forwardRef<ComponentRef<"button">, PrimaryActionProps>((props, ref) => {
+	// `type` flows through; `Button` defaults it to "button".
+	return <Button appearance="outlined" priority="neutral" ref={ref} {...props} />;
+});
 PrimaryAction.displayName = "SplitButtonPrimaryAction";
 
 type MenuTriggerProps = Omit<
 	ComponentProps<typeof IconButton>,
 	"appearance" | "size" | "asChild" | "icon"
-> &
-	Pick<ComponentProps<"button">, "type"> & {
-		icon?: ReactNode;
-	};
+> & {
+	icon?: ReactNode;
+};
 
 const MenuTrigger = forwardRef<ComponentRef<"button">, MenuTriggerProps>(
-	({ icon, type = "button", ...props }, ref) => {
+	({ icon, ...props }, ref) => {
 		return (
 			<DropdownMenu.Trigger asChild className="group">
 				<IconButton
@@ -72,7 +69,6 @@ const MenuTrigger = forwardRef<ComponentRef<"button">, MenuTriggerProps>(
 					}
 					appearance="outlined"
 					ref={ref}
-					type={type}
 					{...props}
 				/>
 			</DropdownMenu.Trigger>


### PR DESCRIPTION
Relax the required `type` prop to optional on Button and IconButton, applying the default at the render site (`type={type ?? "button"}`). This matches the React ecosystem (Radix, shadcn, MUI) and removes the hard TypeScript error on the common `<Button onClick>` case, while preserving asChild's "type is not forwarded to the child" semantics.

Collapse the now-purposeless asChild discriminated union to a single flat WithAsChild-based shape (type was the only prop it gated), and drop split-button's redundant `type` Pick + `type="button"` defaults so it defers to the components' default.

Docs: add a top-level "Type" section to button/icon-button covering the new default and the form-submit opt-in (`type="submit"`), fix the API tables and JSDoc, and regenerate the agent-surface snapshot.

Backward compatible — every existing call site already passes `type`. Shipped as a patch changeset.

Implements decisions/2026-06-17-default-button-type-button.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Button and IconButton components' `type` prop is now optional, defaulting to `"button"`.

* **Documentation**
  * Updated Button and IconButton documentation and API references to reflect the optional `type` prop and its new default behavior. Explicit `type="submit"` is required for form submission functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->