### PR TITLE
chore: update repo references from ngrok-oss/mantle to ngrok/mantle

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "ngrok-oss/mantle"
+      "repo": "ngrok/mantle"
     }
   ],
   "commit": false,

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @ngrok-oss/team-frontend
+*       @ngrok/team-frontend

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.repository == 'ngrok-oss/mantle'
+    if: github.repository == 'ngrok/mantle'
     steps:
       - uses: actions/create-github-app-token@v3
         id: generate-token
@@ -69,5 +69,5 @@ jobs:
             name=$(echo "$pkg" | jq -r '.name')
             version=$(echo "$pkg" | jq -r '.version')
             tag=$(echo "${name}@${version}" | sed 's/@/%40/g; s/\//%2F/g')
-            curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"\`${name}@${version}\` published to npm!\nInstall with: \`pnpm add -E ${name}@${version}\`\n<https://github.com/ngrok-oss/mantle/releases/tag/${tag}|Release Notes>\"}" "$SLACK_WEBHOOK_URL"
+            curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"\`${name}@${version}\` published to npm!\nInstall with: \`pnpm add -E ${name}@${version}\`\n<https://github.com/ngrok/mantle/releases/tag/${tag}|Release Notes>\"}" "$SLACK_WEBHOOK_URL"
           done

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ngrok-oss/mantle/HEAD/.github/mantle-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ngrok-oss/mantle/HEAD/.github/mantle-light.svg">
-    <img alt="Mantle" src="https://raw.githubusercontent.com/ngrok-oss/mantle/HEAD/.github/mantle-light.svg" width="176" height="34" style="max-width: 100%;">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ngrok/mantle/HEAD/.github/mantle-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ngrok/mantle/HEAD/.github/mantle-light.svg">
+    <img alt="Mantle" src="https://raw.githubusercontent.com/ngrok/mantle/HEAD/.github/mantle-light.svg" width="176" height="34" style="max-width: 100%;">
   </picture>
 </p>
 <h1 align="center">

--- a/apps/www/app/components/header.tsx
+++ b/apps/www/app/components/header.tsx
@@ -103,7 +103,7 @@ export function Header({ className, ...props }: Omit<ComponentProps<"header">, "
 							label="ngrok Mantle GitHub repository"
 							icon={<GitHub />}
 						>
-							<a href="https://github.com/ngrok-oss/mantle" target="_blank" rel="noopener" />
+							<a href="https://github.com/ngrok/mantle" target="_blank" rel="noopener" />
 						</IconButton>
 
 						<DropdownMenu.Root>
@@ -132,7 +132,7 @@ export function Header({ className, ...props }: Omit<ComponentProps<"header">, "
 								</DropdownMenu.Item>
 								<DropdownMenu.Item asChild>
 									<a
-										href="https://github.com/ngrok-oss/mantle"
+										href="https://github.com/ngrok/mantle"
 										target="_blank"
 										rel="noopener"
 										className="justify-between gap-4"
@@ -238,14 +238,14 @@ function CommandPalette() {
 							))}
 							<Command.Item asChild onSelect={() => setOpen(false)}>
 								<a
-									href="https://github.com/ngrok-oss/mantle"
+									href="https://github.com/ngrok/mantle"
 									target="_blank"
 									rel="noopener"
 									className="flex items-center gap-2 justify-between"
 								>
 									<ItemName>
 										GitHub Repo
-										<span className="text-muted text-xs font-mono">ngrok-oss/mantle</span>
+										<span className="text-muted text-xs font-mono">ngrok/mantle</span>
 									</ItemName>
 									<ArrowSquareOutIcon />
 								</a>

--- a/apps/www/app/docs/changelog.mdx
+++ b/apps/www/app/docs/changelog.mdx
@@ -7,9 +7,9 @@ import Changelog from "virtual:@ngrok/mantle/changelog.md";
 
 # Changelog
 
-Release notes for `@ngrok/mantle`, generated from the package's [`CHANGELOG.md`](https://github.com/ngrok-oss/mantle/blob/main/packages/mantle/CHANGELOG.md) via [changesets](https://github.com/changesets/changesets). The same content is available as plain markdown at [`/changelog.md`](/changelog.md) for agent and tooling consumption.
+Release notes for `@ngrok/mantle`, generated from the package's [`CHANGELOG.md`](https://github.com/ngrok/mantle/blob/main/packages/mantle/CHANGELOG.md) via [changesets](https://github.com/changesets/changesets). The same content is available as plain markdown at [`/changelog.md`](/changelog.md) for agent and tooling consumption.
 
-See also the [npm version history](https://www.npmjs.com/package/@ngrok/mantle?activeTab=versions) and the [GitHub releases](https://github.com/ngrok-oss/mantle/releases).
+See also the [npm version history](https://www.npmjs.com/package/@ngrok/mantle?activeTab=versions) and the [GitHub releases](https://github.com/ngrok/mantle/releases).
 
 ---
 

--- a/apps/www/app/docs/for-ai-agents.mdx
+++ b/apps/www/app/docs/for-ai-agents.mdx
@@ -71,7 +71,7 @@ design system. Conventions:
 - **Nullish checks use `== null` / `!= null`.** The codebase prefers these over `=== undefined` / `!== undefined`, since `== null` covers both `null` and `undefined`.
 - **Theme + provider setup.** Apps must mount [`ThemeProvider`](/components/theme) and [`Toaster`](/components/toast) at the root. Add [`TooltipProvider`](/components/tooltip) once when using shared tooltip delay or hover settings. Without `ThemeProvider`, theme tokens are unstyled and there's a flash of unstyled content.
 - **Phosphor icons by default.** Import icons from `@phosphor-icons/react/<IconName>` (e.g. `@phosphor-icons/react/Fire`). Custom ngrok icons live at [`@ngrok/mantle/icons`](/components/icons).
-- **No `as` casts in app code.** Use proper null checks and type narrowing. Type assertions are restricted to `as const` and dedicated type guards (see [Conventions](https://github.com/ngrok-oss/mantle/blob/main/CONVENTIONS.md)).
+- **No `as` casts in app code.** Use proper null checks and type narrowing. Type assertions are restricted to `as const` and dedicated type guards (see [Conventions](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md)).
 - **Exact-pinned versions.** When adding a dependency, pin it. No `^` or `~` ranges.
 - **Tailwind 4.** Custom classes use the design tokens defined in `mantle.css`. Prefer semantic tokens (`text-strong`, `bg-form`, `border-accent-600`) over raw color names where they exist.
 

--- a/apps/www/app/docs/index.mdx
+++ b/apps/www/app/docs/index.mdx
@@ -39,7 +39,7 @@ Mantle is a living design system and the standard UI library for all ngrok user 
 continuously evolving as new components, patterns, and improvements are added.
 
 Mantle is available on [NPM](https://www.npmjs.com/package/@ngrok/mantle) and is open source on
-[GitHub](https://github.com/ngrok-oss/mantle).
+[GitHub](https://github.com/ngrok/mantle).
 
 ## Setup
 

--- a/apps/www/app/docs/utils/cx.mdx
+++ b/apps/www/app/docs/utils/cx.mdx
@@ -99,4 +99,4 @@ The return value is a single deduplicated, conflict-resolved class string.
 ## Convention
 
 All `className` values in Mantle must be built with `cx`.
-String interpolation, `+`, ternaries, or conditional expressions directly on `className` are not allowed — see [CONVENTIONS.md](https://github.com/ngrok-oss/mantle/blob/main/CONVENTIONS.md).
+String interpolation, `+`, ternaries, or conditional expressions directly on `className` are not allowed — see [CONVENTIONS.md](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md).

--- a/apps/www/app/routes/llms[.]txt.tsx
+++ b/apps/www/app/routes/llms[.]txt.tsx
@@ -99,7 +99,7 @@ async function buildBody(): Promise<string> {
 		"",
 		`Docs: ${canonicalHref("/")}`,
 		`NPM: https://www.npmjs.com/package/@ngrok/mantle`,
-		`Source: https://github.com/ngrok-oss/mantle`,
+		`Source: https://github.com/ngrok/mantle`,
 		`Component manifest: ${canonicalHref("/api/components.json")}`,
 		`Hooks manifest: ${canonicalHref("/api/hooks.json")}`,
 		`Utilities manifest: ${canonicalHref("/api/utils.json")}`,

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -88,7 +88,7 @@
     "summary": "A date field component that allows users to enter and edit date.",
     "jsdoc": "A calendar component that allows users to select a date or a range of dates.",
     "examples": [
-      "```tsx\n<Calendar\n  mode=\"single\"\n  selected={selectedDate}\n  onSelect={setSelectedDate}\n/>\n\n<Calendar\n  mode=\"range\"\n  selected={dateRange}\n  onSelect={setDateRange}\n/>\n```\n\nhttps://github.com/ngrok-oss/mantle/issues"
+      "```tsx\n<Calendar\n  mode=\"single\"\n  selected={selectedDate}\n  onSelect={setSelectedDate}\n/>\n\n<Calendar\n  mode=\"range\"\n  selected={dateRange}\n  onSelect={setDateRange}\n/>\n```\n\nhttps://github.com/ngrok/mantle/issues"
     ]
   },
   {

--- a/apps/www/app/utilities/changelog.server.test.ts
+++ b/apps/www/app/utilities/changelog.server.test.ts
@@ -4,25 +4,25 @@ import { parseChangeBody, parseVersions } from "./changelog.server";
 describe("parseChangeBody", () => {
 	it("extracts PR, commit, author, and trimmed summary from a typical changesets bullet", () => {
 		const raw =
-			"[#1167](https://github.com/ngrok-oss/mantle/pull/1167) " +
-			"[`acd0c55`](https://github.com/ngrok-oss/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5) " +
+			"[#1167](https://github.com/ngrok/mantle/pull/1167) " +
+			"[`acd0c55`](https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5) " +
 			"Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `OtpInput`.";
 		expect(parseChangeBody(raw)).toEqual({
 			summary: "Add `OtpInput`.",
-			pr: "https://github.com/ngrok-oss/mantle/pull/1167",
-			commit: "https://github.com/ngrok-oss/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5",
+			pr: "https://github.com/ngrok/mantle/pull/1167",
+			commit: "https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5",
 			author: "cody-dot-js",
 		});
 	});
 
 	it("handles partial metadata (no PR link)", () => {
 		const raw =
-			"[`abcdef0`](https://github.com/ngrok-oss/mantle/commit/abcdef0) " +
+			"[`abcdef0`](https://github.com/ngrok/mantle/commit/abcdef0) " +
 			"Thanks [@octocat](https://github.com/octocat)! - patch only";
 		expect(parseChangeBody(raw)).toEqual({
 			summary: "patch only",
 			pr: undefined,
-			commit: "https://github.com/ngrok-oss/mantle/commit/abcdef0",
+			commit: "https://github.com/ngrok/mantle/commit/abcdef0",
 			author: "octocat",
 		});
 	});

--- a/apps/www/app/utilities/release-href.ts
+++ b/apps/www/app/utilities/release-href.ts
@@ -3,8 +3,8 @@
  *
  * @example
  * releaseHref("0.69.0")
- * // "https://github.com/ngrok-oss/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0"
+ * // "https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0"
  */
 export function releaseHref(version: string): string {
-	return `https://github.com/ngrok-oss/mantle/releases/tag/${encodeURIComponent(`@ngrok/mantle@${version}`)}`;
+	return `https://github.com/ngrok/mantle/releases/tag/${encodeURIComponent(`@ngrok/mantle@${version}`)}`;
 }

--- a/decisions/2026-06-16-data-table-empty-and-pagination-recipes.md
+++ b/decisions/2026-06-16-data-table-empty-and-pagination-recipes.md
@@ -15,7 +15,7 @@ Every list-style `DataTable` needs two things the docs under-taught:
 The docs previously shipped only bare `<DataTable.EmptyRow>No results.</DataTable.EmptyRow>`
 and a hand-rolled `<Button>`-based prev/next recipe. Because the source JSDoc `@example`
 blocks feed the `.d.ts`, `llms.txt`, and `/api/components.json` agent manifest (see
-[#1239](https://github.com/ngrok-oss/mantle/pull/1239)), those examples are **normative** —
+[#1239](https://github.com/ngrok/mantle/pull/1239)), those examples are **normative** —
 coding agents reproduce them verbatim. A downstream migration of ~57 tables copied exactly
 the bare-string empty and hand-rolled pagination the docs showed.
 

--- a/decisions/2026-06-17-default-button-type-button.md
+++ b/decisions/2026-06-17-default-button-type-button.md
@@ -29,7 +29,7 @@ Why this is worth changing:
   a hard TypeScript error on the overwhelmingly common case (`<Button onClick={…}>Save</Button>`).
 - **Agent-facing friction.** The source JSDoc `@example` blocks feed the `.d.ts`, `llms.txt`,
   and the `/api/components.json` agent manifest (see
-  [#1239](https://github.com/ngrok-oss/mantle/pull/1239), and the
+  [#1239](https://github.com/ngrok/mantle/pull/1239), and the
   [2026-06-16 DataTable recipes decision](./2026-06-16-data-table-empty-and-pagination-recipes.md)),
   so examples are normative — agents reproduce them. A required `type` means every generated
   button must spell out `type="button"` or fail to compile; agents trained on the ecosystem

--- a/packages/mantle-server-syntax-highlighter/CHANGELOG.md
+++ b/packages/mantle-server-syntax-highlighter/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ### Patch Changes
 
-- [#1241](https://github.com/ngrok-oss/mantle/pull/1241) [`f7be346`](https://github.com/ngrok-oss/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update the `oxc-parser` dependency to `0.136.0` (from `0.135.0`).
+- [#1241](https://github.com/ngrok/mantle/pull/1241) [`f7be346`](https://github.com/ngrok/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update the `oxc-parser` dependency to `0.136.0` (from `0.135.0`).
 
 ## 1.1.3
 
 ### Patch Changes
 
-- [#1223](https://github.com/ngrok-oss/mantle/pull/1223) [`6dc792c`](https://github.com/ngrok-oss/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update `shiki` to 4.2.0.
+- [#1223](https://github.com/ngrok/mantle/pull/1223) [`6dc792c`](https://github.com/ngrok/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update `shiki` to 4.2.0.
 
 ## 1.1.2
 
 ### Patch Changes
 
-- [#1207](https://github.com/ngrok-oss/mantle/pull/1207) [`b9fadca`](https://github.com/ngrok-oss/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162) Thanks [@dependabot](https://github.com/apps/dependabot)! - Lint cleanup round. No behavior changes.
+- [#1207](https://github.com/ngrok/mantle/pull/1207) [`b9fadca`](https://github.com/ngrok/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162) Thanks [@dependabot](https://github.com/apps/dependabot)! - Lint cleanup round. No behavior changes.
 
   Replaced the forbidden inline `typeof import("oxc-parser")` annotations with a type-only namespace import (`import type * as OxcParserModule from "oxc-parser"; type OxcParser = typeof OxcParserModule;`). The lazy `createRequire` loading path is unaffected — `import type * as` is fully erased at compile time.
 
@@ -24,13 +24,13 @@
 
 ### Patch Changes
 
-- [#1197](https://github.com/ngrok-oss/mantle/pull/1197) [`c30e470`](https://github.com/ngrok-oss/mantle/commit/c30e4707bb8d12ae80e59c8f89e87920a2d0d478) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `oxc-parser` to `0.130.0`.
+- [#1197](https://github.com/ngrok/mantle/pull/1197) [`c30e470`](https://github.com/ngrok/mantle/commit/c30e4707bb8d12ae80e59c8f89e87920a2d0d478) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `oxc-parser` to `0.130.0`.
 
 ## 1.1.0
 
 ### Minor Changes
 
-- [#1174](https://github.com/ngrok-oss/mantle/pull/1174) [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend code-block folding toward VS Code parity by switching the JS/TS/JSX/TSX, HTML, XML, and CSS strategies to AST / parser-quality matchers, and adding keyword-pair folding for Bash / Shell / Ruby. The runtime click handler is unchanged — all heavier work runs server- or build-side inside `@ngrok/mantle-server-syntax-highlighter`.
+- [#1174](https://github.com/ngrok/mantle/pull/1174) [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend code-block folding toward VS Code parity by switching the JS/TS/JSX/TSX, HTML, XML, and CSS strategies to AST / parser-quality matchers, and adding keyword-pair folding for Bash / Shell / Ruby. The runtime click handler is unchanged — all heavier work runs server- or build-side inside `@ngrok/mantle-server-syntax-highlighter`.
 
   What now folds (per language):
   - **JS / TS / JSX / TSX** (`oxc-parser`) — block statements, object/array literals, class/interface/type-literal/enum bodies, switch statements, multi-line template literals (including tagged), JSX elements (`<Foo>…</Foo>`), JSX fragments (`<>…</>`), member-expression element names (`<obj.Foo>`), and multi-line self-closing opening tags / attribute lists. Single-line self-closing JSX tags still don't get a toggle.
@@ -48,7 +48,7 @@
 
   Skipping `includeExplanation` on the AST and raw-source paths (JS/TS/HTML/CSS/JSON) keeps the highlight pipeline cheaper than the previous token-only approach for those languages.
 
-- [#1174](https://github.com/ngrok-oss/mantle/pull/1174) [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend fold gutters to every supported language, not just JSON. Each language uses the folding model that fits its grammar:
+- [#1174](https://github.com/ngrok/mantle/pull/1174) [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend fold gutters to every supported language, not just JSON. Each language uses the folding model that fits its grammar:
   - **AST-based** (`javascript`, `typescript`, `jsx`, `tsx`) — `oxc-parser` emits folds for blocks, object/array literals, JSX elements/fragments, multi-line template literals, and TypeScript-only bodies.
   - **Raw-source** (`json`, `css`) — single-pass matchers fold braces/brackets while skipping strings, comments, and escapes without requiring Shiki scope explanations.
   - **Bracket-paired** (`go`, `java`, `csharp`, `rust`) — multi-line `{ … }` and `[ … ]` ranges fold via TextMate-scope-aware token walking.
@@ -71,7 +71,7 @@
 
 ### Patch Changes
 
-- [#1174](https://github.com/ngrok-oss/mantle/pull/1174) [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add VS Code-style fold gutters to JSON code blocks. Every multi-line `{ … }` or `[ … ]` now renders a semantic `<button>` toggle in the gutter; clicking (or focusing and pressing `Enter` / `Space`) hides the inner content while keeping the opener and closer lines visible, with a `⋯` placeholder marking the collapsed region.
+- [#1174](https://github.com/ngrok/mantle/pull/1174) [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add VS Code-style fold gutters to JSON code blocks. Every multi-line `{ … }` or `[ … ]` now renders a semantic `<button>` toggle in the gutter; clicking (or focusing and pressing `Enter` / `Space`) hides the inner content while keeping the opener and closer lines visible, with a `⋯` placeholder marking the collapsed region.
   - Fold ranges are computed at build time, so there is zero highlighting cost in the browser.
   - All toggle interaction runs through a single delegated click handler per `<pre>` — no per-line listeners and no React re-renders. This keeps fold/unfold cheap even on JSON blobs with thousands of lines.
   - New helper exports from `@ngrok/mantle/code-block` and `@ngrok/mantle/highlight-utils`: `computeJsonFoldRanges(code)` and the `FoldableRange` type.
@@ -82,47 +82,47 @@
 
 ### Patch Changes
 
-- [#1119](https://github.com/ngrok-oss/mantle/pull/1119) [`0c20cf7`](https://github.com/ngrok-oss/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default. Single-line shell snippets (`bash`, `sh`, `shell`) default to `false` since line numbers add noise to one-liners like install commands.
+- [#1119](https://github.com/ngrok/mantle/pull/1119) [`0c20cf7`](https://github.com/ngrok/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default. Single-line shell snippets (`bash`, `sh`, `shell`) default to `false` since line numbers add noise to one-liners like install commands.
 
-- Updated dependencies [[`0c20cf7`](https://github.com/ngrok-oss/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9)]:
+- Updated dependencies [[`0c20cf7`](https://github.com/ngrok/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9)]:
   - @ngrok/mantle@0.68.3
 
 ## 1.0.3
 
 ### Patch Changes
 
-- [#1115](https://github.com/ngrok-oss/mantle/pull/1115) [`ea340f6`](https://github.com/ngrok-oss/mantle/commit/ea340f6307f3f0f229395783c0c21f7a35363688) Thanks [@dependabot](https://github.com/apps/dependabot)! - bump shiki from 4.0.1 to 4.0.2
+- [#1115](https://github.com/ngrok/mantle/pull/1115) [`ea340f6`](https://github.com/ngrok/mantle/commit/ea340f6307f3f0f229395783c0c21f7a35363688) Thanks [@dependabot](https://github.com/apps/dependabot)! - bump shiki from 4.0.1 to 4.0.2
 
-- [#1116](https://github.com/ngrok-oss/mantle/pull/1116) [`5b0be5a`](https://github.com/ngrok-oss/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - no-op patch to verify publish CI
+- [#1116](https://github.com/ngrok/mantle/pull/1116) [`5b0be5a`](https://github.com/ngrok/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - no-op patch to verify publish CI
 
-- Updated dependencies [[`5b0be5a`](https://github.com/ngrok-oss/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f)]:
+- Updated dependencies [[`5b0be5a`](https://github.com/ngrok/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f)]:
   - @ngrok/mantle@0.68.2
 
 ## 1.0.2
 
 ### Patch Changes
 
-- [#1112](https://github.com/ngrok-oss/mantle/pull/1112) [`ad24f11`](https://github.com/ngrok-oss/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add README documentation for npm packages, switch to ES2025 preset
+- [#1112](https://github.com/ngrok/mantle/pull/1112) [`ad24f11`](https://github.com/ngrok/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add README documentation for npm packages, switch to ES2025 preset
 
-- Updated dependencies [[`d46e3b3`](https://github.com/ngrok-oss/mantle/commit/d46e3b3fbdcdf561db1d90e89afc8cca8e374be3), [`ad24f11`](https://github.com/ngrok-oss/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2)]:
+- Updated dependencies [[`d46e3b3`](https://github.com/ngrok/mantle/commit/d46e3b3fbdcdf561db1d90e89afc8cca8e374be3), [`ad24f11`](https://github.com/ngrok/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2)]:
   - @ngrok/mantle@0.68.1
 
 ## 1.0.1
 
 ### Patch Changes
 
-- [#1106](https://github.com/ngrok-oss/mantle/pull/1106) [`41ce842`](https://github.com/ngrok-oss/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22) Thanks [@forzalupo](https://github.com/forzalupo)! - Themed code block with granular syntax highlighting: richer Shiki token color palette, semantic background tokens (`bg-card`/`bg-base`), redesigned copy button using `IconButton`, and subtler tab trigger styling. Server highlighter adds fine-grained token scope mappings for types, variables, operators, attributes, properties, and escape characters.
+- [#1106](https://github.com/ngrok/mantle/pull/1106) [`41ce842`](https://github.com/ngrok/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22) Thanks [@forzalupo](https://github.com/forzalupo)! - Themed code block with granular syntax highlighting: richer Shiki token color palette, semantic background tokens (`bg-card`/`bg-base`), redesigned copy button using `IconButton`, and subtler tab trigger styling. Server highlighter adds fine-grained token scope mappings for types, variables, operators, attributes, properties, and escape characters.
 
-- Updated dependencies [[`4a81875`](https://github.com/ngrok-oss/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4), [`383d538`](https://github.com/ngrok-oss/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686), [`ab6da43`](https://github.com/ngrok-oss/mantle/commit/ab6da43e32e3e2e2dadf29aa8d99fcb2738569f4), [`2be1db1`](https://github.com/ngrok-oss/mantle/commit/2be1db1ffb23bb5719181f73090ef28d7e19a50f), [`41ce842`](https://github.com/ngrok-oss/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22)]:
+- Updated dependencies [[`4a81875`](https://github.com/ngrok/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4), [`383d538`](https://github.com/ngrok/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686), [`ab6da43`](https://github.com/ngrok/mantle/commit/ab6da43e32e3e2e2dadf29aa8d99fcb2738569f4), [`2be1db1`](https://github.com/ngrok/mantle/commit/2be1db1ffb23bb5719181f73090ef28d7e19a50f), [`41ce842`](https://github.com/ngrok/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22)]:
   - @ngrok/mantle@0.68.0
 
 ## 1.0.0
 
 ### Minor Changes
 
-- [#1018](https://github.com/ngrok-oss/mantle/pull/1018) [`f27c01f`](https://github.com/ngrok-oss/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: replace PrismJS with Shiki for build-time syntax highlighting, removing Shiki/Prism from the browser bundle
+- [#1018](https://github.com/ngrok/mantle/pull/1018) [`f27c01f`](https://github.com/ngrok/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: replace PrismJS with Shiki for build-time syntax highlighting, removing Shiki/Prism from the browser bundle
 
 ### Patch Changes
 
-- Updated dependencies [[`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`f27c01f`](https://github.com/ngrok-oss/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa), [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`54743f1`](https://github.com/ngrok-oss/mantle/commit/54743f1deee01709952fcf5222e0ea205c282e5d)]:
+- Updated dependencies [[`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`f27c01f`](https://github.com/ngrok/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa), [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`54743f1`](https://github.com/ngrok/mantle/commit/54743f1deee01709952fcf5222e0ea205c282e5d)]:
   - @ngrok/mantle@0.67.0

--- a/packages/mantle-server-syntax-highlighter/README.md
+++ b/packages/mantle-server-syntax-highlighter/README.md
@@ -1,6 +1,6 @@
 # @ngrok/mantle-server-syntax-highlighter
 
-Server-side syntax highlighting for [`@ngrok/mantle`](https://github.com/ngrok-oss/mantle), powered by [Shiki](https://shiki.style).
+Server-side syntax highlighting for [`@ngrok/mantle`](https://github.com/ngrok/mantle), powered by [Shiki](https://shiki.style).
 
 Use this package to highlight code in API routes, server actions, or any Node.js context where you need Mantle-compatible highlighted HTML without a browser or Vite.
 
@@ -104,5 +104,5 @@ Type declarations are included. No `@types/*` package is needed.
 
 ## Related Packages
 
-- [`@ngrok/mantle`](https://github.com/ngrok-oss/mantle/tree/main/packages/mantle) — UI component library ([npm](https://www.npmjs.com/package/@ngrok/mantle))
-- [`@ngrok/mantle-vite-plugins`](https://github.com/ngrok-oss/mantle/tree/main/packages/mantle-vite-plugins) — Vite + rehype plugins ([npm](https://www.npmjs.com/package/@ngrok/mantle-vite-plugins))
+- [`@ngrok/mantle`](https://github.com/ngrok/mantle/tree/main/packages/mantle) — UI component library ([npm](https://www.npmjs.com/package/@ngrok/mantle))
+- [`@ngrok/mantle-vite-plugins`](https://github.com/ngrok/mantle/tree/main/packages/mantle-vite-plugins) — Vite + rehype plugins ([npm](https://www.npmjs.com/package/@ngrok/mantle-vite-plugins))

--- a/packages/mantle-server-syntax-highlighter/package.json
+++ b/packages/mantle-server-syntax-highlighter/package.json
@@ -7,7 +7,7 @@
   "author": "ngrok",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ngrok-oss/mantle"
+    "url": "https://github.com/ngrok/mantle"
   },
   "files": [
     "dist",

--- a/packages/mantle-vite-plugins/CHANGELOG.md
+++ b/packages/mantle-vite-plugins/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ### Patch Changes
 
-- [#1241](https://github.com/ngrok-oss/mantle/pull/1241) [`f7be346`](https://github.com/ngrok-oss/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update the `oxc-parser` dependency to `0.136.0` (from `0.135.0`).
+- [#1241](https://github.com/ngrok/mantle/pull/1241) [`f7be346`](https://github.com/ngrok/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update the `oxc-parser` dependency to `0.136.0` (from `0.135.0`).
 
-- Updated dependencies [[`f7be346`](https://github.com/ngrok-oss/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7)]:
+- Updated dependencies [[`f7be346`](https://github.com/ngrok/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7)]:
   - @ngrok/mantle-server-syntax-highlighter@1.1.4
 
 ## 1.0.13
 
 ### Patch Changes
 
-- [#1223](https://github.com/ngrok-oss/mantle/pull/1223) [`6dc792c`](https://github.com/ngrok-oss/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump the `vite` peer dependency range to `^8.0.16`.
+- [#1223](https://github.com/ngrok/mantle/pull/1223) [`6dc792c`](https://github.com/ngrok/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump the `vite` peer dependency range to `^8.0.16`.
 
-- Updated dependencies [[`6dc792c`](https://github.com/ngrok-oss/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5)]:
+- Updated dependencies [[`6dc792c`](https://github.com/ngrok/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5)]:
   - @ngrok/mantle-server-syntax-highlighter@1.1.3
 
 ## 1.0.12
 
 ### Patch Changes
 
-- [#1218](https://github.com/ngrok-oss/mantle/pull/1218) [`61d638d`](https://github.com/ngrok-oss/mantle/commit/61d638d19f71af96341bd7d128f684b2a4e2c7ba) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `mantleCodeVitePlugin` now inlines nested `mantleCode` fragment interpolations at build time. Interpolating `someFragment.code` into another `mantleCode` template — where `someFragment` is a top-level `mantleCode` `const` declared earlier in the same module, or a named import of a directly-exported top-level `mantleCode` `const` from another module — splices the fragment's source into the highlighted output. The embedded code is highlighted line-for-line in its host language (correct line numbers, folding, and copy text) and pays no runtime substitution cost. Nested fragments resolve recursively across modules; interpolations that can't be resolved statically fall back to the existing runtime placeholder behavior, and an unresolved imported `.code` reference emits a build warning.
+- [#1218](https://github.com/ngrok/mantle/pull/1218) [`61d638d`](https://github.com/ngrok/mantle/commit/61d638d19f71af96341bd7d128f684b2a4e2c7ba) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `mantleCodeVitePlugin` now inlines nested `mantleCode` fragment interpolations at build time. Interpolating `someFragment.code` into another `mantleCode` template — where `someFragment` is a top-level `mantleCode` `const` declared earlier in the same module, or a named import of a directly-exported top-level `mantleCode` `const` from another module — splices the fragment's source into the highlighted output. The embedded code is highlighted line-for-line in its host language (correct line numbers, folding, and copy text) and pays no runtime substitution cost. Nested fragments resolve recursively across modules; interpolations that can't be resolved statically fall back to the existing runtime placeholder behavior, and an unresolved imported `.code` reference emits a build warning.
 
 - Updated dependencies []:
   - @ngrok/mantle-server-syntax-highlighter@1.1.2
@@ -31,36 +31,36 @@
 
 ### Patch Changes
 
-- [#1207](https://github.com/ngrok-oss/mantle/pull/1207) [`b9fadca`](https://github.com/ngrok-oss/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162) Thanks [@dependabot](https://github.com/apps/dependabot)! - Lint cleanup round. No behavior changes.
+- [#1207](https://github.com/ngrok/mantle/pull/1207) [`b9fadca`](https://github.com/ngrok/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162) Thanks [@dependabot](https://github.com/apps/dependabot)! - Lint cleanup round. No behavior changes.
   - Dropped a redundant `?? {}` fallback in an object spread inside `mantleCodeRehypePlugin` (`...preNode.properties` is safe to spread directly — falsy values in object spreads are no-ops).
   - Tightened `vi.fn` generics in tests.
 
-- Updated dependencies [[`b9fadca`](https://github.com/ngrok-oss/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162)]:
+- Updated dependencies [[`b9fadca`](https://github.com/ngrok/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162)]:
   - @ngrok/mantle-server-syntax-highlighter@1.1.2
 
 ## 1.0.10
 
 ### Patch Changes
 
-- [#1197](https://github.com/ngrok-oss/mantle/pull/1197) [`c30e470`](https://github.com/ngrok-oss/mantle/commit/c30e4707bb8d12ae80e59c8f89e87920a2d0d478) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `oxc-parser` to `0.130.0`.
+- [#1197](https://github.com/ngrok/mantle/pull/1197) [`c30e470`](https://github.com/ngrok/mantle/commit/c30e4707bb8d12ae80e59c8f89e87920a2d0d478) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `oxc-parser` to `0.130.0`.
 
-- [#1191](https://github.com/ngrok-oss/mantle/pull/1191) [`e09de2d`](https://github.com/ngrok-oss/mantle/commit/e09de2da092c6f0ab91251ea4a00170593a985a5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `field` to the generated Mantle component name metadata so plugin allowlists and import analysis recognize the new Field component subpath.
+- [#1191](https://github.com/ngrok/mantle/pull/1191) [`e09de2d`](https://github.com/ngrok/mantle/commit/e09de2da092c6f0ab91251ea4a00170593a985a5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `field` to the generated Mantle component name metadata so plugin allowlists and import analysis recognize the new Field component subpath.
 
-- Updated dependencies [[`c30e470`](https://github.com/ngrok-oss/mantle/commit/c30e4707bb8d12ae80e59c8f89e87920a2d0d478)]:
+- Updated dependencies [[`c30e470`](https://github.com/ngrok/mantle/commit/c30e4707bb8d12ae80e59c8f89e87920a2d0d478)]:
   - @ngrok/mantle-server-syntax-highlighter@1.1.1
 
 ## 1.0.9
 
 ### Patch Changes
 
-- Updated dependencies [[`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907), [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907), [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907)]:
+- Updated dependencies [[`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907), [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907), [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907)]:
   - @ngrok/mantle-server-syntax-highlighter@1.1.0
 
 ## 1.0.8
 
 ### Patch Changes
 
-- [#1155](https://github.com/ngrok-oss/mantle/pull/1155) [`0f0b607`](https://github.com/ngrok-oss/mantle/commit/0f0b607813fbe15c969aa1e3e3c0ac9a4d27c8fe) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update `tailwindcss` and `@tailwindcss/vite` to `4.2.4`.
+- [#1155](https://github.com/ngrok/mantle/pull/1155) [`0f0b607`](https://github.com/ngrok/mantle/commit/0f0b607813fbe15c969aa1e3e3c0ac9a4d27c8fe) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update `tailwindcss` and `@tailwindcss/vite` to `4.2.4`.
 
 - Updated dependencies []:
   - @ngrok/mantle-server-syntax-highlighter@1.0.4
@@ -69,7 +69,7 @@
 
 ### Patch Changes
 
-- [#1107](https://github.com/ngrok-oss/mantle/pull/1107) [`4d35209`](https://github.com/ngrok-oss/mantle/commit/4d35209cd3ec2b15215e51107aec3de007768aa6) Thanks [@forzalupo](https://github.com/forzalupo)! - Internal: switch `=== undefined` / `!== undefined` checks to `== null` / `!= null` for consistency with the project's nullish-equality style. No behavior change.
+- [#1107](https://github.com/ngrok/mantle/pull/1107) [`4d35209`](https://github.com/ngrok/mantle/commit/4d35209cd3ec2b15215e51107aec3de007768aa6) Thanks [@forzalupo](https://github.com/forzalupo)! - Internal: switch `=== undefined` / `!== undefined` checks to `== null` / `!= null` for consistency with the project's nullish-equality style. No behavior change.
 
 - Updated dependencies []:
   - @ngrok/mantle-server-syntax-highlighter@1.0.4
@@ -78,7 +78,7 @@
 
 ### Patch Changes
 
-- [#1126](https://github.com/ngrok-oss/mantle/pull/1126) [`545a09d`](https://github.com/ngrok-oss/mantle/commit/545a09d77c0503f7dfdffe5eb1cde69d59aa65f4) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump oxc-parser from 0.124.0 to 0.125.0
+- [#1126](https://github.com/ngrok/mantle/pull/1126) [`545a09d`](https://github.com/ngrok/mantle/commit/545a09d77c0503f7dfdffe5eb1cde69d59aa65f4) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump oxc-parser from 0.124.0 to 0.125.0
 
 - Updated dependencies []:
   - @ngrok/mantle-server-syntax-highlighter@1.0.4
@@ -87,7 +87,7 @@
 
 ### Patch Changes
 
-- [#1141](https://github.com/ngrok-oss/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok-oss/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix several code fence metastring parsing bugs in `mantleCodeRehypePlugin`:
+- [#1141](https://github.com/ngrok/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix several code fence metastring parsing bugs in `mantleCodeRehypePlugin`:
   - `mantleShowLineNumbers`, `mantleCollapsible`, and `mantleDisableCopy` are now stringified on HAST `<pre>` properties. Previously, boolean `false` values were dropped during HAST→JSX compilation, causing `showLineNumbers=false` fence meta to be silently ignored (the rendered `<pre>` ended up with `data-mantle-line-numbers="true"` and no left padding).
   - `collapsible=true`, `collapsible=false`, and `collapsible="true"` in fence meta are no longer silently dropped. The `collapsible` key now accepts the same bare-flag, key-value, and quoted-value forms as `disableCopy`.
   - When a key appears multiple times in fence meta (e.g. `title="first" title="second"`), `getMetaValue` now returns the last value, matching `parseMetastring` semantics. Previously it returned the first.
@@ -100,7 +100,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`0c20cf7`](https://github.com/ngrok-oss/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9)]:
+- Updated dependencies [[`0c20cf7`](https://github.com/ngrok/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9)]:
   - @ngrok/mantle@0.68.3
   - @ngrok/mantle-server-syntax-highlighter@1.0.4
 
@@ -108,9 +108,9 @@
 
 ### Patch Changes
 
-- [#1116](https://github.com/ngrok-oss/mantle/pull/1116) [`5b0be5a`](https://github.com/ngrok-oss/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - no-op patch to verify publish CI
+- [#1116](https://github.com/ngrok/mantle/pull/1116) [`5b0be5a`](https://github.com/ngrok/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - no-op patch to verify publish CI
 
-- Updated dependencies [[`ea340f6`](https://github.com/ngrok-oss/mantle/commit/ea340f6307f3f0f229395783c0c21f7a35363688), [`5b0be5a`](https://github.com/ngrok-oss/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f)]:
+- Updated dependencies [[`ea340f6`](https://github.com/ngrok/mantle/commit/ea340f6307f3f0f229395783c0c21f7a35363688), [`5b0be5a`](https://github.com/ngrok/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f)]:
   - @ngrok/mantle-server-syntax-highlighter@1.0.3
   - @ngrok/mantle@0.68.2
 
@@ -118,9 +118,9 @@
 
 ### Patch Changes
 
-- [#1112](https://github.com/ngrok-oss/mantle/pull/1112) [`ad24f11`](https://github.com/ngrok-oss/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add README documentation for npm packages, switch to ES2025 preset
+- [#1112](https://github.com/ngrok/mantle/pull/1112) [`ad24f11`](https://github.com/ngrok/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add README documentation for npm packages, switch to ES2025 preset
 
-- Updated dependencies [[`d46e3b3`](https://github.com/ngrok-oss/mantle/commit/d46e3b3fbdcdf561db1d90e89afc8cca8e374be3), [`ad24f11`](https://github.com/ngrok-oss/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2)]:
+- Updated dependencies [[`d46e3b3`](https://github.com/ngrok/mantle/commit/d46e3b3fbdcdf561db1d90e89afc8cca8e374be3), [`ad24f11`](https://github.com/ngrok/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2)]:
   - @ngrok/mantle@0.68.1
   - @ngrok/mantle-server-syntax-highlighter@1.0.2
 
@@ -128,11 +128,11 @@
 
 ### Patch Changes
 
-- [#1099](https://github.com/ngrok-oss/mantle/pull/1099) [`4a81875`](https://github.com/ngrok-oss/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump dependencies: oxc-parser to 0.123.0, update vite peer dependency to ^8
+- [#1099](https://github.com/ngrok/mantle/pull/1099) [`4a81875`](https://github.com/ngrok/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump dependencies: oxc-parser to 0.123.0, update vite peer dependency to ^8
 
-- [#1082](https://github.com/ngrok-oss/mantle/pull/1082) [`383d538`](https://github.com/ngrok-oss/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#1082](https://github.com/ngrok/mantle/pull/1082) [`383d538`](https://github.com/ngrok/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
-- Updated dependencies [[`4a81875`](https://github.com/ngrok-oss/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4), [`383d538`](https://github.com/ngrok-oss/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686), [`ab6da43`](https://github.com/ngrok-oss/mantle/commit/ab6da43e32e3e2e2dadf29aa8d99fcb2738569f4), [`2be1db1`](https://github.com/ngrok-oss/mantle/commit/2be1db1ffb23bb5719181f73090ef28d7e19a50f), [`41ce842`](https://github.com/ngrok-oss/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22)]:
+- Updated dependencies [[`4a81875`](https://github.com/ngrok/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4), [`383d538`](https://github.com/ngrok/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686), [`ab6da43`](https://github.com/ngrok/mantle/commit/ab6da43e32e3e2e2dadf29aa8d99fcb2738569f4), [`2be1db1`](https://github.com/ngrok/mantle/commit/2be1db1ffb23bb5719181f73090ef28d7e19a50f), [`41ce842`](https://github.com/ngrok/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22)]:
   - @ngrok/mantle@0.68.0
   - @ngrok/mantle-server-syntax-highlighter@2.0.0
 
@@ -140,11 +140,11 @@
 
 ### Minor Changes
 
-- [#1018](https://github.com/ngrok-oss/mantle/pull/1018) [`f27c01f`](https://github.com/ngrok-oss/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: replace PrismJS with Shiki for build-time syntax highlighting, removing Shiki/Prism from the browser bundle
+- [#1018](https://github.com/ngrok/mantle/pull/1018) [`f27c01f`](https://github.com/ngrok/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: replace PrismJS with Shiki for build-time syntax highlighting, removing Shiki/Prism from the browser bundle
 
 ### Patch Changes
 
-- Updated dependencies [[`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`f27c01f`](https://github.com/ngrok-oss/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa), [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`54743f1`](https://github.com/ngrok-oss/mantle/commit/54743f1deee01709952fcf5222e0ea205c282e5d)]:
+- Updated dependencies [[`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`f27c01f`](https://github.com/ngrok/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa), [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131), [`54743f1`](https://github.com/ngrok/mantle/commit/54743f1deee01709952fcf5222e0ea205c282e5d)]:
   - @ngrok/mantle@0.67.0
   - @ngrok/mantle-server-syntax-highlighter@1.0.0
 
@@ -152,16 +152,16 @@
 
 ### Patch Changes
 
-- [#1061](https://github.com/ngrok-oss/mantle/pull/1061) [`1b0e722`](https://github.com/ngrok-oss/mantle/commit/1b0e7227c79396b48d4845b0ed5b534085aa91f7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `vite` peer dependency to `>=7.3.1`.
+- [#1061](https://github.com/ngrok/mantle/pull/1061) [`1b0e722`](https://github.com/ngrok/mantle/commit/1b0e7227c79396b48d4845b0ed5b534085aa91f7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `vite` peer dependency to `>=7.3.1`.
 
-- Updated dependencies [[`1b0e722`](https://github.com/ngrok-oss/mantle/commit/1b0e7227c79396b48d4845b0ed5b534085aa91f7)]:
+- Updated dependencies [[`1b0e722`](https://github.com/ngrok/mantle/commit/1b0e7227c79396b48d4845b0ed5b534085aa91f7)]:
   - @ngrok/mantle@0.66.13
 
 ## 0.1.4
 
 ### Patch Changes
 
-- [#1044](https://github.com/ngrok-oss/mantle/pull/1044) [`723bce4`](https://github.com/ngrok-oss/mantle/commit/723bce46be2929ee326e6df0ed697a9632747852) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `mantleTwSourcePlugin` correctness for code-split mantle builds:
+- [#1044](https://github.com/ngrok/mantle/pull/1044) [`723bce4`](https://github.com/ngrok/mantle/commit/723bce46be2929ee326e6df0ed697a9632747852) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `mantleTwSourcePlugin` correctness for code-split mantle builds:
   - `@source` directives now emit two patterns per component — an exact entry stub (`button.js`) and a hashed-chunk glob (`button-*.js`) — so Tailwind scans both the named re-export file and the code-split chunk that actually contains class strings. A single `button*.js` glob was intentionally avoided because it would also match prefix-sharing names like `button` matching `button-group`.
   - Added `resolveId` hook for module-graph-aware component tracking: catches mantle imports from workspace packages outside `include` and transitive mantle-internal imports that the directory scan missed.
   - Added `closeBundle` hook that writes the precise set (directory scan ∪ `resolveId` intercepts ∪ allowlist) after a production build. SSR builds are skipped so only the client build's complete component set is written — the server build resolves fewer components and must not overwrite it.
@@ -171,7 +171,7 @@
 
 ### Patch Changes
 
-- [#1042](https://github.com/ngrok-oss/mantle/pull/1042) [`8a46bc2`](https://github.com/ngrok-oss/mantle/commit/8a46bc2908188e5e381fb639372278b2a9cafff4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(mantle-vite-plugins): exclude `.css?url` imports from `@source` injection
+- [#1042](https://github.com/ngrok/mantle/pull/1042) [`8a46bc2`](https://github.com/ngrok/mantle/commit/8a46bc2908188e5e381fb639372278b2a9cafff4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(mantle-vite-plugins): exclude `.css?url` imports from `@source` injection
 
   Vite query suffixes like `?url` on CSS imports (e.g. `@ngrok/mantle/mantle-dark.css?url`) were not being filtered out, causing spurious `@source` directives like `@source "../node_modules/@ngrok/mantle/dist/mantle-dark.css?url.js"` to appear in the generated CSS block. The fix strips the query suffix before checking the file extension.
 
@@ -179,13 +179,13 @@
 
 ### Patch Changes
 
-- [#1040](https://github.com/ngrok-oss/mantle/pull/1040) [`82f1cd9`](https://github.com/ngrok-oss/mantle/commit/82f1cd9c67b14e33d06c97028b2e38555e10ced8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename `mantleSourcePlugin` → `mantleTwSourcePlugin` (and `MantleSourcePluginOptions` → `MantleTwSourcePluginOptions`) to clarify that this plugin is strictly for generating Tailwind `@source` directives for mantle component imports; default `include` to `["app"]` instead of `["src"]`; fix pnpm workspaces generating content-addressed `.pnpm/` paths in `@source` directives by resolving `@ngrok/mantle` via the `node_modules` symlink rather than `require.resolve`
+- [#1040](https://github.com/ngrok/mantle/pull/1040) [`82f1cd9`](https://github.com/ngrok/mantle/commit/82f1cd9c67b14e33d06c97028b2e38555e10ced8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename `mantleSourcePlugin` → `mantleTwSourcePlugin` (and `MantleSourcePluginOptions` → `MantleTwSourcePluginOptions`) to clarify that this plugin is strictly for generating Tailwind `@source` directives for mantle component imports; default `include` to `["app"]` instead of `["src"]`; fix pnpm workspaces generating content-addressed `.pnpm/` paths in `@source` directives by resolving `@ngrok/mantle` via the `node_modules` symlink rather than `require.resolve`
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [#1036](https://github.com/ngrok-oss/mantle/pull/1036) [`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `@ngrok/mantle-vite-plugins` package and `source-all.css`, optimize `mantle.css`
+- [#1036](https://github.com/ngrok/mantle/pull/1036) [`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `@ngrok/mantle-vite-plugins` package and `source-all.css`, optimize `mantle.css`
 
   **New: `@ngrok/mantle-vite-plugins`**
 
@@ -208,5 +208,5 @@
   - Removed 21 light-theme color overrides (`neutral-50`–`neutral-900`, all `red-*` shades) that were identical to Tailwind v4 defaults
   - Moved ~60 semantic tokens (`--background-color-base`, etc.) from `@theme {}` to `@theme inline {}` to stop generating unused utility classes like `bg-background-color-base`
 
-- Updated dependencies [[`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1), [`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1), [`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1)]:
+- Updated dependencies [[`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1), [`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1), [`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1)]:
   - @ngrok/mantle@0.66.7

--- a/packages/mantle-vite-plugins/README.md
+++ b/packages/mantle-vite-plugins/README.md
@@ -1,6 +1,6 @@
 # @ngrok/mantle-vite-plugins
 
-Vite plugins for apps built with [`@ngrok/mantle`](https://github.com/ngrok-oss/mantle).
+Vite plugins for apps built with [`@ngrok/mantle`](https://github.com/ngrok/mantle).
 
 ## Requirements
 
@@ -166,5 +166,5 @@ Type declarations are included. No `@types/*` package is needed.
 
 ## Related Packages
 
-- [`@ngrok/mantle`](https://github.com/ngrok-oss/mantle/tree/main/packages/mantle) — UI component library ([npm](https://www.npmjs.com/package/@ngrok/mantle))
-- [`@ngrok/mantle-server-syntax-highlighter`](https://github.com/ngrok-oss/mantle/tree/main/packages/mantle-server-syntax-highlighter) — Server-side highlighting engine ([npm](https://www.npmjs.com/package/@ngrok/mantle-server-syntax-highlighter))
+- [`@ngrok/mantle`](https://github.com/ngrok/mantle/tree/main/packages/mantle) — UI component library ([npm](https://www.npmjs.com/package/@ngrok/mantle))
+- [`@ngrok/mantle-server-syntax-highlighter`](https://github.com/ngrok/mantle/tree/main/packages/mantle-server-syntax-highlighter) — Server-side highlighting engine ([npm](https://www.npmjs.com/package/@ngrok/mantle-server-syntax-highlighter))

--- a/packages/mantle-vite-plugins/package.json
+++ b/packages/mantle-vite-plugins/package.json
@@ -7,7 +7,7 @@
   "author": "ngrok",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ngrok-oss/mantle"
+    "url": "https://github.com/ngrok/mantle"
   },
   "files": [
     "dist",

--- a/packages/mantle/CHANGELOG.md
+++ b/packages/mantle/CHANGELOG.md
@@ -4,40 +4,40 @@
 
 ### Patch Changes
 
-- [#1241](https://github.com/ngrok-oss/mantle/pull/1241) [`f7be346`](https://github.com/ngrok-oss/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update `react-day-picker` to `10.0.1` (from `9.14.0`) and bump the `tailwindcss` peer dependency to `^4.3.1`. The `Calendar` component already used the v9+ API surface — no removed navigation/focus/event props, formatter or label aliases, or renamed `classNames` keys — so this is a transparent dependency bump with no public API changes.
+- [#1241](https://github.com/ngrok/mantle/pull/1241) [`f7be346`](https://github.com/ngrok/mantle/commit/f7be3464e3d823d8d8e8c1c96ba15b615871ddb7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update `react-day-picker` to `10.0.1` (from `9.14.0`) and bump the `tailwindcss` peer dependency to `^4.3.1`. The `Calendar` component already used the v9+ API surface — no removed navigation/focus/event props, formatter or label aliases, or renamed `classNames` keys — so this is a transparent dependency bump with no public API changes.
 
-- [#1247](https://github.com/ngrok-oss/mantle/pull/1247) [`846f5bd`](https://github.com/ngrok-oss/mantle/commit/846f5bddbb0b4bfbf16aff66960b79f5afd3a8fe) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix two issues with `Checkbox`'s indeterminate handling:
+- [#1247](https://github.com/ngrok/mantle/pull/1247) [`846f5bd`](https://github.com/ngrok/mantle/commit/846f5bddbb0b4bfbf16aff66960b79f5afd3a8fe) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix two issues with `Checkbox`'s indeterminate handling:
 
   - A controlled checkbox toggling through `"indeterminate"` (e.g. a table "select all" header cycling unchecked → indeterminate → checked) logged React's "changing a controlled input to be uncontrolled" warning. The indeterminate frame now keeps `checked` a boolean, so the input stays controlled for its entire lifetime.
   - A controlled `checked="indeterminate"` set on mount did not render the indeterminate visual — two competing effects clobbered each other. The native `indeterminate` DOM property is now driven by a single effect keyed on the effective checked state, so it renders correctly on first paint and on every update.
 
   Add `selectAllChecked` to `@ngrok/mantle/checkbox` — a helper that resolves the tri-state `checked` value (`true` / `"indeterminate"` / `false`) for a "select all" checkbox from `{ allSelected, someSelected }` selection counts, ready to pass straight to `Checkbox`. Encapsulates the correctness-prone tri-state branch every multi-select list reinvents. Also exports the `CheckedState` type.
 
-- [#1247](https://github.com/ngrok-oss/mantle/pull/1247) [`846f5bd`](https://github.com/ngrok-oss/mantle/commit/846f5bddbb0b4bfbf16aff66960b79f5afd3a8fe) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update the `DataTable` source JSDoc `@example` blocks so the regenerated `.d.ts`, `llms.txt`, and agent component manifest teach canonical patterns instead of throwaway ones: the two empty states (an `Empty` hosted in `DataTable.EmptyRow` — "no data yet" vs. "no results for the active filter", with a `Clear filters` reset) and pagination via `CursorPagination` with a page-size dropdown (replacing hand-rolled prev/next `Button`s). No runtime API changes.
+- [#1247](https://github.com/ngrok/mantle/pull/1247) [`846f5bd`](https://github.com/ngrok/mantle/commit/846f5bddbb0b4bfbf16aff66960b79f5afd3a8fe) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update the `DataTable` source JSDoc `@example` blocks so the regenerated `.d.ts`, `llms.txt`, and agent component manifest teach canonical patterns instead of throwaway ones: the two empty states (an `Empty` hosted in `DataTable.EmptyRow` — "no data yet" vs. "no results for the active filter", with a `Clear filters` reset) and pagination via `CursorPagination` with a page-size dropdown (replacing hand-rolled prev/next `Button`s). No runtime API changes.
 
-- [#1249](https://github.com/ngrok-oss/mantle/pull/1249) [`44ee551`](https://github.com/ngrok-oss/mantle/commit/44ee5510ae9ac938b32862244fc2c80848709d18) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Drive the `scroll-fade-x` edge-fade utility with a CSS scroll-driven animation instead of JS-toggled `data-scroll-left` / `data-scroll-right` attributes, and add a matching `scroll-fade-y` utility for vertical scroll containers. Single-edge variants — `scroll-fade-t`, `scroll-fade-b`, `scroll-fade-l`, `scroll-fade-r` — are also available for containers that should fade only one edge (e.g. a sidebar that fades content scrolling under a sticky header but stays flush at the bottom). `Table` and `Tabs` now render their horizontal edge fades purely in CSS: the `Tabs.List` effect no longer runs a scroll listener, `ResizeObserver`, or `MutationObserver` for the fade (it only keeps a keyboard-focused trigger scrolled into view), and `Table` no longer writes the fade attributes. Consumers can still pin an edge opaque by overriding `--_fade-left` / `--_fade-right` (the animation drives the upstream `--_scroll-fade-*` vars). Where `animation-timeline: scroll()` is unsupported (Firefox stable as of mid-2026) the fade is simply absent — content is never clipped.
+- [#1249](https://github.com/ngrok/mantle/pull/1249) [`44ee551`](https://github.com/ngrok/mantle/commit/44ee5510ae9ac938b32862244fc2c80848709d18) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Drive the `scroll-fade-x` edge-fade utility with a CSS scroll-driven animation instead of JS-toggled `data-scroll-left` / `data-scroll-right` attributes, and add a matching `scroll-fade-y` utility for vertical scroll containers. Single-edge variants — `scroll-fade-t`, `scroll-fade-b`, `scroll-fade-l`, `scroll-fade-r` — are also available for containers that should fade only one edge (e.g. a sidebar that fades content scrolling under a sticky header but stays flush at the bottom). `Table` and `Tabs` now render their horizontal edge fades purely in CSS: the `Tabs.List` effect no longer runs a scroll listener, `ResizeObserver`, or `MutationObserver` for the fade (it only keeps a keyboard-focused trigger scrolled into view), and `Table` no longer writes the fade attributes. Consumers can still pin an edge opaque by overriding `--_fade-left` / `--_fade-right` (the animation drives the upstream `--_scroll-fade-*` vars). Where `animation-timeline: scroll()` is unsupported (Firefox stable as of mid-2026) the fade is simply absent — content is never clipped.
 
-- [#1248](https://github.com/ngrok-oss/mantle/pull/1248) [`3a234e0`](https://github.com/ngrok-oss/mantle/commit/3a234e0ea88570d6c08ef3bf4264d138faf3edca) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update Radix UI dependencies to their latest patch/minor releases: `@radix-ui/react-accordion` to `1.2.14`, `@radix-ui/react-dialog` to `1.1.17`, `@radix-ui/react-dropdown-menu` to `2.1.18`, `@radix-ui/react-hover-card` to `1.1.17`, `@radix-ui/react-popover` to `1.1.17`, `@radix-ui/react-progress` to `1.1.10`, `@radix-ui/react-select` to `2.3.1`, `@radix-ui/react-slider` to `1.4.1`, `@radix-ui/react-slot` to `1.3.0`, `@radix-ui/react-switch` to `1.3.1`, `@radix-ui/react-tabs` to `1.1.15`, and `@radix-ui/react-tooltip` to `1.2.10`. No public API changes.
+- [#1248](https://github.com/ngrok/mantle/pull/1248) [`3a234e0`](https://github.com/ngrok/mantle/commit/3a234e0ea88570d6c08ef3bf4264d138faf3edca) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update Radix UI dependencies to their latest patch/minor releases: `@radix-ui/react-accordion` to `1.2.14`, `@radix-ui/react-dialog` to `1.1.17`, `@radix-ui/react-dropdown-menu` to `2.1.18`, `@radix-ui/react-hover-card` to `1.1.17`, `@radix-ui/react-popover` to `1.1.17`, `@radix-ui/react-progress` to `1.1.10`, `@radix-ui/react-select` to `2.3.1`, `@radix-ui/react-slider` to `1.4.1`, `@radix-ui/react-slot` to `1.3.0`, `@radix-ui/react-switch` to `1.3.1`, `@radix-ui/react-tabs` to `1.1.15`, and `@radix-ui/react-tooltip` to `1.2.10`. No public API changes.
 
-- [#1239](https://github.com/ngrok-oss/mantle/pull/1239) [`9b00072`](https://github.com/ngrok-oss/mantle/commit/9b000727a50b90e60c118652ab8bc04703c0839a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Surface each component's JSDoc `@example` blocks in the agent-facing component manifest (`/api/components.json`), giving agents copy-pasteable canonical usage without a network lookup. Fix two malformed examples caught in the process: `Sheet` examples used `opOpenChange` instead of `onOpenChange`, and `SandboxedOnClick`'s example was missing its closing code fence. Also documents the `Field` slot-order anti-pattern — help text (`Field.Description`) renders below `Field.Control`, not above it.
+- [#1239](https://github.com/ngrok/mantle/pull/1239) [`9b00072`](https://github.com/ngrok/mantle/commit/9b000727a50b90e60c118652ab8bc04703c0839a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Surface each component's JSDoc `@example` blocks in the agent-facing component manifest (`/api/components.json`), giving agents copy-pasteable canonical usage without a network lookup. Fix two malformed examples caught in the process: `Sheet` examples used `opOpenChange` instead of `onOpenChange`, and `SandboxedOnClick`'s example was missing its closing code fence. Also documents the `Field` slot-order anti-pattern — help text (`Field.Description`) renders below `Field.Control`, not above it.
 
 ## 0.76.2
 
 ### Patch Changes
 
-- [#1233](https://github.com/ngrok-oss/mantle/pull/1233) [`fa978b0`](https://github.com/ngrok-oss/mantle/commit/fa978b0c5990cdbcb0d61e748419acc36aeb134c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Refine `Empty` and `Well` styling: `Empty` uses tighter padding (`p-6`), `Empty.Icon` is smaller with a neutral color, `Empty.Title` and `Empty.Description` adopt smaller sans-serif text with a muted description, and `Well` uses the muted card border.
+- [#1233](https://github.com/ngrok/mantle/pull/1233) [`fa978b0`](https://github.com/ngrok/mantle/commit/fa978b0c5990cdbcb0d61e748419acc36aeb134c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Refine `Empty` and `Well` styling: `Empty` uses tighter padding (`p-6`), `Empty.Icon` is smaller with a neutral color, `Empty.Title` and `Empty.Description` adopt smaller sans-serif text with a muted description, and `Well` uses the muted card border.
 
 ## 0.76.1
 
 ### Patch Changes
 
-- [#1229](https://github.com/ngrok-oss/mantle/pull/1229) [`a569ca3`](https://github.com/ngrok-oss/mantle/commit/a569ca386a7c779328216c21e54de15500c89503) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Remove the unused `@uidotdev/usehooks` dependency. It was never imported by any mantle code; consumers no longer install it transitively.
+- [#1229](https://github.com/ngrok/mantle/pull/1229) [`a569ca3`](https://github.com/ngrok/mantle/commit/a569ca386a7c779328216c21e54de15500c89503) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Remove the unused `@uidotdev/usehooks` dependency. It was never imported by any mantle code; consumers no longer install it transitively.
 
 ## 0.76.0
 
 ### Minor Changes
 
-- [#1227](https://github.com/ngrok-oss/mantle/pull/1227) [`fbec001`](https://github.com/ngrok-oss/mantle/commit/fbec0010f1ce6048e2468c27983bbeb4ad73e633) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(mantle): Dialog.Footer renders children in DOM order
+- [#1227](https://github.com/ngrok/mantle/pull/1227) [`fbec001`](https://github.com/ngrok/mantle/commit/fbec0010f1ce6048e2468c27983bbeb4ad73e633) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(mantle): Dialog.Footer renders children in DOM order
 
   `Dialog.Footer` previously applied `flex-row-reverse`, laying its children out
   right-to-left so the DOM order was the visual mirror of the source. It now uses
@@ -55,7 +55,7 @@
 
 ### Minor Changes
 
-- [#1225](https://github.com/ngrok-oss/mantle/pull/1225) [`6b22e51`](https://github.com/ngrok-oss/mantle/commit/6b22e51c9829ba17e9c8b62a30f9d5101ec6b434) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - feat(mantle): add Well component
+- [#1225](https://github.com/ngrok/mantle/pull/1225) [`6b22e51`](https://github.com/ngrok/mantle/commit/6b22e51c9829ba17e9c8b62a30f9d5101ec6b434) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - feat(mantle): add Well component
 
   A recessed, inset container that renders like `Card.Root` but with the base
   background and an inset shadow, for grouping and de-emphasizing content such as
@@ -66,29 +66,29 @@
 
 ### Minor Changes
 
-- [#1221](https://github.com/ngrok-oss/mantle/pull/1221) [`100debf`](https://github.com/ngrok-oss/mantle/commit/100debfbb49f035f07f254aece2448ade6a774cd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add the `QrCode` component — a scannable QR code that encodes its `value` with the dependency-free `uqr` library. Compose `QrCode.Root` with a `QrCode.Frame` wrapping a `QrCode.Pattern`, plus an optional `QrCode.Overlay` for a centered brand logo. Always renders black modules on a white background for scannability in any theme. The quiet-zone margin around the code is configurable via the `quietZone` prop (defaults to the spec-recommended `4`).
+- [#1221](https://github.com/ngrok/mantle/pull/1221) [`100debf`](https://github.com/ngrok/mantle/commit/100debfbb49f035f07f254aece2448ade6a774cd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add the `QrCode` component — a scannable QR code that encodes its `value` with the dependency-free `uqr` library. Compose `QrCode.Root` with a `QrCode.Frame` wrapping a `QrCode.Pattern`, plus an optional `QrCode.Overlay` for a centered brand logo. Always renders black modules on a white background for scannability in any theme. The quiet-zone margin around the code is configurable via the `quietZone` prop (defaults to the spec-recommended `4`).
 
 ### Patch Changes
 
-- [#1223](https://github.com/ngrok-oss/mantle/pull/1223) [`6dc792c`](https://github.com/ngrok-oss/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies: `@ariakit/react` to 0.4.29, `@radix-ui/*` packages (accordion, dialog, dropdown-menu, hover-card, popover, progress, select, slider, slot, switch, tabs, tooltip), and `date-fns` to 4.4.0.
+- [#1223](https://github.com/ngrok/mantle/pull/1223) [`6dc792c`](https://github.com/ngrok/mantle/commit/6dc792c0f2f91f4f2b34f5ef5ccc4f5a06b2c1b5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies: `@ariakit/react` to 0.4.29, `@radix-ui/*` packages (accordion, dialog, dropdown-menu, hover-card, popover, progress, select, slider, slot, switch, tabs, tooltip), and `date-fns` to 4.4.0.
 
 ## 0.73.5
 
 ### Patch Changes
 
-- [#1218](https://github.com/ngrok-oss/mantle/pull/1218) [`61d638d`](https://github.com/ngrok-oss/mantle/commit/61d638d19f71af96341bd7d128f684b2a4e2c7ba) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `mantleCode` templates now support nested fragment interpolation: interpolating another top-level `mantleCode` value's `.code` (declared in the same module, or imported from another module) is highlighted inline at build time by the updated `@ngrok/mantle-vite-plugins`, with correct per-line rendering and no runtime substitution cost. There is no runtime API change — without the plugin, `${fragment.code}` continues to fall back to plain string interpolation.
+- [#1218](https://github.com/ngrok/mantle/pull/1218) [`61d638d`](https://github.com/ngrok/mantle/commit/61d638d19f71af96341bd7d128f684b2a4e2c7ba) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `mantleCode` templates now support nested fragment interpolation: interpolating another top-level `mantleCode` value's `.code` (declared in the same module, or imported from another module) is highlighted inline at build time by the updated `@ngrok/mantle-vite-plugins`, with correct per-line rendering and no runtime substitution cost. There is no runtime API change — without the plugin, `${fragment.code}` continues to fall back to plain string interpolation.
 
 ## 0.73.4
 
 ### Patch Changes
 
-- [#1207](https://github.com/ngrok-oss/mantle/pull/1207) [`b9fadca`](https://github.com/ngrok-oss/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162) Thanks [@dependabot](https://github.com/apps/dependabot)! - Lint cleanup round across `@ngrok/mantle`. No public-API changes.
+- [#1207](https://github.com/ngrok/mantle/pull/1207) [`b9fadca`](https://github.com/ngrok/mantle/commit/b9fadca2c3e8ba923ece71578af197aca4220162) Thanks [@dependabot](https://github.com/apps/dependabot)! - Lint cleanup round across `@ngrok/mantle`. No public-API changes.
   - `Checkbox`: the underlying `<input>` no longer receives both `checked` and `defaultChecked` at once (React would warn about this). The component now passes exactly one based on whether it's in controlled mode (`checked !== undefined`). Indeterminate behavior is unchanged for both controlled and uncontrolled usage — the DOM `indeterminate` flag is still applied via a ref effect.
   - Context providers in `Input`, `CursorPagination`, `Dialog`, `Tabs`, `Select`, `Toast`, and the `www` navigation context now memoize their `value` prop via `useMemo`, and `HorizontalSeparatorGroup` lifts its constant value to module scope. This prevents unnecessary re-renders of context consumers when the providing component re-renders for unrelated reasons.
   - `ThemeProvider`: the cross-tab `BroadcastChannel` listener now uses `addEventListener("message", …)` instead of assigning to `onmessage`, matching the modern event API used elsewhere in the file. Cleanup still goes through `BroadcastChannel.close()`.
   - Internal: tightened `vi.fn` generics in tests, normalized JSDoc tag names (`@fileoverview` → `@file`), tightened a few helper JSDocs, and added inline lint-disables with justifications where rules were false-positives (notably `button-has-type` on `<button type={type}>` and `require-post-message-target-origin` on `BroadcastChannel.postMessage`).
 
-- [#1213](https://github.com/ngrok-oss/mantle/pull/1213) [`5a2c3f0`](https://github.com/ngrok-oss/mantle/commit/5a2c3f0b2c9dec32f8dd1bfd6c858607bf29c30c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Breaking:** flattened the `Command.Dialog.*` namespace into top-level members on `Command`.
+- [#1213](https://github.com/ngrok/mantle/pull/1213) [`5a2c3f0`](https://github.com/ngrok/mantle/commit/5a2c3f0b2c9dec32f8dd1bfd6c858607bf29c30c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Breaking:** flattened the `Command.Dialog.*` namespace into top-level members on `Command`.
 
   | Before                   | After                   |
   | ------------------------ | ----------------------- |
@@ -108,7 +108,7 @@
 
 ### Patch Changes
 
-- [#1203](https://github.com/ngrok-oss/mantle/pull/1203) [`f248067`](https://github.com/ngrok-oss/mantle/commit/f248067bf0abbff57539710406a37a396aeb7d93) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `Field.LabelText` — static, label-styled text for `Field.Item` rows that do **not** caption a focusable form control. Renders a `<p>` (not a `<label>`) with the same `text-strong text-sm font-medium` typography as `Field.Label`, so read-only rows (owner cards, derived values, system-managed metadata inside sheets and detail panels) compose cleanly alongside real form fields without misrepresenting themselves as control captions. Supports `asChild` for polymorphic rendering. For rows with a real focusable control, keep using `Field.Label` so the label-to-control association stays wired.
+- [#1203](https://github.com/ngrok/mantle/pull/1203) [`f248067`](https://github.com/ngrok/mantle/commit/f248067bf0abbff57539710406a37a396aeb7d93) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `Field.LabelText` — static, label-styled text for `Field.Item` rows that do **not** caption a focusable form control. Renders a `<p>` (not a `<label>`) with the same `text-strong text-sm font-medium` typography as `Field.Label`, so read-only rows (owner cards, derived values, system-managed metadata inside sheets and detail panels) compose cleanly alongside real form fields without misrepresenting themselves as control captions. Supports `asChild` for polymorphic rendering. For rows with a real focusable control, keep using `Field.Label` so the label-to-control association stays wired.
 
   ```tsx
   <Field.Item name="owner">
@@ -122,7 +122,7 @@
 
 ### Patch Changes
 
-- [#1200](https://github.com/ngrok-oss/mantle/pull/1200) [`c4e968e`](https://github.com/ngrok-oss/mantle/commit/c4e968e5f625b5e89be5f13bbc9426f5a68b9451) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Make `Field.Item` the single source of truth for the control's `name`, `id`, `aria-*`, and `validation`. When a control is wrapped in `Field.*`, all four are owned by the surrounding `Field.Item` and overwrite anything passed on the child or `Field.Control`. To override, set the prop on `Field.Item` itself; to opt out of the contract entirely, render the control without `Field.Control`. The pit of success is "use `Field.*` and let it wire everything up."
+- [#1200](https://github.com/ngrok/mantle/pull/1200) [`c4e968e`](https://github.com/ngrok/mantle/commit/c4e968e5f625b5e89be5f13bbc9426f5a68b9451) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Make `Field.Item` the single source of truth for the control's `name`, `id`, `aria-*`, and `validation`. When a control is wrapped in `Field.*`, all four are owned by the surrounding `Field.Item` and overwrite anything passed on the child or `Field.Control`. To override, set the prop on `Field.Item` itself; to opt out of the contract entirely, render the control without `Field.Control`. The pit of success is "use `Field.*` and let it wire everything up."
 
   **Required `name` on `Field.Item`, automatic id/htmlFor**
   - `Field.Item` now requires a `name: string` prop.
@@ -183,7 +183,7 @@
 
 ### Patch Changes
 
-- [#1198](https://github.com/ngrok-oss/mantle/pull/1198) [`2c00e7c`](https://github.com/ngrok-oss/mantle/commit/2c00e7caad939048b2b02d19919211385566d031) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `toErrorMessages`, a first-class helper exported from `@ngrok/mantle/field` for normalizing TanStack React Form's mixed `field.state.meta.errors` array into a clean `string[]` for `Field.Errors`. Folds together the shapes TanStack Form yields across its built-in validators — plain strings, `{ message }` issue objects (Zod / Standard Schema), thrown `Error` instances, and the falsy slots Standard Schema can produce — into trimmed, non-empty strings without coupling Mantle to a specific form library.
+- [#1198](https://github.com/ngrok/mantle/pull/1198) [`2c00e7c`](https://github.com/ngrok/mantle/commit/2c00e7caad939048b2b02d19919211385566d031) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `toErrorMessages`, a first-class helper exported from `@ngrok/mantle/field` for normalizing TanStack React Form's mixed `field.state.meta.errors` array into a clean `string[]` for `Field.Errors`. Folds together the shapes TanStack Form yields across its built-in validators — plain strings, `{ message }` issue objects (Zod / Standard Schema), thrown `Error` instances, and the falsy slots Standard Schema can produce — into trimmed, non-empty strings without coupling Mantle to a specific form library.
 
   ```tsx
   import { Field, toErrorMessages } from "@ngrok/mantle/field";
@@ -197,7 +197,7 @@
 
 ### Minor Changes
 
-- [#1191](https://github.com/ngrok-oss/mantle/pull/1191) [`e09de2d`](https://github.com/ngrok-oss/mantle/commit/e09de2da092c6f0ab91251ea4a00170593a985a5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `Field`, a compound layout primitive for a single form field. Pair with the existing mantle `<Label>` — the component intentionally does not invent a new label primitive. Layout parts plus `Field.Description`, `Field.Optional`, and `Field.ErrorList` support `asChild`; `Field.Set`, `Field.Legend`, and `Field.ErrorItem` always render `<fieldset>`, `<legend>`, and `<li>` respectively so their core semantics cannot be accidentally removed.
+- [#1191](https://github.com/ngrok/mantle/pull/1191) [`e09de2d`](https://github.com/ngrok/mantle/commit/e09de2da092c6f0ab91251ea4a00170593a985a5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `Field`, a compound layout primitive for a single form field. Pair with the existing mantle `<Label>` — the component intentionally does not invent a new label primitive. Layout parts plus `Field.Description`, `Field.Optional`, and `Field.ErrorList` support `asChild`; `Field.Set`, `Field.Legend`, and `Field.ErrorItem` always render `<fieldset>`, `<legend>`, and `<li>` respectively so their core semantics cannot be accidentally removed.
 
   The default tree is a `Field.Group` of `Field.Item`s — that's all most forms need. Reach for the semantic `Field.Set` + `Field.Legend` only when the grouping itself carries semantic weight (radios, related checkboxes); a `<fieldset>` around plain unrelated inputs reads as noise to assistive tech.
 
@@ -224,27 +224,27 @@
 
 ### Patch Changes
 
-- [#1195](https://github.com/ngrok-oss/mantle/pull/1195) [`fb7d6f3`](https://github.com/ngrok-oss/mantle/commit/fb7d6f33d30aacd6be7b215e5466acd58c3925fa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump `tailwindcss` and `@tailwindcss/vite` to `4.3.0`, and `tailwind-merge` to `3.6.0`.
+- [#1195](https://github.com/ngrok/mantle/pull/1195) [`fb7d6f3`](https://github.com/ngrok/mantle/commit/fb7d6f33d30aacd6be7b215e5466acd58c3925fa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump `tailwindcss` and `@tailwindcss/vite` to `4.3.0`, and `tailwind-merge` to `3.6.0`.
 
-- [#1193](https://github.com/ngrok-oss/mantle/pull/1193) [`985659f`](https://github.com/ngrok-oss/mantle/commit/985659fd8f91b6bae7d971a0a59e7666f79f46ec) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `CodeBlock.CopyButton` now accepts an optional `label` prop for the accessible (screen-reader) label, defaulting to `"Copy code"`.
+- [#1193](https://github.com/ngrok/mantle/pull/1193) [`985659f`](https://github.com/ngrok/mantle/commit/985659fd8f91b6bae7d971a0a59e7666f79f46ec) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `CodeBlock.CopyButton` now accepts an optional `label` prop for the accessible (screen-reader) label, defaulting to `"Copy code"`.
 
-- [#1189](https://github.com/ngrok-oss/mantle/pull/1189) [`e2c07e5`](https://github.com/ngrok-oss/mantle/commit/e2c07e5507fb1819b6e5d8d2237ca9bc6bfc1a16) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `CodeBlock.Code` no longer paints a browser-default focus outline on its `<pre>`, and no longer hardcodes `tabIndex={-1}` on the element.
+- [#1189](https://github.com/ngrok/mantle/pull/1189) [`e2c07e5`](https://github.com/ngrok/mantle/commit/e2c07e5507fb1819b6e5d8d2237ca9bc6bfc1a16) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `CodeBlock.Code` no longer paints a browser-default focus outline on its `<pre>`, and no longer hardcodes `tabIndex={-1}` on the element.
 
   The `tabIndex={-1}` default was a leftover workaround from when Prism.js auto-injected `tabIndex={0}` on every `<pre>` it touched. Prism was replaced with build-time Shiki, so nothing is forcing a tabindex anymore — the override is dead weight that also opted the scroll container out of Chrome's keyboard-focusable-scroller heuristic, hurting keyboard-only users on overflowing blocks. The prop is now passed through cleanly via `...props`, so consumers can still set `tabIndex={-1}` (or any other value) per instance if they want to exclude a block from the tab order.
 
   The `outline-hidden` is paired with the tabindex change so the now-optionally-focusable `<pre>` doesn't paint the browser-default focus ring when scripted focus or scroll-container heuristics put focus on it. Nested controls (fold toggles, copy buttons) keep their own `:focus-visible` styles.
 
-- [#1185](https://github.com/ngrok-oss/mantle/pull/1185) [`72b52b1`](https://github.com/ngrok-oss/mantle/commit/72b52b1bd442a5561a741430193558de84c01c9b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `Label` now defaults to `font-medium` when it doesn't wrap an interactive form control, and inherits weight when it does (e.g. `<Label><Input /></Label>`). The default is applied through a `:where()`-wrapped selector so the rule's total specificity is `(0,0,0)` — a user-supplied `font-bold` / `font-normal` / `font-semibold` overrides it cleanly without needing the `!` important modifier.
+- [#1185](https://github.com/ngrok/mantle/pull/1185) [`72b52b1`](https://github.com/ngrok/mantle/commit/72b52b1bd442a5561a741430193558de84c01c9b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `Label` now defaults to `font-medium` when it doesn't wrap an interactive form control, and inherits weight when it does (e.g. `<Label><Input /></Label>`). The default is applied through a `:where()`-wrapped selector so the rule's total specificity is `(0,0,0)` — a user-supplied `font-bold` / `font-normal` / `font-semibold` overrides it cleanly without needing the `!` important modifier.
 
   Detection covers `<input>`, `<textarea>`, `<select>`, `<button>`, and `[contenteditable]` descendants, which transitively covers mantle's checkbox/radio (real `<input>`), select/multi-select/menu triggers (real `<button>`), and any third-party control built on those primitives. The `[contenteditable]` attribute selector would normally raise the rule's specificity to `(0,1,0)` and tie with a bare utility class — wrapping the whole selector in `:where()` flattens it back to `(0,0,0)` so user overrides still win.
 
-- [#1194](https://github.com/ngrok-oss/mantle/pull/1194) [`40cb820`](https://github.com/ngrok-oss/mantle/commit/40cb82019e4eac86f0f47a42062954c11685d76b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `Dialog.Body` and `Sheet.Body` now reserve space for the scrollbar via `scrollbar-gutter: stable`, preventing horizontal content shift when the body grows past its container and a scrollbar appears.
+- [#1194](https://github.com/ngrok/mantle/pull/1194) [`40cb820`](https://github.com/ngrok/mantle/commit/40cb82019e4eac86f0f47a42062954c11685d76b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `Dialog.Body` and `Sheet.Body` now reserve space for the scrollbar via `scrollbar-gutter: stable`, preventing horizontal content shift when the body grows past its container and a scrollbar appears.
 
 ## 0.72.0
 
 ### Minor Changes
 
-- [#1174](https://github.com/ngrok-oss/mantle/pull/1174) [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend code-block folding toward VS Code parity by switching the JS/TS/JSX/TSX, HTML, XML, and CSS strategies to AST / parser-quality matchers, and adding keyword-pair folding for Bash / Shell / Ruby. The runtime click handler is unchanged — all heavier work runs server- or build-side inside `@ngrok/mantle-server-syntax-highlighter`.
+- [#1174](https://github.com/ngrok/mantle/pull/1174) [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend code-block folding toward VS Code parity by switching the JS/TS/JSX/TSX, HTML, XML, and CSS strategies to AST / parser-quality matchers, and adding keyword-pair folding for Bash / Shell / Ruby. The runtime click handler is unchanged — all heavier work runs server- or build-side inside `@ngrok/mantle-server-syntax-highlighter`.
 
   What now folds (per language):
   - **JS / TS / JSX / TSX** (`oxc-parser`) — block statements, object/array literals, class/interface/type-literal/enum bodies, switch statements, multi-line template literals (including tagged), JSX elements (`<Foo>…</Foo>`), JSX fragments (`<>…</>`), member-expression element names (`<obj.Foo>`), and multi-line self-closing opening tags / attribute lists. Single-line self-closing JSX tags still don't get a toggle.
@@ -262,7 +262,7 @@
 
   Skipping `includeExplanation` on the AST and raw-source paths (JS/TS/HTML/CSS/JSON) keeps the highlight pipeline cheaper than the previous token-only approach for those languages.
 
-- [#1174](https://github.com/ngrok-oss/mantle/pull/1174) [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend fold gutters to every supported language, not just JSON. Each language uses the folding model that fits its grammar:
+- [#1174](https://github.com/ngrok/mantle/pull/1174) [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Extend fold gutters to every supported language, not just JSON. Each language uses the folding model that fits its grammar:
   - **AST-based** (`javascript`, `typescript`, `jsx`, `tsx`) — `oxc-parser` emits folds for blocks, object/array literals, JSX elements/fragments, multi-line template literals, and TypeScript-only bodies.
   - **Raw-source** (`json`, `css`) — single-pass matchers fold braces/brackets while skipping strings, comments, and escapes without requiring Shiki scope explanations.
   - **Bracket-paired** (`go`, `java`, `csharp`, `rust`) — multi-line `{ … }` and `[ … ]` ranges fold via TextMate-scope-aware token walking.
@@ -285,14 +285,14 @@
 
 ### Patch Changes
 
-- [#1174](https://github.com/ngrok-oss/mantle/pull/1174) [`51a0864`](https://github.com/ngrok-oss/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add VS Code-style fold gutters to JSON code blocks. Every multi-line `{ … }` or `[ … ]` now renders a semantic `<button>` toggle in the gutter; clicking (or focusing and pressing `Enter` / `Space`) hides the inner content while keeping the opener and closer lines visible, with a `⋯` placeholder marking the collapsed region.
+- [#1174](https://github.com/ngrok/mantle/pull/1174) [`51a0864`](https://github.com/ngrok/mantle/commit/51a086436804f6c4f576b9021e0e3ab7699e8907) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add VS Code-style fold gutters to JSON code blocks. Every multi-line `{ … }` or `[ … ]` now renders a semantic `<button>` toggle in the gutter; clicking (or focusing and pressing `Enter` / `Space`) hides the inner content while keeping the opener and closer lines visible, with a `⋯` placeholder marking the collapsed region.
   - Fold ranges are computed at build time, so there is zero highlighting cost in the browser.
   - All toggle interaction runs through a single delegated click handler per `<pre>` — no per-line listeners and no React re-renders. This keeps fold/unfold cheap even on JSON blobs with thousands of lines.
   - New helper exports from `@ngrok/mantle/code-block` and `@ngrok/mantle/highlight-utils`: `computeJsonFoldRanges(code)` and the `FoldableRange` type.
   - `decorateHighlightedHtml` accepts a new optional `foldableRanges` input. When omitted, the decorator behaves exactly as before — no fold gutter is rendered.
   - Server-highlighted code blocks can provide fold ranges for every supported language with a folding strategy; raw JSON callers can continue using `computeJsonFoldRanges(code)` directly.
 
-- [#1176](https://github.com/ngrok-oss/mantle/pull/1176) [`5174b31`](https://github.com/ngrok-oss/mantle/commit/5174b313d128c1db89f93cf5d45601ba48d834e0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `OtpInput.Root` now accepts a `validation` prop (`"error" | "success" | "warning" | false`, or a function returning one). When set, each group's outer borders and the active focus ring are recolored with the matching validation hue, mirroring the styling contract of `Input`. `validation="error"` additionally sets `aria-invalid` on the underlying input so assistive tech announces the failure state.
+- [#1176](https://github.com/ngrok/mantle/pull/1176) [`5174b31`](https://github.com/ngrok/mantle/commit/5174b313d128c1db89f93cf5d45601ba48d834e0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `OtpInput.Root` now accepts a `validation` prop (`"error" | "success" | "warning" | false`, or a function returning one). When set, each group's outer borders and the active focus ring are recolored with the matching validation hue, mirroring the styling contract of `Input`. `validation="error"` additionally sets `aria-invalid` on the underlying input so assistive tech announces the failure state.
 
   Internal: `ProgressDonut` now uses the `$cssProperties` helper for inline CSS-variable styles instead of an `as CSSProperties` cast — no behavior change.
 
@@ -300,7 +300,7 @@
 
 ### Patch Changes
 
-- [#1170](https://github.com/ngrok-oss/mantle/pull/1170) [`5c7ea22`](https://github.com/ngrok-oss/mantle/commit/5c7ea22ad5871b05d8b3d1962435cdbe7cda9773) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Expand the machine-readable surface for AI agents.
+- [#1170](https://github.com/ngrok/mantle/pull/1170) [`5c7ea22`](https://github.com/ngrok/mantle/commit/5c7ea22ad5871b05d8b3d1962435cdbe7cda9773) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Expand the machine-readable surface for AI agents.
 
   New endpoints on the docs site:
   - `/api/package.json` — version, peer/dev dependency ranges, and the sorted list of importable `@ngrok/mantle/*` subpaths.
@@ -312,33 +312,33 @@
 
   The published package now ships `@ngrok/mantle/agent.json` and `@ngrok/mantle/llms.txt` — pointers to the live endpoints above plus the package's own subpath inventory — for agents working without network access.
 
-- [#1168](https://github.com/ngrok-oss/mantle/pull/1168) [`9da2cac`](https://github.com/ngrok-oss/mantle/commit/9da2cac4f9b4078fd07cf24feee7ce4fada25303) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Reduce `OtpInput.Slot` transition duration from 300ms to 150ms for snappier focus feedback.
+- [#1168](https://github.com/ngrok/mantle/pull/1168) [`9da2cac`](https://github.com/ngrok/mantle/commit/9da2cac4f9b4078fd07cf24feee7ce4fada25303) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Reduce `OtpInput.Slot` transition duration from 300ms to 150ms for snappier focus feedback.
 
 ## 0.71.0
 
 ### Minor Changes
 
-- [#1167](https://github.com/ngrok-oss/mantle/pull/1167) [`acd0c55`](https://github.com/ngrok-oss/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `OtpInput`, a compound component for capturing one-time passcodes (OTP). Built on top of [`input-otp`](https://github.com/guilhermerodz/input-otp), it renders a single hidden input that handles paste, autofill, and IME correctly while displaying each character in its own styled slot. Composes as `OtpInput.Root` > `OtpInput.Group` > `OtpInput.Slot` with optional `OtpInput.Separator` between groups. Re-exports the `REGEXP_ONLY_DIGITS`, `REGEXP_ONLY_CHARS`, and `REGEXP_ONLY_DIGITS_AND_CHARS` pattern helpers for restricting accepted characters.
+- [#1167](https://github.com/ngrok/mantle/pull/1167) [`acd0c55`](https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `OtpInput`, a compound component for capturing one-time passcodes (OTP). Built on top of [`input-otp`](https://github.com/guilhermerodz/input-otp), it renders a single hidden input that handles paste, autofill, and IME correctly while displaying each character in its own styled slot. Composes as `OtpInput.Root` > `OtpInput.Group` > `OtpInput.Slot` with optional `OtpInput.Separator` between groups. Re-exports the `REGEXP_ONLY_DIGITS`, `REGEXP_ONLY_CHARS`, and `REGEXP_ONLY_DIGITS_AND_CHARS` pattern helpers for restricting accepted characters.
 
 ### Patch Changes
 
-- [#1166](https://github.com/ngrok-oss/mantle/pull/1166) [`4f35862`](https://github.com/ngrok-oss/mantle/commit/4f35862874e471f871865aabd36a40aff494d523) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Significantly expand JSDoc coverage across the package to improve agentic and IntelliSense-driven discovery. Every `index.ts` barrel now ships a `@see` link to its docs page. All hooks (`useCallbackRef`, `useCopyToClipboard`, `useDebouncedCallback`, `useIsomorphicLayoutEffect`, `useMatchesMediaQuery`, `usePrefersReducedMotion`, `useRandomStableId`, `useScrollBehavior`, `useUndoRedo`) now document `@param`, `@returns`, and at least one `@example`. Compound components (`Dialog`, `Sheet`, `AlertDialog`, `Tooltip`, `Popover`, `HoverCard`, `Select`, `Combobox`, `MultiSelect`, `DataTable`) gained "when to use vs alternatives" guidance on their top-level namespace JSDoc, full-tree `@example` blocks across sub-components, and explicit notes on required setup (`TooltipProvider` mount, `useReactTable` instance for `DataTable.Root`, etc.). Also removes the empty `"./date-picker"` export from `package.json` (it had no implementation and was never importable). No runtime behavior changes.
+- [#1166](https://github.com/ngrok/mantle/pull/1166) [`4f35862`](https://github.com/ngrok/mantle/commit/4f35862874e471f871865aabd36a40aff494d523) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Significantly expand JSDoc coverage across the package to improve agentic and IntelliSense-driven discovery. Every `index.ts` barrel now ships a `@see` link to its docs page. All hooks (`useCallbackRef`, `useCopyToClipboard`, `useDebouncedCallback`, `useIsomorphicLayoutEffect`, `useMatchesMediaQuery`, `usePrefersReducedMotion`, `useRandomStableId`, `useScrollBehavior`, `useUndoRedo`) now document `@param`, `@returns`, and at least one `@example`. Compound components (`Dialog`, `Sheet`, `AlertDialog`, `Tooltip`, `Popover`, `HoverCard`, `Select`, `Combobox`, `MultiSelect`, `DataTable`) gained "when to use vs alternatives" guidance on their top-level namespace JSDoc, full-tree `@example` blocks across sub-components, and explicit notes on required setup (`TooltipProvider` mount, `useReactTable` instance for `DataTable.Root`, etc.). Also removes the empty `"./date-picker"` export from `package.json` (it had no implementation and was never importable). No runtime behavior changes.
 
-- [#1161](https://github.com/ngrok-oss/mantle/pull/1161) [`913acb6`](https://github.com/ngrok-oss/mantle/commit/913acb63b7fd17d490aa64cb110e9d57542ed8a6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Expand JSDoc coverage on `Skeleton`, `Badge`, `Code`, `Kbd`, `MediaObject`, `Anchor`, `Flag`, `Label`, `PasswordInput`, and the top-level `DataTable` (full layout examples — sortable+filterable+paginated, sticky action column, and clickable-row-with-Link). All follow the same template as the flagship components: a one-line summary, a "When to use / When not to use" block, accessibility notes where relevant, and `@example`s with imports. No runtime behavior changes — IntelliSense surfaces more guidance for both human contributors and AI agents using the library.
+- [#1161](https://github.com/ngrok/mantle/pull/1161) [`913acb6`](https://github.com/ngrok/mantle/commit/913acb63b7fd17d490aa64cb110e9d57542ed8a6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Expand JSDoc coverage on `Skeleton`, `Badge`, `Code`, `Kbd`, `MediaObject`, `Anchor`, `Flag`, `Label`, `PasswordInput`, and the top-level `DataTable` (full layout examples — sortable+filterable+paginated, sticky action column, and clickable-row-with-Link). All follow the same template as the flagship components: a one-line summary, a "When to use / When not to use" block, accessibility notes where relevant, and `@example`s with imports. No runtime behavior changes — IntelliSense surfaces more guidance for both human contributors and AI agents using the library.
 
-- [#1155](https://github.com/ngrok-oss/mantle/pull/1155) [`0f0b607`](https://github.com/ngrok-oss/mantle/commit/0f0b607813fbe15c969aa1e3e3c0ac9a4d27c8fe) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update `tailwindcss` and `@tailwindcss/vite` to `4.2.4`.
+- [#1155](https://github.com/ngrok/mantle/pull/1155) [`0f0b607`](https://github.com/ngrok/mantle/commit/0f0b607813fbe15c969aa1e3e3c0ac9a4d27c8fe) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update `tailwindcss` and `@tailwindcss/vite` to `4.2.4`.
 
 ## 0.70.2
 
 ### Patch Changes
 
-- [#1152](https://github.com/ngrok-oss/mantle/pull/1152) [`01b04f4`](https://github.com/ngrok-oss/mantle/commit/01b04f4850a38d4f27b87b36eb393150a8098a30) Thanks [@forzalupo](https://github.com/forzalupo)! - Clean up `CodeBlock` copy button placement and wrapper sizing so it aligns consistently within the code block.
+- [#1152](https://github.com/ngrok/mantle/pull/1152) [`01b04f4`](https://github.com/ngrok/mantle/commit/01b04f4850a38d4f27b87b36eb393150a8098a30) Thanks [@forzalupo](https://github.com/forzalupo)! - Clean up `CodeBlock` copy button placement and wrapper sizing so it aligns consistently within the code block.
 
-- [#1160](https://github.com/ngrok-oss/mantle/pull/1160) [`60d8c53`](https://github.com/ngrok-oss/mantle/commit/60d8c53b135181af15654a73588706bb27a57cb5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `DataTable.Row` now auto-applies `cursor-pointer` when an `onClick` handler is provided, so consumers no longer need to add it manually. Pass a different `cursor-*` class via `className` (for example, `cursor-wait`) to override.
+- [#1160](https://github.com/ngrok/mantle/pull/1160) [`60d8c53`](https://github.com/ngrok/mantle/commit/60d8c53b135181af15654a73588706bb27a57cb5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - `DataTable.Row` now auto-applies `cursor-pointer` when an `onClick` handler is provided, so consumers no longer need to add it manually. Pass a different `cursor-*` class via `className` (for example, `cursor-wait`) to override.
 
-- [#1160](https://github.com/ngrok-oss/mantle/pull/1160) [`60d8c53`](https://github.com/ngrok-oss/mantle/commit/60d8c53b135181af15654a73588706bb27a57cb5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `useComposedRefs` returning a thunk (`() => (node) => void`) instead of a ref callback, which meant the composed ref never actually received the DOM node. The hook now returns a stable ref callback that reads the latest refs via an internal ref box, so passed refs stay up-to-date without causing ref thrashing on every render.
+- [#1160](https://github.com/ngrok/mantle/pull/1160) [`60d8c53`](https://github.com/ngrok/mantle/commit/60d8c53b135181af15654a73588706bb27a57cb5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `useComposedRefs` returning a thunk (`() => (node) => void`) instead of a ref callback, which meant the composed ref never actually received the DOM node. The hook now returns a stable ref callback that reads the latest refs via an internal ref box, so passed refs stay up-to-date without causing ref thrashing on every render.
 
-- [#1160](https://github.com/ngrok-oss/mantle/pull/1160) [`60d8c53`](https://github.com/ngrok-oss/mantle/commit/60d8c53b135181af15654a73588706bb27a57cb5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Breaking:** `useCopyToClipboard` now returns the async copy function directly instead of a `[state, copyFn]` tuple. The internal `useState` that tracked the last copied value has been removed, eliminating an extra render per successful copy.
+- [#1160](https://github.com/ngrok/mantle/pull/1160) [`60d8c53`](https://github.com/ngrok/mantle/commit/60d8c53b135181af15654a73588706bb27a57cb5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Breaking:** `useCopyToClipboard` now returns the async copy function directly instead of a `[state, copyFn]` tuple. The internal `useState` that tracked the last copied value has been removed, eliminating an extra render per successful copy.
 
   ```tsx
   // Before
@@ -352,47 +352,47 @@
 
 ### Patch Changes
 
-- [#1148](https://github.com/ngrok-oss/mantle/pull/1148) [`6085190`](https://github.com/ngrok-oss/mantle/commit/60851902cd6ed01ea7c45429817cf16145d84167) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add missing `data-slot` attributes across the component library so every exported component and compound sub-part exposes a stable `data-slot="<name>"` (or `data-slot="<name>-<part>"`) styling hook. Also adds `asChild` support (via `Slot`) to `Empty.Root`, `Empty.Actions`, `Code`, and `ButtonGroup`.
+- [#1148](https://github.com/ngrok/mantle/pull/1148) [`6085190`](https://github.com/ngrok/mantle/commit/60851902cd6ed01ea7c45429817cf16145d84167) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add missing `data-slot` attributes across the component library so every exported component and compound sub-part exposes a stable `data-slot="<name>"` (or `data-slot="<name>-<part>"`) styling hook. Also adds `asChild` support (via `Slot`) to `Empty.Root`, `Empty.Actions`, `Code`, and `ButtonGroup`.
 
   Components updated include (non-exhaustive): `Main`, `SkipToMainLink`, `Empty`, `CodeBlock`, `Tabs`, `TextArea`, `Toast`/`Toaster`, `Separator`, `HorizontalSeparatorGroup`, `Sheet`, `Skeleton`, `Switch`, `Table`, `Label`, `MediaObject`, `Popover`, `RadioGroup`, `Select`, `Flag`, `HoverCard`, `Icon`, `SvgOnly`, `Input`/`PasswordInput`, `Kbd`, `DescriptionList`, `Dialog`, `DropdownMenu`, `DataTable`, `MetaKey`, `CursorPagination`, `ProgressBar`, and `ProgressDonut`. `HoverCard.Trigger`, `Dialog.Trigger`/`Dialog.Close`, and `DropdownMenu.Trigger` are now thin wrappers around their underlying Radix primitives so they can carry a `data-slot` attribute.
 
   Note: `ProgressBar`'s existing `data-slot` values were renamed to follow the compound-component naming convention — `data-slot="progress"` → `data-slot="progress-bar"` and `data-slot="progress-indicator"` → `data-slot="progress-bar-indicator"`. Consumers styling against those specific values will need to update their selectors.
 
-- [#1150](https://github.com/ngrok-oss/mantle/pull/1150) [`e623364`](https://github.com/ngrok-oss/mantle/commit/e623364b21f9e5b8159e8995fdcaf82700195fa6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Anchors (`<a>` elements, including those rendered by the `Anchor` component) that are descendants of `Alert.Root` now inherit the alert's variant text color (e.g. `text-warning-700` inside a warning alert) and are underlined at all times — not just on hover. This keeps inline links visually coherent with the surrounding alert copy while still marking them as links.
+- [#1150](https://github.com/ngrok/mantle/pull/1150) [`e623364`](https://github.com/ngrok/mantle/commit/e623364b21f9e5b8159e8995fdcaf82700195fa6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Anchors (`<a>` elements, including those rendered by the `Anchor` component) that are descendants of `Alert.Root` now inherit the alert's variant text color (e.g. `text-warning-700` inside a warning alert) and are underlined at all times — not just on hover. This keeps inline links visually coherent with the surrounding alert copy while still marking them as links.
 
   **Visual change**: consumers that currently render links inside `Alert.Root` will see those links shift from the default `text-accent-600` to the alert's priority color, and the underline will be persistent rather than hover-only.
 
-- [#1150](https://github.com/ngrok-oss/mantle/pull/1150) [`e623364`](https://github.com/ngrok-oss/mantle/commit/e623364b21f9e5b8159e8995fdcaf82700195fa6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add "when to use" guidance and WAI-ARIA cross-references to the `Tooltip`, `Popover`, and `HoverCard` compound-namespace JSDoc so editor hover tips surface the correct component for each use case.
+- [#1150](https://github.com/ngrok/mantle/pull/1150) [`e623364`](https://github.com/ngrok/mantle/commit/e623364b21f9e5b8159e8995fdcaf82700195fa6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add "when to use" guidance and WAI-ARIA cross-references to the `Tooltip`, `Popover`, and `HoverCard` compound-namespace JSDoc so editor hover tips surface the correct component for each use case.
 
 ## 0.70.0
 
 ### Minor Changes
 
-- [#1147](https://github.com/ngrok-oss/mantle/pull/1147) [`5e3aca7`](https://github.com/ngrok-oss/mantle/commit/5e3aca7c859b54403c9845ce93538c8e0b46f929) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `SkipToMainLink` and `Main` components for accessible "skip to main content" navigation. `SkipToMainLink` is a visually-hidden-until-focused link that uses the browser History API directly, so it works in any framework (React Router, Next.js, plain HTML). `Main` renders a focusable `<main id="main" tabIndex={-1}>` landmark designed to pair with it.
+- [#1147](https://github.com/ngrok/mantle/pull/1147) [`5e3aca7`](https://github.com/ngrok/mantle/commit/5e3aca7c859b54403c9845ce93538c8e0b46f929) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `SkipToMainLink` and `Main` components for accessible "skip to main content" navigation. `SkipToMainLink` is a visually-hidden-until-focused link that uses the browser History API directly, so it works in any framework (React Router, Next.js, plain HTML). `Main` renders a focusable `<main id="main" tabIndex={-1}>` landmark designed to pair with it.
 
   Also registers a new `z-max` utility (backed by `--z-index-max: 2147483647`, i.e. int32 max) so consumers can stack elements above any other z-index layer.
 
 ### Patch Changes
 
-- [#1107](https://github.com/ngrok-oss/mantle/pull/1107) [`4d35209`](https://github.com/ngrok-oss/mantle/commit/4d35209cd3ec2b15215e51107aec3de007768aa6) Thanks [@forzalupo](https://github.com/forzalupo)! - Internal: switch `=== undefined` / `!== undefined` checks to `== null` / `!= null` for consistency with the project's nullish-equality style. No behavior change.
+- [#1107](https://github.com/ngrok/mantle/pull/1107) [`4d35209`](https://github.com/ngrok/mantle/commit/4d35209cd3ec2b15215e51107aec3de007768aa6) Thanks [@forzalupo](https://github.com/forzalupo)! - Internal: switch `=== undefined` / `!== undefined` checks to `== null` / `!= null` for consistency with the project's nullish-equality style. No behavior change.
 
 ## 0.69.2
 
 ### Patch Changes
 
-- [#1126](https://github.com/ngrok-oss/mantle/pull/1126) [`545a09d`](https://github.com/ngrok-oss/mantle/commit/545a09d77c0503f7dfdffe5eb1cde69d59aa65f4) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump @ariakit/react from 0.4.25 to 0.4.26
+- [#1126](https://github.com/ngrok/mantle/pull/1126) [`545a09d`](https://github.com/ngrok/mantle/commit/545a09d77c0503f7dfdffe5eb1cde69d59aa65f4) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump @ariakit/react from 0.4.25 to 0.4.26
 
 ## 0.69.1
 
 ### Patch Changes
 
-- [#1141](https://github.com/ngrok-oss/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok-oss/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add a `Composition` section to every compound component doc page showing the structural tree of its parts (ASCII art). Rename existing `asChild`-style `Composition` sections on `Badge`, `Button`, `IconButton`, `Separator`, and `SplitButton` to `Polymorphism`. Rename the `Input` children-composition section to `Child Elements` and the `Dialog` tooltip section to `Combining with a Tooltip` to avoid colliding with the new `Composition` name.
+- [#1141](https://github.com/ngrok/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add a `Composition` section to every compound component doc page showing the structural tree of its parts (ASCII art). Rename existing `asChild`-style `Composition` sections on `Badge`, `Button`, `IconButton`, `Separator`, and `SplitButton` to `Polymorphism`. Rename the `Input` children-composition section to `Child Elements` and the `Dialog` tooltip section to `Combining with a Tooltip` to avoid colliding with the new `Composition` name.
 
   Add the same ASCII composition tree as a `@example Composition` block to the top-level namespace JSDoc of every compound component (`Accordion`, `Alert`, `AlertDialog`, `Card`, `CodeBlock`, `Combobox`, `Command`, `CursorPagination`, `DataTable`, `DescriptionList`, `Dialog`, `DropdownMenu`, `Empty`, `HoverCard`, `MediaObject`, `MultiSelect`, `Popover`, `ProgressBar`, `ProgressDonut`, `RadioGroup`, `Select`, `Sheet`, `SplitButton`, `Table`, `Tabs`, `Toast`, `Tooltip`) so consumers and LLMs see the full structural shape at a glance in IDE IntelliSense.
 
-- [#1141](https://github.com/ngrok-oss/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok-oss/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Expand JSDoc coverage across `CodeBlock`, `Command`, `Dialog`, `Empty`, `Popover`, `Select`, and `Sheet` compound components and their sub-parts for improved IntelliSense and documentation.
+- [#1141](https://github.com/ngrok/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Expand JSDoc coverage across `CodeBlock`, `Command`, `Dialog`, `Empty`, `Popover`, `Select`, and `Sheet` compound components and their sub-parts for improved IntelliSense and documentation.
 
-- [#1141](https://github.com/ngrok-oss/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok-oss/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix several code fence metastring parsing bugs in `mantleCodeRehypePlugin`:
+- [#1141](https://github.com/ngrok/mantle/pull/1141) [`f82feb8`](https://github.com/ngrok/mantle/commit/f82feb81f2da67d332962cd16e138bd0de9ae45b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix several code fence metastring parsing bugs in `mantleCodeRehypePlugin`:
   - `mantleShowLineNumbers`, `mantleCollapsible`, and `mantleDisableCopy` are now stringified on HAST `<pre>` properties. Previously, boolean `false` values were dropped during HAST→JSX compilation, causing `showLineNumbers=false` fence meta to be silently ignored (the rendered `<pre>` ended up with `data-mantle-line-numbers="true"` and no left padding).
   - `collapsible=true`, `collapsible=false`, and `collapsible="true"` in fence meta are no longer silently dropped. The `collapsible` key now accepts the same bare-flag, key-value, and quoted-value forms as `disableCopy`.
   - When a key appears multiple times in fence meta (e.g. `title="first" title="second"`), `getMetaValue` now returns the last value, matching `parseMetastring` semantics. Previously it returned the first.
@@ -402,25 +402,25 @@
 
 ### Minor Changes
 
-- [#1138](https://github.com/ngrok-oss/mantle/pull/1138) [`3f06774`](https://github.com/ngrok-oss/mantle/commit/3f06774967405751d4eec8be9d479a6b5516a6d7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add new `Empty` compound component for rendering empty states. Includes `Empty.Root`, `Empty.Icon`, `Empty.Title`, `Empty.Description`, and `Empty.Actions` sub-components.
+- [#1138](https://github.com/ngrok/mantle/pull/1138) [`3f06774`](https://github.com/ngrok/mantle/commit/3f06774967405751d4eec8be9d479a6b5516a6d7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add new `Empty` compound component for rendering empty states. Includes `Empty.Root`, `Empty.Icon`, `Empty.Title`, `Empty.Description`, and `Empty.Actions` sub-components.
 
 ## 0.68.7
 
 ### Patch Changes
 
-- [#1134](https://github.com/ngrok-oss/mantle/pull/1134) [`5bde2bb`](https://github.com/ngrok-oss/mantle/commit/5bde2bb43fd24dff97db51d63a559650151d4ed3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix InputContainer focus ring flicker by preventing mousedown default on non-input children. Use `flushSync` in PasswordInput to animate the eye icon inline in the click handler after React commits the new icon to the DOM. Remove `pointer-events-none` from validation feedback icons.
+- [#1134](https://github.com/ngrok/mantle/pull/1134) [`5bde2bb`](https://github.com/ngrok/mantle/commit/5bde2bb43fd24dff97db51d63a559650151d4ed3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix InputContainer focus ring flicker by preventing mousedown default on non-input children. Use `flushSync` in PasswordInput to animate the eye icon inline in the click handler after React commits the new icon to the DOM. Remove `pointer-events-none` from validation feedback icons.
 
 ## 0.68.6
 
 ### Patch Changes
 
-- [#1132](https://github.com/ngrok-oss/mantle/pull/1132) [`c0ea674`](https://github.com/ngrok-oss/mantle/commit/c0ea67486b837fba066000226630f74896ce8dcf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix Input focus ring showing as black when clicking the PasswordInput visibility toggle by using `focus-within` for both ring size and color. Add a blink animation to the PasswordInput eye icon toggle that respects `prefers-reduced-motion`.
+- [#1132](https://github.com/ngrok/mantle/pull/1132) [`c0ea674`](https://github.com/ngrok/mantle/commit/c0ea67486b837fba066000226630f74896ce8dcf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix Input focus ring showing as black when clicking the PasswordInput visibility toggle by using `focus-within` for both ring size and color. Add a blink animation to the PasswordInput eye icon toggle that respects `prefers-reduced-motion`.
 
 ## 0.68.5
 
 ### Patch Changes
 
-- [#1130](https://github.com/ngrok-oss/mantle/pull/1130) [`8c7866b`](https://github.com/ngrok-oss/mantle/commit/8c7866b085a3f508d29fd0eed8361f96f6977f62) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(table): switch to border-separate for continuous sticky column indicator
+- [#1130](https://github.com/ngrok/mantle/pull/1130) [`8c7866b`](https://github.com/ngrok/mantle/commit/8c7866b085a3f508d29fd0eed8361f96f6977f62) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(table): switch to border-separate for continuous sticky column indicator
 
   Replaced `border-collapse` with `border-separate border-spacing-0` on `Table.Element` and moved row dividers from group-level borders (`divide-y` on `<thead>`/`<tbody>`/`<tfoot>`) to cell-level borders. This prevents table cells from clipping overflow content, allowing the `StickyColIndicator` shadow strip to extend across row boundaries and render as one continuous vertical line instead of per-row segments with visible gaps.
 
@@ -430,7 +430,7 @@
 
 ### Patch Changes
 
-- [#1122](https://github.com/ngrok-oss/mantle/pull/1122) [`327d46c`](https://github.com/ngrok-oss/mantle/commit/327d46ca0e950871fbae0b17f4e587b55afa27d0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix table horizontal scroll masking, improve scroll perf, and add `DataTable.ActionHeader`.
+- [#1122](https://github.com/ngrok/mantle/pull/1122) [`327d46c`](https://github.com/ngrok/mantle/commit/327d46ca0e950871fbae0b17f4e587b55afa27d0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix table horizontal scroll masking, improve scroll perf, and add `DataTable.ActionHeader`.
   - **`Table.Root`**: Split into outer wrapper (border, rounded corners, background) and inner scroll container (`scroll-fade-x` mask, `overflow-x: auto`, `overflow-y: clip`, `overscroll-behavior: none`). Tables only scroll horizontally and no longer bounce.
   - **Scroll fade**: Left and right edge fades driven by scroll position. Right-side fade correctly suppressed when a sticky right column is present (`DataTable.ActionCell` / `DataTable.ActionHeader`).
   - **`DataTable.ActionCell`**: Replaced per-cell `box-shadow` with `bg-inherit` and a `StickyColIndicator` child span (1px divider + soft leftward gradient). Tracks the row's background including hover state.
@@ -443,93 +443,93 @@
 
 ### Patch Changes
 
-- [#1119](https://github.com/ngrok-oss/mantle/pull/1119) [`0c20cf7`](https://github.com/ngrok-oss/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default. Single-line shell snippets (`bash`, `sh`, `shell`) default to `false` since line numbers add noise to one-liners like install commands.
+- [#1119](https://github.com/ngrok/mantle/pull/1119) [`0c20cf7`](https://github.com/ngrok/mantle/commit/0c20cf736429dd6e0085d4f38affce86f7de8ee9) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Default `showLineNumbers` to `true` in `mantleCode()` and `highlightWithMantleShiki()` so code blocks show line numbers by default. Single-line shell snippets (`bash`, `sh`, `shell`) default to `false` since line numbers add noise to one-liners like install commands.
 
 ## 0.68.2
 
 ### Patch Changes
 
-- [#1116](https://github.com/ngrok-oss/mantle/pull/1116) [`5b0be5a`](https://github.com/ngrok-oss/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - no-op patch to verify publish CI
+- [#1116](https://github.com/ngrok/mantle/pull/1116) [`5b0be5a`](https://github.com/ngrok/mantle/commit/5b0be5a7ffb8372984477da21cbb85b139d04e3f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - no-op patch to verify publish CI
 
 ## 0.68.1
 
 ### Patch Changes
 
-- [#1114](https://github.com/ngrok-oss/mantle/pull/1114) [`d46e3b3`](https://github.com/ngrok-oss/mantle/commit/d46e3b3fbdcdf561db1d90e89afc8cca8e374be3) Thanks [@forzalupo](https://github.com/forzalupo)! - Improve contrast in code block syntax highlighting
+- [#1114](https://github.com/ngrok/mantle/pull/1114) [`d46e3b3`](https://github.com/ngrok/mantle/commit/d46e3b3fbdcdf561db1d90e89afc8cca8e374be3) Thanks [@forzalupo](https://github.com/forzalupo)! - Improve contrast in code block syntax highlighting
 
-- [#1112](https://github.com/ngrok-oss/mantle/pull/1112) [`ad24f11`](https://github.com/ngrok-oss/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add README documentation for npm packages, switch to ES2025 preset
+- [#1112](https://github.com/ngrok/mantle/pull/1112) [`ad24f11`](https://github.com/ngrok/mantle/commit/ad24f11155af28d4b3141c1fb77416577bc75ed2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add README documentation for npm packages, switch to ES2025 preset
 
 ## 0.68.0
 
 ### Minor Changes
 
-- [#1067](https://github.com/ngrok-oss/mantle/pull/1067) [`ab6da43`](https://github.com/ngrok-oss/mantle/commit/ab6da43e32e3e2e2dadf29aa8d99fcb2738569f4) Thanks [@forzalupo](https://github.com/forzalupo)! - Mantle theme updates: updates the functional colors, and modifies the color treatments across various components. It also adds font smoothing globally, while retaining the "auto" setting for Family, for a perceived higher weight.
+- [#1067](https://github.com/ngrok/mantle/pull/1067) [`ab6da43`](https://github.com/ngrok/mantle/commit/ab6da43e32e3e2e2dadf29aa8d99fcb2738569f4) Thanks [@forzalupo](https://github.com/forzalupo)! - Mantle theme updates: updates the functional colors, and modifies the color treatments across various components. It also adds font smoothing globally, while retaining the "auto" setting for Family, for a perceived higher weight.
 
 ### Patch Changes
 
-- [#1099](https://github.com/ngrok-oss/mantle/pull/1099) [`4a81875`](https://github.com/ngrok-oss/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump dependencies: @ariakit/react to 0.4.24, browserslist to 4.28.2, tailwindcss peer to ^4.2.2
+- [#1099](https://github.com/ngrok/mantle/pull/1099) [`4a81875`](https://github.com/ngrok/mantle/commit/4a81875621f00eb46887b2b83ab5e6021465d7d4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump dependencies: @ariakit/react to 0.4.24, browserslist to 4.28.2, tailwindcss peer to ^4.2.2
 
-- [#1082](https://github.com/ngrok-oss/mantle/pull/1082) [`383d538`](https://github.com/ngrok-oss/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update ariakit and headlessui
+- [#1082](https://github.com/ngrok/mantle/pull/1082) [`383d538`](https://github.com/ngrok/mantle/commit/383d53821a264e59c4532f45e07818f541bfb686) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update ariakit and headlessui
 
-- [#1104](https://github.com/ngrok-oss/mantle/pull/1104) [`2be1db1`](https://github.com/ngrok-oss/mantle/commit/2be1db1ffb23bb5719181f73090ef28d7e19a50f) Thanks [@forzalupo](https://github.com/forzalupo)! - Polish component styles: soften card/popover/dialog hover backgrounds with `color-mix()`, update SplitButton menu item icon placement and gap, use `bg-active-menu-item` in Command palette, reduce table header height, improve Combobox item icon sizing, and flatten DataTable ActionCell layout.
+- [#1104](https://github.com/ngrok/mantle/pull/1104) [`2be1db1`](https://github.com/ngrok/mantle/commit/2be1db1ffb23bb5719181f73090ef28d7e19a50f) Thanks [@forzalupo](https://github.com/forzalupo)! - Polish component styles: soften card/popover/dialog hover backgrounds with `color-mix()`, update SplitButton menu item icon placement and gap, use `bg-active-menu-item` in Command palette, reduce table header height, improve Combobox item icon sizing, and flatten DataTable ActionCell layout.
 
-- [#1106](https://github.com/ngrok-oss/mantle/pull/1106) [`41ce842`](https://github.com/ngrok-oss/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22) Thanks [@forzalupo](https://github.com/forzalupo)! - Themed code block with granular syntax highlighting: richer Shiki token color palette, semantic background tokens (`bg-card`/`bg-base`), redesigned copy button using `IconButton`, and subtler tab trigger styling. Server highlighter adds fine-grained token scope mappings for types, variables, operators, attributes, properties, and escape characters.
+- [#1106](https://github.com/ngrok/mantle/pull/1106) [`41ce842`](https://github.com/ngrok/mantle/commit/41ce842787bcfb6386d94cba4e5e495a298c5a22) Thanks [@forzalupo](https://github.com/forzalupo)! - Themed code block with granular syntax highlighting: richer Shiki token color palette, semantic background tokens (`bg-card`/`bg-base`), redesigned copy button using `IconButton`, and subtler tab trigger styling. Server highlighter adds fine-grained token scope mappings for types, variables, operators, attributes, properties, and escape characters.
 
 ## 0.67.0
 
 ### Minor Changes
 
-- [#1018](https://github.com/ngrok-oss/mantle/pull/1018) [`f27c01f`](https://github.com/ngrok-oss/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: replace PrismJS with Shiki for build-time syntax highlighting, removing Shiki/Prism from the browser bundle
+- [#1018](https://github.com/ngrok/mantle/pull/1018) [`f27c01f`](https://github.com/ngrok/mantle/commit/f27c01fc3291344380f32018d65cd6d21381fcaa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: replace PrismJS with Shiki for build-time syntax highlighting, removing Shiki/Prism from the browser bundle
 
 ### Patch Changes
 
-- [#1089](https://github.com/ngrok-oss/mantle/pull/1089) [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Tabs: use fade mask instead of shadow for horizontal overflow
+- [#1089](https://github.com/ngrok/mantle/pull/1089) [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Tabs: use fade mask instead of shadow for horizontal overflow
 
-- [#1089](https://github.com/ngrok-oss/mantle/pull/1089) [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(tabs): correct border width and focus ring clipping in horizontal classic tabs
+- [#1089](https://github.com/ngrok/mantle/pull/1089) [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(tabs): correct border width and focus ring clipping in horizontal classic tabs
 
-- [#1089](https://github.com/ngrok-oss/mantle/pull/1089) [`36e5921`](https://github.com/ngrok-oss/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(tabs): remove bottom border from horizontal classic tab list
+- [#1089](https://github.com/ngrok/mantle/pull/1089) [`36e5921`](https://github.com/ngrok/mantle/commit/36e59211a9b76f0542d2551bd28d858449d3a131) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(tabs): remove bottom border from horizontal classic tab list
 
-- [#1088](https://github.com/ngrok-oss/mantle/pull/1088) [`54743f1`](https://github.com/ngrok-oss/mantle/commit/54743f1deee01709952fcf5222e0ea205c282e5d) Thanks [@forzalupo](https://github.com/forzalupo)! - MultiSelect: polish styling
+- [#1088](https://github.com/ngrok/mantle/pull/1088) [`54743f1`](https://github.com/ngrok/mantle/commit/54743f1deee01709952fcf5222e0ea205c282e5d) Thanks [@forzalupo](https://github.com/forzalupo)! - MultiSelect: polish styling
 
 ## 0.66.17
 
 ### Patch Changes
 
-- [#1071](https://github.com/ngrok-oss/mantle/pull/1071) [`c32a7d2`](https://github.com/ngrok-oss/mantle/commit/c32a7d23c2d55787042f702377bbdd1ddc923285) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bundle prismjs into the code-block dist output to fix `ReferenceError: Prism is not defined` with Vite 8 / Rollup 4. Previously, prismjs component files (plain IIFEs with no `module.exports`) were left as external imports, and Rollup had no visibility into their implicit dependency on the prismjs main module — causing it to evaluate a component before `window.Prism` was set. Bundling prismjs directly resolves the ordering issue transparently for all consuming apps.
+- [#1071](https://github.com/ngrok/mantle/pull/1071) [`c32a7d2`](https://github.com/ngrok/mantle/commit/c32a7d23c2d55787042f702377bbdd1ddc923285) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bundle prismjs into the code-block dist output to fix `ReferenceError: Prism is not defined` with Vite 8 / Rollup 4. Previously, prismjs component files (plain IIFEs with no `module.exports`) were left as external imports, and Rollup had no visibility into their implicit dependency on the prismjs main module — causing it to evaluate a component before `window.Prism` was set. Bundling prismjs directly resolves the ordering issue transparently for all consuming apps.
 
-- [#1086](https://github.com/ngrok-oss/mantle/pull/1086) [`537de55`](https://github.com/ngrok-oss/mantle/commit/537de55161043570699316e07162c6bf6d93282a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add horizontal overflow scrolling to `Tabs.List` with scroll-position-aware edge shadows. When the tab list overflows its container it scrolls horizontally; fade shadows appear on whichever sides have hidden content and disappear when you reach an edge or when there is no overflow. Keyboard arrow-key navigation smoothly scrolls the focused trigger into view. Scroll bounce is disabled on the list.
+- [#1086](https://github.com/ngrok/mantle/pull/1086) [`537de55`](https://github.com/ngrok/mantle/commit/537de55161043570699316e07162c6bf6d93282a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add horizontal overflow scrolling to `Tabs.List` with scroll-position-aware edge shadows. When the tab list overflows its container it scrolls horizontally; fade shadows appear on whichever sides have hidden content and disappear when you reach an edge or when there is no overflow. Keyboard arrow-key navigation smoothly scrolls the focused trigger into view. Scroll bounce is disabled on the list.
 
 ## 0.66.16
 
 ### Patch Changes
 
-- [#1076](https://github.com/ngrok-oss/mantle/pull/1076) [`582bec9`](https://github.com/ngrok-oss/mantle/commit/582bec9c0cd558fe14ebc5d461b2ddd6debc9c33) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `--spacing-em` (`1em`) theme token for font-relative sizing utilities like `size-em`, `w-em`, `h-em`
+- [#1076](https://github.com/ngrok/mantle/pull/1076) [`582bec9`](https://github.com/ngrok/mantle/commit/582bec9c0cd558fe14ebc5d461b2ddd6debc9c33) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `--spacing-em` (`1em`) theme token for font-relative sizing utilities like `size-em`, `w-em`, `h-em`
 
-- [#1076](https://github.com/ngrok-oss/mantle/pull/1076) [`582bec9`](https://github.com/ngrok-oss/mantle/commit/582bec9c0cd558fe14ebc5d461b2ddd6debc9c33) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add default `width="2.61em" height="1em"` to `NgrokWordmarkIcon` and `width="1em" height="1em"` to `NgrokLettermarkIcon` so they render at font size without requiring explicit sizing classes
+- [#1076](https://github.com/ngrok/mantle/pull/1076) [`582bec9`](https://github.com/ngrok/mantle/commit/582bec9c0cd558fe14ebc5d461b2ddd6debc9c33) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add default `width="2.61em" height="1em"` to `NgrokWordmarkIcon` and `width="1em" height="1em"` to `NgrokLettermarkIcon` so they render at font size without requiring explicit sizing classes
 
 ## 0.66.15
 
 ### Patch Changes
 
-- [#1074](https://github.com/ngrok-oss/mantle/pull/1074) [`284aaa9`](https://github.com/ngrok-oss/mantle/commit/284aaa9e1e3ad894612ea27739a1ae40aa6b06e6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update NgrokLettermarkIcon dimensions
+- [#1074](https://github.com/ngrok/mantle/pull/1074) [`284aaa9`](https://github.com/ngrok/mantle/commit/284aaa9e1e3ad894612ea27739a1ae40aa6b06e6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update NgrokLettermarkIcon dimensions
 
 ## 0.66.14
 
 ### Patch Changes
 
-- [#1072](https://github.com/ngrok-oss/mantle/pull/1072) [`5dcc9be`](https://github.com/ngrok-oss/mantle/commit/5dcc9be89bf4b61216e7229e68b611bb64496082) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename `NgrokIcon` to `NgrokWordmarkIcon` and add new `NgrokLettermarkIcon`
+- [#1072](https://github.com/ngrok/mantle/pull/1072) [`5dcc9be`](https://github.com/ngrok/mantle/commit/5dcc9be89bf4b61216e7229e68b611bb64496082) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename `NgrokIcon` to `NgrokWordmarkIcon` and add new `NgrokLettermarkIcon`
 
 ## 0.66.13
 
 ### Patch Changes
 
-- [#1061](https://github.com/ngrok-oss/mantle/pull/1061) [`1b0e722`](https://github.com/ngrok-oss/mantle/commit/1b0e7227c79396b48d4845b0ed5b534085aa91f7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `@ariakit/react` dependency.
+- [#1061](https://github.com/ngrok/mantle/pull/1061) [`1b0e722`](https://github.com/ngrok/mantle/commit/1b0e7227c79396b48d4845b0ed5b534085aa91f7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump `@ariakit/react` dependency.
 
 ## 0.66.12
 
 ### Patch Changes
 
-- [#1064](https://github.com/ngrok-oss/mantle/pull/1064) [`24ffd25`](https://github.com/ngrok-oss/mantle/commit/24ffd2558567ec81c6576604be4848cdc8ceaa7e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Decompose `Command.Dialog` into a `Root`/`Trigger`/`Content` namespace.
+- [#1064](https://github.com/ngrok/mantle/pull/1064) [`24ffd25`](https://github.com/ngrok/mantle/commit/24ffd2558567ec81c6576604be4848cdc8ceaa7e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Decompose `Command.Dialog` into a `Root`/`Trigger`/`Content` namespace.
 
   **Breaking change**: `Command.Dialog` is now a compound namespace instead of a monolithic component. Migrate existing usage:
 
@@ -568,19 +568,19 @@
 
 ### Patch Changes
 
-- [#1057](https://github.com/ngrok-oss/mantle/pull/1057) [`930e5fb`](https://github.com/ngrok-oss/mantle/commit/930e5fbb5883369ca31a6904d6adc369b7912a23) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Export `fixMediaScriptContent` from `@ngrok/mantle/theme`. This function returns the raw JavaScript string for the inline `<script>` that fixes theme stylesheet `media` attributes — useful for legacy Go services and other non-React servers that need to inline it directly into SSR HTML.
+- [#1057](https://github.com/ngrok/mantle/pull/1057) [`930e5fb`](https://github.com/ngrok/mantle/commit/930e5fbb5883369ca31a6904d6adc369b7912a23) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Export `fixMediaScriptContent` from `@ngrok/mantle/theme`. This function returns the raw JavaScript string for the inline `<script>` that fixes theme stylesheet `media` attributes — useful for legacy Go services and other non-React servers that need to inline it directly into SSR HTML.
 
 ## 0.66.10
 
 ### Patch Changes
 
-- [#1055](https://github.com/ngrok-oss/mantle/pull/1055) [`714c79e`](https://github.com/ngrok-oss/mantle/commit/714c79e0362b3c2a1f4762755b97471041fb2a73) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(use-copy-to-clipboard): remove unnecessary async wrapper, guarantee polyfill DOM cleanup
+- [#1055](https://github.com/ngrok/mantle/pull/1055) [`714c79e`](https://github.com/ngrok/mantle/commit/714c79e0362b3c2a1f4762755b97471041fb2a73) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(use-copy-to-clipboard): remove unnecessary async wrapper, guarantee polyfill DOM cleanup
 
 ## 0.66.9
 
 ### Patch Changes
 
-- [#1048](https://github.com/ngrok-oss/mantle/pull/1048) [`ca1ce98`](https://github.com/ngrok-oss/mantle/commit/ca1ce982cd68cae8e96181031a59673763c259d1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(code-block): restore syntax highlight token styles to mantle.css
+- [#1048](https://github.com/ngrok/mantle/pull/1048) [`ca1ce98`](https://github.com/ngrok/mantle/commit/ca1ce982cd68cae8e96181031a59673763c259d1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix(code-block): restore syntax highlight token styles to mantle.css
 
   The `.token.*` styles were moved out of `mantle.css` into a colocated
   `syntax-highlight.css` imported as a side-effect in `code-block.tsx`.
@@ -593,7 +593,7 @@
 
 ### Patch Changes
 
-- [#1038](https://github.com/ngrok-oss/mantle/pull/1038) [`00fda43`](https://github.com/ngrok-oss/mantle/commit/00fda438dd9818cc3f3a63ab2d4798b96e28ec8f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Breaking:** `MantleStylesheets` is renamed to `MantleStyleSheets` (and `MantleStylesheetsProps` → `MantleStyleSheetsProps`).
+- [#1038](https://github.com/ngrok/mantle/pull/1038) [`00fda43`](https://github.com/ngrok/mantle/commit/00fda438dd9818cc3f3a63ab2d4798b96e28ec8f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Breaking:** `MantleStylesheets` is renamed to `MantleStyleSheets` (and `MantleStylesheetsProps` → `MantleStyleSheetsProps`).
 
   The component no longer imports CSS `?url` paths internally. Instead, pass the browser-accessible CSS URLs as required props using the new `mantleStyleSheetUrls` helper, which collects the three Vite `?url` imports into a spreadable object:
 
@@ -625,13 +625,13 @@
 
 ### Patch Changes
 
-- [#1036](https://github.com/ngrok-oss/mantle/pull/1036) [`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Move syntax highlight token styles into the code-block component
+- [#1036](https://github.com/ngrok/mantle/pull/1036) [`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Move syntax highlight token styles into the code-block component
 
   The `.token.*` CSS rules for syntax highlighting were previously included unconditionally in `mantle.css`, adding to the critical CSS payload for all pages even those with no code blocks.
 
   These styles are now colocated in `packages/mantle/src/components/code-block/syntax-highlight.css` and imported as a side-effect from `code-block.tsx`. Vite bundles them as a CSS chunk associated with the code-block module — apps that never import `@ngrok/mantle/code-block` no longer pay the cost, and apps that do get the styles automatically.
 
-- [#1036](https://github.com/ngrok-oss/mantle/pull/1036) [`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `MantleStylesheets` component and split dark/high-contrast themes into separate CSS files
+- [#1036](https://github.com/ngrok/mantle/pull/1036) [`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `MantleStylesheets` component and split dark/high-contrast themes into separate CSS files
 
   **New: `MantleStylesheets`**
 
@@ -662,7 +662,7 @@
 
   These files contain only CSS custom property blocks and do not need to be added to your app's `@import` chain — `MantleStylesheets` handles loading them via `<link>` tags. `mantle.css` continues to hold the light theme and all Tailwind directives and must remain in your CSS `@import` chain as before.
 
-- [#1036](https://github.com/ngrok-oss/mantle/pull/1036) [`1521814`](https://github.com/ngrok-oss/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `@ngrok/mantle-vite-plugins` package and `source-all.css`, optimize `mantle.css`
+- [#1036](https://github.com/ngrok/mantle/pull/1036) [`1521814`](https://github.com/ngrok/mantle/commit/1521814c50e01d0111bd03696c9698dd718ff5f1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `@ngrok/mantle-vite-plugins` package and `source-all.css`, optimize `mantle.css`
 
   **New: `@ngrok/mantle-vite-plugins`**
 
@@ -689,13 +689,13 @@
 
 ### Patch Changes
 
-- [#1034](https://github.com/ngrok-oss/mantle/pull/1034) [`949ec0f`](https://github.com/ngrok-oss/mantle/commit/949ec0fb0ca512143eb6f355efb88efbf9f1b518) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update `font-display` policy for core fonts: `roobert` and `jetbrains-mono` (normal) use `swap`, italic faces (`jetbrains-mono-italic`, `family-italic`) use `optional`, `family-regular` stays `fallback`.
+- [#1034](https://github.com/ngrok/mantle/pull/1034) [`949ec0f`](https://github.com/ngrok/mantle/commit/949ec0fb0ca512143eb6f355efb88efbf9f1b518) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update `font-display` policy for core fonts: `roobert` and `jetbrains-mono` (normal) use `swap`, italic faces (`jetbrains-mono-italic`, `family-italic`) use `optional`, `family-regular` stays `fallback`.
 
 ## 0.66.5
 
 ### Patch Changes
 
-- [#1032](https://github.com/ngrok-oss/mantle/pull/1032) [`b9a04cc`](https://github.com/ngrok-oss/mantle/commit/b9a04ccbea762504b2dddd450757729dcefe3aa5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Add** `preloadFontLink(name: CoreFontName): string` — returns an HTTP `Link` header value that preloads a single core font. Sending preload hints as response headers lets the browser start fetching fonts before it parses any HTML, improving LCP on mobile.
+- [#1032](https://github.com/ngrok/mantle/pull/1032) [`b9a04cc`](https://github.com/ngrok/mantle/commit/b9a04ccbea762504b2dddd450757729dcefe3aa5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - **Add** `preloadFontLink(name: CoreFontName): string` — returns an HTTP `Link` header value that preloads a single core font. Sending preload hints as response headers lets the browser start fetching fonts before it parses any HTML, improving LCP on mobile.
 
   **Remove** `MantleThemeHeadContent` and `PreloadCoreFonts`.
 
@@ -741,21 +741,21 @@
 
 ### Patch Changes
 
-- [#1030](https://github.com/ngrok-oss/mantle/pull/1030) [`2b740bb`](https://github.com/ngrok-oss/mantle/commit/2b740bbf4e6dc42d6a674e2bd25ee04367ef47bf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - export PreventWrongThemeFlashScript
+- [#1030](https://github.com/ngrok/mantle/pull/1030) [`2b740bb`](https://github.com/ngrok/mantle/commit/2b740bbf4e6dc42d6a674e2bd25ee04367ef47bf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - export PreventWrongThemeFlashScript
 
 ## 0.66.3
 
 ### Patch Changes
 
-- [`0dac608`](https://github.com/ngrok-oss/mantle/commit/0dac6083db43e746213fa4047ac03aaca3e9bce5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Improve code block utility performance by speeding up indentation normalization and `fmtCode`, adding LRU caching for repeated syntax highlighting, and replacing linear language/indentation lookups with set membership checks. Also normalize CRLF input correctly, rename the indentation normalizer to `normalize-indentation`, and guard line-number expansion against excessively large ranges.
+- [`0dac608`](https://github.com/ngrok/mantle/commit/0dac6083db43e746213fa4047ac03aaca3e9bce5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Improve code block utility performance by speeding up indentation normalization and `fmtCode`, adding LRU caching for repeated syntax highlighting, and replacing linear language/indentation lookups with set membership checks. Also normalize CRLF input correctly, rename the indentation normalizer to `normalize-indentation`, and guard line-number expansion against excessively large ranges.
 
-- [#1028](https://github.com/ngrok-oss/mantle/pull/1028) [`11f4575`](https://github.com/ngrok-oss/mantle/commit/11f45750cf33affe31108f0e717e26e3ffbf1705) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add individual PreloadFont component, preload a core font by name
+- [#1028](https://github.com/ngrok/mantle/pull/1028) [`11f4575`](https://github.com/ngrok/mantle/commit/11f45750cf33affe31108f0e717e26e3ffbf1705) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add individual PreloadFont component, preload a core font by name
 
 ## 0.66.2
 
 ### Patch Changes
 
-- [#1023](https://github.com/ngrok-oss/mantle/pull/1023) [`bc1bc6c`](https://github.com/ngrok-oss/mantle/commit/bc1bc6cbb8ebbb34a6a771c4f60b60c2e0271757) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - multi-select.tsx
+- [#1023](https://github.com/ngrok/mantle/pull/1023) [`bc1bc6c`](https://github.com/ngrok/mantle/commit/bc1bc6cbb8ebbb34a6a771c4f60b60c2e0271757) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - multi-select.tsx
   - close the combobox popover on `Escape` at the multi-select trigger level
 
   dialog/primitive.tsx
@@ -778,23 +778,23 @@
 
 ### Patch Changes
 
-- [#1004](https://github.com/ngrok-oss/mantle/pull/1004) [`b04e08f`](https://github.com/ngrok-oss/mantle/commit/b04e08f14262c1dfad91384e9a6ebdeb7be4b5fe) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies: tailwind, ariakit, react-day-picker
+- [#1004](https://github.com/ngrok/mantle/pull/1004) [`b04e08f`](https://github.com/ngrok/mantle/commit/b04e08f14262c1dfad91384e9a6ebdeb7be4b5fe) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies: tailwind, ariakit, react-day-picker
 
-- [#1021](https://github.com/ngrok-oss/mantle/pull/1021) [`aab7d30`](https://github.com/ngrok-oss/mantle/commit/aab7d305ed2d5222b82dfe701377738c0e5f2c10) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Swap from tsup to tsdown (6.2x speedup)
+- [#1021](https://github.com/ngrok/mantle/pull/1021) [`aab7d30`](https://github.com/ngrok/mantle/commit/aab7d305ed2d5222b82dfe701377738c0e5f2c10) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Swap from tsup to tsdown (6.2x speedup)
 
-- [#1022](https://github.com/ngrok-oss/mantle/pull/1022) [`df6d158`](https://github.com/ngrok-oss/mantle/commit/df6d158e4ff64406c5d84a71a3e9d0278ffc3c38) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `MultiSelect.Content` inside modal `Sheet`, `Dialog`, and `AlertDialog` containers so it works with the default modal behavior without requiring `modal={false}`.
+- [#1022](https://github.com/ngrok/mantle/pull/1022) [`df6d158`](https://github.com/ngrok/mantle/commit/df6d158e4ff64406c5d84a71a3e9d0278ffc3c38) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `MultiSelect.Content` inside modal `Sheet`, `Dialog`, and `AlertDialog` containers so it works with the default modal behavior without requiring `modal={false}`.
 
 ## 0.66.0
 
 ### Minor Changes
 
-- [#997](https://github.com/ngrok-oss/mantle/pull/997) [`612171b`](https://github.com/ngrok-oss/mantle/commit/612171b3afb4fb44e5695445d69418bd621a203e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add MultiSelect component
+- [#997](https://github.com/ngrok/mantle/pull/997) [`612171b`](https://github.com/ngrok/mantle/commit/612171b3afb4fb44e5695445d69418bd621a203e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add MultiSelect component
 
 ## 0.65.0
 
 ### Minor Changes
 
-- [#1000](https://github.com/ngrok-oss/mantle/pull/1000) [`56a5245`](https://github.com/ngrok-oss/mantle/commit/56a5245e386fc0dde2688c25d95b52a1d7c1e871) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `@ngrok/mantle/utils` export and new `useInView` hook.
+- [#1000](https://github.com/ngrok/mantle/pull/1000) [`56a5245`](https://github.com/ngrok/mantle/commit/56a5245e386fc0dde2688c25d95b52a1d7c1e871) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `@ngrok/mantle/utils` export and new `useInView` hook.
 
   **Breaking changes:**
   - `@ngrok/mantle/compose-refs` is removed. Import `composeRefs` from `@ngrok/mantle/utils` and `useComposedRefs` from `@ngrok/mantle/hooks` instead.
@@ -810,7 +810,7 @@
 
 ### Patch Changes
 
-- [#1001](https://github.com/ngrok-oss/mantle/pull/1001) [`922a053`](https://github.com/ngrok-oss/mantle/commit/922a053d84fb8ad8f51c42fe1058fb49da7be55d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Address review feedback from PR #1000.
+- [#1001](https://github.com/ngrok/mantle/pull/1001) [`922a053`](https://github.com/ngrok/mantle/commit/922a053d84fb8ad8f51c42fe1058fb49da7be55d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Address review feedback from PR #1000.
   - `inView`: call `observer.unobserve(element)` before `observer.disconnect()` in the cleanup function for cleaner teardown.
   - `useInView`: restore intentional omission of `isInView` from `useEffect` deps (matching the upstream motion implementation); replace the bare eslint-disable comment with an explanation of why including `isInView` would cause the observer to restart on every visibility change.
   - `tsup.config.ts`: exclude `compose-refs` and `sorting` from individual build entries since they are now consolidated into the `./utils` export.
@@ -821,173 +821,173 @@
   - Add `use-in-view.test.tsx` test coverage for the `useInView` hook.
   - Add a Utils section to the docs site with dedicated pages for `cx`, `color`, `inView`, `composeRefs`, and `sorting`.
 
-- [#1002](https://github.com/ngrok-oss/mantle/pull/1002) [`f6e8271`](https://github.com/ngrok-oss/mantle/commit/f6e8271c70f6932d657b552f8cb24bebe6094a2a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add optional `icon` prop to `Alert.DismissIconButton`.
+- [#1002](https://github.com/ngrok/mantle/pull/1002) [`f6e8271`](https://github.com/ngrok/mantle/commit/f6e8271c70f6932d657b552f8cb24bebe6094a2a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add optional `icon` prop to `Alert.DismissIconButton`.
 
   The dismiss button now accepts an `icon` prop (`ReactNode`) to render a custom icon in place of the default `X` icon.
 
-- [#999](https://github.com/ngrok-oss/mantle/pull/999) [`4ebf12b`](https://github.com/ngrok-oss/mantle/commit/4ebf12bdc73f6c88f7968b2378b94b8ff1a3e0eb) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump tsconfig target/lib to ES2023
+- [#999](https://github.com/ngrok/mantle/pull/999) [`4ebf12b`](https://github.com/ngrok/mantle/commit/4ebf12bdc73f6c88f7968b2378b94b8ff1a3e0eb) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump tsconfig target/lib to ES2023
 
-- [#994](https://github.com/ngrok-oss/mantle/pull/994) [`c4d9812`](https://github.com/ngrok-oss/mantle/commit/c4d9812c9c14924418339d52aa06be61191cd224) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump up min version of tailwind
+- [#994](https://github.com/ngrok/mantle/pull/994) [`c4d9812`](https://github.com/ngrok/mantle/commit/c4d9812c9c14924418339d52aa06be61191cd224) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump up min version of tailwind
 
 ## 0.64.3
 
 ### Patch Changes
 
-- [#990](https://github.com/ngrok-oss/mantle/pull/990) [`16c731a`](https://github.com/ngrok-oss/mantle/commit/16c731a10cc1bbfd6299ff0350171ffa48c261e5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - update to tailwind 4.2.0
+- [#990](https://github.com/ngrok/mantle/pull/990) [`16c731a`](https://github.com/ngrok/mantle/commit/16c731a10cc1bbfd6299ff0350171ffa48c261e5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - update to tailwind 4.2.0
 
-- [#988](https://github.com/ngrok-oss/mantle/pull/988) [`7e59d87`](https://github.com/ngrok-oss/mantle/commit/7e59d8722fcf2585105b580e752bf9356e7dea9a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dropdown, select, and combobox menu item styling
+- [#988](https://github.com/ngrok/mantle/pull/988) [`7e59d87`](https://github.com/ngrok/mantle/commit/7e59d8722fcf2585105b580e752bf9356e7dea9a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dropdown, select, and combobox menu item styling
 
 ## 0.64.2
 
 ### Patch Changes
 
-- [#985](https://github.com/ngrok-oss/mantle/pull/985) [`ce626cc`](https://github.com/ngrok-oss/mantle/commit/ce626cc088b7fcf3dc0a36e9c2fa6a2098f5d569) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Slider: Add `color` prop to customize the range fill color (defaults to `"bg-accent-500"`), and `showTicks` prop to render tick marks at each `step` interval. Also adds `--color-card-border` and `--color-card-border-muted` semantic color tokens.
+- [#985](https://github.com/ngrok/mantle/pull/985) [`ce626cc`](https://github.com/ngrok/mantle/commit/ce626cc088b7fcf3dc0a36e9c2fa6a2098f5d569) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Slider: Add `color` prop to customize the range fill color (defaults to `"bg-accent-500"`), and `showTicks` prop to render tick marks at each `step` interval. Also adds `--color-card-border` and `--color-card-border-muted` semantic color tokens.
 
 ## 0.64.1
 
 ### Patch Changes
 
-- [#980](https://github.com/ngrok-oss/mantle/pull/980) [`c2735ed`](https://github.com/ngrok-oss/mantle/commit/c2735ed94e9d7ab8b0e5faec42d19deeb4846cd7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Fix accessibility and linting issues in `Input` and `RadioGroup.InputSandbox`: replace `aria-disabled`/`aria-invalid` CSS hooks on wrapper divs with `data-disabled`, add `role="none"` to presentational wrapper divs
+- [#980](https://github.com/ngrok/mantle/pull/980) [`c2735ed`](https://github.com/ngrok/mantle/commit/c2735ed94e9d7ab8b0e5faec42d19deeb4846cd7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Fix accessibility and linting issues in `Input` and `RadioGroup.InputSandbox`: replace `aria-disabled`/`aria-invalid` CSS hooks on wrapper divs with `data-disabled`, add `role="none"` to presentational wrapper divs
 
-- [#984](https://github.com/ngrok-oss/mantle/pull/984) [`b3a32ec`](https://github.com/ngrok-oss/mantle/commit/b3a32ec036d9913cb2d8260902615d47f44e7968) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Change `font-display` from `swap` to `fallback` in all `@font-face` declarations to eliminate layout shift (font bounce) while still downloading and caching fonts for subsequent loads
+- [#984](https://github.com/ngrok/mantle/pull/984) [`b3a32ec`](https://github.com/ngrok/mantle/commit/b3a32ec036d9913cb2d8260902615d47f44e7968) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Change `font-display` from `swap` to `fallback` in all `@font-face` declarations to eliminate layout shift (font bounce) while still downloading and caching fonts for subsequent loads
 
-- [#981](https://github.com/ngrok-oss/mantle/pull/981) [`e43df1c`](https://github.com/ngrok-oss/mantle/commit/e43df1c81fb5881376756e6918210ec7927cdc82) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump up Slider thumb shadow to shadow-md (from shadow-sm)
+- [#981](https://github.com/ngrok/mantle/pull/981) [`e43df1c`](https://github.com/ngrok/mantle/commit/e43df1c81fb5881376756e6918210ec7927cdc82) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Bump up Slider thumb shadow to shadow-md (from shadow-sm)
 
-- [#980](https://github.com/ngrok-oss/mantle/pull/980) [`c2735ed`](https://github.com/ngrok-oss/mantle/commit/c2735ed94e9d7ab8b0e5faec42d19deeb4846cd7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update tailwind-merge
+- [#980](https://github.com/ngrok/mantle/pull/980) [`c2735ed`](https://github.com/ngrok/mantle/commit/c2735ed94e9d7ab8b0e5faec42d19deeb4846cd7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update tailwind-merge
 
 ## 0.64.0
 
 ### Minor Changes
 
-- [#974](https://github.com/ngrok-oss/mantle/pull/974) [`623935c`](https://github.com/ngrok-oss/mantle/commit/623935c925afad2675aab412ae8ee92e840b7b2f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Remove `AutoScrollToHash` component and `useAutoScrollToHash` hook. This also removes `react-router` as a peer dependency of `@ngrok/mantle`. If you were using `AutoScrollToHash`, move the implementation into your app directly.
+- [#974](https://github.com/ngrok/mantle/pull/974) [`623935c`](https://github.com/ngrok/mantle/commit/623935c925afad2675aab412ae8ee92e840b7b2f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Remove `AutoScrollToHash` component and `useAutoScrollToHash` hook. This also removes `react-router` as a peer dependency of `@ngrok/mantle`. If you were using `AutoScrollToHash`, move the implementation into your app directly.
 
-- [#973](https://github.com/ngrok-oss/mantle/pull/973) [`a8ff1c9`](https://github.com/ngrok-oss/mantle/commit/a8ff1c9857c44abf4bc87c69cc85bb2e54a0a439) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add NgrokIcon to Icons
+- [#973](https://github.com/ngrok/mantle/pull/973) [`a8ff1c9`](https://github.com/ngrok/mantle/commit/a8ff1c9857c44abf4bc87c69cc85bb2e54a0a439) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add NgrokIcon to Icons
 
-- [#979](https://github.com/ngrok-oss/mantle/pull/979) [`68cc794`](https://github.com/ngrok-oss/mantle/commit/68cc7946d887bbca790c36ca9580c454be99cadc) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add new Slider component, supports single, range, and multiple use cases
+- [#979](https://github.com/ngrok/mantle/pull/979) [`68cc794`](https://github.com/ngrok/mantle/commit/68cc7946d887bbca790c36ca9580c454be99cadc) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add new Slider component, supports single, range, and multiple use cases
 
 ### Patch Changes
 
-- [#971](https://github.com/ngrok-oss/mantle/pull/971) [`5781aae`](https://github.com/ngrok-oss/mantle/commit/5781aae83604925bfb03cdbea1d3d85b8e9e47a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix doc block links
+- [#971](https://github.com/ngrok/mantle/pull/971) [`5781aae`](https://github.com/ngrok/mantle/commit/5781aae83604925bfb03cdbea1d3d85b8e9e47a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix doc block links
 
-- [#978](https://github.com/ngrok-oss/mantle/pull/978) [`286fab3`](https://github.com/ngrok-oss/mantle/commit/286fab3721c6aabe27fddaf91e4a8dfb7ba8c5ea) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix jerky accordion close animation. Moved spacing from `padding-top` on the animated container to `margin-top` on the first child so it collapses smoothly with the height animation.
+- [#978](https://github.com/ngrok/mantle/pull/978) [`286fab3`](https://github.com/ngrok/mantle/commit/286fab3721c6aabe27fddaf91e4a8dfb7ba8c5ea) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix jerky accordion close animation. Moved spacing from `padding-top` on the animated container to `margin-top` on the first child so it collapses smoothly with the height animation.
 
-- [#974](https://github.com/ngrok-oss/mantle/pull/974) [`623935c`](https://github.com/ngrok-oss/mantle/commit/623935c925afad2675aab412ae8ee92e840b7b2f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add explicit generic type parameters to `isValidElement` calls in `Button` and `Slot` for React 19 type compatibility. React 19 changed `ReactElement.props` from `any` to `unknown`, requiring explicit type annotations to access props safely. This change is fully backwards compatible with React 18.
+- [#974](https://github.com/ngrok/mantle/pull/974) [`623935c`](https://github.com/ngrok/mantle/commit/623935c925afad2675aab412ae8ee92e840b7b2f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add explicit generic type parameters to `isValidElement` calls in `Button` and `Slot` for React 19 type compatibility. React 19 changed `ReactElement.props` from `any` to `unknown`, requiring explicit type annotations to access props safely. This change is fully backwards compatible with React 18.
 
-- [#978](https://github.com/ngrok-oss/mantle/pull/978) [`286fab3`](https://github.com/ngrok-oss/mantle/commit/286fab3721c6aabe27fddaf91e4a8dfb7ba8c5ea) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `CodeBlock.CopyButton` timeout lifecycle handling by clearing pending timers on unmount and before scheduling a new copy-state reset.
+- [#978](https://github.com/ngrok/mantle/pull/978) [`286fab3`](https://github.com/ngrok/mantle/commit/286fab3721c6aabe27fddaf91e4a8dfb7ba8c5ea) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `CodeBlock.CopyButton` timeout lifecycle handling by clearing pending timers on unmount and before scheduling a new copy-state reset.
 
-- [#975](https://github.com/ngrok-oss/mantle/pull/975) [`d9a7206`](https://github.com/ngrok-oss/mantle/commit/d9a72068b93aac1524334395fbe0fdc761c6e8cd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix theme flash on hydration by reading the theme cookie during SSR. `useInitialHtmlThemeProps` now accepts an optional `ssrCookie` string so the server can render the correct theme class, eliminating the mismatch between server HTML and the inline script.
+- [#975](https://github.com/ngrok/mantle/pull/975) [`d9a7206`](https://github.com/ngrok/mantle/commit/d9a72068b93aac1524334395fbe0fdc761c6e8cd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix theme flash on hydration by reading the theme cookie during SSR. `useInitialHtmlThemeProps` now accepts an optional `ssrCookie` string so the server can render the correct theme class, eliminating the mismatch between server HTML and the inline script.
 
 ## 0.63.2
 
 ### Patch Changes
 
-- [#969](https://github.com/ngrok-oss/mantle/pull/969) [`76e1afd`](https://github.com/ngrok-oss/mantle/commit/76e1afd09e6011650e6b4f3ed14ea348143e1591) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `useIsBelowBreakpoint` performance regression during window resize. The `subscribe` and `getSnapshot` functions passed to `useSyncExternalStore` were recreated on every render, causing listener teardown/re-attach churn on each frame. They are now cached per breakpoint for referential stability.
+- [#969](https://github.com/ngrok/mantle/pull/969) [`76e1afd`](https://github.com/ngrok/mantle/commit/76e1afd09e6011650e6b4f3ed14ea348143e1591) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix `useIsBelowBreakpoint` performance regression during window resize. The `subscribe` and `getSnapshot` functions passed to `useSyncExternalStore` were recreated on every render, causing listener teardown/re-attach churn on each frame. They are now cached per breakpoint for referential stability.
 
-- [#969](https://github.com/ngrok-oss/mantle/pull/969) [`76e1afd`](https://github.com/ngrok-oss/mantle/commit/76e1afd09e6011650e6b4f3ed14ea348143e1591) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Restore all `@custom-variant` definitions in `mantle.css` that were accidentally removed. This includes theme variants (`light`, `dark`, `high-contrast`, `dark-high-contrast`), aria/data attribute variants, hover media query variants (`hover-hover`, `hover-none`), and the `where` variant.
+- [#969](https://github.com/ngrok/mantle/pull/969) [`76e1afd`](https://github.com/ngrok/mantle/commit/76e1afd09e6011650e6b4f3ed14ea348143e1591) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Restore all `@custom-variant` definitions in `mantle.css` that were accidentally removed. This includes theme variants (`light`, `dark`, `high-contrast`, `dark-high-contrast`), aria/data attribute variants, hover media query variants (`hover-hover`, `hover-none`), and the `where` variant.
 
 ## 0.63.1
 
 ### Patch Changes
 
-- [#966](https://github.com/ngrok-oss/mantle/pull/966) [`d26aee3`](https://github.com/ngrok-oss/mantle/commit/d26aee3e3ba025847aef6473a96942a86a8c4875) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix mantle.css exports
+- [#966](https://github.com/ngrok/mantle/pull/966) [`d26aee3`](https://github.com/ngrok/mantle/commit/d26aee3e3ba025847aef6473a96942a86a8c4875) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix mantle.css exports
 
 ## 0.63.0
 
 ### Minor Changes
 
-- [#963](https://github.com/ngrok-oss/mantle/pull/963) [`1a68417`](https://github.com/ngrok-oss/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add "info" as a first-class semantic color (mirrors "accent")
+- [#963](https://github.com/ngrok/mantle/pull/963) [`1a68417`](https://github.com/ngrok/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add "info" as a first-class semantic color (mirrors "accent")
 
-- [#965](https://github.com/ngrok-oss/mantle/pull/965) [`fd7e2eb`](https://github.com/ngrok-oss/mantle/commit/fd7e2eb5119a69f1b505c07f7889ea57686c7258) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add new SplitButton component
+- [#965](https://github.com/ngrok/mantle/pull/965) [`fd7e2eb`](https://github.com/ngrok/mantle/commit/fd7e2eb5119a69f1b505c07f7889ea57686c7258) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add new SplitButton component
 
 ### Patch Changes
 
-- [#963](https://github.com/ngrok-oss/mantle/pull/963) [`1a68417`](https://github.com/ngrok-oss/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix Anchor component target types to delegate to React's built-in types
+- [#963](https://github.com/ngrok/mantle/pull/963) [`1a68417`](https://github.com/ngrok/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix Anchor component target types to delegate to React's built-in types
 
-- [#963](https://github.com/ngrok-oss/mantle/pull/963) [`1a68417`](https://github.com/ngrok-oss/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix mantle.css theme syntax
+- [#963](https://github.com/ngrok/mantle/pull/963) [`1a68417`](https://github.com/ngrok/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix mantle.css theme syntax
 
-- [#963](https://github.com/ngrok-oss/mantle/pull/963) [`1a68417`](https://github.com/ngrok-oss/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Apply font-sans to components for consistent typography
+- [#963](https://github.com/ngrok/mantle/pull/963) [`1a68417`](https://github.com/ngrok/mantle/commit/1a684177f8c07e321620910a9edbb771091d7d52) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Apply font-sans to components for consistent typography
 
-- [#962](https://github.com/ngrok-oss/mantle/pull/962) [`030099b`](https://github.com/ngrok-oss/mantle/commit/030099b6645039f0aadde90324ee19feeeef94c5) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update react-day-picker
+- [#962](https://github.com/ngrok/mantle/pull/962) [`030099b`](https://github.com/ngrok/mantle/commit/030099b6645039f0aadde90324ee19feeeef94c5) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update react-day-picker
 
 ## 0.62.2
 
 ### Patch Changes
 
-- [#957](https://github.com/ngrok-oss/mantle/pull/957) [`141490d`](https://github.com/ngrok-oss/mantle/commit/141490dec9ef4b6b5776986a14cac190b65adc77) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix return type of $cssProperties
+- [#957](https://github.com/ngrok/mantle/pull/957) [`141490d`](https://github.com/ngrok/mantle/commit/141490dec9ef4b6b5776986a14cac190b65adc77) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix return type of $cssProperties
 
 ## 0.62.1
 
 ### Patch Changes
 
-- [#955](https://github.com/ngrok-oss/mantle/pull/955) [`bf79ae2`](https://github.com/ngrok-oss/mantle/commit/bf79ae237df0f9350daf8e998e3b4252f398a2b7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DescriptionList styling fixes
+- [#955](https://github.com/ngrok/mantle/pull/955) [`bf79ae2`](https://github.com/ngrok/mantle/commit/bf79ae237df0f9350daf8e998e3b4252f398a2b7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DescriptionList styling fixes
 
 ## 0.62.0
 
 ### Minor Changes
 
-- [#954](https://github.com/ngrok-oss/mantle/pull/954) [`7235e48`](https://github.com/ngrok-oss/mantle/commit/7235e4823cb9232ef0ed2853bf1b8ad9af48d368) Thanks [@randseay](https://github.com/randseay)! - Add DescriptionList component.
+- [#954](https://github.com/ngrok/mantle/pull/954) [`7235e48`](https://github.com/ngrok/mantle/commit/7235e4823cb9232ef0ed2853bf1b8ad9af48d368) Thanks [@randseay](https://github.com/randseay)! - Add DescriptionList component.
 
   This component is a semantic wrapper for `<dl>`, `<dt>`, and `<dd>` elements. It allows for a more accessible and semantic way to display label/value pairs.
 
 ### Patch Changes
 
-- [#946](https://github.com/ngrok-oss/mantle/pull/946) [`e095088`](https://github.com/ngrok-oss/mantle/commit/e095088e084fa07b138715d74ea04ff7f554f969) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add CssProperties, $cssProperties type and helper for supporting typechecking of react CSSProperties AND custom css properties (--foo-bar)
+- [#946](https://github.com/ngrok/mantle/pull/946) [`e095088`](https://github.com/ngrok/mantle/commit/e095088e084fa07b138715d74ea04ff7f554f969) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add CssProperties, $cssProperties type and helper for supporting typechecking of react CSSProperties AND custom css properties (--foo-bar)
 
 ## 0.61.3
 
 ### Patch Changes
 
-- [#939](https://github.com/ngrok-oss/mantle/pull/939) [`d2922d2`](https://github.com/ngrok-oss/mantle/commit/d2922d2b0199aa1361e11e483fed129c3fcd2d15) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable.HeaderSortButton: remove scaling when active
+- [#939](https://github.com/ngrok/mantle/pull/939) [`d2922d2`](https://github.com/ngrok/mantle/commit/d2922d2b0199aa1361e11e483fed129c3fcd2d15) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable.HeaderSortButton: remove scaling when active
 
 ## 0.61.2
 
 ### Patch Changes
 
-- [#935](https://github.com/ngrok-oss/mantle/pull/935) [`b03ef99`](https://github.com/ngrok-oss/mantle/commit/b03ef99e5a61b81b2b544cce970cfd1b38fed087) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Add 2xs breakpoint (360px)
+- [#935](https://github.com/ngrok/mantle/pull/935) [`b03ef99`](https://github.com/ngrok/mantle/commit/b03ef99e5a61b81b2b544cce970cfd1b38fed087) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Add 2xs breakpoint (360px)
 
 ## 0.60.2
 
 ### Patch Changes
 
-- [#912](https://github.com/ngrok-oss/mantle/pull/912) [`d6c1f46`](https://github.com/ngrok-oss/mantle/commit/d6c1f46e8d10c9783134ef49e1e159ad67a67cb3) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Create fluid typography. Kill references to Inter.
+- [#912](https://github.com/ngrok/mantle/pull/912) [`d6c1f46`](https://github.com/ngrok/mantle/commit/d6c1f46e8d10c9783134ef49e1e159ad67a67cb3) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Create fluid typography. Kill references to Inter.
 
-- [#902](https://github.com/ngrok-oss/mantle/pull/902) [`da31911`](https://github.com/ngrok-oss/mantle/commit/da31911f4c78f86181f43a34b682e49ad84dc5e8) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update runtime dependencies: @ariakit/react, react-day-picker
+- [#902](https://github.com/ngrok/mantle/pull/902) [`da31911`](https://github.com/ngrok/mantle/commit/da31911f4c78f86181f43a34b682e49ad84dc5e8) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update runtime dependencies: @ariakit/react, react-day-picker
 
-- [#914](https://github.com/ngrok-oss/mantle/pull/914) [`e704a7d`](https://github.com/ngrok-oss/mantle/commit/e704a7d314f2341ccea49e6d50bd5f7aa0ae6e82) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies: react-day-picker and @ariakit/react
+- [#914](https://github.com/ngrok/mantle/pull/914) [`e704a7d`](https://github.com/ngrok/mantle/commit/e704a7d314f2341ccea49e6d50bd5f7aa0ae6e82) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies: react-day-picker and @ariakit/react
 
-- [#914](https://github.com/ngrok-oss/mantle/pull/914) [`e704a7d`](https://github.com/ngrok-oss/mantle/commit/e704a7d314f2341ccea49e6d50bd5f7aa0ae6e82) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Toast: support keeping toasts open until manually dismissed by passing `duration_ms <= 0` or `Number.POSITIVE_INFINITY`
+- [#914](https://github.com/ngrok/mantle/pull/914) [`e704a7d`](https://github.com/ngrok/mantle/commit/e704a7d314f2341ccea49e6d50bd5f7aa0ae6e82) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Toast: support keeping toasts open until manually dismissed by passing `duration_ms <= 0` or `Number.POSITIVE_INFINITY`
 
-- [#902](https://github.com/ngrok-oss/mantle/pull/902) [`da31911`](https://github.com/ngrok-oss/mantle/commit/da31911f4c78f86181f43a34b682e49ad84dc5e8) Thanks [@dependabot](https://github.com/apps/dependabot)! - Switch to node-24 as LTS
+- [#902](https://github.com/ngrok/mantle/pull/902) [`da31911`](https://github.com/ngrok/mantle/commit/da31911f4c78f86181f43a34b682e49ad84dc5e8) Thanks [@dependabot](https://github.com/apps/dependabot)! - Switch to node-24 as LTS
 
 ## 0.60.1
 
 ### Patch Changes
 
-- [#900](https://github.com/ngrok-oss/mantle/pull/900) [`5174f39`](https://github.com/ngrok-oss/mantle/commit/5174f3906faf163e575b9cb62f3970c4d426f0df) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button, IconButton: scale w/ transition ease-out
+- [#900](https://github.com/ngrok/mantle/pull/900) [`5174f39`](https://github.com/ngrok/mantle/commit/5174f3906faf163e575b9cb62f3970c4d426f0df) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button, IconButton: scale w/ transition ease-out
 
 ## 0.60.0
 
 ### Minor Changes
 
-- [#896](https://github.com/ngrok-oss/mantle/pull/896) [`b58edd7`](https://github.com/ngrok-oss/mantle/commit/b58edd7c1c97c06ce113a90717c947d6822342c3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add Slot component with automatic className merging
+- [#896](https://github.com/ngrok/mantle/pull/896) [`b58edd7`](https://github.com/ngrok/mantle/commit/b58edd7c1c97c06ce113a90717c947d6822342c3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add Slot component with automatic className merging
 
   Introduces a new `@ngrok/mantle/slot` component that wraps Radix UI's Slot with automatic Tailwind CSS className merging using `cx`. All internal components now use the Mantle Slot instead of importing directly from Radix UI, providing consistent className merge behavior across the design system where child classes take priority over parent classes.
 
 ### Patch Changes
 
-- [#893](https://github.com/ngrok-oss/mantle/pull/893) [`0507080`](https://github.com/ngrok-oss/mantle/commit/05070800b4cf647c9abcf2565902d5b1a1deb976) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button, IconButton: add data-appearance, data-priority to DOM
+- [#893](https://github.com/ngrok/mantle/pull/893) [`0507080`](https://github.com/ngrok/mantle/commit/05070800b4cf647c9abcf2565902d5b1a1deb976) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button, IconButton: add data-appearance, data-priority to DOM
 
 ## 0.59.1
 
 ### Patch Changes
 
-- [#887](https://github.com/ngrok-oss/mantle/pull/887) [`eeca62d`](https://github.com/ngrok-oss/mantle/commit/eeca62d79949a0932c1906bcabf079dbd5a3089c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix tooltip jsdoc urls
+- [#887](https://github.com/ngrok/mantle/pull/887) [`eeca62d`](https://github.com/ngrok/mantle/commit/eeca62d79949a0932c1906bcabf079dbd5a3089c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix tooltip jsdoc urls
 
 ## 0.59.0
 
 ### Minor Changes
 
-- [#885](https://github.com/ngrok-oss/mantle/pull/885) [`918bdd9`](https://github.com/ngrok-oss/mantle/commit/918bdd9078d1edffc7d670326f0600623a4406cc) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Promote Tooltip component out of preview
+- [#885](https://github.com/ngrok/mantle/pull/885) [`918bdd9`](https://github.com/ngrok/mantle/commit/918bdd9078d1edffc7d670326f0600623a4406cc) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Promote Tooltip component out of preview
 
   The Tooltip component has been promoted from preview to stable. This includes:
   - Updated documentation route from `/components/preview/tooltip` to `/components/tooltip`
@@ -1000,9 +1000,9 @@
 
 ### Patch Changes
 
-- [#878](https://github.com/ngrok-oss/mantle/pull/878) [`9ecfcd4`](https://github.com/ngrok-oss/mantle/commit/9ecfcd47242496ad382451183a241cd76fd843b5) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies; bump min version of tailwind
+- [#878](https://github.com/ngrok/mantle/pull/878) [`9ecfcd4`](https://github.com/ngrok/mantle/commit/9ecfcd47242496ad382451183a241cd76fd843b5) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies; bump min version of tailwind
 
-- [#883](https://github.com/ngrok-oss/mantle/pull/883) [`e3d39ef`](https://github.com/ngrok-oss/mantle/commit/e3d39ef80e1ead067b2a27f3e960d45a432be732) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - move mantle.css to src/ and improve HMR
+- [#883](https://github.com/ngrok/mantle/pull/883) [`e3d39ef`](https://github.com/ngrok/mantle/commit/e3d39ef80e1ead067b2a27f3e960d45a432be732) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - move mantle.css to src/ and improve HMR
   - Moved `mantle.css` from `packages/mantle/assets/` to `packages/mantle/src/` to enable proper hot module reload during development
   - Updated `mantle.css` package export to use source conditions (`@ngrok/mantle/source` → `src/mantle.css`, `default` → `dist/mantle.css`), matching the pattern used for component exports
   - Added build step to copy `mantle.css` to `dist/` directory for production builds
@@ -1011,37 +1011,37 @@
 
 ### Patch Changes
 
-- [#879](https://github.com/ngrok-oss/mantle/pull/879) [`8a66858`](https://github.com/ngrok-oss/mantle/commit/8a6685805fa2dc540a5e03a550ebf66e13cae644) Thanks [@acrobat130](https://github.com/acrobat130)! - enable an appearance prop on the tabs root component that allows the user to specify pill-style tabs
+- [#879](https://github.com/ngrok/mantle/pull/879) [`8a66858`](https://github.com/ngrok/mantle/commit/8a6685805fa2dc540a5e03a550ebf66e13cae644) Thanks [@acrobat130](https://github.com/acrobat130)! - enable an appearance prop on the tabs root component that allows the user to specify pill-style tabs
 
 ## 0.58.2
 
 ### Patch Changes
 
-- [#873](https://github.com/ngrok-oss/mantle/pull/873) [`f8170b9`](https://github.com/ngrok-oss/mantle/commit/f8170b9f2a73cde6aa5dfc44b10f64f3c2eb8180) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies; add static white, static black, and ff00ff as colors
+- [#873](https://github.com/ngrok/mantle/pull/873) [`f8170b9`](https://github.com/ngrok/mantle/commit/f8170b9f2a73cde6aa5dfc44b10f64f3c2eb8180) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies; add static white, static black, and ff00ff as colors
 
 ## 0.58.1
 
 ### Patch Changes
 
-- [#871](https://github.com/ngrok-oss/mantle/pull/871) [`61b3eee`](https://github.com/ngrok-oss/mantle/commit/61b3eee335b17bcb12a5df170f070b60d82a1c42) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update Kbd bg color
+- [#871](https://github.com/ngrok/mantle/pull/871) [`61b3eee`](https://github.com/ngrok/mantle/commit/61b3eee335b17bcb12a5df170f070b60d82a1c42) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update Kbd bg color
 
 ## 0.58.0
 
 ### Minor Changes
 
-- [#869](https://github.com/ngrok-oss/mantle/pull/869) [`e38e79a`](https://github.com/ngrok-oss/mantle/commit/e38e79a664f26a1793c74f2d4056c2194bb72507) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add Kbd component and documentation page for keyboard shortcuts
+- [#869](https://github.com/ngrok/mantle/pull/869) [`e38e79a`](https://github.com/ngrok/mantle/commit/e38e79a664f26a1793c74f2d4056c2194bb72507) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add Kbd component and documentation page for keyboard shortcuts
 
 ## 0.57.5
 
 ### Patch Changes
 
-- [#864](https://github.com/ngrok-oss/mantle/pull/864) [`aa7f600`](https://github.com/ngrok-oss/mantle/commit/aa7f600d4abcc7d063da1911e2f2e0acc2d82bb3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `filter` and `shouldFilter` props to `Command.Dialog` for custom filtering behavior
+- [#864](https://github.com/ngrok/mantle/pull/864) [`aa7f600`](https://github.com/ngrok/mantle/commit/aa7f600d4abcc7d063da1911e2f2e0acc2d82bb3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add `filter` and `shouldFilter` props to `Command.Dialog` for custom filtering behavior
 
 ## 0.57.4
 
 ### Patch Changes
 
-- [#858](https://github.com/ngrok-oss/mantle/pull/858) [`df04845`](https://github.com/ngrok-oss/mantle/commit/df048454e61c20712309ac375547b1154e350a3d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix: restore text-size-inherit utility
+- [#858](https://github.com/ngrok/mantle/pull/858) [`df04845`](https://github.com/ngrok/mantle/commit/df048454e61c20712309ac375547b1154e350a3d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix: restore text-size-inherit utility
 
   Re-added `text-size-inherit` font-size utility that was accidentally removed in v0.57.3. This utility allows components to inherit font-size from their parent element.
 
@@ -1056,7 +1056,7 @@
 
 ### Patch Changes
 
-- [#856](https://github.com/ngrok-oss/mantle/pull/856) [`20c2da9`](https://github.com/ngrok-oss/mantle/commit/20c2da97779a267ad4232f83167f357a07fe5a0f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix: enable text-mono font-size overrides with cx helper
+- [#856](https://github.com/ngrok/mantle/pull/856) [`20c2da9`](https://github.com/ngrok/mantle/commit/20c2da97779a267ad4232f83167f357a07fe5a0f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix: enable text-mono font-size overrides with cx helper
 
   Extended the `cx` helper's tailwind-merge configuration to recognize `text-mono` as a font-size class. This allows users to properly override the monospace font size in Table.Cell and CodeBlock components using standard Tailwind font-size utilities like `text-base`, `text-xl`, etc.
 
@@ -1085,7 +1085,7 @@
 
 ### Patch Changes
 
-- [#854](https://github.com/ngrok-oss/mantle/pull/854) [`8819cb0`](https://github.com/ngrok-oss/mantle/commit/8819cb05a05a7db9415db439f0100104391bb41b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix: convert text-size-mono to text-mono for proper tailwind-merge support
+- [#854](https://github.com/ngrok/mantle/pull/854) [`8819cb0`](https://github.com/ngrok/mantle/commit/8819cb05a05a7db9415db439f0100104391bb41b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - fix: convert text-size-mono to text-mono for proper tailwind-merge support
 
   Changed the custom `@utility text-size-mono` to a proper Tailwind theme fontSize extension `--font-size-mono`, which generates the `text-mono` utility class. This allows `text-mono` to be properly overridden by other font-size utilities like `text-base` or `text-xl` when using the `cx` helper.
 
@@ -1107,7 +1107,7 @@
 
 ### Patch Changes
 
-- [#852](https://github.com/ngrok-oss/mantle/pull/852) [`d5cbefb`](https://github.com/ngrok-oss/mantle/commit/d5cbefbbb04d507380c90f1e1a5d6642a6a3790c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Command: export MetaKey component for platform-aware keyboard shortcuts
+- [#852](https://github.com/ngrok/mantle/pull/852) [`d5cbefb`](https://github.com/ngrok/mantle/commit/d5cbefbbb04d507380c90f1e1a5d6642a6a3790c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Command: export MetaKey component for platform-aware keyboard shortcuts
 
   Extract MetaKey as a reusable SSR-safe component that displays the appropriate modifier key (⌘ for macOS/iOS, Ctrl for others) in keyboard shortcut hints.
 
@@ -1115,697 +1115,697 @@
 
 ### Minor Changes
 
-- [#849](https://github.com/ngrok-oss/mantle/pull/849) [`a83221a`](https://github.com/ngrok-oss/mantle/commit/a83221adbe84a309c77b19378ad5ed973584dee7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Remove EuclidSquare bold/semibold; export new theme font helper components
+- [#849](https://github.com/ngrok/mantle/pull/849) [`a83221a`](https://github.com/ngrok/mantle/commit/a83221adbe84a309c77b19378ad5ed973584dee7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Remove EuclidSquare bold/semibold; export new theme font helper components
 
 ## 0.56.0
 
 ### Minor Changes
 
-- [#839](https://github.com/ngrok-oss/mantle/pull/839) [`7dc6877`](https://github.com/ngrok-oss/mantle/commit/7dc68778486e90dd92867c7ecd15450610bd6b8a) Thanks [@randseay](https://github.com/randseay)! - Implement Command component
+- [#839](https://github.com/ngrok/mantle/pull/839) [`7dc6877`](https://github.com/ngrok/mantle/commit/7dc68778486e90dd92867c7ecd15450610bd6b8a) Thanks [@randseay](https://github.com/randseay)! - Implement Command component
 
 ## 0.55.5
 
 ### Patch Changes
 
-- [#842](https://github.com/ngrok-oss/mantle/pull/842) [`0bdcaba`](https://github.com/ngrok-oss/mantle/commit/0bdcaba1b72080d4b90545ca3d3d559b6aed9b22) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - IconButton: add in sr-only label as inner children when using asChild
+- [#842](https://github.com/ngrok/mantle/pull/842) [`0bdcaba`](https://github.com/ngrok/mantle/commit/0bdcaba1b72080d4b90545ca3d3d559b6aed9b22) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - IconButton: add in sr-only label as inner children when using asChild
 
 ## 0.55.4
 
 ### Patch Changes
 
-- [#840](https://github.com/ngrok-oss/mantle/pull/840) [`6d60f2e`](https://github.com/ngrok-oss/mantle/commit/6d60f2ec304241a3a5d98f78c0349eabae78826b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: set overscroll-x-none on Table.Root
+- [#840](https://github.com/ngrok/mantle/pull/840) [`6d60f2e`](https://github.com/ngrok/mantle/commit/6d60f2ec304241a3a5d98f78c0349eabae78826b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: set overscroll-x-none on Table.Root
 
 ## 0.55.3
 
 ### Patch Changes
 
-- [#834](https://github.com/ngrok-oss/mantle/pull/834) [`235593b`](https://github.com/ngrok-oss/mantle/commit/235593be593f2d510ce1917792118c8fa0861ff9) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update ariakit and react-day-picker
+- [#834](https://github.com/ngrok/mantle/pull/834) [`235593b`](https://github.com/ngrok/mantle/commit/235593be593f2d510ce1917792118c8fa0861ff9) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update ariakit and react-day-picker
 
-- [#837](https://github.com/ngrok-oss/mantle/pull/837) [`ba79d27`](https://github.com/ngrok-oss/mantle/commit/ba79d27dd3d04039c81d86cf41abe23d192e13d3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Theme: improve cookie parsing and reduce risk of FOUC, hydration issues
+- [#837](https://github.com/ngrok/mantle/pull/837) [`ba79d27`](https://github.com/ngrok/mantle/commit/ba79d27dd3d04039c81d86cf41abe23d192e13d3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Theme: improve cookie parsing and reduce risk of FOUC, hydration issues
 
 ## 0.55.2
 
 ### Patch Changes
 
-- [#828](https://github.com/ngrok-oss/mantle/pull/828) [`5cdda38`](https://github.com/ngrok-oss/mantle/commit/5cdda38c1278e0fa24f84816ecfc5065db2b6591) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AutoScrollToHash + useAutoScrollToHash: switch to context provider, allow for programmatic scrollToHash()
+- [#828](https://github.com/ngrok/mantle/pull/828) [`5cdda38`](https://github.com/ngrok/mantle/commit/5cdda38c1278e0fa24f84816ecfc5065db2b6591) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AutoScrollToHash + useAutoScrollToHash: switch to context provider, allow for programmatic scrollToHash()
 
 ## 0.55.1
 
 ### Patch Changes
 
-- [#826](https://github.com/ngrok-oss/mantle/pull/826) [`48ce32d`](https://github.com/ngrok-oss/mantle/commit/48ce32d29cb6102620c3658fc5f435608e202248) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add react-router to peer dependencies of mantle, document AutoScrollToHash peerDep on react-router
+- [#826](https://github.com/ngrok/mantle/pull/826) [`48ce32d`](https://github.com/ngrok/mantle/commit/48ce32d29cb6102620c3658fc5f435608e202248) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add react-router to peer dependencies of mantle, document AutoScrollToHash peerDep on react-router
 
 ## 0.55.0
 
 ### Minor Changes
 
-- [#825](https://github.com/ngrok-oss/mantle/pull/825) [`d9dfa70`](https://github.com/ngrok-oss/mantle/commit/d9dfa703c8f3029a00f8fbd8b4f066fdfc0d3f92) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Export AutoScrollToHash, useAutoScrollToHash, and useScrollBehavior
+- [#825](https://github.com/ngrok/mantle/pull/825) [`d9dfa70`](https://github.com/ngrok/mantle/commit/d9dfa703c8f3029a00f8fbd8b4f066fdfc0d3f92) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Export AutoScrollToHash, useAutoScrollToHash, and useScrollBehavior
 
 ### Patch Changes
 
-- [#823](https://github.com/ngrok-oss/mantle/pull/823) [`05ca536`](https://github.com/ngrok-oss/mantle/commit/05ca536b24ca024d44c31bb53d6d6388a02887a4) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#823](https://github.com/ngrok/mantle/pull/823) [`05ca536`](https://github.com/ngrok/mantle/commit/05ca536b24ca024d44c31bb53d6d6388a02887a4) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
 ## 0.54.3
 
 ### Patch Changes
 
-- [#813](https://github.com/ngrok-oss/mantle/pull/813) [`30580b7`](https://github.com/ngrok-oss/mantle/commit/30580b7c30b07421d2226143a3b0f5e2b46568c5) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump tw-animate-css
+- [#813](https://github.com/ngrok/mantle/pull/813) [`30580b7`](https://github.com/ngrok/mantle/commit/30580b7c30b07421d2226143a3b0f5e2b46568c5) Thanks [@dependabot](https://github.com/apps/dependabot)! - Bump tw-animate-css
 
-- [#815](https://github.com/ngrok-oss/mantle/pull/815) [`dd1eb1f`](https://github.com/ngrok-oss/mantle/commit/dd1eb1f5efeff8e044c808ea0f57267abc47ee55) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add visibilitychange handler for ThemeProvider
+- [#815](https://github.com/ngrok/mantle/pull/815) [`dd1eb1f`](https://github.com/ngrok/mantle/commit/dd1eb1f5efeff8e044c808ea0f57267abc47ee55) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add visibilitychange handler for ThemeProvider
 
 ## 0.54.2
 
 ### Patch Changes
 
-- [#810](https://github.com/ngrok-oss/mantle/pull/810) [`8005c93`](https://github.com/ngrok-oss/mantle/commit/8005c937d5780c45c2a3573023df5967851e08d2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Theme: fix cross-tab theme sync when the cookie changes
+- [#810](https://github.com/ngrok/mantle/pull/810) [`8005c93`](https://github.com/ngrok/mantle/commit/8005c937d5780c45c2a3573023df5967851e08d2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Theme: fix cross-tab theme sync when the cookie changes
 
 ## 0.54.1
 
 ### Patch Changes
 
-- [#808](https://github.com/ngrok-oss/mantle/pull/808) [`1f943b7`](https://github.com/ngrok-oss/mantle/commit/1f943b7266c9bf3464d4271b8fdc93a421f59eab) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - remove microtask in FOUC script
+- [#808](https://github.com/ngrok/mantle/pull/808) [`1f943b7`](https://github.com/ngrok/mantle/commit/1f943b7266c9bf3464d4271b8fdc93a421f59eab) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - remove microtask in FOUC script
 
 ## 0.54.0
 
 ### Minor Changes
 
-- [#806](https://github.com/ngrok-oss/mantle/pull/806) [`c1162a4`](https://github.com/ngrok-oss/mantle/commit/c1162a40080c574acb76fba83f24b0c4d756a18b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Switch from localStorage to cookie for theme preference storage primitive
+- [#806](https://github.com/ngrok/mantle/pull/806) [`c1162a4`](https://github.com/ngrok/mantle/commit/c1162a40080c574acb76fba83f24b0c4d756a18b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Switch from localStorage to cookie for theme preference storage primitive
 
 ## 0.53.0
 
 ### Minor Changes
 
-- [#804](https://github.com/ngrok-oss/mantle/pull/804) [`9286f3a`](https://github.com/ngrok-oss/mantle/commit/9286f3afb365ae4a7f8881905e8890a0ef7740ef) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename theme-provider export to theme
+- [#804](https://github.com/ngrok/mantle/pull/804) [`9286f3a`](https://github.com/ngrok/mantle/commit/9286f3afb365ae4a7f8881905e8890a0ef7740ef) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename theme-provider export to theme
 
 ### Patch Changes
 
-- [#803](https://github.com/ngrok-oss/mantle/pull/803) [`165981f`](https://github.com/ngrok-oss/mantle/commit/165981f4334a389da899787530cf8b80c2ff52a9) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update react day picker dependency
+- [#803](https://github.com/ngrok/mantle/pull/803) [`165981f`](https://github.com/ngrok/mantle/commit/165981f4334a389da899787530cf8b80c2ff52a9) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update react day picker dependency
 
-- [#801](https://github.com/ngrok-oss/mantle/pull/801) [`47ecff2`](https://github.com/ngrok-oss/mantle/commit/47ecff27f9bea00f5d4b4fc72fb9d281fb331174) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Add the xs breakpoint to the breakpoint component
+- [#801](https://github.com/ngrok/mantle/pull/801) [`47ecff2`](https://github.com/ngrok/mantle/commit/47ecff27f9bea00f5d4b4fc72fb9d281fb331174) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Add the xs breakpoint to the breakpoint component
 
 ## 0.52.9
 
 ### Patch Changes
 
-- [#797](https://github.com/ngrok-oss/mantle/pull/797) [`a5a1b91`](https://github.com/ngrok-oss/mantle/commit/a5a1b91428b682c32657540c84ff1912368bf734) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Dialog Overlay Primitive: add data-overlay attribute to Overlay primitive
+- [#797](https://github.com/ngrok/mantle/pull/797) [`a5a1b91`](https://github.com/ngrok/mantle/commit/a5a1b91428b682c32657540c84ff1912368bf734) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Dialog Overlay Primitive: add data-overlay attribute to Overlay primitive
 
 ## 0.52.8
 
 ### Patch Changes
 
-- [#790](https://github.com/ngrok-oss/mantle/pull/790) [`2806bb4`](https://github.com/ngrok-oss/mantle/commit/2806bb4efd2cedaf5e6b1a4a3e40a79ed7a31f8d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Combobox: fix scrolling presentation in content
+- [#790](https://github.com/ngrok/mantle/pull/790) [`2806bb4`](https://github.com/ngrok/mantle/commit/2806bb4efd2cedaf5e6b1a4a3e40a79ed7a31f8d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Combobox: fix scrolling presentation in content
 
-- [#790](https://github.com/ngrok-oss/mantle/pull/790) [`2806bb4`](https://github.com/ngrok-oss/mantle/commit/2806bb4efd2cedaf5e6b1a4a3e40a79ed7a31f8d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Combobox: bump up spacing between input and content
+- [#790](https://github.com/ngrok/mantle/pull/790) [`2806bb4`](https://github.com/ngrok/mantle/commit/2806bb4efd2cedaf5e6b1a4a3e40a79ed7a31f8d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Combobox: bump up spacing between input and content
 
-- [#789](https://github.com/ngrok-oss/mantle/pull/789) [`df7b954`](https://github.com/ngrok-oss/mantle/commit/df7b9546cfb478605528450346560f9fd8d70582) Thanks [@dependabot](https://github.com/apps/dependabot)! - bump headlessui version
+- [#789](https://github.com/ngrok/mantle/pull/789) [`df7b954`](https://github.com/ngrok/mantle/commit/df7b9546cfb478605528450346560f9fd8d70582) Thanks [@dependabot](https://github.com/apps/dependabot)! - bump headlessui version
 
 ## 0.52.7
 
 ### Patch Changes
 
-- [#777](https://github.com/ngrok-oss/mantle/pull/777) [`a484cab`](https://github.com/ngrok-oss/mantle/commit/a484cab854475ccc0e4288d2a6046e896bbe553a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button: remove the need for inner span
+- [#777](https://github.com/ngrok/mantle/pull/777) [`a484cab`](https://github.com/ngrok/mantle/commit/a484cab854475ccc0e4288d2a6046e896bbe553a) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button: remove the need for inner span
 
-- [#779](https://github.com/ngrok-oss/mantle/pull/779) [`37f40bd`](https://github.com/ngrok-oss/mantle/commit/37f40bd43c97665e412600ce991cb70a83524ae6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button, IconButton: add active:scale-[0.97]
+- [#779](https://github.com/ngrok/mantle/pull/779) [`37f40bd`](https://github.com/ngrok/mantle/commit/37f40bd43c97665e412600ce991cb70a83524ae6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Button, IconButton: add active:scale-[0.97]
 
 ## 0.52.6
 
 ### Patch Changes
 
-- [#775](https://github.com/ngrok-oss/mantle/pull/775) [`3519c45`](https://github.com/ngrok-oss/mantle/commit/3519c45582baf2d2c74daeaddece917062c392db) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - anchor: fix ring class on focus-visible
+- [#775](https://github.com/ngrok/mantle/pull/775) [`3519c45`](https://github.com/ngrok/mantle/commit/3519c45582baf2d2c74daeaddece917062c392db) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - anchor: fix ring class on focus-visible
 
-- [#773](https://github.com/ngrok-oss/mantle/pull/773) [`17dcb26`](https://github.com/ngrok-oss/mantle/commit/17dcb264e1dd504c5cb78bd20ec0a32acfb7a503) Thanks [@dependabot](https://github.com/apps/dependabot)! - update tailwindcss min peer dep
+- [#773](https://github.com/ngrok/mantle/pull/773) [`17dcb26`](https://github.com/ngrok/mantle/commit/17dcb264e1dd504c5cb78bd20ec0a32acfb7a503) Thanks [@dependabot](https://github.com/apps/dependabot)! - update tailwindcss min peer dep
 
 ## 0.52.5
 
 ### Patch Changes
 
-- [#770](https://github.com/ngrok-oss/mantle/pull/770) [`9f55e0e`](https://github.com/ngrok-oss/mantle/commit/9f55e0ecebbb3dcaa0644a973038a758d1681acf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Alert: when appearance="banner", also remove the top border
+- [#770](https://github.com/ngrok/mantle/pull/770) [`9f55e0e`](https://github.com/ngrok/mantle/commit/9f55e0ecebbb3dcaa0644a973038a758d1681acf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Alert: when appearance="banner", also remove the top border
 
 ## 0.52.4
 
 ### Patch Changes
 
-- [#767](https://github.com/ngrok-oss/mantle/pull/767) [`10899b2`](https://github.com/ngrok-oss/mantle/commit/10899b27d6b3dcc49222a558af86210cf99b82dc) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update tw-animate-css
+- [#767](https://github.com/ngrok/mantle/pull/767) [`10899b2`](https://github.com/ngrok/mantle/commit/10899b27d6b3dcc49222a558af86210cf99b82dc) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update tw-animate-css
 
-- [#768](https://github.com/ngrok-oss/mantle/pull/768) [`b8cd5d3`](https://github.com/ngrok-oss/mantle/commit/b8cd5d35dcbe349c4d88d22786a4ec6dd1faeb35) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Alert: add appearance prop to support "banner" alerts
+- [#768](https://github.com/ngrok/mantle/pull/768) [`b8cd5d3`](https://github.com/ngrok/mantle/commit/b8cd5d35dcbe349c4d88d22786a4ec6dd1faeb35) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Alert: add appearance prop to support "banner" alerts
 
 ## 0.52.3
 
 ### Patch Changes
 
-- [#763](https://github.com/ngrok-oss/mantle/pull/763) [`fe24bbb`](https://github.com/ngrok-oss/mantle/commit/fe24bbbfb36d9b325b7b92d1a29d53c7ab73cb5b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Card: fix how we render borders between Card.Header, Card.Body, and Card.Footer
+- [#763](https://github.com/ngrok/mantle/pull/763) [`fe24bbb`](https://github.com/ngrok/mantle/commit/fe24bbbfb36d9b325b7b92d1a29d53c7ab73cb5b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Card: fix how we render borders between Card.Header, Card.Body, and Card.Footer
 
 ## 0.52.2
 
 ### Patch Changes
 
-- [#760](https://github.com/ngrok-oss/mantle/pull/760) [`9b8ea0b`](https://github.com/ngrok-oss/mantle/commit/9b8ea0b409420effb979f4f9a752fc3ed5d962b5) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - ProgressDonut: add `indeterminateRotationSpeed` prop to control spin speed. Fix default `animation-duration-[15s]` so it no longer overrides consumer-provided `animation-duration-*` classes.
+- [#760](https://github.com/ngrok/mantle/pull/760) [`9b8ea0b`](https://github.com/ngrok/mantle/commit/9b8ea0b409420effb979f4f9a752fc3ed5d962b5) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - ProgressDonut: add `indeterminateRotationSpeed` prop to control spin speed. Fix default `animation-duration-[15s]` so it no longer overrides consumer-provided `animation-duration-*` classes.
 
 ## 0.52.1
 
 ### Patch Changes
 
-- [#752](https://github.com/ngrok-oss/mantle/pull/752) [`be2c37a`](https://github.com/ngrok-oss/mantle/commit/be2c37a5df3b9908dd2ed48df0c58acb23ac5b19) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Combobox: fix ItemValue data-user-value bolding
+- [#752](https://github.com/ngrok/mantle/pull/752) [`be2c37a`](https://github.com/ngrok/mantle/commit/be2c37a5df3b9908dd2ed48df0c58acb23ac5b19) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Combobox: fix ItemValue data-user-value bolding
 
 ## 0.52.0
 
 ### Minor Changes
 
-- [#748](https://github.com/ngrok-oss/mantle/pull/748) [`2e7509c`](https://github.com/ngrok-oss/mantle/commit/2e7509c937086d51bd7c8dfa00d57cf2dc105212) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add useIsBelowBreakpoint hook, improve performance of breakpoint hooks
+- [#748](https://github.com/ngrok/mantle/pull/748) [`2e7509c`](https://github.com/ngrok/mantle/commit/2e7509c937086d51bd7c8dfa00d57cf2dc105212) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add useIsBelowBreakpoint hook, improve performance of breakpoint hooks
 
-- [#745](https://github.com/ngrok-oss/mantle/pull/745) [`9611901`](https://github.com/ngrok-oss/mantle/commit/9611901fc1db0daec0691044dcf95535bdf75218) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename InlineCode to Code
+- [#745](https://github.com/ngrok/mantle/pull/745) [`9611901`](https://github.com/ngrok/mantle/commit/9611901fc1db0daec0691044dcf95535bdf75218) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Rename InlineCode to Code
 
-- [#746](https://github.com/ngrok-oss/mantle/pull/746) [`639eed2`](https://github.com/ngrok-oss/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add useIsHydrated hook
+- [#746](https://github.com/ngrok/mantle/pull/746) [`639eed2`](https://github.com/ngrok/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add useIsHydrated hook
 
-- [#746](https://github.com/ngrok-oss/mantle/pull/746) [`639eed2`](https://github.com/ngrok-oss/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add useBreakpoint hook
+- [#746](https://github.com/ngrok/mantle/pull/746) [`639eed2`](https://github.com/ngrok/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add useBreakpoint hook
 
-- [#746](https://github.com/ngrok-oss/mantle/pull/746) [`639eed2`](https://github.com/ngrok-oss/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add BrowserOnly component
+- [#746](https://github.com/ngrok/mantle/pull/746) [`639eed2`](https://github.com/ngrok/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add BrowserOnly component
 
 ### Patch Changes
 
-- [#743](https://github.com/ngrok-oss/mantle/pull/743) [`9e2621c`](https://github.com/ngrok-oss/mantle/commit/9e2621c83d289ff71f864c1405dccd8367a139a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Switch Alert, Dialog, and AlertDialog Description components to render a div instead of a p by default
+- [#743](https://github.com/ngrok/mantle/pull/743) [`9e2621c`](https://github.com/ngrok/mantle/commit/9e2621c83d289ff71f864c1405dccd8367a139a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Switch Alert, Dialog, and AlertDialog Description components to render a div instead of a p by default
 
-- [#746](https://github.com/ngrok-oss/mantle/pull/746) [`639eed2`](https://github.com/ngrok-oss/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update hooks documentation for useMatchesMediaQuery and useCopyToClipboard
+- [#746](https://github.com/ngrok/mantle/pull/746) [`639eed2`](https://github.com/ngrok/mantle/commit/639eed24e29b23856fec43b99ea11a20fe9da0eb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update hooks documentation for useMatchesMediaQuery and useCopyToClipboard
 
 ## 0.51.3
 
 ### Patch Changes
 
-- [#740](https://github.com/ngrok-oss/mantle/pull/740) [`bbfd6d4`](https://github.com/ngrok-oss/mantle/commit/bbfd6d418d51e8780c108fb905c42fbdb44e95ec) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Accordion: fix export object for compound component definition
+- [#740](https://github.com/ngrok/mantle/pull/740) [`bbfd6d4`](https://github.com/ngrok/mantle/commit/bbfd6d418d51e8780c108fb905c42fbdb44e95ec) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Accordion: fix export object for compound component definition
 
 ## 0.51.2
 
 ### Patch Changes
 
-- [#733](https://github.com/ngrok-oss/mantle/pull/733) [`55565dc`](https://github.com/ngrok-oss/mantle/commit/55565dcbb954f938f4f08ec2171959532a595813) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update react-day-picker and tw-animate-css
+- [#733](https://github.com/ngrok/mantle/pull/733) [`55565dc`](https://github.com/ngrok/mantle/commit/55565dcbb954f938f4f08ec2171959532a595813) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update react-day-picker and tw-animate-css
 
 ## 0.51.1
 
 ### Patch Changes
 
-- [#731](https://github.com/ngrok-oss/mantle/pull/731) [`cd19eb1`](https://github.com/ngrok-oss/mantle/commit/cd19eb172a1bcad11137eecb9a0bd5f32e192088) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DropdownMenu: support tooltips on disabled dropdown menu items
+- [#731](https://github.com/ngrok/mantle/pull/731) [`cd19eb1`](https://github.com/ngrok/mantle/commit/cd19eb172a1bcad11137eecb9a0bd5f32e192088) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DropdownMenu: support tooltips on disabled dropdown menu items
 
 ## 0.51.0
 
 ### Minor Changes
 
-- [#730](https://github.com/ngrok-oss/mantle/pull/730) [`e61565f`](https://github.com/ngrok-oss/mantle/commit/e61565f9dc66197c65f377afed37642a99822856) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: remove DataTable.Rows convenience component; instead prefer to map over rows directly
+- [#730](https://github.com/ngrok/mantle/pull/730) [`e61565f`](https://github.com/ngrok/mantle/commit/e61565f9dc66197c65f377afed37642a99822856) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: remove DataTable.Rows convenience component; instead prefer to map over rows directly
 
 ### Patch Changes
 
-- [#728](https://github.com/ngrok-oss/mantle/pull/728) [`521d59f`](https://github.com/ngrok-oss/mantle/commit/521d59ffe88f8af4aae54d49b365593eeef0621f) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#728](https://github.com/ngrok/mantle/pull/728) [`521d59f`](https://github.com/ngrok/mantle/commit/521d59ffe88f8af4aae54d49b365593eeef0621f) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
 ## 0.50.4
 
 ### Patch Changes
 
-- [#722](https://github.com/ngrok-oss/mantle/pull/722) [`961e157`](https://github.com/ngrok-oss/mantle/commit/961e15757e9147818a9527126b77c002975d58c8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: support passing fn as child to DataTable.Rows
+- [#722](https://github.com/ngrok/mantle/pull/722) [`961e157`](https://github.com/ngrok/mantle/commit/961e15757e9147818a9527126b77c002975d58c8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: support passing fn as child to DataTable.Rows
 
 ## 0.50.3
 
 ### Patch Changes
 
-- [#719](https://github.com/ngrok-oss/mantle/pull/719) [`7cab99c`](https://github.com/ngrok-oss/mantle/commit/7cab99cb6fa934beae615be4e90391ec0727482b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Toast: for toast message, use font-body instead of font-sans
+- [#719](https://github.com/ngrok/mantle/pull/719) [`7cab99c`](https://github.com/ngrok/mantle/commit/7cab99cb6fa934beae615be4e90391ec0727482b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Toast: for toast message, use font-body instead of font-sans
 
-- [#721](https://github.com/ngrok-oss/mantle/pull/721) [`31c6ec0`](https://github.com/ngrok-oss/mantle/commit/31c6ec03a466da457e875eb61c7fee07ba56b3a3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: export cell component too
+- [#721](https://github.com/ngrok/mantle/pull/721) [`31c6ec0`](https://github.com/ngrok/mantle/commit/31c6ec03a466da457e875eb61c7fee07ba56b3a3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: export cell component too
 
 ## 0.50.2
 
 ### Patch Changes
 
-- [#717](https://github.com/ngrok-oss/mantle/pull/717) [`024cf70`](https://github.com/ngrok-oss/mantle/commit/024cf70f82bd0aed57992ecaa4002868861ecce2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Colors: fix dark mode swap of white and black as semantic colors
+- [#717](https://github.com/ngrok/mantle/pull/717) [`024cf70`](https://github.com/ngrok/mantle/commit/024cf70f82bd0aed57992ecaa4002868861ecce2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Colors: fix dark mode swap of white and black as semantic colors
 
-- [#717](https://github.com/ngrok-oss/mantle/pull/717) [`024cf70`](https://github.com/ngrok-oss/mantle/commit/024cf70f82bd0aed57992ecaa4002868861ecce2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - replace remaining hsl() usages with oklch() and --color-\* css vars
+- [#717](https://github.com/ngrok/mantle/pull/717) [`024cf70`](https://github.com/ngrok/mantle/commit/024cf70f82bd0aed57992ecaa4002868861ecce2) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - replace remaining hsl() usages with oklch() and --color-\* css vars
 
 ## 0.50.1
 
 ### Patch Changes
 
-- [#714](https://github.com/ngrok-oss/mantle/pull/714) [`6507acf`](https://github.com/ngrok-oss/mantle/commit/6507acf7248389e94a6c841802241e14621df324) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix missing production dependency for tw-animate-css
+- [#714](https://github.com/ngrok/mantle/pull/714) [`6507acf`](https://github.com/ngrok/mantle/commit/6507acf7248389e94a6c841802241e14621df324) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix missing production dependency for tw-animate-css
 
 ## 0.50.0
 
 ### Minor Changes (0.x breaking)
 
-- [#656](https://github.com/ngrok-oss/mantle/pull/656) [`e0846f8`](https://github.com/ngrok-oss/mantle/commit/e0846f8f5dc22ef63efc2fcb776b9161f4eace20) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Migrate mantle to Tailwind v4
+- [#656](https://github.com/ngrok/mantle/pull/656) [`e0846f8`](https://github.com/ngrok/mantle/commit/e0846f8f5dc22ef63efc2fcb776b9161f4eace20) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Migrate mantle to Tailwind v4
 
 ## 0.40.1
 
 ### Patch Changes
 
-- [#711](https://github.com/ngrok-oss/mantle/pull/711) [`3f531c5`](https://github.com/ngrok-oss/mantle/commit/3f531c587caa33a532fb0cc2434cb15d321a302d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update ariakit (combobox improvements)
+- [#711](https://github.com/ngrok/mantle/pull/711) [`3f531c5`](https://github.com/ngrok/mantle/commit/3f531c587caa33a532fb0cc2434cb15d321a302d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update ariakit (combobox improvements)
 
 ## 0.40.0
 
 ### Minor Changes (0.x breaking)
 
-- [#687](https://github.com/ngrok-oss/mantle/pull/687) [`a3b49ab`](https://github.com/ngrok-oss/mantle/commit/a3b49ab9a832c6636416792b73d648dc782265c3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Implement composite named exports
+- [#687](https://github.com/ngrok/mantle/pull/687) [`a3b49ab`](https://github.com/ngrok/mantle/commit/a3b49ab9a832c6636416792b73d648dc782265c3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Implement composite named exports
 
 ## 0.32.3
 
 ### Patch Changes
 
-- [#699](https://github.com/ngrok-oss/mantle/pull/699) [`82f26dc`](https://github.com/ngrok-oss/mantle/commit/82f26dccb2605cf9a1dab9e4d8d91d45f929e24d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add nonce prop to MantleThemeHeadContent, update doc blocks
+- [#699](https://github.com/ngrok/mantle/pull/699) [`82f26dc`](https://github.com/ngrok/mantle/commit/82f26dccb2605cf9a1dab9e4d8d91d45f929e24d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add nonce prop to MantleThemeHeadContent, update doc blocks
 
 ## 0.32.2
 
 ### Patch Changes
 
-- [#695](https://github.com/ngrok-oss/mantle/pull/695) [`0b342d7`](https://github.com/ngrok-oss/mantle/commit/0b342d7675e53317324636309be01d76dfd7b63a) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update headlessui and sonner dependencies
+- [#695](https://github.com/ngrok/mantle/pull/695) [`0b342d7`](https://github.com/ngrok/mantle/commit/0b342d7675e53317324636309be01d76dfd7b63a) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update headlessui and sonner dependencies
 
 ## 0.32.1
 
 ### Patch Changes
 
-- [#678](https://github.com/ngrok-oss/mantle/pull/678) [`c303597`](https://github.com/ngrok-oss/mantle/commit/c30359783e449583ac522bddb36ef92225e5ba84) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add explicit displayNames to all mantle components
+- [#678](https://github.com/ngrok/mantle/pull/678) [`c303597`](https://github.com/ngrok/mantle/commit/c30359783e449583ac522bddb36ef92225e5ba84) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add explicit displayNames to all mantle components
 
-- [#680](https://github.com/ngrok-oss/mantle/pull/680) [`7b6b15a`](https://github.com/ngrok-oss/mantle/commit/7b6b15afdcc42104dbefb9a1213d694c2c7d39dd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add missing intellisense jsdocs to all mantle components
+- [#680](https://github.com/ngrok/mantle/pull/680) [`7b6b15a`](https://github.com/ngrok/mantle/commit/7b6b15afdcc42104dbefb9a1213d694c2c7d39dd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add missing intellisense jsdocs to all mantle components
 
 ## 0.32.0
 
 ### Minor Changes
 
-- [#675](https://github.com/ngrok-oss/mantle/pull/675) [`4a65a5a`](https://github.com/ngrok-oss/mantle/commit/4a65a5ac00c0d656f0771503fbe1f8ffeada8057) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add ProgressBar component
+- [#675](https://github.com/ngrok/mantle/pull/675) [`4a65a5a`](https://github.com/ngrok/mantle/commit/4a65a5ac00c0d656f0771503fbe1f8ffeada8057) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add ProgressBar component
 
 ## 0.31.6
 
 ### Patch Changes
 
-- [#670](https://github.com/ngrok-oss/mantle/pull/670) [`bc3e6ac`](https://github.com/ngrok-oss/mantle/commit/bc3e6ac87bd453b7af82dddad013cd9fd7de0671) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - remove zod as a peerDependency of mantle
+- [#670](https://github.com/ngrok/mantle/pull/670) [`bc3e6ac`](https://github.com/ngrok/mantle/commit/bc3e6ac87bd453b7af82dddad013cd9fd7de0671) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - remove zod as a peerDependency of mantle
 
 ## 0.31.5
 
 ### Patch Changes
 
-- [#662](https://github.com/ngrok-oss/mantle/pull/662) [`1cfccd6`](https://github.com/ngrok-oss/mantle/commit/1cfccd66c5e4091c34553436e422e2e1cda356a4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Sprinkle use client everywhere
+- [#662](https://github.com/ngrok/mantle/pull/662) [`1cfccd6`](https://github.com/ngrok/mantle/commit/1cfccd66c5e4091c34553436e422e2e1cda356a4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Sprinkle use client everywhere
 
 ## 0.31.4
 
 ### Patch Changes
 
-- [#660](https://github.com/ngrok-oss/mantle/pull/660) [`2fddd06`](https://github.com/ngrok-oss/mantle/commit/2fddd06a2d7ac056f022a96d64888230bb261dcf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Change peerDependencies for react and react-dom
+- [#660](https://github.com/ngrok/mantle/pull/660) [`2fddd06`](https://github.com/ngrok/mantle/commit/2fddd06a2d7ac056f022a96d64888230bb261dcf) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Change peerDependencies for react and react-dom
 
 ## 0.31.3
 
 ### Patch Changes
 
-- [#642](https://github.com/ngrok-oss/mantle/pull/642) [`1bb8fdd`](https://github.com/ngrok-oss/mantle/commit/1bb8fdd7769f39dfc5fd2556cee5a8d08e3d006d) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
+- [#642](https://github.com/ngrok/mantle/pull/642) [`1bb8fdd`](https://github.com/ngrok/mantle/commit/1bb8fdd7769f39dfc5fd2556cee5a8d08e3d006d) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
 
-- [#651](https://github.com/ngrok-oss/mantle/pull/651) [`57d5b60`](https://github.com/ngrok-oss/mantle/commit/57d5b6054b96c5e68ecafa35099aabcb1adbdce7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#651](https://github.com/ngrok/mantle/pull/651) [`57d5b60`](https://github.com/ngrok/mantle/commit/57d5b6054b96c5e68ecafa35099aabcb1adbdce7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
-- [#659](https://github.com/ngrok-oss/mantle/pull/659) [`1d43071`](https://github.com/ngrok-oss/mantle/commit/1d43071a93f4d5d618dd503ddf9dfbd2a89adf6b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix mantle react, react-dom peer dependencies range
+- [#659](https://github.com/ngrok/mantle/pull/659) [`1d43071`](https://github.com/ngrok/mantle/commit/1d43071a93f4d5d618dd503ddf9dfbd2a89adf6b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fix mantle react, react-dom peer dependencies range
 
-- [#658](https://github.com/ngrok-oss/mantle/pull/658) [`ad402db`](https://github.com/ngrok-oss/mantle/commit/ad402dbf34c05825538f89ddb4ee03cf778a0bce) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Fix bug where `setValueOnClick` prop was destructured (to set a default) but then never passed along and used (so the consumer could never override it).
+- [#658](https://github.com/ngrok/mantle/pull/658) [`ad402db`](https://github.com/ngrok/mantle/commit/ad402dbf34c05825538f89ddb4ee03cf778a0bce) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Fix bug where `setValueOnClick` prop was destructured (to set a default) but then never passed along and used (so the consumer could never override it).
 
 ## 0.31.2
 
 ### Patch Changes
 
-- [#643](https://github.com/ngrok-oss/mantle/pull/643) [`148dd76`](https://github.com/ngrok-oss/mantle/commit/148dd764cbcbd4025503e0cbcfb2a5ea24a40b76) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Fix breakpoint configuration to allow for arbitrary breakpoint
+- [#643](https://github.com/ngrok/mantle/pull/643) [`148dd76`](https://github.com/ngrok/mantle/commit/148dd764cbcbd4025503e0cbcfb2a5ea24a40b76) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Fix breakpoint configuration to allow for arbitrary breakpoint
 
 ## 0.31.1
 
 ### Patch Changes
 
-- [#635](https://github.com/ngrok-oss/mantle/pull/635) [`baa2d7f`](https://github.com/ngrok-oss/mantle/commit/baa2d7fe2008c1e14baeec8618209e48c2ce835b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - RadioIndicator: add shrink-0 so the indicator does not shrink in flex contexts
+- [#635](https://github.com/ngrok/mantle/pull/635) [`baa2d7f`](https://github.com/ngrok/mantle/commit/baa2d7fe2008c1e14baeec8618209e48c2ce835b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - RadioIndicator: add shrink-0 so the indicator does not shrink in flex contexts
 
 ## 0.31.0
 
 ### Minor Changes
 
-- [#633](https://github.com/ngrok-oss/mantle/pull/633) [`0632cca`](https://github.com/ngrok-oss/mantle/commit/0632cca37f5376072f086256dfc25c69c973e53c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - SelectItem: allow for icon slot
+- [#633](https://github.com/ngrok/mantle/pull/633) [`0632cca`](https://github.com/ngrok/mantle/commit/0632cca37f5376072f086256dfc25c69c973e53c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - SelectItem: allow for icon slot
 
-- [#633](https://github.com/ngrok-oss/mantle/pull/633) [`0632cca`](https://github.com/ngrok-oss/mantle/commit/0632cca37f5376072f086256dfc25c69c973e53c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Icons: export AutoThemeIcon and ThemeIcon
+- [#633](https://github.com/ngrok/mantle/pull/633) [`0632cca`](https://github.com/ngrok/mantle/commit/0632cca37f5376072f086256dfc25c69c973e53c) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Icons: export AutoThemeIcon and ThemeIcon
 
 ### Patch Changes
 
-- [#631](https://github.com/ngrok-oss/mantle/pull/631) [`2d18988`](https://github.com/ngrok-oss/mantle/commit/2d18988384fee665f88aa316e2bec112434cb35c) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#631](https://github.com/ngrok/mantle/pull/631) [`2d18988`](https://github.com/ngrok/mantle/commit/2d18988384fee665f88aa316e2bec112434cb35c) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
-- [#609](https://github.com/ngrok-oss/mantle/pull/609) [`fc8b793`](https://github.com/ngrok-oss/mantle/commit/fc8b793e1c7ea43b7575cff89f15ed645f3c9ce7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#609](https://github.com/ngrok/mantle/pull/609) [`fc8b793`](https://github.com/ngrok/mantle/commit/fc8b793e1c7ea43b7575cff89f15ed645f3c9ce7) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
 ## 0.30.0
 
 ### Minor Changes
 
-- [#620](https://github.com/ngrok-oss/mantle/pull/620) [`c76d1bd`](https://github.com/ngrok-oss/mantle/commit/c76d1bd1c32fbc84ccbe69a176e8ea06326cfd28) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Add `AlertDismissIconButton` to `Alert` component
+- [#620](https://github.com/ngrok/mantle/pull/620) [`c76d1bd`](https://github.com/ngrok/mantle/commit/c76d1bd1c32fbc84ccbe69a176e8ea06326cfd28) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Add `AlertDismissIconButton` to `Alert` component
 
 ### Patch Changes
 
-- [#617](https://github.com/ngrok-oss/mantle/pull/617) [`c72c6e1`](https://github.com/ngrok-oss/mantle/commit/c72c6e1228f5b62a0fa7ec39957ac71081df2667) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Table edge case refinements and a sans serif font on tooltips by default
+- [#617](https://github.com/ngrok/mantle/pull/617) [`c72c6e1`](https://github.com/ngrok/mantle/commit/c72c6e1228f5b62a0fa7ec39957ac71081df2667) Thanks [@aaronshekey](https://github.com/aaronshekey)! - Table edge case refinements and a sans serif font on tooltips by default
 
 ## 0.29.0
 
 ### Minor Changes
 
-- [#603](https://github.com/ngrok-oss/mantle/pull/603) [`264dc1b`](https://github.com/ngrok-oss/mantle/commit/264dc1b8947b9c44fac3eef97e22446c249e0f17) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies; use named \*Icon imports from phosphor
+- [#603](https://github.com/ngrok/mantle/pull/603) [`264dc1b`](https://github.com/ngrok/mantle/commit/264dc1b8947b9c44fac3eef97e22446c249e0f17) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies; use named \*Icon imports from phosphor
 
 ## 0.28.1
 
 ### Patch Changes
 
-- [#595](https://github.com/ngrok-oss/mantle/pull/595) [`26cdffa`](https://github.com/ngrok-oss/mantle/commit/26cdffa6a10da1a6eb7b868db892f3c60e15bef6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Revert phosphor update
+- [#595](https://github.com/ngrok/mantle/pull/595) [`26cdffa`](https://github.com/ngrok/mantle/commit/26cdffa6a10da1a6eb7b868db892f3c60e15bef6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Revert phosphor update
 
 ## 0.28.0
 
 ### Minor Changes
 
-- [#591](https://github.com/ngrok-oss/mantle/pull/591) [`2cf4f4c`](https://github.com/ngrok-oss/mantle/commit/2cf4f4c6cd219172f6d8131a4a6b2270152b53d4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update phosphor icons to new suffix Icon imports
+- [#591](https://github.com/ngrok/mantle/pull/591) [`2cf4f4c`](https://github.com/ngrok/mantle/commit/2cf4f4c6cd219172f6d8131a4a6b2270152b53d4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update phosphor icons to new suffix Icon imports
 
 ## 0.27.4
 
 ### Patch Changes
 
-- [#589](https://github.com/ngrok-oss/mantle/pull/589) [`2eb2764`](https://github.com/ngrok-oss/mantle/commit/2eb2764c12bcb0cab0e9d99801dc1b8e0ed60dc4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - RadioButton: don't highlight border on hover when checked AND disabled
+- [#589](https://github.com/ngrok/mantle/pull/589) [`2eb2764`](https://github.com/ngrok/mantle/commit/2eb2764c12bcb0cab0e9d99801dc1b8e0ed60dc4) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - RadioButton: don't highlight border on hover when checked AND disabled
 
 ## 0.27.3
 
 ### Patch Changes
 
-- [#559](https://github.com/ngrok-oss/mantle/pull/559) [`9da7027`](https://github.com/ngrok-oss/mantle/commit/9da7027f0009b0f57df385377c73da262177efee) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - tsconfig: improve tsconfigs and remove unused imports/vars
+- [#559](https://github.com/ngrok/mantle/pull/559) [`9da7027`](https://github.com/ngrok/mantle/commit/9da7027f0009b0f57df385377c73da262177efee) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - tsconfig: improve tsconfigs and remove unused imports/vars
 
-- [#551](https://github.com/ngrok-oss/mantle/pull/551) [`fceb2ef`](https://github.com/ngrok-oss/mantle/commit/fceb2effdc828719a340110e5e3fd216d88ae564) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: improve component design and styling
+- [#551](https://github.com/ngrok/mantle/pull/551) [`fceb2ef`](https://github.com/ngrok/mantle/commit/fceb2effdc828719a340110e5e3fd216d88ae564) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: improve component design and styling
 
-- [#576](https://github.com/ngrok-oss/mantle/pull/576) [`ce359c0`](https://github.com/ngrok-oss/mantle/commit/ce359c0e5046d00af54814693dddad7b95099d66) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
+- [#576](https://github.com/ngrok/mantle/pull/576) [`ce359c0`](https://github.com/ngrok/mantle/commit/ce359c0e5046d00af54814693dddad7b95099d66) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
 
-- [#568](https://github.com/ngrok-oss/mantle/pull/568) [`3d9c378`](https://github.com/ngrok-oss/mantle/commit/3d9c378c01d278e6376e8a668d465d93666b281a) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
+- [#568](https://github.com/ngrok/mantle/pull/568) [`3d9c378`](https://github.com/ngrok/mantle/commit/3d9c378c01d278e6376e8a668d465d93666b281a) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
 
 ## 0.27.2
 
 ### Patch Changes
 
-- [#544](https://github.com/ngrok-oss/mantle/pull/544) [`cc043a7`](https://github.com/ngrok-oss/mantle/commit/cc043a74bd909c4c1c4d77027fee10c8ae5653db) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: fix react key errors in DataTableHead and DataTableRow
+- [#544](https://github.com/ngrok/mantle/pull/544) [`cc043a7`](https://github.com/ngrok/mantle/commit/cc043a74bd909c4c1c4d77027fee10c8ae5653db) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: fix react key errors in DataTableHead and DataTableRow
 
-- [#546](https://github.com/ngrok-oss/mantle/pull/546) [`44cc9b9`](https://github.com/ngrok-oss/mantle/commit/44cc9b9d3eef4f09a87579350e12d12fcf7d78aa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: fix hover styles, add DataTableActionCell
+- [#546](https://github.com/ngrok/mantle/pull/546) [`44cc9b9`](https://github.com/ngrok/mantle/commit/44cc9b9d3eef4f09a87579350e12d12fcf7d78aa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: fix hover styles, add DataTableActionCell
 
-- [#546](https://github.com/ngrok-oss/mantle/pull/546) [`44cc9b9`](https://github.com/ngrok-oss/mantle/commit/44cc9b9d3eef4f09a87579350e12d12fcf7d78aa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Tailwind Preset: fix content glob, should point to dist folder now
+- [#546](https://github.com/ngrok/mantle/pull/546) [`44cc9b9`](https://github.com/ngrok/mantle/commit/44cc9b9d3eef4f09a87579350e12d12fcf7d78aa) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Tailwind Preset: fix content glob, should point to dist folder now
 
 ## 0.27.1
 
 ### Patch Changes
 
-- [#538](https://github.com/ngrok-oss/mantle/pull/538) [`1c2f1af`](https://github.com/ngrok-oss/mantle/commit/1c2f1af3d26841671fd53f2334d722790bd03454) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: add most of the remaining core components
+- [#538](https://github.com/ngrok/mantle/pull/538) [`1c2f1af`](https://github.com/ngrok/mantle/commit/1c2f1af3d26841671fd53f2334d722790bd03454) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: add most of the remaining core components
 
-- [#536](https://github.com/ngrok-oss/mantle/pull/536) [`585624a`](https://github.com/ngrok-oss/mantle/commit/585624a29920d6c92d5e2bf81ea682a56cd89f47) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: export both DataTableHeaderSortButton and DataTableHeader, decouple behavior to make it fully customizable
+- [#536](https://github.com/ngrok/mantle/pull/536) [`585624a`](https://github.com/ngrok/mantle/commit/585624a29920d6c92d5e2bf81ea682a56cd89f47) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: export both DataTableHeaderSortButton and DataTableHeader, decouple behavior to make it fully customizable
 
 ## 0.27.0
 
 ### Minor Changes
 
-- [#533](https://github.com/ngrok-oss/mantle/pull/533) [`8211d3b`](https://github.com/ngrok-oss/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Tailwind Preset: replace 'text-mono' with 'text-size-mono' (so it doesn't clash with tw-merge text-\* color classes)
+- [#533](https://github.com/ngrok/mantle/pull/533) [`8211d3b`](https://github.com/ngrok/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Tailwind Preset: replace 'text-mono' with 'text-size-mono' (so it doesn't clash with tw-merge text-\* color classes)
 
 ### Patch Changes
 
-- [#533](https://github.com/ngrok-oss/mantle/pull/533) [`8211d3b`](https://github.com/ngrok-oss/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: add tests to helper methods, render example on docs site
+- [#533](https://github.com/ngrok/mantle/pull/533) [`8211d3b`](https://github.com/ngrok/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: add tests to helper methods, render example on docs site
 
-- [#533](https://github.com/ngrok-oss/mantle/pull/533) [`8211d3b`](https://github.com/ngrok-oss/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Toast: change class from .mantle-prompt to .overlay-prompt, improve compat w/ legacy ui components
+- [#533](https://github.com/ngrok/mantle/pull/533) [`8211d3b`](https://github.com/ngrok/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Toast: change class from .mantle-prompt to .overlay-prompt, improve compat w/ legacy ui components
 
-- [#533](https://github.com/ngrok-oss/mantle/pull/533) [`8211d3b`](https://github.com/ngrok-oss/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: fix/improve styling
+- [#533](https://github.com/ngrok/mantle/pull/533) [`8211d3b`](https://github.com/ngrok/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: fix/improve styling
 
-- [#533](https://github.com/ngrok-oss/mantle/pull/533) [`8211d3b`](https://github.com/ngrok-oss/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies
+- [#533](https://github.com/ngrok/mantle/pull/533) [`8211d3b`](https://github.com/ngrok/mantle/commit/8211d3b636a5197b305ed4774d7316cf8cf09ca6) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies
 
 ## 0.26.0
 
 ### Minor Changes
 
-- [#525](https://github.com/ngrok-oss/mantle/pull/525) [`bf41174`](https://github.com/ngrok-oss/mantle/commit/bf41174756a5fe1b563e5fe43ea6f80ec3df09d3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add custom mantle icons exports (Sort, TrafficPolicyFile) and sorting helper functions, types
+- [#525](https://github.com/ngrok/mantle/pull/525) [`bf41174`](https://github.com/ngrok/mantle/commit/bf41174756a5fe1b563e5fe43ea6f80ec3df09d3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add custom mantle icons exports (Sort, TrafficPolicyFile) and sorting helper functions, types
 
-- [#527](https://github.com/ngrok-oss/mantle/pull/527) [`f702d8a`](https://github.com/ngrok-oss/mantle/commit/f702d8a8a228eb568f3273c650b0ad00d0b35adb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: add DataTableHeader component, which supports column sorting by default (if enabled on the column)
+- [#527](https://github.com/ngrok/mantle/pull/527) [`f702d8a`](https://github.com/ngrok/mantle/commit/f702d8a8a228eb568f3273c650b0ad00d0b35adb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DataTable: add DataTableHeader component, which supports column sorting by default (if enabled on the column)
 
-- [#527](https://github.com/ngrok-oss/mantle/pull/527) [`f702d8a`](https://github.com/ngrok-oss/mantle/commit/f702d8a8a228eb568f3273c650b0ad00d0b35adb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: improve documentation and fix markup, exports to match html spec 1:1; improve styling and include horizontal overflow detection
+- [#527](https://github.com/ngrok/mantle/pull/527) [`f702d8a`](https://github.com/ngrok/mantle/commit/f702d8a8a228eb568f3273c650b0ad00d0b35adb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: improve documentation and fix markup, exports to match html spec 1:1; improve styling and include horizontal overflow detection
 
 ### Patch Changes
 
-- [#524](https://github.com/ngrok-oss/mantle/pull/524) [`38ac3db`](https://github.com/ngrok-oss/mantle/commit/38ac3dbadfa45dfa283bc4a8853966b190839776) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#524](https://github.com/ngrok/mantle/pull/524) [`38ac3db`](https://github.com/ngrok/mantle/commit/38ac3dbadfa45dfa283bc4a8853966b190839776) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
-- [#527](https://github.com/ngrok-oss/mantle/pull/527) [`f702d8a`](https://github.com/ngrok-oss/mantle/commit/f702d8a8a228eb568f3273c650b0ad00d0b35adb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: Improve Table component docs
+- [#527](https://github.com/ngrok/mantle/pull/527) [`f702d8a`](https://github.com/ngrok/mantle/commit/f702d8a8a228eb568f3273c650b0ad00d0b35adb) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Table: Improve Table component docs
 
 ## 0.25.2
 
 ### Patch Changes
 
-- [#515](https://github.com/ngrok-oss/mantle/pull/515) [`eb03234`](https://github.com/ngrok-oss/mantle/commit/eb03234c6ef14d63d4e7d15320a6a8123ef16237) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - PopoverContent: add preferredWidth prop, use that instead of explicit width
+- [#515](https://github.com/ngrok/mantle/pull/515) [`eb03234`](https://github.com/ngrok/mantle/commit/eb03234c6ef14d63d4e7d15320a6a8123ef16237) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - PopoverContent: add preferredWidth prop, use that instead of explicit width
 
-- [#515](https://github.com/ngrok-oss/mantle/pull/515) [`eb03234`](https://github.com/ngrok-oss/mantle/commit/eb03234c6ef14d63d4e7d15320a6a8123ef16237) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Calendar: add min-w-min to months container (prevent overflow in nav)
+- [#515](https://github.com/ngrok/mantle/pull/515) [`eb03234`](https://github.com/ngrok/mantle/commit/eb03234c6ef14d63d4e7d15320a6a8123ef16237) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Calendar: add min-w-min to months container (prevent overflow in nav)
 
 ## 0.25.1
 
 ### Patch Changes
 
-- [#513](https://github.com/ngrok-oss/mantle/pull/513) [`052f571`](https://github.com/ngrok-oss/mantle/commit/052f57113ae811c6dbefbb293c0cb22fbcfaf950) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialogContent, DialogContent: add preferredWidth prop
+- [#513](https://github.com/ngrok/mantle/pull/513) [`052f571`](https://github.com/ngrok/mantle/commit/052f57113ae811c6dbefbb293c0cb22fbcfaf950) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialogContent, DialogContent: add preferredWidth prop
 
-- [#510](https://github.com/ngrok-oss/mantle/pull/510) [`7dcc1e0`](https://github.com/ngrok-oss/mantle/commit/7dcc1e050bc181d2f193257d51a1df3092a016ef) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#510](https://github.com/ngrok/mantle/pull/510) [`7dcc1e0`](https://github.com/ngrok/mantle/commit/7dcc1e050bc181d2f193257d51a1df3092a016ef) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
 ## 0.25.0
 
 ### Minor Changes
 
-- [#501](https://github.com/ngrok-oss/mantle/pull/501) [`a669615`](https://github.com/ngrok-oss/mantle/commit/a6696155e7fab6651d331af6bfe6459b7b8ecac1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: add support for setting the indentation used (tabs vs spaces), fallback to detecting what the given language prefers or spaces if none
+- [#501](https://github.com/ngrok/mantle/pull/501) [`a669615`](https://github.com/ngrok/mantle/commit/a6696155e7fab6651d331af6bfe6459b7b8ecac1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: add support for setting the indentation used (tabs vs spaces), fallback to detecting what the given language prefers or spaces if none
 
 ### Patch Changes
 
-- [#500](https://github.com/ngrok-oss/mantle/pull/500) [`275f8d1`](https://github.com/ngrok-oss/mantle/commit/275f8d1b40bbc9e87d7271ddcab4b94748fc8744) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
+- [#500](https://github.com/ngrok/mantle/pull/500) [`275f8d1`](https://github.com/ngrok/mantle/commit/275f8d1b40bbc9e87d7271ddcab4b94748fc8744) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
 
-- [#501](https://github.com/ngrok-oss/mantle/pull/501) [`a669615`](https://github.com/ngrok-oss/mantle/commit/a6696155e7fab6651d331af6bfe6459b7b8ecac1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: improve documentation and intellisense
+- [#501](https://github.com/ngrok/mantle/pull/501) [`a669615`](https://github.com/ngrok/mantle/commit/a6696155e7fab6651d331af6bfe6459b7b8ecac1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: improve documentation and intellisense
 
 ## 0.24.1
 
 ### Patch Changes
 
-- [#497](https://github.com/ngrok-oss/mantle/pull/497) [`b5526a0`](https://github.com/ngrok-oss/mantle/commit/b5526a01de147d8ca7f74e0ceca3b0a0b6f5868d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialog: improve intellisense and docs, support asChild
+- [#497](https://github.com/ngrok/mantle/pull/497) [`b5526a0`](https://github.com/ngrok/mantle/commit/b5526a01de147d8ca7f74e0ceca3b0a0b6f5868d) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialog: improve intellisense and docs, support asChild
 
-- [#496](https://github.com/ngrok-oss/mantle/pull/496) [`8d88570`](https://github.com/ngrok-oss/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flag: improve intellisense
+- [#496](https://github.com/ngrok/mantle/pull/496) [`8d88570`](https://github.com/ngrok/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flag: improve intellisense
 
-- [#496](https://github.com/ngrok-oss/mantle/pull/496) [`8d88570`](https://github.com/ngrok-oss/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Icon: update docs and intellisense
+- [#496](https://github.com/ngrok/mantle/pull/496) [`8d88570`](https://github.com/ngrok/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Icon: update docs and intellisense
 
-- [#496](https://github.com/ngrok-oss/mantle/pull/496) [`8d88570`](https://github.com/ngrok-oss/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Label: update docs and intellisense
+- [#496](https://github.com/ngrok/mantle/pull/496) [`8d88570`](https://github.com/ngrok/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Label: update docs and intellisense
 
-- [#496](https://github.com/ngrok-oss/mantle/pull/496) [`8d88570`](https://github.com/ngrok-oss/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - MediaObject: update docs and intellisense, add asChild support
+- [#496](https://github.com/ngrok/mantle/pull/496) [`8d88570`](https://github.com/ngrok/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - MediaObject: update docs and intellisense, add asChild support
 
-- [#494](https://github.com/ngrok-oss/mantle/pull/494) [`c4961ac`](https://github.com/ngrok-oss/mantle/commit/c4961ac846a3d5dddac9d0c9cf371b14c63240a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Card: improve docs and intellisense, support asChild on all sub-components
+- [#494](https://github.com/ngrok/mantle/pull/494) [`c4961ac`](https://github.com/ngrok/mantle/commit/c4961ac846a3d5dddac9d0c9cf371b14c63240a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Card: improve docs and intellisense, support asChild on all sub-components
 
-- [#496](https://github.com/ngrok-oss/mantle/pull/496) [`8d88570`](https://github.com/ngrok-oss/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Badge: improve intellisense
+- [#496](https://github.com/ngrok/mantle/pull/496) [`8d88570`](https://github.com/ngrok/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Badge: improve intellisense
 
-- [#493](https://github.com/ngrok-oss/mantle/pull/493) [`410bc33`](https://github.com/ngrok-oss/mantle/commit/410bc330fd2715ca47e1858a1c5949e02d3a7b7e) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Combobox: fix intellisense on `ComboboxItemValue`
+- [#493](https://github.com/ngrok/mantle/pull/493) [`410bc33`](https://github.com/ngrok/mantle/commit/410bc330fd2715ca47e1858a1c5949e02d3a7b7e) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Combobox: fix intellisense on `ComboboxItemValue`
 
-- [#496](https://github.com/ngrok-oss/mantle/pull/496) [`8d88570`](https://github.com/ngrok-oss/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Skeleton: update docs and intellisense, add asChild support
+- [#496](https://github.com/ngrok/mantle/pull/496) [`8d88570`](https://github.com/ngrok/mantle/commit/8d885708597d45decf0addf40dd5c0179f6b73c0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Skeleton: update docs and intellisense, add asChild support
 
 ## 0.24.0
 
 ### Minor Changes
 
-- [#491](https://github.com/ngrok-oss/mantle/pull/491) [`97538d9`](https://github.com/ngrok-oss/mantle/commit/97538d9986c5b38098729b10acd3274ce28cc98b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Anchor: add support for icons and their placement, improve docs and intellisense
+- [#491](https://github.com/ngrok/mantle/pull/491) [`97538d9`](https://github.com/ngrok/mantle/commit/97538d9986c5b38098729b10acd3274ce28cc98b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Anchor: add support for icons and their placement, improve docs and intellisense
 
 ## 0.23.2
 
 ### Patch Changes
 
-- [#489](https://github.com/ngrok-oss/mantle/pull/489) [`1c47edc`](https://github.com/ngrok-oss/mantle/commit/1c47edc8c4ac9a352befc154e11be5610f523870) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: fix unescaped inner html on initial render
+- [#489](https://github.com/ngrok/mantle/pull/489) [`1c47edc`](https://github.com/ngrok/mantle/commit/1c47edc8c4ac9a352befc154e11be5610f523870) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: fix unescaped inner html on initial render
 
 ## 0.23.1
 
 ### Patch Changes
 
-- [#486](https://github.com/ngrok-oss/mantle/pull/486) [`671867c`](https://github.com/ngrok-oss/mantle/commit/671867cb3a23797a28a0434b86e1be1f6df28955) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Switch: improve intellisense and docs, fix readOnly prop
+- [#486](https://github.com/ngrok/mantle/pull/486) [`671867c`](https://github.com/ngrok/mantle/commit/671867cb3a23797a28a0434b86e1be1f6df28955) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Switch: improve intellisense and docs, fix readOnly prop
 
-- [#483](https://github.com/ngrok-oss/mantle/pull/483) [`247bbc4`](https://github.com/ngrok-oss/mantle/commit/247bbc45dde598f90862ebd051be8fad695f9312) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Separator, ProgressDonut: improve docs and intellisense
+- [#483](https://github.com/ngrok/mantle/pull/483) [`247bbc4`](https://github.com/ngrok/mantle/commit/247bbc45dde598f90862ebd051be8fad695f9312) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Separator, ProgressDonut: improve docs and intellisense
 
-- [#485](https://github.com/ngrok-oss/mantle/pull/485) [`13d21f3`](https://github.com/ngrok-oss/mantle/commit/13d21f3d01ae93300fc379c8439834c03fbe1d5b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Checkbox: improve intellisense and docs
+- [#485](https://github.com/ngrok/mantle/pull/485) [`13d21f3`](https://github.com/ngrok/mantle/commit/13d21f3d01ae93300fc379c8439834c03fbe1d5b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Checkbox: improve intellisense and docs
 
 ## 0.23.0
 
 ### Minor Changes
 
-- [#478](https://github.com/ngrok-oss/mantle/pull/478) [`1b8857b`](https://github.com/ngrok-oss/mantle/commit/1b8857b0bfc23b027ffadf29f3bb8eb9a7535181) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add SandboxedOnClick component
+- [#478](https://github.com/ngrok/mantle/pull/478) [`1b8857b`](https://github.com/ngrok/mantle/commit/1b8857b0bfc23b027ffadf29f3bb8eb9a7535181) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add SandboxedOnClick component
 
-- [#477](https://github.com/ngrok-oss/mantle/pull/477) [`de42d20`](https://github.com/ngrok-oss/mantle/commit/de42d2073df5d23609df63606e2ebbd9c4565e5b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - SheetContent: add preferredWidth prop, remove side: "top" and "bottom" options
+- [#477](https://github.com/ngrok/mantle/pull/477) [`de42d20`](https://github.com/ngrok/mantle/commit/de42d2073df5d23609df63606e2ebbd9c4565e5b) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - SheetContent: add preferredWidth prop, remove side: "top" and "bottom" options
 
 ### Patch Changes
 
-- [#469](https://github.com/ngrok-oss/mantle/pull/469) [`d879af8`](https://github.com/ngrok-oss/mantle/commit/d879af88e3aff48523b94cd618dee720813ba878) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies, add dependabot config, clean up scripts
+- [#469](https://github.com/ngrok/mantle/pull/469) [`d879af8`](https://github.com/ngrok/mantle/commit/d879af88e3aff48523b94cd618dee720813ba878) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies, add dependabot config, clean up scripts
 
-- [#479](https://github.com/ngrok-oss/mantle/pull/479) [`e775e11`](https://github.com/ngrok-oss/mantle/commit/e775e1115626eb7b38480e36507e44d74ac45b5f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - PopoverContent: prevent click events from bubbling out of the PopoverContent container
+- [#479](https://github.com/ngrok/mantle/pull/479) [`e775e11`](https://github.com/ngrok/mantle/commit/e775e1115626eb7b38480e36507e44d74ac45b5f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - PopoverContent: prevent click events from bubbling out of the PopoverContent container
 
-- [#480](https://github.com/ngrok-oss/mantle/pull/480) [`c87c906`](https://github.com/ngrok-oss/mantle/commit/c87c906f5d91c6d5988097eb8ca8f461038355a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - TextArea: improve docs and intellisense
+- [#480](https://github.com/ngrok/mantle/pull/480) [`c87c906`](https://github.com/ngrok/mantle/commit/c87c906f5d91c6d5988097eb8ca8f461038355a0) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - TextArea: improve docs and intellisense
 
 ## 0.22.2
 
 ### Patch Changes
 
-- [#467](https://github.com/ngrok-oss/mantle/pull/467) [`1556c80`](https://github.com/ngrok-oss/mantle/commit/1556c80892e453eb0ce76ba4638a3c2ab79b03a6) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#467](https://github.com/ngrok/mantle/pull/467) [`1556c80`](https://github.com/ngrok/mantle/commit/1556c80892e453eb0ce76ba4638a3c2ab79b03a6) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
 ## 0.22.1
 
 ### Patch Changes
 
-- [#464](https://github.com/ngrok-oss/mantle/pull/464) [`b55338e`](https://github.com/ngrok-oss/mantle/commit/b55338ea37f0f1a074713990bdcb96b998ef8c09) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
+- [#464](https://github.com/ngrok/mantle/pull/464) [`b55338e`](https://github.com/ngrok/mantle/commit/b55338ea37f0f1a074713990bdcb96b998ef8c09) Thanks [@dependabot](https://github.com/apps/dependabot)! - Update dependencies
 
-- [#466](https://github.com/ngrok-oss/mantle/pull/466) [`a708b7f`](https://github.com/ngrok-oss/mantle/commit/a708b7f298dcd75c5607f4a226f1fede0d593921) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Sheet: improve inline intellisense and docsite documentation
+- [#466](https://github.com/ngrok/mantle/pull/466) [`a708b7f`](https://github.com/ngrok/mantle/commit/a708b7f298dcd75c5607f4a226f1fede0d593921) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Sheet: improve inline intellisense and docsite documentation
 
 ## 0.22.0
 
 ### Minor Changes
 
-- [#462](https://github.com/ngrok-oss/mantle/pull/462) [`2e9f116`](https://github.com/ngrok-oss/mantle/commit/2e9f11667f8f2f895ac81883efc386e7df8131d1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Checkbox: remove zodCheckbox export
+- [#462](https://github.com/ngrok/mantle/pull/462) [`2e9f116`](https://github.com/ngrok/mantle/commit/2e9f11667f8f2f895ac81883efc386e7df8131d1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Checkbox: remove zodCheckbox export
 
 ### Patch Changes
 
-- [#460](https://github.com/ngrok-oss/mantle/pull/460) [`e62f0ef`](https://github.com/ngrok-oss/mantle/commit/e62f0ef753984366b4c3f3bc53e656abfc0f4b98) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Select: improve component docs, add inline intellisense examples w/ links, make content width default to "trigger"
+- [#460](https://github.com/ngrok/mantle/pull/460) [`e62f0ef`](https://github.com/ngrok/mantle/commit/e62f0ef753984366b4c3f3bc53e656abfc0f4b98) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Select: improve component docs, add inline intellisense examples w/ links, make content width default to "trigger"
 
 ## 0.21.5
 
 ### Patch Changes
 
-- [#458](https://github.com/ngrok-oss/mantle/pull/458) [`494430c`](https://github.com/ngrok-oss/mantle/commit/494430cfa5e08958de9fc8eb7710644362dee18b) Thanks [@dependabot](https://github.com/apps/dependabot)! - update prism to fix security vulnerability
+- [#458](https://github.com/ngrok/mantle/pull/458) [`494430c`](https://github.com/ngrok/mantle/commit/494430cfa5e08958de9fc8eb7710644362dee18b) Thanks [@dependabot](https://github.com/apps/dependabot)! - update prism to fix security vulnerability
 
 ## 0.21.4
 
 ### Patch Changes
 
-- [#456](https://github.com/ngrok-oss/mantle/pull/456) [`2ed9953`](https://github.com/ngrok-oss/mantle/commit/2ed9953b76c231445a67a63b3f4be31158968306) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Alert: improve doc site entry and intellisense for each component; remove unused default priority and make priority required; add AlertIcon component
+- [#456](https://github.com/ngrok/mantle/pull/456) [`2ed9953`](https://github.com/ngrok/mantle/commit/2ed9953b76c231445a67a63b3f4be31158968306) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Alert: improve doc site entry and intellisense for each component; remove unused default priority and make priority required; add AlertIcon component
 
 ## 0.21.3
 
 ### Patch Changes
 
-- [#454](https://github.com/ngrok-oss/mantle/pull/454) [`2ddbdab`](https://github.com/ngrok-oss/mantle/commit/2ddbdab61f0a875854452c11a3b7dba1913b4737) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - ProgressDonut: properly fix the render AND hydration issue
+- [#454](https://github.com/ngrok/mantle/pull/454) [`2ddbdab`](https://github.com/ngrok/mantle/commit/2ddbdab61f0a875854452c11a3b7dba1913b4737) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - ProgressDonut: properly fix the render AND hydration issue
 
 ## 0.21.2
 
 ### Patch Changes
 
-- [#452](https://github.com/ngrok-oss/mantle/pull/452) [`f76dc0e`](https://github.com/ngrok-oss/mantle/commit/f76dc0e7f3e862f4f50e0270fe29709facd88803) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - ProgressDonut: fix hydration error, add examples in intellisense
+- [#452](https://github.com/ngrok/mantle/pull/452) [`f76dc0e`](https://github.com/ngrok/mantle/commit/f76dc0e7f3e862f4f50e0270fe29709facd88803) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - ProgressDonut: fix hydration error, add examples in intellisense
 
 ## 0.21.1
 
 ### Patch Changes
 
-- [#450](https://github.com/ngrok-oss/mantle/pull/450) [`00de431`](https://github.com/ngrok-oss/mantle/commit/00de431a6f3f95d877a62a89a6d305d82b56b639) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: fix alignment of absolutely positioned copy button
+- [#450](https://github.com/ngrok/mantle/pull/450) [`00de431`](https://github.com/ngrok/mantle/commit/00de431a6f3f95d877a62a89a6d305d82b56b639) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: fix alignment of absolutely positioned copy button
 
 ## 0.21.0
 
 ### Minor Changes
 
-- [#428](https://github.com/ngrok-oss/mantle/pull/428) [`944e9a6`](https://github.com/ngrok-oss/mantle/commit/944e9a69b0e295d2794e6dbcbc3bdc6fc922e990) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add combobox component
+- [#428](https://github.com/ngrok/mantle/pull/428) [`944e9a6`](https://github.com/ngrok/mantle/commit/944e9a69b0e295d2794e6dbcbc3bdc6fc922e990) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add combobox component
 
 ### Patch Changes
 
-- [#447](https://github.com/ngrok-oss/mantle/pull/447) [`8d47922`](https://github.com/ngrok-oss/mantle/commit/8d47922ad3d3cba9305eaab75552c9910f6af7e9) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flags: add GB alias for UK flag
+- [#447](https://github.com/ngrok/mantle/pull/447) [`8d47922`](https://github.com/ngrok/mantle/commit/8d47922ad3d3cba9305eaab75552c9910f6af7e9) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flags: add GB alias for UK flag
 
 ## 0.20.2
 
 ### Patch Changes
 
-- [#444](https://github.com/ngrok-oss/mantle/pull/444) [`63ce798`](https://github.com/ngrok-oss/mantle/commit/63ce7986ea424774168209218d4562cbda5906d1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flags: rename Flags type to CountryCode, export countryCodes list and isCountryCode type predicate fn
+- [#444](https://github.com/ngrok/mantle/pull/444) [`63ce798`](https://github.com/ngrok/mantle/commit/63ce7986ea424774168209218d4562cbda5906d1) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flags: rename Flags type to CountryCode, export countryCodes list and isCountryCode type predicate fn
 
 ## 0.20.1
 
 ### Patch Changes
 
-- [#443](https://github.com/ngrok-oss/mantle/pull/443) [`46087c5`](https://github.com/ngrok-oss/mantle/commit/46087c5e763c2c0d034f5d9d1e1b48191dfe1ccd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flag: add border radius and inset transparent black border
+- [#443](https://github.com/ngrok/mantle/pull/443) [`46087c5`](https://github.com/ngrok/mantle/commit/46087c5e763c2c0d034f5d9d1e1b48191dfe1ccd) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Flag: add border radius and inset transparent black border
 
-- [#441](https://github.com/ngrok-oss/mantle/pull/441) [`2867bdf`](https://github.com/ngrok-oss/mantle/commit/2867bdfb23df6d35da1e50bd9ad95b65c70cc3e3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Prep for react 19: swap react-19-deprecated ElementRef type for ComponentRef type
+- [#441](https://github.com/ngrok/mantle/pull/441) [`2867bdf`](https://github.com/ngrok/mantle/commit/2867bdfb23df6d35da1e50bd9ad95b65c70cc3e3) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Prep for react 19: swap react-19-deprecated ElementRef type for ComponentRef type
 
 ## 0.20.0
 
 ### Minor Changes
 
-- [#439](https://github.com/ngrok-oss/mantle/pull/439) [`1523118`](https://github.com/ngrok-oss/mantle/commit/15231189ac7f5818fd963d4dc4162c5ca1cfebba) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add Flag component
+- [#439](https://github.com/ngrok/mantle/pull/439) [`1523118`](https://github.com/ngrok/mantle/commit/15231189ac7f5818fd963d4dc4162c5ca1cfebba) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Add Flag component
 
 ## 0.19.17
 
 ### Patch Changes
 
-- [#435](https://github.com/ngrok-oss/mantle/pull/435) [`0aac02a`](https://github.com/ngrok-oss/mantle/commit/0aac02a732b0c32c21c2183282a1c9fd0b7e5dc5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialog: actually export AlertDialogClose
+- [#435](https://github.com/ngrok/mantle/pull/435) [`0aac02a`](https://github.com/ngrok/mantle/commit/0aac02a732b0c32c21c2183282a1c9fd0b7e5dc5) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialog: actually export AlertDialogClose
 
 ## 0.19.16
 
 ### Patch Changes
 
-- [#433](https://github.com/ngrok-oss/mantle/pull/433) [`4744706`](https://github.com/ngrok-oss/mantle/commit/474470667d728a02615fb68b9fc5612635c96882) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialog: export AlertDialogClose
+- [#433](https://github.com/ngrok/mantle/pull/433) [`4744706`](https://github.com/ngrok/mantle/commit/474470667d728a02615fb68b9fc5612635c96882) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - AlertDialog: export AlertDialogClose
 
 ## 0.19.15
 
 ### Patch Changes
 
-- [#431](https://github.com/ngrok-oss/mantle/pull/431) [`7358307`](https://github.com/ngrok-oss/mantle/commit/7358307706b78eb459803632df08547e588b5cca) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DropdownMenuRadioItem: only take up space for the checkmark when an item is checked
+- [#431](https://github.com/ngrok/mantle/pull/431) [`7358307`](https://github.com/ngrok/mantle/commit/7358307706b78eb459803632df08547e588b5cca) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - DropdownMenuRadioItem: only take up space for the checkmark when an item is checked
 
 ## 0.19.14
 
 ### Patch Changes
 
-- [#430](https://github.com/ngrok-oss/mantle/pull/430) [`ec4e2e4`](https://github.com/ngrok-oss/mantle/commit/ec4e2e4867e7eecfd8571abc4092e83ad1e3c2fe) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - button: fix underline on group-hover bug of <Button appearance="link"> bug
+- [#430](https://github.com/ngrok/mantle/pull/430) [`ec4e2e4`](https://github.com/ngrok/mantle/commit/ec4e2e4867e7eecfd8571abc4092e83ad1e3c2fe) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - button: fix underline on group-hover bug of <Button appearance="link"> bug
 
-- [#427](https://github.com/ngrok-oss/mantle/pull/427) [`7b9ef0b`](https://github.com/ngrok-oss/mantle/commit/7b9ef0b44b0f16ff36bd2c9dcfc2d3a74915f1f7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies
+- [#427](https://github.com/ngrok/mantle/pull/427) [`7b9ef0b`](https://github.com/ngrok/mantle/commit/7b9ef0b44b0f16ff36bd2c9dcfc2d3a74915f1f7) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update dependencies
 
-- [#425](https://github.com/ngrok-oss/mantle/pull/425) [`0dad7df`](https://github.com/ngrok-oss/mantle/commit/0dad7df13a14b59be0c53605bc3fec471ead73e1) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
+- [#425](https://github.com/ngrok/mantle/pull/425) [`0dad7df`](https://github.com/ngrok/mantle/commit/0dad7df13a14b59be0c53605bc3fec471ead73e1) Thanks [@dependabot](https://github.com/apps/dependabot)! - update dependencies
 
 ## 0.19.13
 
 ### Patch Changes
 
-- [#422](https://github.com/ngrok-oss/mantle/pull/422) [`e87acd6`](https://github.com/ngrok-oss/mantle/commit/e87acd639bf7c5ad0826b0014733491400daa71f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - types: export parseBooleanish
+- [#422](https://github.com/ngrok/mantle/pull/422) [`e87acd6`](https://github.com/ngrok/mantle/commit/e87acd639bf7c5ad0826b0014733491400daa71f) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - types: export parseBooleanish
 
 ## 0.19.12
 
 ### Patch Changes
 
-- [#419](https://github.com/ngrok-oss/mantle/pull/419) [`d78b2ce`](https://github.com/ngrok-oss/mantle/commit/d78b2ceb6bea4beca93358d7732117d7e97fb1bb) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Make the `className` arg on `anchorClassNames` optional
+- [#419](https://github.com/ngrok/mantle/pull/419) [`d78b2ce`](https://github.com/ngrok/mantle/commit/d78b2ceb6bea4beca93358d7732117d7e97fb1bb) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Make the `className` arg on `anchorClassNames` optional
 
 ## 0.19.11
 
 ### Patch Changes
 
-- [#417](https://github.com/ngrok-oss/mantle/pull/417) [`298b175`](https://github.com/ngrok-oss/mantle/commit/298b1753231f89c8102d469d5d79b6492364a9d8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: adjust styles, add defensive css (for docs)
+- [#417](https://github.com/ngrok/mantle/pull/417) [`298b175`](https://github.com/ngrok/mantle/commit/298b1753231f89c8102d469d5d79b6492364a9d8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: adjust styles, add defensive css (for docs)
 
 ## 0.19.10
 
 ### Patch Changes
 
-- [#415](https://github.com/ngrok-oss/mantle/pull/415) [`4275988`](https://github.com/ngrok-oss/mantle/commit/427598893d974cdbd27fea55bfe322ab437d7a48) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - mantle.css: improve matching for css vars on root
+- [#415](https://github.com/ngrok/mantle/pull/415) [`4275988`](https://github.com/ngrok/mantle/commit/427598893d974cdbd27fea55bfe322ab437d7a48) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - mantle.css: improve matching for css vars on root
 
 ## 0.19.9
 
 ### Patch Changes
 
-- [#413](https://github.com/ngrok-oss/mantle/pull/413) [`d42bb6f`](https://github.com/ngrok-oss/mantle/commit/d42bb6f7843060a84a363e5162b7d1cbedd59946) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - SelectItem: improve styling to fix hover bg color on selected items in docs use case
+- [#413](https://github.com/ngrok/mantle/pull/413) [`d42bb6f`](https://github.com/ngrok/mantle/commit/d42bb6f7843060a84a363e5162b7d1cbedd59946) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - SelectItem: improve styling to fix hover bg color on selected items in docs use case
 
 ## 0.19.8
 
 ### Patch Changes
 
-- [#411](https://github.com/ngrok-oss/mantle/pull/411) [`88727bd`](https://github.com/ngrok-oss/mantle/commit/88727bd71171ef05ca83dbd43bad1b2449464c2e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: add CodeBlockIcon component and fix some styling
+- [#411](https://github.com/ngrok/mantle/pull/411) [`88727bd`](https://github.com/ngrok/mantle/commit/88727bd71171ef05ca83dbd43bad1b2449464c2e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - CodeBlock: add CodeBlockIcon component and fix some styling
 
 ## 0.19.7
 
 ### Patch Changes
 
-- [#408](https://github.com/ngrok-oss/mantle/pull/408) [`0868adb`](https://github.com/ngrok-oss/mantle/commit/0868adbcf65936e0377236d353610e063a6279f7) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Revamp the readme and contributing guide
+- [#408](https://github.com/ngrok/mantle/pull/408) [`0868adb`](https://github.com/ngrok/mantle/commit/0868adbcf65936e0377236d353610e063a6279f7) Thanks [@melanieseltzer](https://github.com/melanieseltzer)! - Revamp the readme and contributing guide
 
-- [#410](https://github.com/ngrok-oss/mantle/pull/410) [`de54a95`](https://github.com/ngrok-oss/mantle/commit/de54a953fcaf64344c652c5cc573515197e68555) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add fade-in keyframes to tailwind preset
+- [#410](https://github.com/ngrok/mantle/pull/410) [`de54a95`](https://github.com/ngrok/mantle/commit/de54a953fcaf64344c652c5cc573515197e68555) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - add fade-in keyframes to tailwind preset
 
 ## 0.19.6
 
 ### Patch Changes
 
-- [`1d83e1d`](https://github.com/ngrok-oss/mantle/commit/1d83e1df14d7848a7eb14de13699aac7d846dcc8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Slack post will work this time for real i promise u 🦐
+- [`1d83e1d`](https://github.com/ngrok/mantle/commit/1d83e1df14d7848a7eb14de13699aac7d846dcc8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Slack post will work this time for real i promise u 🦐
 
 ## 0.19.5
 
 ### Patch Changes
 
-- [`595e6c1`](https://github.com/ngrok-oss/mantle/commit/595e6c1dc9758a68602492e270452891d3482f60) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fixing the post to slack webhook on mantle release
+- [`595e6c1`](https://github.com/ngrok/mantle/commit/595e6c1dc9758a68602492e270452891d3482f60) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Fixing the post to slack webhook on mantle release
 
 ## 0.19.4
 
 ### Patch Changes
 
-- [`cf2d8c2`](https://github.com/ngrok-oss/mantle/commit/cf2d8c25e1f3525165e0510ae51dc9162a6439c8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Debugging changesets release
+- [`cf2d8c2`](https://github.com/ngrok/mantle/commit/cf2d8c25e1f3525165e0510ae51dc9162a6439c8) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Debugging changesets release
 
 ## 0.19.3
 
 ### Patch Changes
 
-- [#399](https://github.com/ngrok-oss/mantle/pull/399) [`cbeec74`](https://github.com/ngrok-oss/mantle/commit/cbeec7482e7b19fba9202d80e842a6785018728e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update patch dependencies of radix component packages https://github.com/ngrok-oss/mantle/pull/396
-  Improve code quality (suggestions from trialing biomejs) https://github.com/ngrok-oss/mantle/pull/398
+- [#399](https://github.com/ngrok/mantle/pull/399) [`cbeec74`](https://github.com/ngrok/mantle/commit/cbeec7482e7b19fba9202d80e842a6785018728e) Thanks [@cody-dot-js](https://github.com/cody-dot-js)! - Update patch dependencies of radix component packages https://github.com/ngrok/mantle/pull/396
+  Improve code quality (suggestions from trialing biomejs) https://github.com/ngrok/mantle/pull/398
 
-  For historical release notes prior to `v0.19.3`, please consult https://github.com/ngrok-oss/mantle/releases
+  For historical release notes prior to `v0.19.3`, please consult https://github.com/ngrok/mantle/releases

--- a/packages/mantle/README.md
+++ b/packages/mantle/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ngrok-oss/mantle/HEAD/.github/mantle-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ngrok-oss/mantle/HEAD/.github/mantle-light.svg">
-    <img alt="Mantle" src="https://raw.githubusercontent.com/ngrok-oss/mantle/HEAD/.github/mantle-light.svg" width="176" height="34" style="max-width: 100%;">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ngrok/mantle/HEAD/.github/mantle-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ngrok/mantle/HEAD/.github/mantle-light.svg">
+    <img alt="Mantle" src="https://raw.githubusercontent.com/ngrok/mantle/HEAD/.github/mantle-light.svg" width="176" height="34" style="max-width: 100%;">
   </picture>
 </p>
 <h1 align="center">
@@ -74,11 +74,11 @@ const result = await highlighter.highlight({
 
 ## Related Packages
 
-| Package                                   | Description                                                                            | Links                                                                                                                                                                            |
-| ----------------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@ngrok/mantle-vite-plugins`              | Vite + rehype plugins for code block highlighting and Tailwind CSS source optimization | [GitHub](https://github.com/ngrok-oss/mantle/tree/main/packages/mantle-vite-plugins) · [npm](https://www.npmjs.com/package/@ngrok/mantle-vite-plugins)                           |
-| `@ngrok/mantle-server-syntax-highlighter` | Server-side syntax highlighting engine powered by Shiki                                | [GitHub](https://github.com/ngrok-oss/mantle/tree/main/packages/mantle-server-syntax-highlighter) · [npm](https://www.npmjs.com/package/@ngrok/mantle-server-syntax-highlighter) |
+| Package                                   | Description                                                                            | Links                                                                                                                                                                        |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@ngrok/mantle-vite-plugins`              | Vite + rehype plugins for code block highlighting and Tailwind CSS source optimization | [GitHub](https://github.com/ngrok/mantle/tree/main/packages/mantle-vite-plugins) · [npm](https://www.npmjs.com/package/@ngrok/mantle-vite-plugins)                           |
+| `@ngrok/mantle-server-syntax-highlighter` | Server-side syntax highlighting engine powered by Shiki                                | [GitHub](https://github.com/ngrok/mantle/tree/main/packages/mantle-server-syntax-highlighter) · [npm](https://www.npmjs.com/package/@ngrok/mantle-server-syntax-highlighter) |
 
 ## Contributing
 
-Please read our [contribution guide](https://github.com/ngrok-oss/mantle/blob/main/CONTRIBUTING.md) and [conventions](https://github.com/ngrok-oss/mantle/blob/main/CONVENTIONS.md).
+Please read our [contribution guide](https://github.com/ngrok/mantle/blob/main/CONTRIBUTING.md) and [conventions](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md).

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -7,7 +7,7 @@
 	"author": "ngrok",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/ngrok-oss/mantle"
+		"url": "https://github.com/ngrok/mantle"
 	},
 	"files": [
 		"dist",

--- a/packages/mantle/src/components/calendar/calendar.tsx
+++ b/packages/mantle/src/components/calendar/calendar.tsx
@@ -33,7 +33,7 @@ type CalendarProps = ComponentProps<typeof DayPicker>;
  * />
  * ```
  *
- * https://github.com/ngrok-oss/mantle/issues
+ * https://github.com/ngrok/mantle/issues
  */
 function Calendar({ className, classNames, showOutsideDays = false, ...props }: CalendarProps) {
 	return (


### PR DESCRIPTION
Repo was transferred from the ngrok-oss org to ngrok. Update all references to the old path:

- .changeset/config.json: repo field for future changelog links
- publish-npm.yml: github.repository publish guard + Slack release link
- CODEOWNERS: @ngrok-oss/team-frontend -> @ngrok/team-frontend (a CODEOWNERS team must belong to the repo's own org)
- package.json repository.url for all three packages
- docs site links/labels (header, *.mdx, llms.txt, release-href)
- README files, decision records, calendar JSDoc
- auto-generated CHANGELOG PR/commit URLs
- changelog test fixtures + components-surface snapshot