### PR TITLE
perf(mantle): vendor cx engine and export clsx

### DIFF
--- a/.changeset/vendor-cx-engine.md
+++ b/.changeset/vendor-cx-engine.md
@@ -1,0 +1,16 @@
+---
+"@ngrok/mantle": patch
+---
+
+Vendor the `cx` class-merge engine and drop the `clsx` + `tailwind-merge` runtime dependencies.
+
+`cx` is now powered by a vendored, byte-for-byte port of `clsx` + `tailwind-merge` (adapted from [`cnfast`](https://github.com/aidenybai/cnfast)), living in `src/utils/cx/vendor`. Mantle's previous `extendTailwindMerge` overrides — the `em` spacing scale (`w-em`, `p-em`, …) and the `text-mono` / `text-size-inherit` font-size utilities — are now baked directly into the vendored default config, so no extend call is needed.
+
+- **Output is byte-identical** to the previous `clsx` + `extendTailwindMerge` implementation (guarded by a 3,200+ case parity fixture).
+- **Same public API:** `cx(...inputs)` is unchanged (`(...inputs: ClassValue[]) => string`).
+- **Faster**, with the largest gains on repeated re-render call sites (interned conflict keys, per-token descriptor caching, and a V8 arg cache).
+- **New, additive:** `cx` can also be called as a tagged template — `` cx`px-2 px-4 ${active && "bg-blue-500"}` `` — which caches by call-site identity.
+
+`clsx` and `tailwind-merge` are no longer dependencies of `@ngrok/mantle`. (`clsx` remains available transitively via `class-variance-authority`.)
+
+Export `clsx` from the `@ngrok/mantle/cx` subpath alongside `cx`.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -110,6 +110,7 @@
     "dist",
     "node_modules",
     "public",
-    "*/code-gen"
+    "*/code-gen",
+    "packages/mantle/src/utils/cx/vendor"
   ]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,8 @@ node_modules
 public
 */code-gen
 packages/mantle/package.json
+packages/mantle/src/utils/cx/vendor
+packages/mantle/src/utils/cx/__fixtures__
 *.svg
 *.yaml
 bun.lockb

--- a/apps/www/app/docs/utils/cx.mdx
+++ b/apps/www/app/docs/utils/cx.mdx
@@ -7,7 +7,7 @@ description: Class name composition utility from @ngrok/mantle/cx
 
 A class name composition utility that combines conditional class names and resolves Tailwind CSS conflicts using left-to-right merge order.
 
-Wraps [`clsx`](https://github.com/lukeed/clsx) for conditional class handling and [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) for conflict resolution, so later classes override earlier ones (same behavior as inline styles).
+Powered by a vendored, byte-for-byte port of [`clsx`](https://github.com/lukeed/clsx) (conditional class handling) and [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) (conflict resolution), adapted from [`cnfast`](https://github.com/aidenybai/cnfast). Later classes override earlier ones (same behavior as inline styles). Mantle's Tailwind overrides — the `em` spacing scale (`w-em`, `p-em`, …) and the `text-mono` / `text-size-inherit` font-size utilities — are baked in, so neither `clsx` nor `tailwind-merge` is a runtime dependency.
 
 ```ts
 import { cx } from "@ngrok/mantle/cx";
@@ -66,12 +66,24 @@ function Button({ className }: ButtonProps) {
 // → "text-white px-4 py-2 rounded bg-red-500"
 ```
 
+## Tagged template
+
+`cx` can also be called as a tagged template. A tagged template reuses the same static
+strings array on every render, so `cx` caches the result by call-site identity — useful for
+hot re-rendering paths. The behavior is otherwise identical to the call form.
+
+```tsx
+cx`px-2 px-4 ${isActive && "bg-blue-500"}`;
+// → "px-4 bg-blue-500"
+```
+
 ## API
 
 ```ts
 function cx(...inputs: ClassValue[]): string;
+// also callable as a tagged template: cx`px-2 ${cond && "px-4"}`
 
-// ClassValue comes from clsx, looks like this 👇
+// ClassValue, looks like this 👇
 type ClassValue =
 	| ClassArray
 	| ClassDictionary

--- a/apps/www/app/utilities/agent-manifests.server.test.ts
+++ b/apps/www/app/utilities/agent-manifests.server.test.ts
@@ -23,7 +23,7 @@ describe("agent manifests", () => {
 		const cx = manifest.utilities.find((utility) => utility.name === "cx");
 		const highlightUtils = manifest.utilities.find((utility) => utility.name === "highlight-utils");
 
-		expect(cx?.summary).toContain("Conditionally add Tailwind");
+		expect(cx?.summary).toContain("Conditionally compose class names");
 		expect(highlightUtils?.summary).toContain("React-free highlighting utilities");
 	});
 

--- a/mise.toml
+++ b/mise.toml
@@ -18,8 +18,8 @@ DO_NOT_TRACK = "1"
 TURBO_TELEMETRY_DISABLED = "1"
 VERCEL_TELEMETRY_DISABLED = "1"
 TURBO_TEAM = "ngrok-frontend"
-# Local runs read-only; CI is the sole writer to ensure cache correctness and reproducibility.
-TURBO_CACHE = "remote:r"
+# Local runs may write local cache; CI is the sole remote writer for reproducibility.
+TURBO_CACHE = "local:rw,remote:r"
 
 [tasks.install]
 description = "Install workspace dependencies using the committed lockfile"

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -371,12 +371,10 @@
 		"@radix-ui/react-tooltip": "1.2.10",
 		"@tanstack/react-table": "8.21.3",
 		"class-variance-authority": "0.7.1",
-		"clsx": "2.1.1",
 		"cmdk": "1.1.1",
 		"input-otp": "1.4.2",
 		"react-day-picker": "10.0.1",
 		"sonner": "2.0.7",
-		"tailwind-merge": "3.6.0",
 		"tiny-invariant": "1.3.3",
 		"tw-animate-css": "1.4.0",
 		"uqr": "0.1.3"

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -1,12 +1,12 @@
 import { CircleNotchIcon } from "@phosphor-icons/react/CircleNotch";
 import { cva } from "class-variance-authority";
-import clsx from "clsx";
 import type { ComponentProps, ReactNode } from "react";
 import { Children, cloneElement, forwardRef, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import { parseBooleanish } from "../../types/index.js";
 import type { WithAsChild } from "../../types/index.js";
 import type { VariantProps } from "../../types/variant-props.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Icon } from "../icon/index.js";
 import { Slot } from "../slot/index.js";

--- a/packages/mantle/src/components/checkbox/checkbox.tsx
+++ b/packages/mantle/src/components/checkbox/checkbox.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import clsx from "clsx";
 import { forwardRef, useEffect, useRef, useState } from "react";
 import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { composeRefs } from "../../utils/compose-refs/index.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
 import type { WithValidation } from "../field/validation.js";
 

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -3,7 +3,6 @@
 import { CheckCircleIcon } from "@phosphor-icons/react/CheckCircle";
 import { WarningIcon } from "@phosphor-icons/react/Warning";
 import { WarningDiamondIcon } from "@phosphor-icons/react/WarningDiamond";
-import clsx from "clsx";
 import type {
 	ComponentRef,
 	ForwardedRef,
@@ -13,6 +12,7 @@ import type {
 } from "react";
 import { createContext, forwardRef, useContext, useMemo, useRef } from "react";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
 import type { Validation, WithValidation } from "../field/validation.js";

--- a/packages/mantle/src/components/progress/progress-donut.tsx
+++ b/packages/mantle/src/components/progress/progress-donut.tsx
@@ -1,7 +1,7 @@
-import clsx from "clsx";
 import { createContext, useContext, useId, useMemo } from "react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { $cssProperties } from "../../types/index.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { clamp, isNumber, isValidMaxNumber, isValidValueNumber } from "./math.js";
 import type { ValueType } from "./types.js";

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -5,7 +5,6 @@ import type {
 	RadioGroupProps as HeadlessRadioGroupProps,
 	RadioProps as HeadlessRadioProps,
 } from "@headlessui/react";
-import clsx from "clsx";
 import {
 	Children,
 	cloneElement,
@@ -17,6 +16,7 @@ import {
 } from "react";
 import type { ComponentRef, HTMLAttributes, PropsWithChildren, ReactNode } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { FieldControlContext } from "../field/field-context.js";
 import { isInput } from "../input/is-input.js";

--- a/packages/mantle/src/components/switch/switch.tsx
+++ b/packages/mantle/src/components/switch/switch.tsx
@@ -1,8 +1,8 @@
 import { Root as SwitchPrimitiveRoot, Thumb as SwitchPrimitiveThumb } from "@radix-ui/react-switch";
-import clsx from "clsx";
 import { forwardRef } from "react";
 import type { ComponentPropsWithoutRef, ComponentRef } from "react";
 import { parseBooleanish } from "../../types/booleanish.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
 import type { WithValidation } from "../field/validation.js";

--- a/packages/mantle/src/components/tabs/tabs.tsx
+++ b/packages/mantle/src/components/tabs/tabs.tsx
@@ -5,7 +5,6 @@ import {
 	Trigger as TabsPrimitiveTrigger,
 } from "@radix-ui/react-tabs";
 import { cva } from "class-variance-authority";
-import clsx from "clsx";
 import type { ComponentPropsWithoutRef, ComponentRef, HTMLAttributes } from "react";
 import {
 	Children,
@@ -21,6 +20,7 @@ import {
 import invariant from "tiny-invariant";
 import { parseBooleanish } from "../../types/booleanish.js";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
+import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { getPrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 import type { ScrollBehavior } from "../../hooks/use-scroll-behavior.js";

--- a/packages/mantle/src/utils/cx/__fixtures__/parity.json
+++ b/packages/mantle/src/utils/cx/__fixtures__/parity.json
@@ -1,0 +1,21984 @@
+[
+	{
+		"args": [
+			""
+		],
+		"expected": ""
+	},
+	{
+		"args": [
+			"a"
+		],
+		"expected": "a"
+	},
+	{
+		"args": [
+			"p-4 pt-5 pb-6 pr-3 pb-3"
+		],
+		"expected": "p-4 pt-5 pr-3 pb-3"
+	},
+	{
+		"args": [
+			"pb-6 pb-8"
+		],
+		"expected": "pb-8"
+	},
+	{
+		"args": [
+			"pb-8 pb-6"
+		],
+		"expected": "pb-6"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-base leading-4 text-blue text-xl leading-5"
+		],
+		"expected": "mb-2 text-blue text-xl leading-5"
+	},
+	{
+		"args": [
+			"text-mono text-base"
+		],
+		"expected": "text-base"
+	},
+	{
+		"args": [
+			"text-base text-mono"
+		],
+		"expected": "text-mono"
+	},
+	{
+		"args": [
+			"text-size-inherit text-base"
+		],
+		"expected": "text-base"
+	},
+	{
+		"args": [
+			"text-base text-size-inherit"
+		],
+		"expected": "text-size-inherit"
+	},
+	{
+		"args": [
+			"font-mono text-mono p-4 text-xl"
+		],
+		"expected": "font-mono p-4 text-xl"
+	},
+	{
+		"args": [
+			"text-mono text-size-inherit text-xl"
+		],
+		"expected": "text-xl"
+	},
+	{
+		"args": [
+			"text-xl text-mono"
+		],
+		"expected": "text-mono"
+	},
+	{
+		"args": [
+			"w-4 w-em"
+		],
+		"expected": "w-em"
+	},
+	{
+		"args": [
+			"h-em h-6"
+		],
+		"expected": "h-6"
+	},
+	{
+		"args": [
+			"p-em p-2"
+		],
+		"expected": "p-2"
+	},
+	{
+		"args": [
+			"gap-4 gap-em"
+		],
+		"expected": "gap-em"
+	},
+	{
+		"args": [
+			"m-em m-4"
+		],
+		"expected": "m-4"
+	},
+	{
+		"args": [
+			"px-2 px-em"
+		],
+		"expected": "px-em"
+	},
+	{
+		"args": [
+			"mt-em mt-4"
+		],
+		"expected": "mt-4"
+	},
+	{
+		"args": [
+			"w-em h-em p-em gap-em"
+		],
+		"expected": "w-em h-em p-em gap-em"
+	},
+	{
+		"args": [
+			"size-4 size-em"
+		],
+		"expected": "size-em"
+	},
+	{
+		"args": [
+			"hover:bg-red-500 hover:bg-blue-500"
+		],
+		"expected": "hover:bg-blue-500"
+	},
+	{
+		"args": [
+			"md:p-4 md:p-8"
+		],
+		"expected": "md:p-8"
+	},
+	{
+		"args": [
+			"dark:text-white dark:text-black"
+		],
+		"expected": "dark:text-black"
+	},
+	{
+		"args": [
+			"hover:md:p-2 hover:md:p-4"
+		],
+		"expected": "hover:md:p-4"
+	},
+	{
+		"args": [
+			"focus-visible:ring-2 focus-visible:ring-4"
+		],
+		"expected": "focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"data-[state=open]:bg-red-500 data-[state=open]:bg-blue-500"
+		],
+		"expected": "data-[state=open]:bg-blue-500"
+	},
+	{
+		"args": [
+			"p-4! p-8!"
+		],
+		"expected": "p-8!"
+	},
+	{
+		"args": [
+			"!p-4 !p-8"
+		],
+		"expected": "!p-8"
+	},
+	{
+		"args": [
+			"p-4 p-8!"
+		],
+		"expected": "p-4 p-8!"
+	},
+	{
+		"args": [
+			"hover:!text-red-500 hover:!text-blue-500"
+		],
+		"expected": "hover:!text-blue-500"
+	},
+	{
+		"args": [
+			"bg-red-500/50 bg-red-500/75"
+		],
+		"expected": "bg-red-500/75"
+	},
+	{
+		"args": [
+			"text-black/50 text-black/80"
+		],
+		"expected": "text-black/80"
+	},
+	{
+		"args": [
+			"w-[10px] w-[20px]"
+		],
+		"expected": "w-[20px]"
+	},
+	{
+		"args": [
+			"p-[3px] p-[5px]"
+		],
+		"expected": "p-[5px]"
+	},
+	{
+		"args": [
+			"[mask-type:luminance] [mask-type:alpha]"
+		],
+		"expected": "[mask-type:alpha]"
+	},
+	{
+		"args": [
+			"[r:var(--radius)] origin-center"
+		],
+		"expected": "[r:var(--radius)] origin-center"
+	},
+	{
+		"args": [
+			"bg-[#fff] bg-[#000]"
+		],
+		"expected": "bg-[#000]"
+	},
+	{
+		"args": [
+			"grid-cols-[1fr_2fr] grid-cols-3"
+		],
+		"expected": "grid-cols-3"
+	},
+	{
+		"args": [
+			"-mt-2 -mt-4"
+		],
+		"expected": "-mt-4"
+	},
+	{
+		"args": [
+			"-inset-1 inset-2"
+		],
+		"expected": "inset-2"
+	},
+	{
+		"args": [
+			"-z-10 z-20"
+		],
+		"expected": "z-20"
+	},
+	{
+		"args": [
+			"p-4 pb-6 not-a-tailwind-class pb-3"
+		],
+		"expected": "p-4 not-a-tailwind-class pb-3"
+	},
+	{
+		"args": [
+			"custom-class another-custom"
+		],
+		"expected": "custom-class another-custom"
+	},
+	{
+		"args": [
+			"flex items-center justify-between gap-2 rounded border px-4 py-2 text-sm font-medium"
+		],
+		"expected": "flex items-center justify-between gap-2 rounded border px-4 py-2 text-sm font-medium"
+	},
+	{
+		"args": [
+			"*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+		],
+		"expected": "*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+	},
+	{
+		"args": [
+			"-inset-y-px"
+		],
+		"expected": "-inset-y-px"
+	},
+	{
+		"args": [
+			"-mx-1 my-1 h-px w-auto"
+		],
+		"expected": "-mx-1 my-1 h-px w-auto"
+	},
+	{
+		"args": [
+			"-mx-1 my-1 w-auto"
+		],
+		"expected": "-mx-1 my-1 w-auto"
+	},
+	{
+		"args": [
+			"-mx-1.25 my-1 w-auto"
+		],
+		"expected": "-mx-1.25 my-1 w-auto"
+	},
+	{
+		"args": [
+			"-my-0.5"
+		],
+		"expected": "-my-0.5"
+	},
+	{
+		"args": [
+			"-u"
+		],
+		"expected": "-u"
+	},
+	{
+		"args": [
+			"2xs:absolute 2xs:left-[44.5%] 2xs:justify-start 2xs:pt-0 2xs:pl-0 bottom-[7%] flex items-center gap-2 pt-4 pl-1.5 font-mono text-xs text-emerald-600 hover:text-emerald-700 min-[27rem]:left-[44.8%] min-[27rem]:text-sm"
+		],
+		"expected": "2xs:absolute 2xs:left-[44.5%] 2xs:justify-start 2xs:pt-0 2xs:pl-0 bottom-[7%] flex items-center gap-2 pt-4 pl-1.5 font-mono text-xs text-emerald-600 hover:text-emerald-700 min-[27rem]:left-[44.8%] min-[27rem]:text-sm"
+	},
+	{
+		"args": [
+			"@ariakit/react"
+		],
+		"expected": "@ariakit/react"
+	},
+	{
+		"args": [
+			"@changesets/cli"
+		],
+		"expected": "@changesets/cli"
+	},
+	{
+		"args": [
+			"@headlessui/react"
+		],
+		"expected": "@headlessui/react"
+	},
+	{
+		"args": [
+			"@mdx-js/react"
+		],
+		"expected": "@mdx-js/react"
+	},
+	{
+		"args": [
+			"@ngrok/mantle"
+		],
+		"expected": "@ngrok/mantle"
+	},
+	{
+		"args": [
+			"@ngrok/mantle-server-syntax-highlighter"
+		],
+		"expected": "@ngrok/mantle-server-syntax-highlighter"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/*"
+		],
+		"expected": "@ngrok/mantle/*"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/alert"
+		],
+		"expected": "@ngrok/mantle/alert"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/alpha"
+		],
+		"expected": "@ngrok/mantle/alpha"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/anchor"
+		],
+		"expected": "@ngrok/mantle/anchor"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/badge"
+		],
+		"expected": "@ngrok/mantle/badge"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/browser-only"
+		],
+		"expected": "@ngrok/mantle/browser-only"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/button"
+		],
+		"expected": "@ngrok/mantle/button"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/calendar"
+		],
+		"expected": "@ngrok/mantle/calendar"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/card"
+		],
+		"expected": "@ngrok/mantle/card"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/checkbox"
+		],
+		"expected": "@ngrok/mantle/checkbox"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/code"
+		],
+		"expected": "@ngrok/mantle/code"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/code-block"
+		],
+		"expected": "@ngrok/mantle/code-block"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/command"
+		],
+		"expected": "@ngrok/mantle/command"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/cx"
+		],
+		"expected": "@ngrok/mantle/cx"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/data-table"
+		],
+		"expected": "@ngrok/mantle/data-table"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/description-list"
+		],
+		"expected": "@ngrok/mantle/description-list"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/dropdown-menu"
+		],
+		"expected": "@ngrok/mantle/dropdown-menu"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/empty"
+		],
+		"expected": "@ngrok/mantle/empty"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/field"
+		],
+		"expected": "@ngrok/mantle/field"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/hooks"
+		],
+		"expected": "@ngrok/mantle/hooks"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/icon"
+		],
+		"expected": "@ngrok/mantle/icon"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/icons"
+		],
+		"expected": "@ngrok/mantle/icons"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/input"
+		],
+		"expected": "@ngrok/mantle/input"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/kbd"
+		],
+		"expected": "@ngrok/mantle/kbd"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/label"
+		],
+		"expected": "@ngrok/mantle/label"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/main"
+		],
+		"expected": "@ngrok/mantle/main"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/mantle-dark-high-contrast.css?url"
+		],
+		"expected": "@ngrok/mantle/mantle-dark-high-contrast.css?url"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/mantle-dark.css?url"
+		],
+		"expected": "@ngrok/mantle/mantle-dark.css?url"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/mantle-light-high-contrast.css?url"
+		],
+		"expected": "@ngrok/mantle/mantle-light-high-contrast.css?url"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/media-object"
+		],
+		"expected": "@ngrok/mantle/media-object"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/multi-select"
+		],
+		"expected": "@ngrok/mantle/multi-select"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/package.json"
+		],
+		"expected": "@ngrok/mantle/package.json"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/pagination"
+		],
+		"expected": "@ngrok/mantle/pagination"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/popover"
+		],
+		"expected": "@ngrok/mantle/popover"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/progress"
+		],
+		"expected": "@ngrok/mantle/progress"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/separator"
+		],
+		"expected": "@ngrok/mantle/separator"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/sheet"
+		],
+		"expected": "@ngrok/mantle/sheet"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/skeleton"
+		],
+		"expected": "@ngrok/mantle/skeleton"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/skip-to-main-link"
+		],
+		"expected": "@ngrok/mantle/skip-to-main-link"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/slot"
+		],
+		"expected": "@ngrok/mantle/slot"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/split-button"
+		],
+		"expected": "@ngrok/mantle/split-button"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/switch"
+		],
+		"expected": "@ngrok/mantle/switch"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/table"
+		],
+		"expected": "@ngrok/mantle/table"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/text-area"
+		],
+		"expected": "@ngrok/mantle/text-area"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/theme"
+		],
+		"expected": "@ngrok/mantle/theme"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/toast"
+		],
+		"expected": "@ngrok/mantle/toast"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/tooltip"
+		],
+		"expected": "@ngrok/mantle/tooltip"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/types"
+		],
+		"expected": "@ngrok/mantle/types"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/utils"
+		],
+		"expected": "@ngrok/mantle/utils"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/zed"
+		],
+		"expected": "@ngrok/mantle/zed"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react"
+		],
+		"expected": "@phosphor-icons/react"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Calendar"
+		],
+		"expected": "@phosphor-icons/react/Calendar"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretDown"
+		],
+		"expected": "@phosphor-icons/react/CaretDown"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretLeft"
+		],
+		"expected": "@phosphor-icons/react/CaretLeft"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretRight"
+		],
+		"expected": "@phosphor-icons/react/CaretRight"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretUp"
+		],
+		"expected": "@phosphor-icons/react/CaretUp"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Check"
+		],
+		"expected": "@phosphor-icons/react/Check"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CheckCircle"
+		],
+		"expected": "@phosphor-icons/react/CheckCircle"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CircleNotch"
+		],
+		"expected": "@phosphor-icons/react/CircleNotch"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Copy"
+		],
+		"expected": "@phosphor-icons/react/Copy"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Desktop"
+		],
+		"expected": "@phosphor-icons/react/Desktop"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/DotsThree"
+		],
+		"expected": "@phosphor-icons/react/DotsThree"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Eye"
+		],
+		"expected": "@phosphor-icons/react/Eye"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/EyeClosed"
+		],
+		"expected": "@phosphor-icons/react/EyeClosed"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/FileText"
+		],
+		"expected": "@phosphor-icons/react/FileText"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Globe"
+		],
+		"expected": "@phosphor-icons/react/Globe"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/HandPalm"
+		],
+		"expected": "@phosphor-icons/react/HandPalm"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Info"
+		],
+		"expected": "@phosphor-icons/react/Info"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Link"
+		],
+		"expected": "@phosphor-icons/react/Link"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/List"
+		],
+		"expected": "@phosphor-icons/react/List"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Lock"
+		],
+		"expected": "@phosphor-icons/react/Lock"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/MagnifyingGlass"
+		],
+		"expected": "@phosphor-icons/react/MagnifyingGlass"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Megaphone"
+		],
+		"expected": "@phosphor-icons/react/Megaphone"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Minus"
+		],
+		"expected": "@phosphor-icons/react/Minus"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Moon"
+		],
+		"expected": "@phosphor-icons/react/Moon"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/PencilSimple"
+		],
+		"expected": "@phosphor-icons/react/PencilSimple"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Plus"
+		],
+		"expected": "@phosphor-icons/react/Plus"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Question"
+		],
+		"expected": "@phosphor-icons/react/Question"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/SmileyMelting"
+		],
+		"expected": "@phosphor-icons/react/SmileyMelting"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/SortAscending"
+		],
+		"expected": "@phosphor-icons/react/SortAscending"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/SortDescending"
+		],
+		"expected": "@phosphor-icons/react/SortDescending"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Sparkle"
+		],
+		"expected": "@phosphor-icons/react/Sparkle"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Sun"
+		],
+		"expected": "@phosphor-icons/react/Sun"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Terminal"
+		],
+		"expected": "@phosphor-icons/react/Terminal"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Trash"
+		],
+		"expected": "@phosphor-icons/react/Trash"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Tray"
+		],
+		"expected": "@phosphor-icons/react/Tray"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Warning"
+		],
+		"expected": "@phosphor-icons/react/Warning"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/WarningDiamond"
+		],
+		"expected": "@phosphor-icons/react/WarningDiamond"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/X"
+		],
+		"expected": "@phosphor-icons/react/X"
+	},
+	{
+		"args": [
+			"@radix-ui/react-accordion"
+		],
+		"expected": "@radix-ui/react-accordion"
+	},
+	{
+		"args": [
+			"@radix-ui/react-dialog"
+		],
+		"expected": "@radix-ui/react-dialog"
+	},
+	{
+		"args": [
+			"@radix-ui/react-dropdown-menu"
+		],
+		"expected": "@radix-ui/react-dropdown-menu"
+	},
+	{
+		"args": [
+			"@radix-ui/react-hover-card"
+		],
+		"expected": "@radix-ui/react-hover-card"
+	},
+	{
+		"args": [
+			"@radix-ui/react-popover"
+		],
+		"expected": "@radix-ui/react-popover"
+	},
+	{
+		"args": [
+			"@radix-ui/react-progress"
+		],
+		"expected": "@radix-ui/react-progress"
+	},
+	{
+		"args": [
+			"@radix-ui/react-select"
+		],
+		"expected": "@radix-ui/react-select"
+	},
+	{
+		"args": [
+			"@radix-ui/react-slider"
+		],
+		"expected": "@radix-ui/react-slider"
+	},
+	{
+		"args": [
+			"@radix-ui/react-slot"
+		],
+		"expected": "@radix-ui/react-slot"
+	},
+	{
+		"args": [
+			"@radix-ui/react-switch"
+		],
+		"expected": "@radix-ui/react-switch"
+	},
+	{
+		"args": [
+			"@radix-ui/react-tabs"
+		],
+		"expected": "@radix-ui/react-tabs"
+	},
+	{
+		"args": [
+			"@radix-ui/react-tooltip"
+		],
+		"expected": "@radix-ui/react-tooltip"
+	},
+	{
+		"args": [
+			"@react-router/dev/routes"
+		],
+		"expected": "@react-router/dev/routes"
+	},
+	{
+		"args": [
+			"@react-router/node"
+		],
+		"expected": "@react-router/node"
+	},
+	{
+		"args": [
+			"@tanstack/react-form"
+		],
+		"expected": "@tanstack/react-form"
+	},
+	{
+		"args": [
+			"@tanstack/react-query"
+		],
+		"expected": "@tanstack/react-query"
+	},
+	{
+		"args": [
+			"@tanstack/react-query-devtools/production"
+		],
+		"expected": "@tanstack/react-query-devtools/production"
+	},
+	{
+		"args": [
+			"@tanstack/react-table"
+		],
+		"expected": "@tanstack/react-table"
+	},
+	{
+		"args": [
+			"@testing-library/react"
+		],
+		"expected": "@testing-library/react"
+	},
+	{
+		"args": [
+			"@testing-library/user-event"
+		],
+		"expected": "@testing-library/user-event"
+	},
+	{
+		"args": [
+			"Access-Control-Allow-Origin"
+		],
+		"expected": "Access-Control-Allow-Origin"
+	},
+	{
+		"args": [
+			"Auto-Theme-Icon"
+		],
+		"expected": "Auto-Theme-Icon"
+	},
+	{
+		"args": [
+			"BQ-BO"
+		],
+		"expected": "BQ-BO"
+	},
+	{
+		"args": [
+			"BQ-SA"
+		],
+		"expected": "BQ-SA"
+	},
+	{
+		"args": [
+			"BQ-SE"
+		],
+		"expected": "BQ-SE"
+	},
+	{
+		"args": [
+			"Cache-Control"
+		],
+		"expected": "Cache-Control"
+	},
+	{
+		"args": [
+			"Content-Disposition"
+		],
+		"expected": "Content-Disposition"
+	},
+	{
+		"args": [
+			"Content-Type"
+		],
+		"expected": "Content-Type"
+	},
+	{
+		"args": [
+			"GB-ENG"
+		],
+		"expected": "GB-ENG"
+	},
+	{
+		"args": [
+			"GB-NIR"
+		],
+		"expected": "GB-NIR"
+	},
+	{
+		"args": [
+			"GB-SCT"
+		],
+		"expected": "GB-SCT"
+	},
+	{
+		"args": [
+			"GB-UKM"
+		],
+		"expected": "GB-UKM"
+	},
+	{
+		"args": [
+			"GB-WLS"
+		],
+		"expected": "GB-WLS"
+	},
+	{
+		"args": [
+			"If-None-Match"
+		],
+		"expected": "If-None-Match"
+	},
+	{
+		"args": [
+			"KN-SK"
+		],
+		"expected": "KN-SK"
+	},
+	{
+		"args": [
+			"M0,0h10v10h-10zM10,10h10v10h-10z"
+		],
+		"expected": "M0,0h10v10h-10zM10,10h10v10h-10z"
+	},
+	{
+		"args": [
+			"M4,0h4v4h-4z"
+		],
+		"expected": "M4,0h4v4h-4z"
+	},
+	{
+		"args": [
+			"Set-Cookie"
+		],
+		"expected": "Set-Cookie"
+	},
+	{
+		"args": [
+			"Sort-alphanumeric-asc"
+		],
+		"expected": "Sort-alphanumeric-asc"
+	},
+	{
+		"args": [
+			"Sort-alphanumeric-desc"
+		],
+		"expected": "Sort-alphanumeric-desc"
+	},
+	{
+		"args": [
+			"Sort-time-newest-to-oldest"
+		],
+		"expected": "Sort-time-newest-to-oldest"
+	},
+	{
+		"args": [
+			"Sort-time-oldest-to-newest"
+		],
+		"expected": "Sort-time-oldest-to-newest"
+	},
+	{
+		"args": [
+			"Theme-Icon-Dark"
+		],
+		"expected": "Theme-Icon-Dark"
+	},
+	{
+		"args": [
+			"Theme-Icon-Dark-High-Contrast"
+		],
+		"expected": "Theme-Icon-Dark-High-Contrast"
+	},
+	{
+		"args": [
+			"Theme-Icon-Light"
+		],
+		"expected": "Theme-Icon-Light"
+	},
+	{
+		"args": [
+			"Theme-Icon-Light-High-Contrast"
+		],
+		"expected": "Theme-Icon-Light-High-Contrast"
+	},
+	{
+		"args": [
+			"Theme-Icon-System"
+		],
+		"expected": "Theme-Icon-System"
+	},
+	{
+		"args": [
+			"UTF-8"
+		],
+		"expected": "UTF-8"
+	},
+	{
+		"args": [
+			"X-Content-Type-Options"
+		],
+		"expected": "X-Content-Type-Options"
+	},
+	{
+		"args": [
+			"X-Robots-Tag"
+		],
+		"expected": "X-Robots-Tag"
+	},
+	{
+		"args": [
+			"a:"
+		],
+		"expected": "a:"
+	},
+	{
+		"args": [
+			"absolute inline-flex size-full animate-ping rounded-full"
+		],
+		"expected": "absolute inline-flex size-full animate-ping rounded-full"
+	},
+	{
+		"args": [
+			"absolute inset-0 border border-[#000]/10"
+		],
+		"expected": "absolute inset-0 border border-[#000]/10"
+	},
+	{
+		"args": [
+			"absolute left-0"
+		],
+		"expected": "absolute left-0"
+	},
+	{
+		"args": [
+			"absolute right-0"
+		],
+		"expected": "absolute right-0"
+	},
+	{
+		"args": [
+			"absolute right-2 flex h-3.5 w-3.5 items-center justify-center"
+		],
+		"expected": "absolute right-2 flex h-3.5 w-3.5 items-center justify-center"
+	},
+	{
+		"args": [
+			"absolute right-2 flex items-center"
+		],
+		"expected": "absolute right-2 flex items-center"
+	},
+	{
+		"args": [
+			"absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex"
+		],
+		"expected": "absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex"
+	},
+	{
+		"args": [
+			"absolute top-1.5 right-1.5"
+		],
+		"expected": "absolute top-1.5 right-1.5"
+	},
+	{
+		"args": [
+			"accent-600"
+		],
+		"expected": "accent-600"
+	},
+	{
+		"args": [
+			"accordion-content"
+		],
+		"expected": "accordion-content"
+	},
+	{
+		"args": [
+			"accordion-heading"
+		],
+		"expected": "accordion-heading"
+	},
+	{
+		"args": [
+			"accordion-item"
+		],
+		"expected": "accordion-item"
+	},
+	{
+		"args": [
+			"accordion-trigger"
+		],
+		"expected": "accordion-trigger"
+	},
+	{
+		"args": [
+			"accordion-trigger-icon"
+		],
+		"expected": "accordion-trigger-icon"
+	},
+	{
+		"args": [
+			"admin:secret"
+		],
+		"expected": "admin:secret"
+	},
+	{
+		"args": [
+			"alert-content"
+		],
+		"expected": "alert-content"
+	},
+	{
+		"args": [
+			"alert-description"
+		],
+		"expected": "alert-description"
+	},
+	{
+		"args": [
+			"alert-dialog-overlay"
+		],
+		"expected": "alert-dialog-overlay"
+	},
+	{
+		"args": [
+			"alert-dialog-trigger"
+		],
+		"expected": "alert-dialog-trigger"
+	},
+	{
+		"args": [
+			"alert-dismiss-icon-button"
+		],
+		"expected": "alert-dismiss-icon-button"
+	},
+	{
+		"args": [
+			"alert-icon"
+		],
+		"expected": "alert-icon"
+	},
+	{
+		"args": [
+			"alert-title"
+		],
+		"expected": "alert-title"
+	},
+	{
+		"args": [
+			"animate-spin"
+		],
+		"expected": "animate-spin"
+	},
+	{
+		"args": [
+			"animation-duration-[15s]"
+		],
+		"expected": "animation-duration-[15s]"
+	},
+	{
+		"args": [
+			"api-changelog-json"
+		],
+		"expected": "api-changelog-json"
+	},
+	{
+		"args": [
+			"api-components-json"
+		],
+		"expected": "api-components-json"
+	},
+	{
+		"args": [
+			"api-hooks-json"
+		],
+		"expected": "api-hooks-json"
+	},
+	{
+		"args": [
+			"api-package-json"
+		],
+		"expected": "api-package-json"
+	},
+	{
+		"args": [
+			"api-schema-json"
+		],
+		"expected": "api-schema-json"
+	},
+	{
+		"args": [
+			"api-search-index-json"
+		],
+		"expected": "api-search-index-json"
+	},
+	{
+		"args": [
+			"api-utils-json"
+		],
+		"expected": "api-utils-json"
+	},
+	{
+		"args": [
+			"api/changelog.json"
+		],
+		"expected": "api/changelog.json"
+	},
+	{
+		"args": [
+			"api/components.json"
+		],
+		"expected": "api/components.json"
+	},
+	{
+		"args": [
+			"api/hooks.json"
+		],
+		"expected": "api/hooks.json"
+	},
+	{
+		"args": [
+			"api/package.json"
+		],
+		"expected": "api/package.json"
+	},
+	{
+		"args": [
+			"api/schema.json"
+		],
+		"expected": "api/schema.json"
+	},
+	{
+		"args": [
+			"api/search-index.json"
+		],
+		"expected": "api/search-index.json"
+	},
+	{
+		"args": [
+			"api/shiki-highlight"
+		],
+		"expected": "api/shiki-highlight"
+	},
+	{
+		"args": [
+			"api/utils.json"
+		],
+		"expected": "api/utils.json"
+	},
+	{
+		"args": [
+			"appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded text-mono leading-none font-mono"
+		],
+		"expected": "appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded text-mono leading-none font-mono"
+	},
+	{
+		"args": [
+			"apple-touch-icon"
+		],
+		"expected": "apple-touch-icon"
+	},
+	{
+		"args": [
+			"application/json"
+		],
+		"expected": "application/json"
+	},
+	{
+		"args": [
+			"application/schema+json"
+		],
+		"expected": "application/schema+json"
+	},
+	{
+		"args": [
+			"aria-*"
+		],
+		"expected": "aria-*"
+	},
+	{
+		"args": [
+			"aria-checked:bg-selected-menu-item"
+		],
+		"expected": "aria-checked:bg-selected-menu-item"
+	},
+	{
+		"args": [
+			"aria-checked:bg-selected-menu-item aria-checked:pr-9"
+		],
+		"expected": "aria-checked:bg-selected-menu-item aria-checked:pr-9"
+	},
+	{
+		"args": [
+			"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600"
+		],
+		"expected": "aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600"
+	},
+	{
+		"args": [
+			"aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600"
+		],
+		"expected": "aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600"
+	},
+	{
+		"args": [
+			"aria-controls"
+		],
+		"expected": "aria-controls"
+	},
+	{
+		"args": [
+			"aria-describedby"
+		],
+		"expected": "aria-describedby"
+	},
+	{
+		"args": [
+			"aria-disabled"
+		],
+		"expected": "aria-disabled"
+	},
+	{
+		"args": [
+			"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600"
+		],
+		"expected": "aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600"
+	},
+	{
+		"args": [
+			"aria-errormessage"
+		],
+		"expected": "aria-errormessage"
+	},
+	{
+		"args": [
+			"aria-expanded"
+		],
+		"expected": "aria-expanded"
+	},
+	{
+		"args": [
+			"aria-hidden"
+		],
+		"expected": "aria-hidden"
+	},
+	{
+		"args": [
+			"aria-invalid"
+		],
+		"expected": "aria-invalid"
+	},
+	{
+		"args": [
+			"aria-label"
+		],
+		"expected": "aria-label"
+	},
+	{
+		"args": [
+			"aria-orientation"
+		],
+		"expected": "aria-orientation"
+	},
+	{
+		"args": [
+			"aria-readonly"
+		],
+		"expected": "aria-readonly"
+	},
+	{
+		"args": [
+			"au-syd-1"
+		],
+		"expected": "au-syd-1"
+	},
+	{
+		"args": [
+			"autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]"
+		],
+		"expected": "autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]"
+	},
+	{
+		"args": [
+			"base/"
+		],
+		"expected": "base/"
+	},
+	{
+		"args": [
+			"base/breakpoints"
+		],
+		"expected": "base/breakpoints"
+	},
+	{
+		"args": [
+			"base/colors"
+		],
+		"expected": "base/colors"
+	},
+	{
+		"args": [
+			"base/scroll-fade"
+		],
+		"expected": "base/scroll-fade"
+	},
+	{
+		"args": [
+			"base/shadows"
+		],
+		"expected": "base/shadows"
+	},
+	{
+		"args": [
+			"base/tailwind-variants"
+		],
+		"expected": "base/tailwind-variants"
+	},
+	{
+		"args": [
+			"base/typography"
+		],
+		"expected": "base/typography"
+	},
+	{
+		"args": [
+			"bg-*"
+		],
+		"expected": "bg-*"
+	},
+	{
+		"args": [
+			"bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent"
+		],
+		"expected": "bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent"
+	},
+	{
+		"args": [
+			"bg-accent-100"
+		],
+		"expected": "bg-accent-100"
+	},
+	{
+		"args": [
+			"bg-accent-200"
+		],
+		"expected": "bg-accent-200"
+	},
+	{
+		"args": [
+			"bg-accent-300"
+		],
+		"expected": "bg-accent-300"
+	},
+	{
+		"args": [
+			"bg-accent-400"
+		],
+		"expected": "bg-accent-400"
+	},
+	{
+		"args": [
+			"bg-accent-50"
+		],
+		"expected": "bg-accent-50"
+	},
+	{
+		"args": [
+			"bg-accent-500"
+		],
+		"expected": "bg-accent-500"
+	},
+	{
+		"args": [
+			"bg-accent-500/20"
+		],
+		"expected": "bg-accent-500/20"
+	},
+	{
+		"args": [
+			"bg-accent-600"
+		],
+		"expected": "bg-accent-600"
+	},
+	{
+		"args": [
+			"bg-accent-600 h-full w-full flex-1 transition-all"
+		],
+		"expected": "bg-accent-600 h-full w-full flex-1 transition-all"
+	},
+	{
+		"args": [
+			"bg-accent-700"
+		],
+		"expected": "bg-accent-700"
+	},
+	{
+		"args": [
+			"bg-accent-800"
+		],
+		"expected": "bg-accent-800"
+	},
+	{
+		"args": [
+			"bg-accent-900"
+		],
+		"expected": "bg-accent-900"
+	},
+	{
+		"args": [
+			"bg-accent-950"
+		],
+		"expected": "bg-accent-950"
+	},
+	{
+		"args": [
+			"bg-amber-100"
+		],
+		"expected": "bg-amber-100"
+	},
+	{
+		"args": [
+			"bg-amber-200"
+		],
+		"expected": "bg-amber-200"
+	},
+	{
+		"args": [
+			"bg-amber-300"
+		],
+		"expected": "bg-amber-300"
+	},
+	{
+		"args": [
+			"bg-amber-400"
+		],
+		"expected": "bg-amber-400"
+	},
+	{
+		"args": [
+			"bg-amber-50"
+		],
+		"expected": "bg-amber-50"
+	},
+	{
+		"args": [
+			"bg-amber-500"
+		],
+		"expected": "bg-amber-500"
+	},
+	{
+		"args": [
+			"bg-amber-500/20"
+		],
+		"expected": "bg-amber-500/20"
+	},
+	{
+		"args": [
+			"bg-amber-600"
+		],
+		"expected": "bg-amber-600"
+	},
+	{
+		"args": [
+			"bg-amber-700"
+		],
+		"expected": "bg-amber-700"
+	},
+	{
+		"args": [
+			"bg-amber-800"
+		],
+		"expected": "bg-amber-800"
+	},
+	{
+		"args": [
+			"bg-amber-900"
+		],
+		"expected": "bg-amber-900"
+	},
+	{
+		"args": [
+			"bg-amber-950"
+		],
+		"expected": "bg-amber-950"
+	},
+	{
+		"args": [
+			"bg-base"
+		],
+		"expected": "bg-base"
+	},
+	{
+		"args": [
+			"bg-base-hover dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md"
+		],
+		"expected": "bg-base-hover dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md"
+	},
+	{
+		"args": [
+			"bg-blue-100"
+		],
+		"expected": "bg-blue-100"
+	},
+	{
+		"args": [
+			"bg-blue-200"
+		],
+		"expected": "bg-blue-200"
+	},
+	{
+		"args": [
+			"bg-blue-300"
+		],
+		"expected": "bg-blue-300"
+	},
+	{
+		"args": [
+			"bg-blue-400"
+		],
+		"expected": "bg-blue-400"
+	},
+	{
+		"args": [
+			"bg-blue-50"
+		],
+		"expected": "bg-blue-50"
+	},
+	{
+		"args": [
+			"bg-blue-500"
+		],
+		"expected": "bg-blue-500"
+	},
+	{
+		"args": [
+			"bg-blue-500/20"
+		],
+		"expected": "bg-blue-500/20"
+	},
+	{
+		"args": [
+			"bg-blue-600"
+		],
+		"expected": "bg-blue-600"
+	},
+	{
+		"args": [
+			"bg-blue-700"
+		],
+		"expected": "bg-blue-700"
+	},
+	{
+		"args": [
+			"bg-blue-800"
+		],
+		"expected": "bg-blue-800"
+	},
+	{
+		"args": [
+			"bg-blue-900"
+		],
+		"expected": "bg-blue-900"
+	},
+	{
+		"args": [
+			"bg-blue-950"
+		],
+		"expected": "bg-blue-950"
+	},
+	{
+		"args": [
+			"bg-card fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden"
+		],
+		"expected": "bg-card fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden"
+	},
+	{
+		"args": [
+			"bg-card h-full min-h-full overflow-y-scroll scrollbar isolate relative"
+		],
+		"expected": "bg-card h-full min-h-full overflow-y-scroll scrollbar isolate relative"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-2xl"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-2xl"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-inner"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-inner"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-lg"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-lg"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-md"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-md"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-xl"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-xl"
+	},
+	{
+		"args": [
+			"bg-center bg-no-repeat focus:outline-hidden"
+		],
+		"expected": "bg-center bg-no-repeat focus:outline-hidden"
+	},
+	{
+		"args": [
+			"bg-cyan-100"
+		],
+		"expected": "bg-cyan-100"
+	},
+	{
+		"args": [
+			"bg-cyan-200"
+		],
+		"expected": "bg-cyan-200"
+	},
+	{
+		"args": [
+			"bg-cyan-300"
+		],
+		"expected": "bg-cyan-300"
+	},
+	{
+		"args": [
+			"bg-cyan-400"
+		],
+		"expected": "bg-cyan-400"
+	},
+	{
+		"args": [
+			"bg-cyan-50"
+		],
+		"expected": "bg-cyan-50"
+	},
+	{
+		"args": [
+			"bg-cyan-500"
+		],
+		"expected": "bg-cyan-500"
+	},
+	{
+		"args": [
+			"bg-cyan-500/20"
+		],
+		"expected": "bg-cyan-500/20"
+	},
+	{
+		"args": [
+			"bg-cyan-600"
+		],
+		"expected": "bg-cyan-600"
+	},
+	{
+		"args": [
+			"bg-cyan-700"
+		],
+		"expected": "bg-cyan-700"
+	},
+	{
+		"args": [
+			"bg-cyan-800"
+		],
+		"expected": "bg-cyan-800"
+	},
+	{
+		"args": [
+			"bg-cyan-900"
+		],
+		"expected": "bg-cyan-900"
+	},
+	{
+		"args": [
+			"bg-cyan-950"
+		],
+		"expected": "bg-cyan-950"
+	},
+	{
+		"args": [
+			"bg-danger-100"
+		],
+		"expected": "bg-danger-100"
+	},
+	{
+		"args": [
+			"bg-danger-200"
+		],
+		"expected": "bg-danger-200"
+	},
+	{
+		"args": [
+			"bg-danger-300"
+		],
+		"expected": "bg-danger-300"
+	},
+	{
+		"args": [
+			"bg-danger-400"
+		],
+		"expected": "bg-danger-400"
+	},
+	{
+		"args": [
+			"bg-danger-50"
+		],
+		"expected": "bg-danger-50"
+	},
+	{
+		"args": [
+			"bg-danger-500"
+		],
+		"expected": "bg-danger-500"
+	},
+	{
+		"args": [
+			"bg-danger-500/20"
+		],
+		"expected": "bg-danger-500/20"
+	},
+	{
+		"args": [
+			"bg-danger-600"
+		],
+		"expected": "bg-danger-600"
+	},
+	{
+		"args": [
+			"bg-danger-700"
+		],
+		"expected": "bg-danger-700"
+	},
+	{
+		"args": [
+			"bg-danger-800"
+		],
+		"expected": "bg-danger-800"
+	},
+	{
+		"args": [
+			"bg-danger-900"
+		],
+		"expected": "bg-danger-900"
+	},
+	{
+		"args": [
+			"bg-danger-950"
+		],
+		"expected": "bg-danger-950"
+	},
+	{
+		"args": [
+			"bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+		],
+		"expected": "bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+	},
+	{
+		"args": [
+			"bg-emerald-100"
+		],
+		"expected": "bg-emerald-100"
+	},
+	{
+		"args": [
+			"bg-emerald-200"
+		],
+		"expected": "bg-emerald-200"
+	},
+	{
+		"args": [
+			"bg-emerald-300"
+		],
+		"expected": "bg-emerald-300"
+	},
+	{
+		"args": [
+			"bg-emerald-400"
+		],
+		"expected": "bg-emerald-400"
+	},
+	{
+		"args": [
+			"bg-emerald-50"
+		],
+		"expected": "bg-emerald-50"
+	},
+	{
+		"args": [
+			"bg-emerald-500"
+		],
+		"expected": "bg-emerald-500"
+	},
+	{
+		"args": [
+			"bg-emerald-500/20"
+		],
+		"expected": "bg-emerald-500/20"
+	},
+	{
+		"args": [
+			"bg-emerald-600"
+		],
+		"expected": "bg-emerald-600"
+	},
+	{
+		"args": [
+			"bg-emerald-700"
+		],
+		"expected": "bg-emerald-700"
+	},
+	{
+		"args": [
+			"bg-emerald-800"
+		],
+		"expected": "bg-emerald-800"
+	},
+	{
+		"args": [
+			"bg-emerald-900"
+		],
+		"expected": "bg-emerald-900"
+	},
+	{
+		"args": [
+			"bg-emerald-950"
+		],
+		"expected": "bg-emerald-950"
+	},
+	{
+		"args": [
+			"bg-filled-accent text-white focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover h-9 border border-transparent px-3 text-sm font-medium"
+		],
+		"expected": "bg-filled-accent text-white focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover h-9 border border-transparent px-3 text-sm font-medium"
+	},
+	{
+		"args": [
+			"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4"
+		],
+		"expected": "bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4"
+	},
+	{
+		"args": [
+			"bg-fuchsia-100"
+		],
+		"expected": "bg-fuchsia-100"
+	},
+	{
+		"args": [
+			"bg-fuchsia-200"
+		],
+		"expected": "bg-fuchsia-200"
+	},
+	{
+		"args": [
+			"bg-fuchsia-300"
+		],
+		"expected": "bg-fuchsia-300"
+	},
+	{
+		"args": [
+			"bg-fuchsia-400"
+		],
+		"expected": "bg-fuchsia-400"
+	},
+	{
+		"args": [
+			"bg-fuchsia-50"
+		],
+		"expected": "bg-fuchsia-50"
+	},
+	{
+		"args": [
+			"bg-fuchsia-500"
+		],
+		"expected": "bg-fuchsia-500"
+	},
+	{
+		"args": [
+			"bg-fuchsia-500/20"
+		],
+		"expected": "bg-fuchsia-500/20"
+	},
+	{
+		"args": [
+			"bg-fuchsia-600"
+		],
+		"expected": "bg-fuchsia-600"
+	},
+	{
+		"args": [
+			"bg-fuchsia-700"
+		],
+		"expected": "bg-fuchsia-700"
+	},
+	{
+		"args": [
+			"bg-fuchsia-800"
+		],
+		"expected": "bg-fuchsia-800"
+	},
+	{
+		"args": [
+			"bg-fuchsia-900"
+		],
+		"expected": "bg-fuchsia-900"
+	},
+	{
+		"args": [
+			"bg-fuchsia-950"
+		],
+		"expected": "bg-fuchsia-950"
+	},
+	{
+		"args": [
+			"bg-gray-100"
+		],
+		"expected": "bg-gray-100"
+	},
+	{
+		"args": [
+			"bg-gray-200"
+		],
+		"expected": "bg-gray-200"
+	},
+	{
+		"args": [
+			"bg-gray-300"
+		],
+		"expected": "bg-gray-300"
+	},
+	{
+		"args": [
+			"bg-gray-400"
+		],
+		"expected": "bg-gray-400"
+	},
+	{
+		"args": [
+			"bg-gray-50"
+		],
+		"expected": "bg-gray-50"
+	},
+	{
+		"args": [
+			"bg-gray-500"
+		],
+		"expected": "bg-gray-500"
+	},
+	{
+		"args": [
+			"bg-gray-500/20"
+		],
+		"expected": "bg-gray-500/20"
+	},
+	{
+		"args": [
+			"bg-gray-600"
+		],
+		"expected": "bg-gray-600"
+	},
+	{
+		"args": [
+			"bg-gray-700"
+		],
+		"expected": "bg-gray-700"
+	},
+	{
+		"args": [
+			"bg-gray-800"
+		],
+		"expected": "bg-gray-800"
+	},
+	{
+		"args": [
+			"bg-gray-900"
+		],
+		"expected": "bg-gray-900"
+	},
+	{
+		"args": [
+			"bg-gray-950"
+		],
+		"expected": "bg-gray-950"
+	},
+	{
+		"args": [
+			"bg-green-100"
+		],
+		"expected": "bg-green-100"
+	},
+	{
+		"args": [
+			"bg-green-200"
+		],
+		"expected": "bg-green-200"
+	},
+	{
+		"args": [
+			"bg-green-300"
+		],
+		"expected": "bg-green-300"
+	},
+	{
+		"args": [
+			"bg-green-400"
+		],
+		"expected": "bg-green-400"
+	},
+	{
+		"args": [
+			"bg-green-50"
+		],
+		"expected": "bg-green-50"
+	},
+	{
+		"args": [
+			"bg-green-500"
+		],
+		"expected": "bg-green-500"
+	},
+	{
+		"args": [
+			"bg-green-500/20"
+		],
+		"expected": "bg-green-500/20"
+	},
+	{
+		"args": [
+			"bg-green-600"
+		],
+		"expected": "bg-green-600"
+	},
+	{
+		"args": [
+			"bg-green-700"
+		],
+		"expected": "bg-green-700"
+	},
+	{
+		"args": [
+			"bg-green-800"
+		],
+		"expected": "bg-green-800"
+	},
+	{
+		"args": [
+			"bg-green-900"
+		],
+		"expected": "bg-green-900"
+	},
+	{
+		"args": [
+			"bg-green-950"
+		],
+		"expected": "bg-green-950"
+	},
+	{
+		"args": [
+			"bg-important-500/20"
+		],
+		"expected": "bg-important-500/20"
+	},
+	{
+		"args": [
+			"bg-indigo-100"
+		],
+		"expected": "bg-indigo-100"
+	},
+	{
+		"args": [
+			"bg-indigo-200"
+		],
+		"expected": "bg-indigo-200"
+	},
+	{
+		"args": [
+			"bg-indigo-300"
+		],
+		"expected": "bg-indigo-300"
+	},
+	{
+		"args": [
+			"bg-indigo-400"
+		],
+		"expected": "bg-indigo-400"
+	},
+	{
+		"args": [
+			"bg-indigo-50"
+		],
+		"expected": "bg-indigo-50"
+	},
+	{
+		"args": [
+			"bg-indigo-500"
+		],
+		"expected": "bg-indigo-500"
+	},
+	{
+		"args": [
+			"bg-indigo-500/20"
+		],
+		"expected": "bg-indigo-500/20"
+	},
+	{
+		"args": [
+			"bg-indigo-600"
+		],
+		"expected": "bg-indigo-600"
+	},
+	{
+		"args": [
+			"bg-indigo-700"
+		],
+		"expected": "bg-indigo-700"
+	},
+	{
+		"args": [
+			"bg-indigo-800"
+		],
+		"expected": "bg-indigo-800"
+	},
+	{
+		"args": [
+			"bg-indigo-900"
+		],
+		"expected": "bg-indigo-900"
+	},
+	{
+		"args": [
+			"bg-indigo-950"
+		],
+		"expected": "bg-indigo-950"
+	},
+	{
+		"args": [
+			"bg-info-100"
+		],
+		"expected": "bg-info-100"
+	},
+	{
+		"args": [
+			"bg-info-200"
+		],
+		"expected": "bg-info-200"
+	},
+	{
+		"args": [
+			"bg-info-300"
+		],
+		"expected": "bg-info-300"
+	},
+	{
+		"args": [
+			"bg-info-400"
+		],
+		"expected": "bg-info-400"
+	},
+	{
+		"args": [
+			"bg-info-50"
+		],
+		"expected": "bg-info-50"
+	},
+	{
+		"args": [
+			"bg-info-500"
+		],
+		"expected": "bg-info-500"
+	},
+	{
+		"args": [
+			"bg-info-500/20"
+		],
+		"expected": "bg-info-500/20"
+	},
+	{
+		"args": [
+			"bg-info-600"
+		],
+		"expected": "bg-info-600"
+	},
+	{
+		"args": [
+			"bg-info-700"
+		],
+		"expected": "bg-info-700"
+	},
+	{
+		"args": [
+			"bg-info-800"
+		],
+		"expected": "bg-info-800"
+	},
+	{
+		"args": [
+			"bg-info-900"
+		],
+		"expected": "bg-info-900"
+	},
+	{
+		"args": [
+			"bg-info-950"
+		],
+		"expected": "bg-info-950"
+	},
+	{
+		"args": [
+			"bg-lime-100"
+		],
+		"expected": "bg-lime-100"
+	},
+	{
+		"args": [
+			"bg-lime-200"
+		],
+		"expected": "bg-lime-200"
+	},
+	{
+		"args": [
+			"bg-lime-300"
+		],
+		"expected": "bg-lime-300"
+	},
+	{
+		"args": [
+			"bg-lime-400"
+		],
+		"expected": "bg-lime-400"
+	},
+	{
+		"args": [
+			"bg-lime-50"
+		],
+		"expected": "bg-lime-50"
+	},
+	{
+		"args": [
+			"bg-lime-500"
+		],
+		"expected": "bg-lime-500"
+	},
+	{
+		"args": [
+			"bg-lime-500/20"
+		],
+		"expected": "bg-lime-500/20"
+	},
+	{
+		"args": [
+			"bg-lime-600"
+		],
+		"expected": "bg-lime-600"
+	},
+	{
+		"args": [
+			"bg-lime-700"
+		],
+		"expected": "bg-lime-700"
+	},
+	{
+		"args": [
+			"bg-lime-800"
+		],
+		"expected": "bg-lime-800"
+	},
+	{
+		"args": [
+			"bg-lime-900"
+		],
+		"expected": "bg-lime-900"
+	},
+	{
+		"args": [
+			"bg-lime-950"
+		],
+		"expected": "bg-lime-950"
+	},
+	{
+		"args": [
+			"bg-linear-to-l to-transparent"
+		],
+		"expected": "bg-linear-to-l to-transparent"
+	},
+	{
+		"args": [
+			"bg-muted text-muted pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none"
+		],
+		"expected": "bg-muted text-muted pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none"
+	},
+	{
+		"args": [
+			"bg-neutral-100"
+		],
+		"expected": "bg-neutral-100"
+	},
+	{
+		"args": [
+			"bg-neutral-200"
+		],
+		"expected": "bg-neutral-200"
+	},
+	{
+		"args": [
+			"bg-neutral-300"
+		],
+		"expected": "bg-neutral-300"
+	},
+	{
+		"args": [
+			"bg-neutral-400"
+		],
+		"expected": "bg-neutral-400"
+	},
+	{
+		"args": [
+			"bg-neutral-50"
+		],
+		"expected": "bg-neutral-50"
+	},
+	{
+		"args": [
+			"bg-neutral-500"
+		],
+		"expected": "bg-neutral-500"
+	},
+	{
+		"args": [
+			"bg-neutral-500/20"
+		],
+		"expected": "bg-neutral-500/20"
+	},
+	{
+		"args": [
+			"bg-neutral-600"
+		],
+		"expected": "bg-neutral-600"
+	},
+	{
+		"args": [
+			"bg-neutral-700"
+		],
+		"expected": "bg-neutral-700"
+	},
+	{
+		"args": [
+			"bg-neutral-800"
+		],
+		"expected": "bg-neutral-800"
+	},
+	{
+		"args": [
+			"bg-neutral-900"
+		],
+		"expected": "bg-neutral-900"
+	},
+	{
+		"args": [
+			"bg-neutral-950"
+		],
+		"expected": "bg-neutral-950"
+	},
+	{
+		"args": [
+			"bg-orange-100"
+		],
+		"expected": "bg-orange-100"
+	},
+	{
+		"args": [
+			"bg-orange-200"
+		],
+		"expected": "bg-orange-200"
+	},
+	{
+		"args": [
+			"bg-orange-300"
+		],
+		"expected": "bg-orange-300"
+	},
+	{
+		"args": [
+			"bg-orange-400"
+		],
+		"expected": "bg-orange-400"
+	},
+	{
+		"args": [
+			"bg-orange-50"
+		],
+		"expected": "bg-orange-50"
+	},
+	{
+		"args": [
+			"bg-orange-500"
+		],
+		"expected": "bg-orange-500"
+	},
+	{
+		"args": [
+			"bg-orange-500/20"
+		],
+		"expected": "bg-orange-500/20"
+	},
+	{
+		"args": [
+			"bg-orange-600"
+		],
+		"expected": "bg-orange-600"
+	},
+	{
+		"args": [
+			"bg-orange-700"
+		],
+		"expected": "bg-orange-700"
+	},
+	{
+		"args": [
+			"bg-orange-800"
+		],
+		"expected": "bg-orange-800"
+	},
+	{
+		"args": [
+			"bg-orange-900"
+		],
+		"expected": "bg-orange-900"
+	},
+	{
+		"args": [
+			"bg-orange-950"
+		],
+		"expected": "bg-orange-950"
+	},
+	{
+		"args": [
+			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs"
+		],
+		"expected": "bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs"
+	},
+	{
+		"args": [
+			"bg-pink-100"
+		],
+		"expected": "bg-pink-100"
+	},
+	{
+		"args": [
+			"bg-pink-200"
+		],
+		"expected": "bg-pink-200"
+	},
+	{
+		"args": [
+			"bg-pink-300"
+		],
+		"expected": "bg-pink-300"
+	},
+	{
+		"args": [
+			"bg-pink-400"
+		],
+		"expected": "bg-pink-400"
+	},
+	{
+		"args": [
+			"bg-pink-50"
+		],
+		"expected": "bg-pink-50"
+	},
+	{
+		"args": [
+			"bg-pink-500"
+		],
+		"expected": "bg-pink-500"
+	},
+	{
+		"args": [
+			"bg-pink-500/20"
+		],
+		"expected": "bg-pink-500/20"
+	},
+	{
+		"args": [
+			"bg-pink-600"
+		],
+		"expected": "bg-pink-600"
+	},
+	{
+		"args": [
+			"bg-pink-700"
+		],
+		"expected": "bg-pink-700"
+	},
+	{
+		"args": [
+			"bg-pink-800"
+		],
+		"expected": "bg-pink-800"
+	},
+	{
+		"args": [
+			"bg-pink-900"
+		],
+		"expected": "bg-pink-900"
+	},
+	{
+		"args": [
+			"bg-pink-950"
+		],
+		"expected": "bg-pink-950"
+	},
+	{
+		"args": [
+			"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden"
+		],
+		"expected": "bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden"
+	},
+	{
+		"args": [
+			"bg-popover flex h-full w-full flex-col overflow-hidden rounded-md"
+		],
+		"expected": "bg-popover flex h-full w-full flex-col overflow-hidden rounded-md"
+	},
+	{
+		"args": [
+			"bg-popover font-sans"
+		],
+		"expected": "bg-popover font-sans"
+	},
+	{
+		"args": [
+			"bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg"
+		],
+		"expected": "bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg"
+	},
+	{
+		"args": [
+			"bg-purple-100"
+		],
+		"expected": "bg-purple-100"
+	},
+	{
+		"args": [
+			"bg-purple-200"
+		],
+		"expected": "bg-purple-200"
+	},
+	{
+		"args": [
+			"bg-purple-300"
+		],
+		"expected": "bg-purple-300"
+	},
+	{
+		"args": [
+			"bg-purple-400"
+		],
+		"expected": "bg-purple-400"
+	},
+	{
+		"args": [
+			"bg-purple-50"
+		],
+		"expected": "bg-purple-50"
+	},
+	{
+		"args": [
+			"bg-purple-500"
+		],
+		"expected": "bg-purple-500"
+	},
+	{
+		"args": [
+			"bg-purple-500/20"
+		],
+		"expected": "bg-purple-500/20"
+	},
+	{
+		"args": [
+			"bg-purple-600"
+		],
+		"expected": "bg-purple-600"
+	},
+	{
+		"args": [
+			"bg-purple-700"
+		],
+		"expected": "bg-purple-700"
+	},
+	{
+		"args": [
+			"bg-purple-800"
+		],
+		"expected": "bg-purple-800"
+	},
+	{
+		"args": [
+			"bg-purple-900"
+		],
+		"expected": "bg-purple-900"
+	},
+	{
+		"args": [
+			"bg-purple-950"
+		],
+		"expected": "bg-purple-950"
+	},
+	{
+		"args": [
+			"bg-red-100"
+		],
+		"expected": "bg-red-100"
+	},
+	{
+		"args": [
+			"bg-red-200"
+		],
+		"expected": "bg-red-200"
+	},
+	{
+		"args": [
+			"bg-red-300"
+		],
+		"expected": "bg-red-300"
+	},
+	{
+		"args": [
+			"bg-red-400"
+		],
+		"expected": "bg-red-400"
+	},
+	{
+		"args": [
+			"bg-red-50"
+		],
+		"expected": "bg-red-50"
+	},
+	{
+		"args": [
+			"bg-red-500"
+		],
+		"expected": "bg-red-500"
+	},
+	{
+		"args": [
+			"bg-red-500/20"
+		],
+		"expected": "bg-red-500/20"
+	},
+	{
+		"args": [
+			"bg-red-600"
+		],
+		"expected": "bg-red-600"
+	},
+	{
+		"args": [
+			"bg-red-700"
+		],
+		"expected": "bg-red-700"
+	},
+	{
+		"args": [
+			"bg-red-800"
+		],
+		"expected": "bg-red-800"
+	},
+	{
+		"args": [
+			"bg-red-900"
+		],
+		"expected": "bg-red-900"
+	},
+	{
+		"args": [
+			"bg-red-950"
+		],
+		"expected": "bg-red-950"
+	},
+	{
+		"args": [
+			"bg-rose-100"
+		],
+		"expected": "bg-rose-100"
+	},
+	{
+		"args": [
+			"bg-rose-200"
+		],
+		"expected": "bg-rose-200"
+	},
+	{
+		"args": [
+			"bg-rose-300"
+		],
+		"expected": "bg-rose-300"
+	},
+	{
+		"args": [
+			"bg-rose-400"
+		],
+		"expected": "bg-rose-400"
+	},
+	{
+		"args": [
+			"bg-rose-50"
+		],
+		"expected": "bg-rose-50"
+	},
+	{
+		"args": [
+			"bg-rose-500"
+		],
+		"expected": "bg-rose-500"
+	},
+	{
+		"args": [
+			"bg-rose-500/20"
+		],
+		"expected": "bg-rose-500/20"
+	},
+	{
+		"args": [
+			"bg-rose-600"
+		],
+		"expected": "bg-rose-600"
+	},
+	{
+		"args": [
+			"bg-rose-700"
+		],
+		"expected": "bg-rose-700"
+	},
+	{
+		"args": [
+			"bg-rose-800"
+		],
+		"expected": "bg-rose-800"
+	},
+	{
+		"args": [
+			"bg-rose-900"
+		],
+		"expected": "bg-rose-900"
+	},
+	{
+		"args": [
+			"bg-rose-950"
+		],
+		"expected": "bg-rose-950"
+	},
+	{
+		"args": [
+			"bg-sky-100"
+		],
+		"expected": "bg-sky-100"
+	},
+	{
+		"args": [
+			"bg-sky-200"
+		],
+		"expected": "bg-sky-200"
+	},
+	{
+		"args": [
+			"bg-sky-300"
+		],
+		"expected": "bg-sky-300"
+	},
+	{
+		"args": [
+			"bg-sky-400"
+		],
+		"expected": "bg-sky-400"
+	},
+	{
+		"args": [
+			"bg-sky-50"
+		],
+		"expected": "bg-sky-50"
+	},
+	{
+		"args": [
+			"bg-sky-500"
+		],
+		"expected": "bg-sky-500"
+	},
+	{
+		"args": [
+			"bg-sky-500/20"
+		],
+		"expected": "bg-sky-500/20"
+	},
+	{
+		"args": [
+			"bg-sky-600"
+		],
+		"expected": "bg-sky-600"
+	},
+	{
+		"args": [
+			"bg-sky-700"
+		],
+		"expected": "bg-sky-700"
+	},
+	{
+		"args": [
+			"bg-sky-800"
+		],
+		"expected": "bg-sky-800"
+	},
+	{
+		"args": [
+			"bg-sky-900"
+		],
+		"expected": "bg-sky-900"
+	},
+	{
+		"args": [
+			"bg-sky-950"
+		],
+		"expected": "bg-sky-950"
+	},
+	{
+		"args": [
+			"bg-static-white"
+		],
+		"expected": "bg-static-white"
+	},
+	{
+		"args": [
+			"bg-strong h-4 w-px animate-pulse"
+		],
+		"expected": "bg-strong h-4 w-px animate-pulse"
+	},
+	{
+		"args": [
+			"bg-success-100"
+		],
+		"expected": "bg-success-100"
+	},
+	{
+		"args": [
+			"bg-success-200"
+		],
+		"expected": "bg-success-200"
+	},
+	{
+		"args": [
+			"bg-success-300"
+		],
+		"expected": "bg-success-300"
+	},
+	{
+		"args": [
+			"bg-success-400"
+		],
+		"expected": "bg-success-400"
+	},
+	{
+		"args": [
+			"bg-success-50"
+		],
+		"expected": "bg-success-50"
+	},
+	{
+		"args": [
+			"bg-success-500"
+		],
+		"expected": "bg-success-500"
+	},
+	{
+		"args": [
+			"bg-success-500/20"
+		],
+		"expected": "bg-success-500/20"
+	},
+	{
+		"args": [
+			"bg-success-600"
+		],
+		"expected": "bg-success-600"
+	},
+	{
+		"args": [
+			"bg-success-700"
+		],
+		"expected": "bg-success-700"
+	},
+	{
+		"args": [
+			"bg-success-800"
+		],
+		"expected": "bg-success-800"
+	},
+	{
+		"args": [
+			"bg-success-900"
+		],
+		"expected": "bg-success-900"
+	},
+	{
+		"args": [
+			"bg-success-950"
+		],
+		"expected": "bg-success-950"
+	},
+	{
+		"args": [
+			"bg-teal-100"
+		],
+		"expected": "bg-teal-100"
+	},
+	{
+		"args": [
+			"bg-teal-200"
+		],
+		"expected": "bg-teal-200"
+	},
+	{
+		"args": [
+			"bg-teal-300"
+		],
+		"expected": "bg-teal-300"
+	},
+	{
+		"args": [
+			"bg-teal-400"
+		],
+		"expected": "bg-teal-400"
+	},
+	{
+		"args": [
+			"bg-teal-50"
+		],
+		"expected": "bg-teal-50"
+	},
+	{
+		"args": [
+			"bg-teal-500"
+		],
+		"expected": "bg-teal-500"
+	},
+	{
+		"args": [
+			"bg-teal-500/20"
+		],
+		"expected": "bg-teal-500/20"
+	},
+	{
+		"args": [
+			"bg-teal-600"
+		],
+		"expected": "bg-teal-600"
+	},
+	{
+		"args": [
+			"bg-teal-700"
+		],
+		"expected": "bg-teal-700"
+	},
+	{
+		"args": [
+			"bg-teal-800"
+		],
+		"expected": "bg-teal-800"
+	},
+	{
+		"args": [
+			"bg-teal-900"
+		],
+		"expected": "bg-teal-900"
+	},
+	{
+		"args": [
+			"bg-teal-950"
+		],
+		"expected": "bg-teal-950"
+	},
+	{
+		"args": [
+			"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow"
+		],
+		"expected": "bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow"
+	},
+	{
+		"args": [
+			"bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs"
+		],
+		"expected": "bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs"
+	},
+	{
+		"args": [
+			"bg-violet-100"
+		],
+		"expected": "bg-violet-100"
+	},
+	{
+		"args": [
+			"bg-violet-200"
+		],
+		"expected": "bg-violet-200"
+	},
+	{
+		"args": [
+			"bg-violet-300"
+		],
+		"expected": "bg-violet-300"
+	},
+	{
+		"args": [
+			"bg-violet-400"
+		],
+		"expected": "bg-violet-400"
+	},
+	{
+		"args": [
+			"bg-violet-50"
+		],
+		"expected": "bg-violet-50"
+	},
+	{
+		"args": [
+			"bg-violet-500"
+		],
+		"expected": "bg-violet-500"
+	},
+	{
+		"args": [
+			"bg-violet-500/20"
+		],
+		"expected": "bg-violet-500/20"
+	},
+	{
+		"args": [
+			"bg-violet-600"
+		],
+		"expected": "bg-violet-600"
+	},
+	{
+		"args": [
+			"bg-violet-700"
+		],
+		"expected": "bg-violet-700"
+	},
+	{
+		"args": [
+			"bg-violet-800"
+		],
+		"expected": "bg-violet-800"
+	},
+	{
+		"args": [
+			"bg-violet-900"
+		],
+		"expected": "bg-violet-900"
+	},
+	{
+		"args": [
+			"bg-violet-950"
+		],
+		"expected": "bg-violet-950"
+	},
+	{
+		"args": [
+			"bg-warning-100"
+		],
+		"expected": "bg-warning-100"
+	},
+	{
+		"args": [
+			"bg-warning-200"
+		],
+		"expected": "bg-warning-200"
+	},
+	{
+		"args": [
+			"bg-warning-300"
+		],
+		"expected": "bg-warning-300"
+	},
+	{
+		"args": [
+			"bg-warning-400"
+		],
+		"expected": "bg-warning-400"
+	},
+	{
+		"args": [
+			"bg-warning-50"
+		],
+		"expected": "bg-warning-50"
+	},
+	{
+		"args": [
+			"bg-warning-500"
+		],
+		"expected": "bg-warning-500"
+	},
+	{
+		"args": [
+			"bg-warning-500/20"
+		],
+		"expected": "bg-warning-500/20"
+	},
+	{
+		"args": [
+			"bg-warning-600"
+		],
+		"expected": "bg-warning-600"
+	},
+	{
+		"args": [
+			"bg-warning-700"
+		],
+		"expected": "bg-warning-700"
+	},
+	{
+		"args": [
+			"bg-warning-800"
+		],
+		"expected": "bg-warning-800"
+	},
+	{
+		"args": [
+			"bg-warning-900"
+		],
+		"expected": "bg-warning-900"
+	},
+	{
+		"args": [
+			"bg-warning-950"
+		],
+		"expected": "bg-warning-950"
+	},
+	{
+		"args": [
+			"bg-white border-card flex flex-col items-center justify-center gap-2 rounded border p-6 text-black"
+		],
+		"expected": "bg-white border-card flex flex-col items-center justify-center gap-2 rounded border p-6 text-black"
+	},
+	{
+		"args": [
+			"bg-yellow-100"
+		],
+		"expected": "bg-yellow-100"
+	},
+	{
+		"args": [
+			"bg-yellow-200"
+		],
+		"expected": "bg-yellow-200"
+	},
+	{
+		"args": [
+			"bg-yellow-300"
+		],
+		"expected": "bg-yellow-300"
+	},
+	{
+		"args": [
+			"bg-yellow-400"
+		],
+		"expected": "bg-yellow-400"
+	},
+	{
+		"args": [
+			"bg-yellow-50"
+		],
+		"expected": "bg-yellow-50"
+	},
+	{
+		"args": [
+			"bg-yellow-500"
+		],
+		"expected": "bg-yellow-500"
+	},
+	{
+		"args": [
+			"bg-yellow-500/20"
+		],
+		"expected": "bg-yellow-500/20"
+	},
+	{
+		"args": [
+			"bg-yellow-600"
+		],
+		"expected": "bg-yellow-600"
+	},
+	{
+		"args": [
+			"bg-yellow-700"
+		],
+		"expected": "bg-yellow-700"
+	},
+	{
+		"args": [
+			"bg-yellow-800"
+		],
+		"expected": "bg-yellow-800"
+	},
+	{
+		"args": [
+			"bg-yellow-900"
+		],
+		"expected": "bg-yellow-900"
+	},
+	{
+		"args": [
+			"bg-yellow-950"
+		],
+		"expected": "bg-yellow-950"
+	},
+	{
+		"args": [
+			"block"
+		],
+		"expected": "block"
+	},
+	{
+		"args": [
+			"blocks/"
+		],
+		"expected": "blocks/"
+	},
+	{
+		"args": [
+			"border-0"
+		],
+		"expected": "border-0"
+	},
+	{
+		"args": [
+			"border-accent-600"
+		],
+		"expected": "border-accent-600"
+	},
+	{
+		"args": [
+			"border-accent-600 bg-accent-600"
+		],
+		"expected": "border-accent-600 bg-accent-600"
+	},
+	{
+		"args": [
+			"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border px-3 text-sm font-medium"
+		],
+		"expected": "border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border px-3 text-sm font-medium"
+	},
+	{
+		"args": [
+			"border-accent-600 ring-focus-accent ring-4"
+		],
+		"expected": "border-accent-600 ring-focus-accent ring-4"
+	},
+	{
+		"args": [
+			"border-card bg-card relative rounded-md border"
+		],
+		"expected": "border-card bg-card relative rounded-md border"
+	},
+	{
+		"args": [
+			"border-card rounded-md border p-2 shadow-md"
+		],
+		"expected": "border-card rounded-md border p-2 shadow-md"
+	},
+	{
+		"args": [
+			"border-card-muted bg-base relative rounded-md border shadow-inner"
+		],
+		"expected": "border-card-muted bg-base relative rounded-md border shadow-inner"
+	},
+	{
+		"args": [
+			"border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50"
+		],
+		"expected": "border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50"
+	},
+	{
+		"args": [
+			"border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600"
+		],
+		"expected": "border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600"
+	},
+	{
+		"args": [
+			"border-form flex size-4 items-center justify-center rounded-full border shrink-0"
+		],
+		"expected": "border-form flex size-4 items-center justify-center rounded-full border shrink-0"
+	},
+	{
+		"args": [
+			"border-form inline-flex items-center rounded-md"
+		],
+		"expected": "border-form inline-flex items-center rounded-md"
+	},
+	{
+		"args": [
+			"border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent"
+		],
+		"expected": "border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent"
+	},
+	{
+		"args": [
+			"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600"
+		],
+		"expected": "border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600"
+	},
+	{
+		"args": [
+			"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]"
+		],
+		"expected": "border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]"
+	},
+	{
+		"args": [
+			"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+		],
+		"expected": "border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+	},
+	{
+		"args": [
+			"border-l"
+		],
+		"expected": "border-l"
+	},
+	{
+		"args": [
+			"border-neutral-500/50 bg-neutral-500/10 text-neutral-700"
+		],
+		"expected": "border-neutral-500/50 bg-neutral-500/10 text-neutral-700"
+	},
+	{
+		"args": [
+			"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md"
+		],
+		"expected": "border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md"
+	},
+	{
+		"args": [
+			"border-r"
+		],
+		"expected": "border-r"
+	},
+	{
+		"args": [
+			"border-r border-gray-200"
+		],
+		"expected": "border-r border-gray-200"
+	},
+	{
+		"args": [
+			"border-x-0 border-t-0 rounded-none z-50 sticky"
+		],
+		"expected": "border-x-0 border-t-0 rounded-none z-50 sticky"
+	},
+	{
+		"args": [
+			"br-sao-1"
+		],
+		"expected": "br-sao-1"
+	},
+	{
+		"args": [
+			"build/server/..."
+		],
+		"expected": "build/server/..."
+	},
+	{
+		"args": [
+			"button-group"
+		],
+		"expected": "button-group"
+	},
+	{
+		"args": [
+			"button/"
+		],
+		"expected": "button/"
+	},
+	{
+		"args": [
+			"button/button.tsx"
+		],
+		"expected": "button/button.tsx"
+	},
+	{
+		"args": [
+			"card-body"
+		],
+		"expected": "card-body"
+	},
+	{
+		"args": [
+			"card-footer"
+		],
+		"expected": "card-footer"
+	},
+	{
+		"args": [
+			"card-header"
+		],
+		"expected": "card-header"
+	},
+	{
+		"args": [
+			"card-title"
+		],
+		"expected": "card-title"
+	},
+	{
+		"args": [
+			"catch-all"
+		],
+		"expected": "catch-all"
+	},
+	{
+		"args": [
+			"changelog-md"
+		],
+		"expected": "changelog-md"
+	},
+	{
+		"args": [
+			"changelog-mdx"
+		],
+		"expected": "changelog-mdx"
+	},
+	{
+		"args": [
+			"checked:border-accent-600 checked:bg-accent-600 checked:bg-checked-icon"
+		],
+		"expected": "checked:border-accent-600 checked:bg-checked-icon"
+	},
+	{
+		"args": [
+			"child-class"
+		],
+		"expected": "child-class"
+	},
+	{
+		"args": [
+			"child-error"
+		],
+		"expected": "child-error"
+	},
+	{
+		"args": [
+			"child-help"
+		],
+		"expected": "child-help"
+	},
+	{
+		"args": [
+			"child-only-class"
+		],
+		"expected": "child-only-class"
+	},
+	{
+		"args": [
+			"class-variance-authority"
+		],
+		"expected": "class-variance-authority"
+	},
+	{
+		"args": [
+			"click-state"
+		],
+		"expected": "click-state"
+	},
+	{
+		"args": [
+			"code-block"
+		],
+		"expected": "code-block"
+	},
+	{
+		"args": [
+			"code-block-body"
+		],
+		"expected": "code-block-body"
+	},
+	{
+		"args": [
+			"code-block-code"
+		],
+		"expected": "code-block-code"
+	},
+	{
+		"args": [
+			"code-block-migration"
+		],
+		"expected": "code-block-migration"
+	},
+	{
+		"args": [
+			"cody-dot-js"
+		],
+		"expected": "cody-dot-js"
+	},
+	{
+		"args": [
+			"color:var(--shiki-token-escape, var(--shiki-token-constant))"
+		],
+		"expected": "color:var(--shiki-token-escape, var(--shiki-token-constant))"
+	},
+	{
+		"args": [
+			"color:var(--shiki-token-keyword)"
+		],
+		"expected": "color:var(--shiki-token-keyword)"
+	},
+	{
+		"args": [
+			"color:var(--shiki-token-string-expression)"
+		],
+		"expected": "color:var(--shiki-token-string-expression)"
+	},
+	{
+		"args": [
+			"combobox-item-value"
+		],
+		"expected": "combobox-item-value"
+	},
+	{
+		"args": [
+			"combobox-separator"
+		],
+		"expected": "combobox-separator"
+	},
+	{
+		"args": [
+			"command-empty"
+		],
+		"expected": "command-empty"
+	},
+	{
+		"args": [
+			"command-group"
+		],
+		"expected": "command-group"
+	},
+	{
+		"args": [
+			"command-input"
+		],
+		"expected": "command-input"
+	},
+	{
+		"args": [
+			"command-input-wrapper"
+		],
+		"expected": "command-input-wrapper"
+	},
+	{
+		"args": [
+			"command-item"
+		],
+		"expected": "command-item"
+	},
+	{
+		"args": [
+			"command-list"
+		],
+		"expected": "command-list"
+	},
+	{
+		"args": [
+			"command-separator"
+		],
+		"expected": "command-separator"
+	},
+	{
+		"args": [
+			"command-shortcut"
+		],
+		"expected": "command-shortcut"
+	},
+	{
+		"args": [
+			"comment.line.double-slash.js"
+		],
+		"expected": "comment.line.double-slash.js"
+	},
+	{
+		"args": [
+			"commit-sha"
+		],
+		"expected": "commit-sha"
+	},
+	{
+		"args": [
+			"components/"
+		],
+		"expected": "components/"
+	},
+	{
+		"args": [
+			"components/alert"
+		],
+		"expected": "components/alert"
+	},
+	{
+		"args": [
+			"components/alert-dialog"
+		],
+		"expected": "components/alert-dialog"
+	},
+	{
+		"args": [
+			"components/alpha"
+		],
+		"expected": "components/alpha"
+	},
+	{
+		"args": [
+			"components/anchor"
+		],
+		"expected": "components/anchor"
+	},
+	{
+		"args": [
+			"components/badge"
+		],
+		"expected": "components/badge"
+	},
+	{
+		"args": [
+			"components/browser-only"
+		],
+		"expected": "components/browser-only"
+	},
+	{
+		"args": [
+			"components/button"
+		],
+		"expected": "components/button"
+	},
+	{
+		"args": [
+			"components/card"
+		],
+		"expected": "components/card"
+	},
+	{
+		"args": [
+			"components/checkbox"
+		],
+		"expected": "components/checkbox"
+	},
+	{
+		"args": [
+			"components/code"
+		],
+		"expected": "components/code"
+	},
+	{
+		"args": [
+			"components/code-block"
+		],
+		"expected": "components/code-block"
+	},
+	{
+		"args": [
+			"components/code-block/folding-by-language"
+		],
+		"expected": "components/code-block/folding-by-language"
+	},
+	{
+		"args": [
+			"components/combobox"
+		],
+		"expected": "components/combobox"
+	},
+	{
+		"args": [
+			"components/command"
+		],
+		"expected": "components/command"
+	},
+	{
+		"args": [
+			"components/data-table"
+		],
+		"expected": "components/data-table"
+	},
+	{
+		"args": [
+			"components/description-list"
+		],
+		"expected": "components/description-list"
+	},
+	{
+		"args": [
+			"components/dialog"
+		],
+		"expected": "components/dialog"
+	},
+	{
+		"args": [
+			"components/dropdown-menu"
+		],
+		"expected": "components/dropdown-menu"
+	},
+	{
+		"args": [
+			"components/empty"
+		],
+		"expected": "components/empty"
+	},
+	{
+		"args": [
+			"components/field"
+		],
+		"expected": "components/field"
+	},
+	{
+		"args": [
+			"components/flag"
+		],
+		"expected": "components/flag"
+	},
+	{
+		"args": [
+			"components/hover-card"
+		],
+		"expected": "components/hover-card"
+	},
+	{
+		"args": [
+			"components/icon"
+		],
+		"expected": "components/icon"
+	},
+	{
+		"args": [
+			"components/icon-button"
+		],
+		"expected": "components/icon-button"
+	},
+	{
+		"args": [
+			"components/icons"
+		],
+		"expected": "components/icons"
+	},
+	{
+		"args": [
+			"components/input"
+		],
+		"expected": "components/input"
+	},
+	{
+		"args": [
+			"components/kbd"
+		],
+		"expected": "components/kbd"
+	},
+	{
+		"args": [
+			"components/label"
+		],
+		"expected": "components/label"
+	},
+	{
+		"args": [
+			"components/main"
+		],
+		"expected": "components/main"
+	},
+	{
+		"args": [
+			"components/media-object"
+		],
+		"expected": "components/media-object"
+	},
+	{
+		"args": [
+			"components/multi-select"
+		],
+		"expected": "components/multi-select"
+	},
+	{
+		"args": [
+			"components/otp-input"
+		],
+		"expected": "components/otp-input"
+	},
+	{
+		"args": [
+			"components/pagination"
+		],
+		"expected": "components/pagination"
+	},
+	{
+		"args": [
+			"components/password-input"
+		],
+		"expected": "components/password-input"
+	},
+	{
+		"args": [
+			"components/popover"
+		],
+		"expected": "components/popover"
+	},
+	{
+		"args": [
+			"components/preview/"
+		],
+		"expected": "components/preview/"
+	},
+	{
+		"args": [
+			"components/preview/accordion"
+		],
+		"expected": "components/preview/accordion"
+	},
+	{
+		"args": [
+			"components/preview/calendar"
+		],
+		"expected": "components/preview/calendar"
+	},
+	{
+		"args": [
+			"components/progress-bar"
+		],
+		"expected": "components/progress-bar"
+	},
+	{
+		"args": [
+			"components/progress-donut"
+		],
+		"expected": "components/progress-donut"
+	},
+	{
+		"args": [
+			"components/qr-code"
+		],
+		"expected": "components/qr-code"
+	},
+	{
+		"args": [
+			"components/radio-group"
+		],
+		"expected": "components/radio-group"
+	},
+	{
+		"args": [
+			"components/sandboxed-on-click"
+		],
+		"expected": "components/sandboxed-on-click"
+	},
+	{
+		"args": [
+			"components/select"
+		],
+		"expected": "components/select"
+	},
+	{
+		"args": [
+			"components/separator"
+		],
+		"expected": "components/separator"
+	},
+	{
+		"args": [
+			"components/sheet"
+		],
+		"expected": "components/sheet"
+	},
+	{
+		"args": [
+			"components/skeleton"
+		],
+		"expected": "components/skeleton"
+	},
+	{
+		"args": [
+			"components/skip-to-main-link"
+		],
+		"expected": "components/skip-to-main-link"
+	},
+	{
+		"args": [
+			"components/slider"
+		],
+		"expected": "components/slider"
+	},
+	{
+		"args": [
+			"components/slot"
+		],
+		"expected": "components/slot"
+	},
+	{
+		"args": [
+			"components/split-button"
+		],
+		"expected": "components/split-button"
+	},
+	{
+		"args": [
+			"components/switch"
+		],
+		"expected": "components/switch"
+	},
+	{
+		"args": [
+			"components/table"
+		],
+		"expected": "components/table"
+	},
+	{
+		"args": [
+			"components/tabs"
+		],
+		"expected": "components/tabs"
+	},
+	{
+		"args": [
+			"components/text-area"
+		],
+		"expected": "components/text-area"
+	},
+	{
+		"args": [
+			"components/theme"
+		],
+		"expected": "components/theme"
+	},
+	{
+		"args": [
+			"components/toast"
+		],
+		"expected": "components/toast"
+	},
+	{
+		"args": [
+			"components/tooltip"
+		],
+		"expected": "components/tooltip"
+	},
+	{
+		"args": [
+			"components/well"
+		],
+		"expected": "components/well"
+	},
+	{
+		"args": [
+			"components/zed"
+		],
+		"expected": "components/zed"
+	},
+	{
+		"args": [
+			"container"
+		],
+		"expected": "container"
+	},
+	{
+		"args": [
+			"content-length"
+		],
+		"expected": "content-length"
+	},
+	{
+		"args": [
+			"contents"
+		],
+		"expected": "contents"
+	},
+	{
+		"args": [
+			"cursor-*"
+		],
+		"expected": "cursor-*"
+	},
+	{
+		"args": [
+			"cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal"
+		],
+		"expected": "cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal"
+	},
+	{
+		"args": [
+			"cursor-default opacity-50"
+		],
+		"expected": "cursor-default opacity-50"
+	},
+	{
+		"args": [
+			"cursor-pagination"
+		],
+		"expected": "cursor-pagination"
+	},
+	{
+		"args": [
+			"cursor-pagination-buttons"
+		],
+		"expected": "cursor-pagination-buttons"
+	},
+	{
+		"args": [
+			"cursor-pagination-next"
+		],
+		"expected": "cursor-pagination-next"
+	},
+	{
+		"args": [
+			"cursor-pagination-previous"
+		],
+		"expected": "cursor-pagination-previous"
+	},
+	{
+		"args": [
+			"cursor-pagination-separator"
+		],
+		"expected": "cursor-pagination-separator"
+	},
+	{
+		"args": [
+			"cursor-pointer"
+		],
+		"expected": "cursor-pointer"
+	},
+	{
+		"args": [
+			"cursor-pointer aria-disabled:cursor-default focus:outline-hidden"
+		],
+		"expected": "cursor-pointer aria-disabled:cursor-default focus:outline-hidden"
+	},
+	{
+		"args": [
+			"cursor-pointer rounded bg-transparent text-accent-600 hover:underline focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "cursor-pointer rounded bg-transparent text-accent-600 hover:underline focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"cursor-text select-none font-sans text-sm"
+		],
+		"expected": "cursor-text select-none font-sans text-sm"
+	},
+	{
+		"args": [
+			"cursor-wait"
+		],
+		"expected": "cursor-wait"
+	},
+	{
+		"args": [
+			"custom-class"
+		],
+		"expected": "custom-class"
+	},
+	{
+		"args": [
+			"custom-copy-button"
+		],
+		"expected": "custom-copy-button"
+	},
+	{
+		"args": [
+			"custom-group"
+		],
+		"expected": "custom-group"
+	},
+	{
+		"args": [
+			"custom-slot"
+		],
+		"expected": "custom-slot"
+	},
+	{
+		"args": [
+			"dark-high-contrast"
+		],
+		"expected": "dark-high-contrast"
+	},
+	{
+		"args": [
+			"dark-high-contrast:bg-black high-contrast:bg-black bg-gray-500/20 dark:bg-gray-600/20"
+		],
+		"expected": "dark-high-contrast:bg-black high-contrast:bg-black bg-gray-500/20 dark:bg-gray-600/20"
+	},
+	{
+		"args": [
+			"dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10"
+		],
+		"expected": "dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10"
+	},
+	{
+		"args": [
+			"dark-high-contrast:border-green-600 dark-high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "dark-high-contrast:border-green-600 dark-high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"data-*"
+		],
+		"expected": "data-*"
+	},
+	{
+		"args": [
+			"data-analytics-id"
+		],
+		"expected": "data-analytics-id"
+	},
+	{
+		"args": [
+			"data-appearance"
+		],
+		"expected": "data-appearance"
+	},
+	{
+		"args": [
+			"data-applied-theme"
+		],
+		"expected": "data-applied-theme"
+	},
+	{
+		"args": [
+			"data-custom"
+		],
+		"expected": "data-custom"
+	},
+	{
+		"args": [
+			"data-disabled"
+		],
+		"expected": "data-disabled"
+	},
+	{
+		"args": [
+			"data-disabled:cursor-default data-disabled:opacity-50"
+		],
+		"expected": "data-disabled:cursor-default data-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"data-disabled:opacity-50"
+		],
+		"expected": "data-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"data-disabled:pointer-events-none data-disabled:opacity-50"
+		],
+		"expected": "data-disabled:pointer-events-none data-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"data-fold-hidden"
+		],
+		"expected": "data-fold-hidden"
+	},
+	{
+		"args": [
+			"data-fold-line"
+		],
+		"expected": "data-fold-line"
+	},
+	{
+		"args": [
+			"data-fold-regions"
+		],
+		"expected": "data-fold-regions"
+	},
+	{
+		"args": [
+			"data-folded-regions"
+		],
+		"expected": "data-folded-regions"
+	},
+	{
+		"args": [
+			"data-highlighted:aria-checked:bg-active-selected-menu-item!"
+		],
+		"expected": "data-highlighted:aria-checked:bg-active-selected-menu-item!"
+	},
+	{
+		"args": [
+			"data-highlighted:bg-active-menu-item"
+		],
+		"expected": "data-highlighted:bg-active-menu-item"
+	},
+	{
+		"args": [
+			"data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item"
+		],
+		"expected": "data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item"
+	},
+	{
+		"args": [
+			"data-line-number"
+		],
+		"expected": "data-line-number"
+	},
+	{
+		"args": [
+			"data-loading"
+		],
+		"expected": "data-loading"
+	},
+	{
+		"args": [
+			"data-otp-state"
+		],
+		"expected": "data-otp-state"
+	},
+	{
+		"args": [
+			"data-priority"
+		],
+		"expected": "data-priority"
+	},
+	{
+		"args": [
+			"data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95"
+		],
+		"expected": "data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95"
+	},
+	{
+		"args": [
+			"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)"
+		],
+		"expected": "data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)"
+	},
+	{
+		"args": [
+			"data-slot"
+		],
+		"expected": "data-slot"
+	},
+	{
+		"args": [
+			"data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400"
+		],
+		"expected": "data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400"
+	},
+	{
+		"args": [
+			"data-state-checked:bg-selected-menu-item"
+		],
+		"expected": "data-state-checked:bg-selected-menu-item"
+	},
+	{
+		"args": [
+			"data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5"
+		],
+		"expected": "data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5"
+	},
+	{
+		"args": [
+			"data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4"
+		],
+		"expected": "data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4"
+	},
+	{
+		"args": [
+			"data-state-closed:slide-out-to-left data-state-open:slide-in-from-left left-0 border-r"
+		],
+		"expected": "data-state-closed:slide-out-to-left data-state-open:slide-in-from-left left-0 border-r"
+	},
+	{
+		"args": [
+			"data-state-closed:slide-out-to-right data-state-open:slide-in-from-right right-0 border-l"
+		],
+		"expected": "data-state-closed:slide-out-to-right data-state-open:slide-in-from-right right-0 border-l"
+	},
+	{
+		"args": [
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs"
+		],
+		"expected": "data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs"
+	},
+	{
+		"args": [
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2"
+		],
+		"expected": "data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2"
+	},
+	{
+		"args": [
+			"data-table"
+		],
+		"expected": "data-table"
+	},
+	{
+		"args": [
+			"data-table-action-header-migration"
+		],
+		"expected": "data-table-action-header-migration"
+	},
+	{
+		"args": [
+			"data-table-empty-row"
+		],
+		"expected": "data-table-empty-row"
+	},
+	{
+		"args": [
+			"data-table-head"
+		],
+		"expected": "data-table-head"
+	},
+	{
+		"args": [
+			"data-table-header-sort-button"
+		],
+		"expected": "data-table-header-sort-button"
+	},
+	{
+		"args": [
+			"data-table-row-expand-button"
+		],
+		"expected": "data-table-row-expand-button"
+	},
+	{
+		"args": [
+			"data-testid"
+		],
+		"expected": "data-testid"
+	},
+	{
+		"args": [
+			"data-theme"
+		],
+		"expected": "data-theme"
+	},
+	{
+		"args": [
+			"data-validation"
+		],
+		"expected": "data-validation"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger"
+		],
+		"expected": "data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			"data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+		],
+		"expected": "data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success"
+		],
+		"expected": "data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success"
+		],
+		"expected": "data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning"
+		],
+		"expected": "data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning"
+	},
+	{
+		"args": [
+			"data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+		],
+		"expected": "data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+	},
+	{
+		"args": [
+			"data:…"
+		],
+		"expected": "data:…"
+	},
+	{
+		"args": [
+			"datetime-local"
+		],
+		"expected": "datetime-local"
+	},
+	{
+		"args": [
+			"day size-full rounded-md not-aria-selected:not-disabled:hover:bg-filled-accent/15"
+		],
+		"expected": "day size-full rounded-md not-aria-selected:not-disabled:hover:bg-filled-accent/15"
+	},
+	{
+		"args": [
+			"day-outside aria-selected:text-on-filled opacity-50 text-muted"
+		],
+		"expected": "day-outside aria-selected:text-on-filled opacity-50 text-muted"
+	},
+	{
+		"args": [
+			"day-range-middle not-disabled:aria-selected:bg-filled-accent/15 aria-selected:text-strong rounded-none not-disabled:aria-selected:hover:bg-filled-accent/25"
+		],
+		"expected": "day-range-middle not-disabled:aria-selected:bg-filled-accent/15 aria-selected:text-strong rounded-none not-disabled:aria-selected:hover:bg-filled-accent/25"
+	},
+	{
+		"args": [
+			"de-fra-1"
+		],
+		"expected": "de-fra-1"
+	},
+	{
+		"args": [
+			"deployment-id"
+		],
+		"expected": "deployment-id"
+	},
+	{
+		"args": [
+			"description-list"
+		],
+		"expected": "description-list"
+	},
+	{
+		"args": [
+			"description-list-item"
+		],
+		"expected": "description-list-item"
+	},
+	{
+		"args": [
+			"description-list-label"
+		],
+		"expected": "description-list-label"
+	},
+	{
+		"args": [
+			"description-list-value"
+		],
+		"expected": "description-list-value"
+	},
+	{
+		"args": [
+			"dialog-footer-dom-order-migration"
+		],
+		"expected": "dialog-footer-dom-order-migration"
+	},
+	{
+		"args": [
+			"dialog-trigger"
+		],
+		"expected": "dialog-trigger"
+	},
+	{
+		"args": [
+			"disabled:cursor-default disabled:opacity-50"
+		],
+		"expected": "disabled:cursor-default disabled:opacity-50"
+	},
+	{
+		"args": [
+			"disabled:cursor-not-allowed"
+		],
+		"expected": "disabled:cursor-not-allowed"
+	},
+	{
+		"args": [
+			"dns-prefetch"
+		],
+		"expected": "dns-prefetch"
+	},
+	{
+		"args": [
+			"docs-changelog"
+		],
+		"expected": "docs-changelog"
+	},
+	{
+		"args": [
+			"docs-index-md"
+		],
+		"expected": "docs-index-md"
+	},
+	{
+		"args": [
+			"dropdown-menu-checkbox-item"
+		],
+		"expected": "dropdown-menu-checkbox-item"
+	},
+	{
+		"args": [
+			"dropdown-menu-content"
+		],
+		"expected": "dropdown-menu-content"
+	},
+	{
+		"args": [
+			"dropdown-menu-group"
+		],
+		"expected": "dropdown-menu-group"
+	},
+	{
+		"args": [
+			"dropdown-menu-item"
+		],
+		"expected": "dropdown-menu-item"
+	},
+	{
+		"args": [
+			"dropdown-menu-label"
+		],
+		"expected": "dropdown-menu-label"
+	},
+	{
+		"args": [
+			"dropdown-menu-radio-group"
+		],
+		"expected": "dropdown-menu-radio-group"
+	},
+	{
+		"args": [
+			"dropdown-menu-radio-item"
+		],
+		"expected": "dropdown-menu-radio-item"
+	},
+	{
+		"args": [
+			"dropdown-menu-separator"
+		],
+		"expected": "dropdown-menu-separator"
+	},
+	{
+		"args": [
+			"dropdown-menu-shortcut"
+		],
+		"expected": "dropdown-menu-shortcut"
+	},
+	{
+		"args": [
+			"dropdown-menu-sub-content"
+		],
+		"expected": "dropdown-menu-sub-content"
+	},
+	{
+		"args": [
+			"dropdown-menu-sub-trigger"
+		],
+		"expected": "dropdown-menu-sub-trigger"
+	},
+	{
+		"args": [
+			"dropdown-menu-trigger"
+		],
+		"expected": "dropdown-menu-trigger"
+	},
+	{
+		"args": [
+			"ease-in-out"
+		],
+		"expected": "ease-in-out"
+	},
+	{
+		"args": [
+			"ease-out"
+		],
+		"expected": "ease-out"
+	},
+	{
+		"args": [
+			"email-input"
+		],
+		"expected": "email-input"
+	},
+	{
+		"args": [
+			"empty-actions"
+		],
+		"expected": "empty-actions"
+	},
+	{
+		"args": [
+			"empty-description"
+		],
+		"expected": "empty-description"
+	},
+	{
+		"args": [
+			"empty-icon"
+		],
+		"expected": "empty-icon"
+	},
+	{
+		"args": [
+			"empty-state"
+		],
+		"expected": "empty-state"
+	},
+	{
+		"args": [
+			"empty-title"
+		],
+		"expected": "empty-title"
+	},
+	{
+		"args": [
+			"en-US"
+		],
+		"expected": "en-US"
+	},
+	{
+		"args": [
+			"european-union"
+		],
+		"expected": "european-union"
+	},
+	{
+		"args": [
+			"family-italic"
+		],
+		"expected": "family-italic"
+	},
+	{
+		"args": [
+			"family-regular"
+		],
+		"expected": "family-regular"
+	},
+	{
+		"args": [
+			"field-description"
+		],
+		"expected": "field-description"
+	},
+	{
+		"args": [
+			"field-error-item"
+		],
+		"expected": "field-error-item"
+	},
+	{
+		"args": [
+			"field-error-list"
+		],
+		"expected": "field-error-list"
+	},
+	{
+		"args": [
+			"field-group"
+		],
+		"expected": "field-group"
+	},
+	{
+		"args": [
+			"field-help-content"
+		],
+		"expected": "field-help-content"
+	},
+	{
+		"args": [
+			"field-item"
+		],
+		"expected": "field-item"
+	},
+	{
+		"args": [
+			"field-label-text"
+		],
+		"expected": "field-label-text"
+	},
+	{
+		"args": [
+			"field-legend"
+		],
+		"expected": "field-legend"
+	},
+	{
+		"args": [
+			"field-set"
+		],
+		"expected": "field-set"
+	},
+	{
+		"args": [
+			"first-letter:uppercase"
+		],
+		"expected": "first-letter:uppercase"
+	},
+	{
+		"args": [
+			"first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md"
+		],
+		"expected": "first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md"
+	},
+	{
+		"args": [
+			"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md"
+		],
+		"expected": "first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md"
+	},
+	{
+		"args": [
+			"first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+		],
+		"expected": "first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+	},
+	{
+		"args": [
+			"flex"
+		],
+		"expected": "flex"
+	},
+	{
+		"args": [
+			"flex absolute right-2.5 top-2.5 z-10 rounded bg-filled-success text-on-filled hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success w-auto gap-1 border-transparent items-center pl-2 pr-1.5 hover:border-transparent"
+		],
+		"expected": "flex absolute right-2.5 top-2.5 z-10 rounded bg-filled-success text-on-filled hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success w-auto gap-1 border-transparent items-center pl-2 pr-1.5 hover:border-transparent"
+	},
+	{
+		"args": [
+			"flex cursor-default items-center justify-center py-1"
+		],
+		"expected": "flex cursor-default items-center justify-center py-1"
+	},
+	{
+		"args": [
+			"flex flex-col"
+		],
+		"expected": "flex flex-col"
+	},
+	{
+		"args": [
+			"flex flex-col gap-2"
+		],
+		"expected": "flex flex-col gap-2"
+	},
+	{
+		"args": [
+			"flex flex-col gap-3"
+		],
+		"expected": "flex flex-col gap-3"
+	},
+	{
+		"args": [
+			"flex flex-col items-center gap-4 px-8 py-6"
+		],
+		"expected": "flex flex-col items-center gap-4 px-8 py-6"
+	},
+	{
+		"args": [
+			"flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0 relative max-w-min"
+		],
+		"expected": "flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0 relative max-w-min"
+	},
+	{
+		"args": [
+			"flex flex-row gap-2 min-[70.625rem]:flex-col"
+		],
+		"expected": "flex flex-row gap-2 min-[70.625rem]:flex-col"
+	},
+	{
+		"args": [
+			"flex flex-wrap items-center gap-2"
+		],
+		"expected": "flex flex-wrap items-center gap-2"
+	},
+	{
+		"args": [
+			"flex flex-wrap items-center gap-3 mb-6"
+		],
+		"expected": "flex flex-wrap items-center gap-3 mb-6"
+	},
+	{
+		"args": [
+			"flex gap-4"
+		],
+		"expected": "flex gap-4"
+	},
+	{
+		"args": [
+			"flex grow flex-col gap-1"
+		],
+		"expected": "flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			"flex grow flex-col gap-1 font-mono"
+		],
+		"expected": "flex grow flex-col gap-1 font-mono"
+	},
+	{
+		"args": [
+			"flex h-28 w-64 items-center justify-center rounded-xl border-2 font-mono text-sm transition-all duration-500"
+		],
+		"expected": "flex h-28 w-64 items-center justify-center rounded-xl border-2 font-mono text-sm transition-all duration-500"
+	},
+	{
+		"args": [
+			"flex h-9 items-center gap-2 border-b border-popover px-3"
+		],
+		"expected": "flex h-9 items-center gap-2 border-b border-popover px-3"
+	},
+	{
+		"args": [
+			"flex items-center"
+		],
+		"expected": "flex items-center"
+	},
+	{
+		"args": [
+			"flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+		],
+		"expected": "flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+	},
+	{
+		"args": [
+			"flex items-center gap-2"
+		],
+		"expected": "flex items-center gap-2"
+	},
+	{
+		"args": [
+			"flex items-center gap-2 has-disabled:opacity-50"
+		],
+		"expected": "flex items-center gap-2 has-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"flex items-center gap-2 justify-between"
+		],
+		"expected": "flex items-center gap-2 justify-between"
+	},
+	{
+		"args": [
+			"flex items-center gap-2 rounded font-mono text-xl leading-8 text-strong/90 hover:text-strong focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "flex items-center gap-2 rounded font-mono text-xl leading-8 text-strong/90 hover:text-strong focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"flex items-center justify-between"
+		],
+		"expected": "flex items-center justify-between"
+	},
+	{
+		"args": [
+			"flex items-center justify-center rounded-lg rounded-b-none border border-b-0 border-gray-300 p-4 md:p-16"
+		],
+		"expected": "flex items-center justify-center rounded-lg rounded-b-none border border-b-0 border-gray-300 p-4 md:p-16"
+	},
+	{
+		"args": [
+			"flex items-center ml-auto"
+		],
+		"expected": "flex items-center ml-auto"
+	},
+	{
+		"args": [
+			"flex items-center rounded justify-between gap-4 bg-accent-600/10 p-4 m-1"
+		],
+		"expected": "flex items-center rounded justify-between gap-4 bg-accent-600/10 p-4 m-1"
+	},
+	{
+		"args": [
+			"flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+		],
+		"expected": "flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+	},
+	{
+		"args": [
+			"flex justify-center pt-1 relative items-center"
+		],
+		"expected": "flex justify-center pt-1 relative items-center"
+	},
+	{
+		"args": [
+			"flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted"
+		],
+		"expected": "flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted"
+	},
+	{
+		"args": [
+			"flex md:hidden"
+		],
+		"expected": "flex md:hidden"
+	},
+	{
+		"args": [
+			"flex min-h-full flex-col"
+		],
+		"expected": "flex min-h-full flex-col"
+	},
+	{
+		"args": [
+			"flex min-w-0 flex-1 flex-col"
+		],
+		"expected": "flex min-w-0 flex-1 flex-col"
+	},
+	{
+		"args": [
+			"flex min-w-0 flex-1 items-center justify-between gap-2"
+		],
+		"expected": "flex min-w-0 flex-1 items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			"flex w-full flex-col gap-1.5"
+		],
+		"expected": "flex w-full flex-col gap-1.5"
+	},
+	{
+		"args": [
+			"flex w-full flex-col items-end justify-between gap-6 sm:flex-row"
+		],
+		"expected": "flex w-full flex-col items-end justify-between gap-6 sm:flex-row"
+	},
+	{
+		"args": [
+			"flex w-full max-w-270 flex-col items-center"
+		],
+		"expected": "flex w-full max-w-270 flex-col items-center"
+	},
+	{
+		"args": [
+			"flex w-full max-w-lg flex-col gap-1.5"
+		],
+		"expected": "flex w-full max-w-lg flex-col gap-1.5"
+	},
+	{
+		"args": [
+			"flex w-full min-w-0 flex-col gap-4 border-0 p-0"
+		],
+		"expected": "flex w-full min-w-0 flex-col gap-4 border-0 p-0"
+	},
+	{
+		"args": [
+			"flex w-full mt-1"
+		],
+		"expected": "flex w-full mt-1"
+	},
+	{
+		"args": [
+			"flex-col"
+		],
+		"expected": "flex-col"
+	},
+	{
+		"args": [
+			"flex-col items-end gap-3.5 self-stretch"
+		],
+		"expected": "flex-col items-end gap-3.5 self-stretch"
+	},
+	{
+		"args": [
+			"flex-row"
+		],
+		"expected": "flex-row"
+	},
+	{
+		"args": [
+			"flex-wrap gap-4"
+		],
+		"expected": "flex-wrap gap-4"
+	},
+	{
+		"args": [
+			"fmt:check"
+		],
+		"expected": "fmt:check"
+	},
+	{
+		"args": [
+			"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+		],
+		"expected": "focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4"
+		],
+		"expected": "focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4"
+		],
+		"expected": "focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 text-sm outline-hidden"
+		],
+		"expected": "focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 text-sm outline-hidden"
+	},
+	{
+		"args": [
+			"focus:bg-accent focus:text-accent-foreground"
+		],
+		"expected": "focus:bg-accent focus:text-accent-foreground"
+	},
+	{
+		"args": [
+			"focus:bg-active-menu-item"
+		],
+		"expected": "focus:bg-active-menu-item"
+	},
+	{
+		"args": [
+			"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent"
+		],
+		"expected": "focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent"
+	},
+	{
+		"args": [
+			"focus:data-state-checked:bg-active-selected-menu-item"
+		],
+		"expected": "focus:data-state-checked:bg-active-selected-menu-item"
+	},
+	{
+		"args": [
+			"focus:outline-hidden"
+		],
+		"expected": "focus:outline-hidden"
+	},
+	{
+		"args": [
+			"focus:outline-hidden focus-visible:ring-4"
+		],
+		"expected": "focus:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"focus:outline-hidden focus:ring-4 aria-expanded:ring-4"
+		],
+		"expected": "focus:outline-hidden focus:ring-4 aria-expanded:ring-4"
+	},
+	{
+		"args": [
+			"fold%20%22one%22%20region"
+		],
+		"expected": "fold%20%22one%22%20region"
+	},
+	{
+		"args": [
+			"fold-ellipsis"
+		],
+		"expected": "fold-ellipsis"
+	},
+	{
+		"args": [
+			"fold-runtime"
+		],
+		"expected": "fold-runtime"
+	},
+	{
+		"args": [
+			"fold-spacer"
+		],
+		"expected": "fold-spacer"
+	},
+	{
+		"args": [
+			"font-body text-body mt-3"
+		],
+		"expected": "font-body text-body mt-3"
+	},
+	{
+		"args": [
+			"font-bold"
+		],
+		"expected": "font-bold"
+	},
+	{
+		"args": [
+			"font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+		],
+		"expected": "font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+	},
+	{
+		"args": [
+			"font-family text-strong text-8xl leading-none md:text-9xl"
+		],
+		"expected": "font-family text-strong text-8xl leading-none md:text-9xl"
+	},
+	{
+		"args": [
+			"font-medium"
+		],
+		"expected": "font-medium"
+	},
+	{
+		"args": [
+			"font-medium text-strong group-hover:text-accent-600"
+		],
+		"expected": "font-medium text-strong group-hover:text-accent-600"
+	},
+	{
+		"args": [
+			"font-mono"
+		],
+		"expected": "font-mono"
+	},
+	{
+		"args": [
+			"font-mono p-4 text-xl"
+		],
+		"expected": "font-mono p-4 text-xl"
+	},
+	{
+		"args": [
+			"font-normal"
+		],
+		"expected": "font-normal"
+	},
+	{
+		"args": [
+			"font-sans"
+		],
+		"expected": "font-sans"
+	},
+	{
+		"args": [
+			"font-size"
+		],
+		"expected": "font-size"
+	},
+	{
+		"args": [
+			"font/woff2"
+		],
+		"expected": "font/woff2"
+	},
+	{
+		"args": [
+			"for-ai-agents"
+		],
+		"expected": "for-ai-agents"
+	},
+	{
+		"args": [
+			"for/done"
+		],
+		"expected": "for/done"
+	},
+	{
+		"args": [
+			"from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)]"
+		],
+		"expected": "from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)]"
+	},
+	{
+		"args": [
+			"gap-*"
+		],
+		"expected": "gap-*"
+	},
+	{
+		"args": [
+			"gap-0.5"
+		],
+		"expected": "gap-0.5"
+	},
+	{
+		"args": [
+			"gap-1"
+		],
+		"expected": "gap-1"
+	},
+	{
+		"args": [
+			"gap-1 pb-1 -mb-1"
+		],
+		"expected": "gap-1 pb-1 -mb-1"
+	},
+	{
+		"args": [
+			"gap-1.5"
+		],
+		"expected": "gap-1.5"
+	},
+	{
+		"args": [
+			"gap-2"
+		],
+		"expected": "gap-2"
+	},
+	{
+		"args": [
+			"gap-4"
+		],
+		"expected": "gap-4"
+	},
+	{
+		"args": [
+			"gap-6"
+		],
+		"expected": "gap-6"
+	},
+	{
+		"args": [
+			"gap-em"
+		],
+		"expected": "gap-em"
+	},
+	{
+		"args": [
+			"grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+		],
+		"expected": "grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+	},
+	{
+		"args": [
+			"grid grid-cols-1 gap-2 p-3"
+		],
+		"expected": "grid grid-cols-1 gap-2 p-3"
+	},
+	{
+		"args": [
+			"grid grid-cols-4 gap-2"
+		],
+		"expected": "grid grid-cols-4 gap-2"
+	},
+	{
+		"args": [
+			"grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+		],
+		"expected": "grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+	},
+	{
+		"args": [
+			"grid w-full max-w-2xl grid-cols-2 gap-6 gap-y-12 font-mono text-[0.8125rem] min-[70.625rem]:max-w-none min-[70.625rem]:grid-cols-5"
+		],
+		"expected": "grid w-full max-w-2xl grid-cols-2 gap-6 gap-y-12 font-mono text-[0.8125rem] min-[70.625rem]:max-w-none min-[70.625rem]:grid-cols-5"
+	},
+	{
+		"args": [
+			"group"
+		],
+		"expected": "group"
+	},
+	{
+		"args": [
+			"group block rounded py-4 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "group block rounded py-4 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"group flex items-center gap-1.5"
+		],
+		"expected": "group flex items-center gap-1.5"
+	},
+	{
+		"args": [
+			"group-child"
+		],
+		"expected": "group-child"
+	},
+	{
+		"args": [
+			"group-data-*"
+		],
+		"expected": "group-data-*"
+	},
+	{
+		"args": [
+			"group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong"
+		],
+		"expected": "group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong"
+	},
+	{
+		"args": [
+			"group-data-validation"
+		],
+		"expected": "group-data-validation"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:border-y-(--otp-validation-border)"
+		],
+		"expected": "group-data-validation/otp:border-y-(--otp-validation-border)"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:first:border-l-(--otp-validation-border)"
+		],
+		"expected": "group-data-validation/otp:first:border-l-(--otp-validation-border)"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)"
+		],
+		"expected": "group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:last:border-r-(--otp-validation-border)"
+		],
+		"expected": "group-data-validation/otp:last:border-r-(--otp-validation-border)"
+	},
+	{
+		"args": [
+			"group-hover/tab-trigger:group-enabled/tab-trigger:text-gray-700"
+		],
+		"expected": "group-hover/tab-trigger:group-enabled/tab-trigger:text-gray-700"
+	},
+	{
+		"args": [
+			"group/dropdown-menu-radio-item"
+		],
+		"expected": "group/dropdown-menu-radio-item"
+	},
+	{
+		"args": [
+			"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm"
+		],
+		"expected": "group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm"
+	},
+	{
+		"args": [
+			"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm"
+		],
+		"expected": "group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm"
+	},
+	{
+		"args": [
+			"group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden"
+		],
+		"expected": "group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden"
+	},
+	{
+		"args": [
+			"h-(--radix-select-trigger-height) w-full"
+		],
+		"expected": "h-(--radix-select-trigger-height) w-full"
+	},
+	{
+		"args": [
+			"h-*"
+		],
+		"expected": "h-*"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded"
+		],
+		"expected": "h-10 w-full rounded"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950"
+		],
+		"expected": "h-10 w-full rounded bg-neutral-950"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950/50"
+		],
+		"expected": "h-10 w-full rounded bg-neutral-950/50"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950/60"
+		],
+		"expected": "h-10 w-full rounded bg-neutral-950/60"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950/75"
+		],
+		"expected": "h-10 w-full rounded bg-neutral-950/75"
+	},
+	{
+		"args": [
+			"h-6"
+		],
+		"expected": "h-6"
+	},
+	{
+		"args": [
+			"h-60"
+		],
+		"expected": "h-60"
+	},
+	{
+		"args": [
+			"h-72 w-full overflow-y-scroll overscroll-contain"
+		],
+		"expected": "h-72 w-full overflow-y-scroll overscroll-contain"
+	},
+	{
+		"args": [
+			"h-9"
+		],
+		"expected": "h-9"
+	},
+	{
+		"args": [
+			"h-9 text-sm"
+		],
+		"expected": "h-9 text-sm"
+	},
+	{
+		"args": [
+			"h-auto w-full max-w-126 text-neutral-200"
+		],
+		"expected": "h-auto w-full max-w-126 text-neutral-200"
+	},
+	{
+		"args": [
+			"h-full"
+		],
+		"expected": "h-full"
+	},
+	{
+		"args": [
+			"h-full border border-card-muted hover:border-card flex flex-col items-center gap-1 justify-center relative bg-card ring-accent-600 hover:bg-card-hover focus-visible:bg-card-hover group w-full cursor-pointer rounded-md px-4 py-3 focus:outline-hidden focus-visible:ring-2"
+		],
+		"expected": "h-full border border-card-muted hover:border-card flex flex-col items-center gap-1 justify-center relative bg-card ring-accent-600 hover:bg-card-hover focus-visible:bg-card-hover group w-full cursor-pointer rounded-md px-4 py-3 focus:outline-hidden focus-visible:ring-2"
+	},
+	{
+		"args": [
+			"h-full w-full block object-cover"
+		],
+		"expected": "h-full w-full block object-cover"
+	},
+	{
+		"args": [
+			"h-full w-px"
+		],
+		"expected": "h-full w-px"
+	},
+	{
+		"args": [
+			"h-px w-full group-data-horizontal-separator-group:flex-1"
+		],
+		"expected": "h-px w-full group-data-horizontal-separator-group:flex-1"
+	},
+	{
+		"args": [
+			"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2"
+		],
+		"expected": "has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2"
+	},
+	{
+		"args": [
+			"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4"
+		],
+		"expected": "has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4"
+	},
+	{
+		"args": [
+			"has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent"
+		],
+		"expected": "has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent"
+	},
+	{
+		"args": [
+			"has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4"
+		],
+		"expected": "has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4"
+	},
+	{
+		"args": [
+			"hidden"
+		],
+		"expected": "hidden"
+	},
+	{
+		"args": [
+			"hidden md:flex"
+		],
+		"expected": "hidden md:flex"
+	},
+	{
+		"args": [
+			"hidden md:flex items-center gap-1"
+		],
+		"expected": "hidden md:flex items-center gap-1"
+	},
+	{
+		"args": [
+			"hidden md:inline-flex"
+		],
+		"expected": "hidden md:inline-flex"
+	},
+	{
+		"args": [
+			"hidden min-[70.625rem]:block"
+		],
+		"expected": "hidden min-[70.625rem]:block"
+	},
+	{
+		"args": [
+			"hidden w-40 xl:block"
+		],
+		"expected": "hidden w-40 xl:block"
+	},
+	{
+		"args": [
+			"high-contrast:border-green-600 high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "high-contrast:border-green-600 high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"highlight-utils"
+		],
+		"expected": "highlight-utils"
+	},
+	{
+		"args": [
+			"horizontal-separator-group"
+		],
+		"expected": "horizontal-separator-group"
+	},
+	{
+		"args": [
+			"hover-card-content"
+		],
+		"expected": "hover-card-content"
+	},
+	{
+		"args": [
+			"hover-card-trigger"
+		],
+		"expected": "hover-card-trigger"
+	},
+	{
+		"args": [
+			"hover-hover:border-green-600 hover-hover:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "hover-hover:border-green-600 hover-hover:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"hover-none:border-green-600 hover-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "hover-none:border-green-600 hover-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"hover:border-neutral-400"
+		],
+		"expected": "hover:border-neutral-400"
+	},
+	{
+		"args": [
+			"hover:text-danger-700"
+		],
+		"expected": "hover:text-danger-700"
+	},
+	{
+		"args": [
+			"hover:text-emerald-700"
+		],
+		"expected": "hover:text-emerald-700"
+	},
+	{
+		"args": [
+			"hover:text-orange-700"
+		],
+		"expected": "hover:text-orange-700"
+	},
+	{
+		"args": [
+			"hover:text-strong"
+		],
+		"expected": "hover:text-strong"
+	},
+	{
+		"args": [
+			"hover:text-yellow-700"
+		],
+		"expected": "hover:text-yellow-700"
+	},
+	{
+		"args": [
+			"http-request"
+		],
+		"expected": "http-request"
+	},
+	{
+		"args": [
+			"http://json-schema.org/draft-07/schema#"
+		],
+		"expected": "http://json-schema.org/draft-07/schema#"
+	},
+	{
+		"args": [
+			"http://localhost:4444"
+		],
+		"expected": "http://localhost:4444"
+	},
+	{
+		"args": [
+			"http://ngrok.com/foo"
+		],
+		"expected": "http://ngrok.com/foo"
+	},
+	{
+		"args": [
+			"http://www.sitemaps.org/schemas/sitemap/0.9"
+		],
+		"expected": "http://www.sitemaps.org/schemas/sitemap/0.9"
+	},
+	{
+		"args": [
+			"https:"
+		],
+		"expected": "https:"
+	},
+	{
+		"args": [
+			"https://assets.ngrok.com"
+		],
+		"expected": "https://assets.ngrok.com"
+	},
+	{
+		"args": [
+			"https://bsky.app/profile/ngrok.com"
+		],
+		"expected": "https://bsky.app/profile/ngrok.com"
+	},
+	{
+		"args": [
+			"https://evil.com/foo"
+		],
+		"expected": "https://evil.com/foo"
+	},
+	{
+		"args": [
+			"https://example.com"
+		],
+		"expected": "https://example.com"
+	},
+	{
+		"args": [
+			"https://foo/bar"
+		],
+		"expected": "https://foo/bar"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok"
+		],
+		"expected": "https://github.com/ngrok"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle"
+		],
+		"expected": "https://github.com/ngrok/mantle"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/commit/abcdef0"
+		],
+		"expected": "https://github.com/ngrok/mantle/commit/abcdef0"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5"
+		],
+		"expected": "https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/pull/1167"
+		],
+		"expected": "https://github.com/ngrok/mantle/pull/1167"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0"
+		],
+		"expected": "https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com"
+		],
+		"expected": "https://mantle.ngrok.com"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/api/package.json"
+		],
+		"expected": "https://mantle.ngrok.com/api/package.json"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/api/schema.json"
+		],
+		"expected": "https://mantle.ngrok.com/api/schema.json"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/alpha"
+		],
+		"expected": "https://mantle.ngrok.com/components/alpha"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/alpha.md"
+		],
+		"expected": "https://mantle.ngrok.com/components/alpha.md"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/zed"
+		],
+		"expected": "https://mantle.ngrok.com/components/zed"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/zed.md"
+		],
+		"expected": "https://mantle.ngrok.com/components/zed.md"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/hooks"
+		],
+		"expected": "https://mantle.ngrok.com/hooks"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/hooks.md"
+		],
+		"expected": "https://mantle.ngrok.com/hooks.md"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/utils/gamma"
+		],
+		"expected": "https://mantle.ngrok.com/utils/gamma"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/utils/gamma.md"
+		],
+		"expected": "https://mantle.ngrok.com/utils/gamma.md"
+	},
+	{
+		"args": [
+			"https://ngrok-mantle-pr-123.vercel.app"
+		],
+		"expected": "https://ngrok-mantle-pr-123.vercel.app"
+	},
+	{
+		"args": [
+			"https://ngrok.ai"
+		],
+		"expected": "https://ngrok.ai"
+	},
+	{
+		"args": [
+			"https://ngrok.ai/"
+		],
+		"expected": "https://ngrok.ai/"
+	},
+	{
+		"args": [
+			"https://ngrok.com"
+		],
+		"expected": "https://ngrok.com"
+	},
+	{
+		"args": [
+			"https://ngrok.com/about"
+		],
+		"expected": "https://ngrok.com/about"
+	},
+	{
+		"args": [
+			"https://ngrok.com/abuse"
+		],
+		"expected": "https://ngrok.com/abuse"
+	},
+	{
+		"args": [
+			"https://ngrok.com/blog"
+		],
+		"expected": "https://ngrok.com/blog"
+	},
+	{
+		"args": [
+			"https://ngrok.com/blog/rss.xml"
+		],
+		"expected": "https://ngrok.com/blog/rss.xml"
+	},
+	{
+		"args": [
+			"https://ngrok.com/brand"
+		],
+		"expected": "https://ngrok.com/brand"
+	},
+	{
+		"args": [
+			"https://ngrok.com/careers"
+		],
+		"expected": "https://ngrok.com/careers"
+	},
+	{
+		"args": [
+			"https://ngrok.com/contact"
+		],
+		"expected": "https://ngrok.com/contact"
+	},
+	{
+		"args": [
+			"https://ngrok.com/customers"
+		],
+		"expected": "https://ngrok.com/customers"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/agent/overview"
+		],
+		"expected": "https://ngrok.com/docs/agent/overview"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides"
+		],
+		"expected": "https://ngrok.com/docs/guides"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides/api-gateway/get-started"
+		],
+		"expected": "https://ngrok.com/docs/guides/api-gateway/get-started"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides/device-gateway/agent"
+		],
+		"expected": "https://ngrok.com/docs/guides/device-gateway/agent"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides/ssh-rdp"
+		],
+		"expected": "https://ngrok.com/docs/guides/ssh-rdp"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/integrations"
+		],
+		"expected": "https://ngrok.com/docs/integrations"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/k8s"
+		],
+		"expected": "https://ngrok.com/docs/k8s"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/k8s/guides/local-projection"
+		],
+		"expected": "https://ngrok.com/docs/k8s/guides/local-projection"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/obs"
+		],
+		"expected": "https://ngrok.com/docs/obs"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/start"
+		],
+		"expected": "https://ngrok.com/docs/start"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/traffic-policy"
+		],
+		"expected": "https://ngrok.com/docs/traffic-policy"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/examples/ephemeral-workloads"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/examples/ephemeral-workloads"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/examples/minecraft"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/examples/minecraft"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/examples/webhook-gateway"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/examples/webhook-gateway"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/overview"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/overview"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/using-ngrok-with/using-mcp"
+		],
+		"expected": "https://ngrok.com/docs/using-ngrok-with/using-mcp"
+	},
+	{
+		"args": [
+			"https://ngrok.com/download"
+		],
+		"expected": "https://ngrok.com/download"
+	},
+	{
+		"args": [
+			"https://ngrok.com/dpa"
+		],
+		"expected": "https://ngrok.com/dpa"
+	},
+	{
+		"args": [
+			"https://ngrok.com/foo"
+		],
+		"expected": "https://ngrok.com/foo"
+	},
+	{
+		"args": [
+			"https://ngrok.com/newsletter"
+		],
+		"expected": "https://ngrok.com/newsletter"
+	},
+	{
+		"args": [
+			"https://ngrok.com/press"
+		],
+		"expected": "https://ngrok.com/press"
+	},
+	{
+		"args": [
+			"https://ngrok.com/pricing"
+		],
+		"expected": "https://ngrok.com/pricing"
+	},
+	{
+		"args": [
+			"https://ngrok.com/privacy"
+		],
+		"expected": "https://ngrok.com/privacy"
+	},
+	{
+		"args": [
+			"https://ngrok.com/privacy-preferences"
+		],
+		"expected": "https://ngrok.com/privacy-preferences"
+	},
+	{
+		"args": [
+			"https://ngrok.com/security"
+		],
+		"expected": "https://ngrok.com/security"
+	},
+	{
+		"args": [
+			"https://ngrok.com/support"
+		],
+		"expected": "https://ngrok.com/support"
+	},
+	{
+		"args": [
+			"https://ngrok.com/tos"
+		],
+		"expected": "https://ngrok.com/tos"
+	},
+	{
+		"args": [
+			"https://ngrok.com/use-cases/developer-preview"
+		],
+		"expected": "https://ngrok.com/use-cases/developer-preview"
+	},
+	{
+		"args": [
+			"https://ngrok.com/use-cases/site-to-site-connectivity"
+		],
+		"expected": "https://ngrok.com/use-cases/site-to-site-connectivity"
+	},
+	{
+		"args": [
+			"https://ngrok.com/use-cases/webhook-testing"
+		],
+		"expected": "https://ngrok.com/use-cases/webhook-testing"
+	},
+	{
+		"args": [
+			"https://schema.org"
+		],
+		"expected": "https://schema.org"
+	},
+	{
+		"args": [
+			"https://status.ngrok.com/"
+		],
+		"expected": "https://status.ngrok.com/"
+	},
+	{
+		"args": [
+			"https://status.ngrok.com/api/v2/status.json"
+		],
+		"expected": "https://status.ngrok.com/api/v2/status.json"
+	},
+	{
+		"args": [
+			"https://trust.ngrok.com/"
+		],
+		"expected": "https://trust.ngrok.com/"
+	},
+	{
+		"args": [
+			"https://upstream-service.internal/ping"
+		],
+		"expected": "https://upstream-service.internal/ping"
+	},
+	{
+		"args": [
+			"https://www.linkedin.com/company/ngrok/"
+		],
+		"expected": "https://www.linkedin.com/company/ngrok/"
+	},
+	{
+		"args": [
+			"https://www.youtube.com/@ngrokHQ"
+		],
+		"expected": "https://www.youtube.com/@ngrokHQ"
+	},
+	{
+		"args": [
+			"https://x.com/ngrokHQ"
+		],
+		"expected": "https://x.com/ngrokHQ"
+	},
+	{
+		"args": [
+			"icon-button"
+		],
+		"expected": "icon-button"
+	},
+	{
+		"args": [
+			"icon-search"
+		],
+		"expected": "icon-search"
+	},
+	{
+		"args": [
+			"if/fi"
+		],
+		"expected": "if/fi"
+	},
+	{
+		"args": [
+			"ignored-by-context"
+		],
+		"expected": "ignored-by-context"
+	},
+	{
+		"args": [
+			"ignored-description"
+		],
+		"expected": "ignored-description"
+	},
+	{
+		"args": [
+			"ignored-error"
+		],
+		"expected": "ignored-error"
+	},
+	{
+		"args": [
+			"ignored-input"
+		],
+		"expected": "ignored-input"
+	},
+	{
+		"args": [
+			"ignored-name"
+		],
+		"expected": "ignored-name"
+	},
+	{
+		"args": [
+			"ignored-trigger"
+		],
+		"expected": "ignored-trigger"
+	},
+	{
+		"args": [
+			"in-mum-1"
+		],
+		"expected": "in-mum-1"
+	},
+	{
+		"args": [
+			"indeterminate:border-accent-600 indeterminate:bg-accent-600 indeterminate:bg-indeterminate-icon"
+		],
+		"expected": "indeterminate:border-accent-600 indeterminate:bg-indeterminate-icon"
+	},
+	{
+		"args": [
+			"inline-block ml-1.5"
+		],
+		"expected": "inline-block ml-1.5"
+	},
+	{
+		"args": [
+			"inline-block mr-1.5"
+		],
+		"expected": "inline-block mr-1.5"
+	},
+	{
+		"args": [
+			"inline-flex"
+		],
+		"expected": "inline-flex"
+	},
+	{
+		"args": [
+			"inline-flex gap-1 items-center pointer-events-none select-none"
+		],
+		"expected": "inline-flex gap-1 items-center pointer-events-none select-none"
+	},
+	{
+		"args": [
+			"inline-flex items-center justify-between gap-2"
+		],
+		"expected": "inline-flex items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			"inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md"
+		],
+		"expected": "inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md"
+	},
+	{
+		"args": [
+			"inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-strong hover:bg-neutral-500/10 focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent"
+		],
+		"expected": "inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-strong hover:bg-neutral-500/10 focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"inline-flex md:hidden"
+		],
+		"expected": "inline-flex md:hidden"
+	},
+	{
+		"args": [
+			"inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border"
+		],
+		"expected": "inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border"
+	},
+	{
+		"args": [
+			"inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 font-medium text-xs font-sans"
+		],
+		"expected": "inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 font-medium text-xs font-sans"
+	},
+	{
+		"args": [
+			"input-capture"
+		],
+		"expected": "input-capture"
+	},
+	{
+		"args": [
+			"input-otp"
+		],
+		"expected": "input-otp"
+	},
+	{
+		"args": [
+			"input/"
+		],
+		"expected": "input/"
+	},
+	{
+		"args": [
+			"isolate"
+		],
+		"expected": "isolate"
+	},
+	{
+		"args": [
+			"item-child"
+		],
+		"expected": "item-child"
+	},
+	{
+		"args": [
+			"items-center"
+		],
+		"expected": "items-center"
+	},
+	{
+		"args": [
+			"items-start"
+		],
+		"expected": "items-start"
+	},
+	{
+		"args": [
+			"javascript:alert(1)"
+		],
+		"expected": "javascript:alert(1)"
+	},
+	{
+		"args": [
+			"javascript:…"
+		],
+		"expected": "javascript:…"
+	},
+	{
+		"args": [
+			"jetbrains-mono"
+		],
+		"expected": "jetbrains-mono"
+	},
+	{
+		"args": [
+			"jetbrains-mono-italic"
+		],
+		"expected": "jetbrains-mono-italic"
+	},
+	{
+		"args": [
+			"jp-tokyo-1"
+		],
+		"expected": "jp-tokyo-1"
+	},
+	{
+		"args": [
+			"json-raw"
+		],
+		"expected": "json-raw"
+	},
+	{
+		"args": [
+			"justify-between gap-4"
+		],
+		"expected": "justify-between gap-4"
+	},
+	{
+		"args": [
+			"justify-end"
+		],
+		"expected": "justify-end"
+	},
+	{
+		"args": [
+			"label-row-child"
+		],
+		"expected": "label-row-child"
+	},
+	{
+		"args": [
+			"lang-"
+		],
+		"expected": "lang-"
+	},
+	{
+		"args": [
+			"lang-fake"
+		],
+		"expected": "lang-fake"
+	},
+	{
+		"args": [
+			"lang-tsx"
+		],
+		"expected": "lang-tsx"
+	},
+	{
+		"args": [
+			"language-"
+		],
+		"expected": "language-"
+	},
+	{
+		"args": [
+			"language-fake"
+		],
+		"expected": "language-fake"
+	},
+	{
+		"args": [
+			"language-tsx"
+		],
+		"expected": "language-tsx"
+	},
+	{
+		"args": [
+			"light-high-contrast"
+		],
+		"expected": "light-high-contrast"
+	},
+	{
+		"args": [
+			"line-content"
+		],
+		"expected": "line-content"
+	},
+	{
+		"args": [
+			"list-none"
+		],
+		"expected": "list-none"
+	},
+	{
+		"args": [
+			"llms-full-txt"
+		],
+		"expected": "llms-full-txt"
+	},
+	{
+		"args": [
+			"llms-full.txt"
+		],
+		"expected": "llms-full.txt"
+	},
+	{
+		"args": [
+			"llms-txt"
+		],
+		"expected": "llms-txt"
+	},
+	{
+		"args": [
+			"localhost:8080"
+		],
+		"expected": "localhost:8080"
+	},
+	{
+		"args": [
+			"localhost:9090"
+		],
+		"expected": "localhost:9090"
+	},
+	{
+		"args": [
+			"m-0"
+		],
+		"expected": "m-0"
+	},
+	{
+		"args": [
+			"m-0 flex w-full flex-col list-none p-0"
+		],
+		"expected": "m-0 flex w-full flex-col list-none p-0"
+	},
+	{
+		"args": [
+			"mailto:foo@bar.com"
+		],
+		"expected": "mailto:foo@bar.com"
+	},
+	{
+		"args": [
+			"mailto:…"
+		],
+		"expected": "mailto:…"
+	},
+	{
+		"args": [
+			"mantle-code-fold-ellipsis"
+		],
+		"expected": "mantle-code-fold-ellipsis"
+	},
+	{
+		"args": [
+			"mantle-code-fold-toggle"
+		],
+		"expected": "mantle-code-fold-toggle"
+	},
+	{
+		"args": [
+			"mantle-code-line"
+		],
+		"expected": "mantle-code-line"
+	},
+	{
+		"args": [
+			"mantle-code-line-content"
+		],
+		"expected": "mantle-code-line-content"
+	},
+	{
+		"args": [
+			"mantle-code-line-number"
+		],
+		"expected": "mantle-code-line-number"
+	},
+	{
+		"args": [
+			"mantle-css-variables"
+		],
+		"expected": "mantle-css-variables"
+	},
+	{
+		"args": [
+			"mantle-dark-high-contrast-styles"
+		],
+		"expected": "mantle-dark-high-contrast-styles"
+	},
+	{
+		"args": [
+			"mantle-dark-high-contrast.css"
+		],
+		"expected": "mantle-dark-high-contrast.css"
+	},
+	{
+		"args": [
+			"mantle-dark-styles"
+		],
+		"expected": "mantle-dark-styles"
+	},
+	{
+		"args": [
+			"mantle-dark.css"
+		],
+		"expected": "mantle-dark.css"
+	},
+	{
+		"args": [
+			"mantle-light-high-contrast-styles"
+		],
+		"expected": "mantle-light-high-contrast-styles"
+	},
+	{
+		"args": [
+			"mantle-light-high-contrast.css"
+		],
+		"expected": "mantle-light-high-contrast.css"
+	},
+	{
+		"args": [
+			"mantle-ui-theme"
+		],
+		"expected": "mantle-ui-theme"
+	},
+	{
+		"args": [
+			"match-sorter"
+		],
+		"expected": "match-sorter"
+	},
+	{
+		"args": [
+			"max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+		],
+		"expected": "max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+	},
+	{
+		"args": [
+			"max-w-"
+		],
+		"expected": "max-w-"
+	},
+	{
+		"args": [
+			"max-w-72"
+		],
+		"expected": "max-w-72"
+	},
+	{
+		"args": [
+			"max-w-lg"
+		],
+		"expected": "max-w-lg"
+	},
+	{
+		"args": [
+			"max-w-md"
+		],
+		"expected": "max-w-md"
+	},
+	{
+		"args": [
+			"mb-*"
+		],
+		"expected": "mb-*"
+	},
+	{
+		"args": [
+			"mb-1 size-10 text-neutral-400"
+		],
+		"expected": "mb-1 size-10 text-neutral-400"
+	},
+	{
+		"args": [
+			"mb-1.5"
+		],
+		"expected": "mb-1.5"
+	},
+	{
+		"args": [
+			"mb-2 text-blue text-xl leading-5"
+		],
+		"expected": "mb-2 text-blue text-xl leading-5"
+	},
+	{
+		"args": [
+			"mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+		],
+		"expected": "mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			"mb-3 text-xs font-medium uppercase tracking-wider font-mono"
+		],
+		"expected": "mb-3 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			"mb-4 leading-relaxed text-pretty text-body"
+		],
+		"expected": "mb-4 leading-relaxed text-pretty text-body"
+	},
+	{
+		"args": [
+			"mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0"
+		],
+		"expected": "mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0"
+	},
+	{
+		"args": [
+			"mb-6"
+		],
+		"expected": "mb-6"
+	},
+	{
+		"args": [
+			"md:hidden"
+		],
+		"expected": "md:hidden"
+	},
+	{
+		"args": [
+			"media-object"
+		],
+		"expected": "media-object"
+	},
+	{
+		"args": [
+			"media-object-content"
+		],
+		"expected": "media-object-content"
+	},
+	{
+		"args": [
+			"media-object-media"
+		],
+		"expected": "media-object-media"
+	},
+	{
+		"args": [
+			"meta-key"
+		],
+		"expected": "meta-key"
+	},
+	{
+		"args": [
+			"mfa-qr"
+		],
+		"expected": "mfa-qr"
+	},
+	{
+		"args": [
+			"migrations/"
+		],
+		"expected": "migrations/"
+	},
+	{
+		"args": [
+			"min-h-5"
+		],
+		"expected": "min-h-5"
+	},
+	{
+		"args": [
+			"min-w-0"
+		],
+		"expected": "min-w-0"
+	},
+	{
+		"args": [
+			"min-w-0 flex-1"
+		],
+		"expected": "min-w-0 flex-1"
+	},
+	{
+		"args": [
+			"min-w-0 flex-1 has-data-alert-dismiss:pr-6"
+		],
+		"expected": "min-w-0 flex-1 has-data-alert-dismiss:pr-6"
+	},
+	{
+		"args": [
+			"min-width"
+		],
+		"expected": "min-width"
+	},
+	{
+		"args": [
+			"ml-auto text-xs tracking-widest opacity-60"
+		],
+		"expected": "ml-auto text-xs tracking-widest opacity-60"
+	},
+	{
+		"args": [
+			"msg:"
+		],
+		"expected": "msg:"
+	},
+	{
+		"args": [
+			"mt-1 text-sm leading-relaxed text-body"
+		],
+		"expected": "mt-1 text-sm leading-relaxed text-body"
+	},
+	{
+		"args": [
+			"mt-2"
+		],
+		"expected": "mt-2"
+	},
+	{
+		"args": [
+			"mt-2 flex flex-col"
+		],
+		"expected": "mt-2 flex flex-col"
+	},
+	{
+		"args": [
+			"mt-2 flex flex-col gap-2 overflow-hidden text-xs md:flex-row"
+		],
+		"expected": "mt-2 flex flex-col gap-2 overflow-hidden text-xs md:flex-row"
+	},
+	{
+		"args": [
+			"mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row"
+		],
+		"expected": "mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row"
+	},
+	{
+		"args": [
+			"mt-4 flex items-center gap-2"
+		],
+		"expected": "mt-4 flex items-center gap-2"
+	},
+	{
+		"args": [
+			"mt-6 text-xs font-medium uppercase tracking-wider font-mono"
+		],
+		"expected": "mt-6 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			"mt-8 flex flex-wrap gap-4 font-mono text-xs"
+		],
+		"expected": "mt-8 flex flex-wrap gap-4 font-mono text-xs"
+	},
+	{
+		"args": [
+			"mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+		],
+		"expected": "mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+	},
+	{
+		"args": [
+			"mt-8 text-xl font-medium capitalize"
+		],
+		"expected": "mt-8 text-xl font-medium capitalize"
+	},
+	{
+		"args": [
+			"multi-select-tag"
+		],
+		"expected": "multi-select-tag"
+	},
+	{
+		"args": [
+			"multi-select-trigger"
+		],
+		"expected": "multi-select-trigger"
+	},
+	{
+		"args": [
+			"mx-1 h-5 md:hidden"
+		],
+		"expected": "mx-1 h-5 md:hidden"
+	},
+	{
+		"args": [
+			"mx-3 h-5 hidden md:block"
+		],
+		"expected": "mx-3 h-5 hidden md:block"
+	},
+	{
+		"args": [
+			"mx-auto flex h-15 w-full max-w-7xl items-center gap-3 px-4 md:gap-4"
+		],
+		"expected": "mx-auto flex h-15 w-full max-w-7xl items-center gap-3 px-4 md:gap-4"
+	},
+	{
+		"args": [
+			"mx-auto flex max-w-lg flex-col items-center p-6 text-center"
+		],
+		"expected": "mx-auto flex max-w-lg flex-col items-center p-6 text-center"
+	},
+	{
+		"args": [
+			"mx-auto max-w-full overflow-x-auto rounded-md bg-gray-100 p-4 text-left text-xs text-body"
+		],
+		"expected": "mx-auto max-w-full overflow-x-auto rounded-md bg-gray-100 p-4 text-left text-xs text-body"
+	},
+	{
+		"args": [
+			"mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+		],
+		"expected": "mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+	},
+	{
+		"args": [
+			"my-2 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] overflow-auto"
+		],
+		"expected": "my-2 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] overflow-auto"
+	},
+	{
+		"args": [
+			"newest-to-oldest"
+		],
+		"expected": "newest-to-oldest"
+	},
+	{
+		"args": [
+			"no-underline"
+		],
+		"expected": "no-underline"
+	},
+	{
+		"args": [
+			"node:crypto"
+		],
+		"expected": "node:crypto"
+	},
+	{
+		"args": [
+			"node:path"
+		],
+		"expected": "node:path"
+	},
+	{
+		"args": [
+			"node:stream"
+		],
+		"expected": "node:stream"
+	},
+	{
+		"args": [
+			"not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50"
+		],
+		"expected": "not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"not-aria-selected:not-disabled:text-accent-600 font-medium not-aria-selected:not-disabled:bg-filled-accent/10 rounded-md"
+		],
+		"expected": "not-aria-selected:not-disabled:text-accent-600 font-medium not-aria-selected:not-disabled:bg-filled-accent/10 rounded-md"
+	},
+	{
+		"args": [
+			"not-disabled:active:scale-97 ease-out transition-transform duration-150"
+		],
+		"expected": "not-disabled:active:scale-97 ease-out transition-transform duration-150"
+	},
+	{
+		"args": [
+			"not-disabled:bg-filled-accent text-on-filled not-disabled:hover:bg-filled-accent"
+		],
+		"expected": "not-disabled:bg-filled-accent text-on-filled not-disabled:hover:bg-filled-accent"
+	},
+	{
+		"args": [
+			"not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color)"
+		],
+		"expected": "not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color)"
+	},
+	{
+		"args": [
+			"not-focus:sr-only bg-card fixed top-2 left-2 z-max px-4 py-2 shadow-lg"
+		],
+		"expected": "not-focus:sr-only bg-card fixed top-2 left-2 z-max px-4 py-2 shadow-lg"
+	},
+	{
+		"args": [
+			"not-found"
+		],
+		"expected": "not-found"
+	},
+	{
+		"args": [
+			"nth-child(odd)"
+		],
+		"expected": "nth-child(odd)"
+	},
+	{
+		"args": [
+			"number[]"
+		],
+		"expected": "number[]"
+	},
+	{
+		"args": [
+			"og:description"
+		],
+		"expected": "og:description"
+	},
+	{
+		"args": [
+			"og:image"
+		],
+		"expected": "og:image"
+	},
+	{
+		"args": [
+			"og:locale"
+		],
+		"expected": "og:locale"
+	},
+	{
+		"args": [
+			"og:site_name"
+		],
+		"expected": "og:site_name"
+	},
+	{
+		"args": [
+			"og:title"
+		],
+		"expected": "og:title"
+	},
+	{
+		"args": [
+			"og:type"
+		],
+		"expected": "og:type"
+	},
+	{
+		"args": [
+			"og:url"
+		],
+		"expected": "og:url"
+	},
+	{
+		"args": [
+			"ok-on-element-form"
+		],
+		"expected": "ok-on-element-form"
+	},
+	{
+		"args": [
+			"old-etag"
+		],
+		"expected": "old-etag"
+	},
+	{
+		"args": [
+			"oldest-to-newest"
+		],
+		"expected": "oldest-to-newest"
+	},
+	{
+		"args": [
+			"opacity-50"
+		],
+		"expected": "opacity-50"
+	},
+	{
+		"args": [
+			"opacity-75"
+		],
+		"expected": "opacity-75"
+	},
+	{
+		"args": [
+			"options:"
+		],
+		"expected": "options:"
+	},
+	{
+		"args": [
+			"order-last"
+		],
+		"expected": "order-last"
+	},
+	{
+		"args": [
+			"order-last -mt-4 self-start sm:order-first sm:mt-0 sm:self-auto"
+		],
+		"expected": "order-last -mt-4 self-start sm:order-first sm:mt-0 sm:self-auto"
+	},
+	{
+		"args": [
+			"otp-input"
+		],
+		"expected": "otp-input"
+	},
+	{
+		"args": [
+			"otp-input-group"
+		],
+		"expected": "otp-input-group"
+	},
+	{
+		"args": [
+			"otp-input-separator"
+		],
+		"expected": "otp-input-separator"
+	},
+	{
+		"args": [
+			"otp-input-slot"
+		],
+		"expected": "otp-input-slot"
+	},
+	{
+		"args": [
+			"overflow-hidden p-0 relative"
+		],
+		"expected": "overflow-hidden p-0 relative"
+	},
+	{
+		"args": [
+			"overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+		],
+		"expected": "overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+	},
+	{
+		"args": [
+			"p-0"
+		],
+		"expected": "p-0"
+	},
+	{
+		"args": [
+			"p-1 space-y-px"
+		],
+		"expected": "p-1 space-y-px"
+	},
+	{
+		"args": [
+			"p-2"
+		],
+		"expected": "p-2"
+	},
+	{
+		"args": [
+			"p-3 pl-3.75"
+		],
+		"expected": "p-3 pl-3.75"
+	},
+	{
+		"args": [
+			"p-4 not-a-tailwind-class pb-3"
+		],
+		"expected": "p-4 not-a-tailwind-class pb-3"
+	},
+	{
+		"args": [
+			"p-4 pt-5 pr-3 pb-3"
+		],
+		"expected": "p-4 pt-5 pr-3 pb-3"
+	},
+	{
+		"args": [
+			"p-6 border-t border-card-muted first:border-t-0"
+		],
+		"expected": "p-6 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			"packages/mantle/CHANGELOG.md"
+		],
+		"expected": "packages/mantle/CHANGELOG.md"
+	},
+	{
+		"args": [
+			"packages/mantle/src"
+		],
+		"expected": "packages/mantle/src"
+	},
+	{
+		"args": [
+			"password-input"
+		],
+		"expected": "password-input"
+	},
+	{
+		"args": [
+			"pattern-a"
+		],
+		"expected": "pattern-a"
+	},
+	{
+		"args": [
+			"pattern-b"
+		],
+		"expected": "pattern-b"
+	},
+	{
+		"args": [
+			"pb-6"
+		],
+		"expected": "pb-6"
+	},
+	{
+		"args": [
+			"pb-8"
+		],
+		"expected": "pb-8"
+	},
+	{
+		"args": [
+			"pe-2.5"
+		],
+		"expected": "pe-2.5"
+	},
+	{
+		"args": [
+			"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden"
+		],
+		"expected": "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden"
+	},
+	{
+		"args": [
+			"pl-8"
+		],
+		"expected": "pl-8"
+	},
+	{
+		"args": [
+			"placeholder:text-muted flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+		],
+		"expected": "placeholder:text-muted flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+	},
+	{
+		"args": [
+			"placeholder:text-placeholder data-drag-over:border-dashed"
+		],
+		"expected": "placeholder:text-placeholder data-drag-over:border-dashed"
+	},
+	{
+		"args": [
+			"placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden"
+		],
+		"expected": "placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden"
+	},
+	{
+		"args": [
+			"pointer-coarse:border-green-600 pointer-coarse:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "pointer-coarse:border-green-600 pointer-coarse:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+		],
+		"expected": "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+	},
+	{
+		"args": [
+			"pointer-coarse:text-base h-9 text-sm"
+		],
+		"expected": "pointer-coarse:text-base h-9 text-sm"
+	},
+	{
+		"args": [
+			"pointer-events-none"
+		],
+		"expected": "pointer-events-none"
+	},
+	{
+		"args": [
+			"pointer-events-none absolute inset-0 flex items-center justify-center"
+		],
+		"expected": "pointer-events-none absolute inset-0 flex items-center justify-center"
+	},
+	{
+		"args": [
+			"pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform"
+		],
+		"expected": "pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform"
+	},
+	{
+		"args": [
+			"pointer-fine:border-green-600 pointer-fine:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "pointer-fine:border-green-600 pointer-fine:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"pointer-none:border-green-600 pointer-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "pointer-none:border-green-600 pointer-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"pre[data-lang]"
+		],
+		"expected": "pre[data-lang]"
+	},
+	{
+		"args": [
+			"privacy-policy"
+		],
+		"expected": "privacy-policy"
+	},
+	{
+		"args": [
+			"profile-card"
+		],
+		"expected": "profile-card"
+	},
+	{
+		"args": [
+			"profile-name"
+		],
+		"expected": "profile-name"
+	},
+	{
+		"args": [
+			"progress-bar"
+		],
+		"expected": "progress-bar"
+	},
+	{
+		"args": [
+			"progress-bar-indicator"
+		],
+		"expected": "progress-bar-indicator"
+	},
+	{
+		"args": [
+			"progress-donut-indicator"
+		],
+		"expected": "progress-donut-indicator"
+	},
+	{
+		"args": [
+			"ps-1"
+		],
+		"expected": "ps-1"
+	},
+	{
+		"args": [
+			"ps-2.5"
+		],
+		"expected": "ps-2.5"
+	},
+	{
+		"args": [
+			"px-2"
+		],
+		"expected": "px-2"
+	},
+	{
+		"args": [
+			"px-2 py-1.5 text-sm font-medium"
+		],
+		"expected": "px-2 py-1.5 text-sm font-medium"
+	},
+	{
+		"args": [
+			"px-4"
+		],
+		"expected": "px-4"
+	},
+	{
+		"args": [
+			"px-6 py-3 border-t border-card-muted first:border-t-0"
+		],
+		"expected": "px-6 py-3 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			"py-12 sm:py-20 px-4 flex justify-center"
+		],
+		"expected": "py-12 sm:py-20 px-4 flex justify-center"
+	},
+	{
+		"args": [
+			"py-2"
+		],
+		"expected": "py-2"
+	},
+	{
+		"args": [
+			"py-6 text-center text-sm"
+		],
+		"expected": "py-6 text-center text-sm"
+	},
+	{
+		"args": [
+			"qr-code"
+		],
+		"expected": "qr-code"
+	},
+	{
+		"args": [
+			"qr-code-frame"
+		],
+		"expected": "qr-code-frame"
+	},
+	{
+		"args": [
+			"qr-code-overlay"
+		],
+		"expected": "qr-code-overlay"
+	},
+	{
+		"args": [
+			"qr-code-pattern"
+		],
+		"expected": "qr-code-pattern"
+	},
+	{
+		"args": [
+			"radio-group-button"
+		],
+		"expected": "radio-group-button"
+	},
+	{
+		"args": [
+			"radio-group-input-sandbox"
+		],
+		"expected": "radio-group-input-sandbox"
+	},
+	{
+		"args": [
+			"radio-group-item"
+		],
+		"expected": "radio-group-item"
+	},
+	{
+		"args": [
+			"radio-group-list-item"
+		],
+		"expected": "radio-group-list-item"
+	},
+	{
+		"args": [
+			"react-day-picker"
+		],
+		"expected": "react-day-picker"
+	},
+	{
+		"args": [
+			"react-dom"
+		],
+		"expected": "react-dom"
+	},
+	{
+		"args": [
+			"react-dom/client"
+		],
+		"expected": "react-dom/client"
+	},
+	{
+		"args": [
+			"react-dom/server"
+		],
+		"expected": "react-dom/server"
+	},
+	{
+		"args": [
+			"react-hotkeys-hook"
+		],
+		"expected": "react-hotkeys-hook"
+	},
+	{
+		"args": [
+			"react-router"
+		],
+		"expected": "react-router"
+	},
+	{
+		"args": [
+			"react-router/dom"
+		],
+		"expected": "react-router/dom"
+	},
+	{
+		"args": [
+			"relative"
+		],
+		"expected": "relative"
+	},
+	{
+		"args": [
+			"relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors"
+		],
+		"expected": "relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors"
+	},
+	{
+		"args": [
+			"relative flex flex-col items-center gap-8"
+		],
+		"expected": "relative flex flex-col items-center gap-8"
+	},
+	{
+		"args": [
+			"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden"
+		],
+		"expected": "relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden"
+	},
+	{
+		"args": [
+			"relative flex items-center rounded-md"
+		],
+		"expected": "relative flex items-center rounded-md"
+	},
+	{
+		"args": [
+			"relative flex items-start gap-2 text-sm font-sans"
+		],
+		"expected": "relative flex items-start gap-2 text-sm font-sans"
+	},
+	{
+		"args": [
+			"relative flex min-h-[70vh] flex-col items-center justify-center px-4 py-12 text-center md:py-20"
+		],
+		"expected": "relative flex min-h-[70vh] flex-col items-center justify-center px-4 py-12 text-center md:py-20"
+	},
+	{
+		"args": [
+			"relative flex size-2"
+		],
+		"expected": "relative flex size-2"
+	},
+	{
+		"args": [
+			"relative flex w-full gap-1.5 rounded-md border p-2.5 text-sm font-sans"
+		],
+		"expected": "relative flex w-full gap-1.5 rounded-md border p-2.5 text-sm font-sans"
+	},
+	{
+		"args": [
+			"relative inline-flex size-2 rounded-full"
+		],
+		"expected": "relative inline-flex size-2 rounded-full"
+	},
+	{
+		"args": [
+			"relative ml-auto max-w-full"
+		],
+		"expected": "relative ml-auto max-w-full"
+	},
+	{
+		"args": [
+			"remark-frontmatter"
+		],
+		"expected": "remark-frontmatter"
+	},
+	{
+		"args": [
+			"remark-gfm"
+		],
+		"expected": "remark-gfm"
+	},
+	{
+		"args": [
+			"remark-mdx"
+		],
+		"expected": "remark-mdx"
+	},
+	{
+		"args": [
+			"remark-parse"
+		],
+		"expected": "remark-parse"
+	},
+	{
+		"args": [
+			"remark-stringify"
+		],
+		"expected": "remark-stringify"
+	},
+	{
+		"args": [
+			"right-1.5 top-1.5 absolute"
+		],
+		"expected": "right-1.5 top-1.5 absolute"
+	},
+	{
+		"args": [
+			"robots-txt"
+		],
+		"expected": "robots-txt"
+	},
+	{
+		"args": [
+			"root:"
+		],
+		"expected": "root:"
+	},
+	{
+		"args": [
+			"rounded"
+		],
+		"expected": "rounded"
+	},
+	{
+		"args": [
+			"rounded-*"
+		],
+		"expected": "rounded-*"
+	},
+	{
+		"args": [
+			"rounded-[0.0625rem]"
+		],
+		"expected": "rounded-[0.0625rem]"
+	},
+	{
+		"args": [
+			"rounded-[0.09375rem]"
+		],
+		"expected": "rounded-[0.09375rem]"
+	},
+	{
+		"args": [
+			"rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600"
+		],
+		"expected": "rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600"
+	},
+	{
+		"args": [
+			"rounded-full size-5"
+		],
+		"expected": "rounded-full size-5"
+	},
+	{
+		"args": [
+			"rounded-sm col-span-full grid grid-cols-subgrid items-center"
+		],
+		"expected": "rounded-sm col-span-full grid grid-cols-subgrid items-center"
+	},
+	{
+		"args": [
+			"rounded-xs"
+		],
+		"expected": "rounded-xs"
+	},
+	{
+		"args": [
+			"row-1"
+		],
+		"expected": "row-1"
+	},
+	{
+		"args": [
+			"scale-100 border-accent-600 bg-accent-600/10 text-accent-600 opacity-100"
+		],
+		"expected": "scale-100 border-accent-600 bg-accent-600/10 text-accent-600 opacity-100"
+	},
+	{
+		"args": [
+			"scale-95 border-card-muted bg-gray-50 text-muted opacity-30"
+		],
+		"expected": "scale-95 border-card-muted bg-gray-50 text-muted opacity-30"
+	},
+	{
+		"args": [
+			"script:ld+json"
+		],
+		"expected": "script:ld+json"
+	},
+	{
+		"args": [
+			"scroll-behavior"
+		],
+		"expected": "scroll-behavior"
+	},
+	{
+		"args": [
+			"scroll-fade-b h-44 overflow-y-auto"
+		],
+		"expected": "scroll-fade-b h-44 overflow-y-auto"
+	},
+	{
+		"args": [
+			"scroll-fade-l overflow-x-auto"
+		],
+		"expected": "scroll-fade-l overflow-x-auto"
+	},
+	{
+		"args": [
+			"scroll-fade-r overflow-x-auto"
+		],
+		"expected": "scroll-fade-r overflow-x-auto"
+	},
+	{
+		"args": [
+			"scroll-fade-t h-44 overflow-y-auto"
+		],
+		"expected": "scroll-fade-t h-44 overflow-y-auto"
+	},
+	{
+		"args": [
+			"scroll-fade-x"
+		],
+		"expected": "scroll-fade-x"
+	},
+	{
+		"args": [
+			"scroll-fade-x flex-row items-center overflow-x-auto overscroll-x-none w-full min-w-0 pt-1 -mt-1 px-1 -mx-1"
+		],
+		"expected": "scroll-fade-x flex-row items-center overflow-x-auto overscroll-x-none w-full min-w-0 pt-1 -mt-1 px-1 -mx-1"
+	},
+	{
+		"args": [
+			"scroll-fade-y scrollbar h-full overflow-auto overscroll-contain px-1"
+		],
+		"expected": "scroll-fade-y scrollbar h-full overflow-auto overscroll-contain px-1"
+	},
+	{
+		"args": [
+			"scroll-fade-y scrollbar min-h-0 flex-1 overflow-y-auto pb-4"
+		],
+		"expected": "scroll-fade-y scrollbar min-h-0 flex-1 overflow-y-auto pb-4"
+	},
+	{
+		"args": [
+			"scroll-fade-y scrollbar sticky top-15 hidden max-h-[calc(100vh-3.75rem)] w-44 overflow-y-auto px-1 pb-4 md:block"
+		],
+		"expected": "scroll-fade-y scrollbar sticky top-15 hidden max-h-[calc(100vh-3.75rem)] w-44 overflow-y-auto px-1 pb-4 md:block"
+	},
+	{
+		"args": [
+			"scroll-mt-24"
+		],
+		"expected": "scroll-mt-24"
+	},
+	{
+		"args": [
+			"scroll-my-6"
+		],
+		"expected": "scroll-my-6"
+	},
+	{
+		"args": [
+			"scroll-smooth"
+		],
+		"expected": "scroll-smooth"
+	},
+	{
+		"args": [
+			"select-content"
+		],
+		"expected": "select-content"
+	},
+	{
+		"args": [
+			"select-item"
+		],
+		"expected": "select-item"
+	},
+	{
+		"args": [
+			"select-none font-mono text-sm text-muted"
+		],
+		"expected": "select-none font-mono text-sm text-muted"
+	},
+	{
+		"args": [
+			"select-separator"
+		],
+		"expected": "select-separator"
+	},
+	{
+		"args": [
+			"select-trigger"
+		],
+		"expected": "select-trigger"
+	},
+	{
+		"args": [
+			"server-error"
+		],
+		"expected": "server-error"
+	},
+	{
+		"args": [
+			"server:"
+		],
+		"expected": "server:"
+	},
+	{
+		"args": [
+			"sg-sin-1"
+		],
+		"expected": "sg-sin-1"
+	},
+	{
+		"args": [
+			"shadow-2xl"
+		],
+		"expected": "shadow-2xl"
+	},
+	{
+		"args": [
+			"shadow-inner"
+		],
+		"expected": "shadow-inner"
+	},
+	{
+		"args": [
+			"shape-rendering"
+		],
+		"expected": "shape-rendering"
+	},
+	{
+		"args": [
+			"sheet-async"
+		],
+		"expected": "sheet-async"
+	},
+	{
+		"args": [
+			"sheet-async-user"
+		],
+		"expected": "sheet-async-user"
+	},
+	{
+		"args": [
+			"sheet-overlay"
+		],
+		"expected": "sheet-overlay"
+	},
+	{
+		"args": [
+			"should-not-typecheck"
+		],
+		"expected": "should-not-typecheck"
+	},
+	{
+		"args": [
+			"shrink-0"
+		],
+		"expected": "shrink-0"
+	},
+	{
+		"args": [
+			"shrink-0 leading-none"
+		],
+		"expected": "shrink-0 leading-none"
+	},
+	{
+		"args": [
+			"shrink-0 size-12 sm:size-16"
+		],
+		"expected": "shrink-0 size-12 sm:size-16"
+	},
+	{
+		"args": [
+			"shrink-0 size-20 sm:size-28"
+		],
+		"expected": "shrink-0 size-20 sm:size-28"
+	},
+	{
+		"args": [
+			"sitemap-xml"
+		],
+		"expected": "sitemap-xml"
+	},
+	{
+		"args": [
+			"size-10"
+		],
+		"expected": "size-10"
+	},
+	{
+		"args": [
+			"size-12 sm:size-16"
+		],
+		"expected": "size-12 sm:size-16"
+	},
+	{
+		"args": [
+			"size-2 rounded-full bg-white shrink-0"
+		],
+		"expected": "size-2 rounded-full bg-white shrink-0"
+	},
+	{
+		"args": [
+			"size-20 sm:size-28"
+		],
+		"expected": "size-20 sm:size-28"
+	},
+	{
+		"args": [
+			"size-3"
+		],
+		"expected": "size-3"
+	},
+	{
+		"args": [
+			"size-4"
+		],
+		"expected": "size-4"
+	},
+	{
+		"args": [
+			"size-4 text-accent-600"
+		],
+		"expected": "size-4 text-accent-600"
+	},
+	{
+		"args": [
+			"size-5"
+		],
+		"expected": "size-5"
+	},
+	{
+		"args": [
+			"size-5 shrink-0 opacity-50"
+		],
+		"expected": "size-5 shrink-0 opacity-50"
+	},
+	{
+		"args": [
+			"size-6"
+		],
+		"expected": "size-6"
+	},
+	{
+		"args": [
+			"size-64"
+		],
+		"expected": "size-64"
+	},
+	{
+		"args": [
+			"size-7"
+		],
+		"expected": "size-7"
+	},
+	{
+		"args": [
+			"size-9"
+		],
+		"expected": "size-9"
+	},
+	{
+		"args": [
+			"slot-class"
+		],
+		"expected": "slot-class"
+	},
+	{
+		"args": [
+			"slot-only-class"
+		],
+		"expected": "slot-only-class"
+	},
+	{
+		"args": [
+			"sm:max-w-[560px]"
+		],
+		"expected": "sm:max-w-[560px]"
+	},
+	{
+		"args": [
+			"space-y-1"
+		],
+		"expected": "space-y-1"
+	},
+	{
+		"args": [
+			"space-y-1 border-l border-gray-300"
+		],
+		"expected": "space-y-1 border-l border-gray-300"
+	},
+	{
+		"args": [
+			"space-y-2"
+		],
+		"expected": "space-y-2"
+	},
+	{
+		"args": [
+			"space-y-3"
+		],
+		"expected": "space-y-3"
+	},
+	{
+		"args": [
+			"space-y-4"
+		],
+		"expected": "space-y-4"
+	},
+	{
+		"args": [
+			"space-y-4 mb-4"
+		],
+		"expected": "space-y-4 mb-4"
+	},
+	{
+		"args": [
+			"space-y-4 text-center"
+		],
+		"expected": "space-y-4 text-center"
+	},
+	{
+		"args": [
+			"space-y-px"
+		],
+		"expected": "space-y-px"
+	},
+	{
+		"args": [
+			"split-button"
+		],
+		"expected": "split-button"
+	},
+	{
+		"args": [
+			"sr-only"
+		],
+		"expected": "sr-only"
+	},
+	{
+		"args": [
+			"sr-only absolute"
+		],
+		"expected": "sr-only absolute"
+	},
+	{
+		"args": [
+			"start-end"
+		],
+		"expected": "start-end"
+	},
+	{
+		"args": [
+			"sticky top-0 z-30 bg-card"
+		],
+		"expected": "sticky top-0 z-30 bg-card"
+	},
+	{
+		"args": [
+			"sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4"
+		],
+		"expected": "sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4"
+	},
+	{
+		"args": [
+			"sticky z-10 right-0 bg-inherit"
+		],
+		"expected": "sticky z-10 right-0 bg-inherit"
+	},
+	{
+		"args": [
+			"stop-opacity-0 stop-color-current"
+		],
+		"expected": "stop-opacity-0 stop-color-current"
+	},
+	{
+		"args": [
+			"stop-opacity-100 stop-color-current"
+		],
+		"expected": "stop-opacity-100 stop-color-current"
+	},
+	{
+		"args": [
+			"string[]"
+		],
+		"expected": "string[]"
+	},
+	{
+		"args": [
+			"submit-state"
+		],
+		"expected": "submit-state"
+	},
+	{
+		"args": [
+			"svg-only"
+		],
+		"expected": "svg-only"
+	},
+	{
+		"args": [
+			"table"
+		],
+		"expected": "table"
+	},
+	{
+		"args": [
+			"tabs-badge"
+		],
+		"expected": "tabs-badge"
+	},
+	{
+		"args": [
+			"tabs-content"
+		],
+		"expected": "tabs-content"
+	},
+	{
+		"args": [
+			"tabs-trigger"
+		],
+		"expected": "tabs-trigger"
+	},
+	{
+		"args": [
+			"tailwind-merge"
+		],
+		"expected": "tailwind-merge"
+	},
+	{
+		"args": [
+			"terms-of-service"
+		],
+		"expected": "terms-of-service"
+	},
+	{
+		"args": [
+			"text-(--alert-dismiss-icon-color)"
+		],
+		"expected": "text-(--alert-dismiss-icon-color)"
+	},
+	{
+		"args": [
+			"text-2xl"
+		],
+		"expected": "text-2xl"
+	},
+	{
+		"args": [
+			"text-4xl font-medium sm:text-5xl font-family"
+		],
+		"expected": "text-4xl font-medium sm:text-5xl font-family"
+	},
+	{
+		"args": [
+			"text-4xl font-medium text-strong sm:text-5xl font-family mb-4"
+		],
+		"expected": "text-4xl font-medium text-strong sm:text-5xl font-family mb-4"
+	},
+	{
+		"args": [
+			"text-[0.75em]"
+		],
+		"expected": "text-[0.75em]"
+	},
+	{
+		"args": [
+			"text-accent-600"
+		],
+		"expected": "text-accent-600"
+	},
+	{
+		"args": [
+			"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border border-transparent px-3 text-sm font-medium"
+		],
+		"expected": "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border border-transparent px-3 text-sm font-medium"
+	},
+	{
+		"args": [
+			"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group/button-link border-transparent"
+		],
+		"expected": "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group/button-link border-transparent"
+	},
+	{
+		"args": [
+			"text-accent-600 hover:text-accent-600 font-medium high-contrast:bg-filled-accent high-contrast:text-on-filled high-contrast:hover:text-on-filled high-contrast:rounded-md high-contrast:px-2 high-contrast:-ml-2"
+		],
+		"expected": "text-accent-600 hover:text-accent-600 font-medium high-contrast:bg-filled-accent high-contrast:text-on-filled high-contrast:hover:text-on-filled high-contrast:rounded-md high-contrast:px-2 high-contrast:-ml-2"
+	},
+	{
+		"args": [
+			"text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+		],
+		"expected": "text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+	},
+	{
+		"args": [
+			"text-accent-600 text-sm font-medium flex-1"
+		],
+		"expected": "text-accent-600 text-sm font-medium flex-1"
+	},
+	{
+		"args": [
+			"text-area"
+		],
+		"expected": "text-area"
+	},
+	{
+		"args": [
+			"text-base"
+		],
+		"expected": "text-base"
+	},
+	{
+		"args": [
+			"text-blue"
+		],
+		"expected": "text-blue"
+	},
+	{
+		"args": [
+			"text-blue-500"
+		],
+		"expected": "text-blue-500"
+	},
+	{
+		"args": [
+			"text-blue-500 no-underline"
+		],
+		"expected": "text-blue-500 no-underline"
+	},
+	{
+		"args": [
+			"text-blue-500 px-2 py-2"
+		],
+		"expected": "text-blue-500 px-2 py-2"
+	},
+	{
+		"args": [
+			"text-body"
+		],
+		"expected": "text-body"
+	},
+	{
+		"args": [
+			"text-body -my-0.5"
+		],
+		"expected": "text-body -my-0.5"
+	},
+	{
+		"args": [
+			"text-body font-mono text-mono py-2 px-3"
+		],
+		"expected": "text-body font-mono text-mono py-2 px-3"
+	},
+	{
+		"args": [
+			"text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
+		],
+		"expected": "text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
+	},
+	{
+		"args": [
+			"text-body text-sm leading-4"
+		],
+		"expected": "text-body text-sm leading-4"
+	},
+	{
+		"args": [
+			"text-body w-7 text-[0.8rem] text-center font-normal"
+		],
+		"expected": "text-body w-7 text-[0.8rem] text-center font-normal"
+	},
+	{
+		"args": [
+			"text-center space-y-1"
+		],
+		"expected": "text-center space-y-1"
+	},
+	{
+		"args": [
+			"text-danger-600"
+		],
+		"expected": "text-danger-600"
+	},
+	{
+		"args": [
+			"text-danger-600 block size-4"
+		],
+		"expected": "text-danger-600 block size-4"
+	},
+	{
+		"args": [
+			"text-danger-600 flex items-center gap-2"
+		],
+		"expected": "text-danger-600 flex items-center gap-2"
+	},
+	{
+		"args": [
+			"text-danger-600 order-last select-none"
+		],
+		"expected": "text-danger-600 order-last select-none"
+	},
+	{
+		"args": [
+			"text-danger-700 dark-high-contrast:hidden block size-4"
+		],
+		"expected": "text-danger-700 dark-high-contrast:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-danger-700 high-contrast:hidden block size-4"
+		],
+		"expected": "text-danger-700 high-contrast:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-danger-700 hover-hover:hidden block size-4"
+		],
+		"expected": "text-danger-700 hover-hover:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-danger-700 hover-none:hidden block size-4"
+		],
+		"expected": "text-danger-700 hover-none:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-danger-700 pointer-coarse:hidden block size-4"
+		],
+		"expected": "text-danger-700 pointer-coarse:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-danger-700 pointer-fine:hidden block size-4"
+		],
+		"expected": "text-danger-700 pointer-fine:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-danger-700 pointer-none:hidden block size-4"
+		],
+		"expected": "text-danger-700 pointer-none:hidden block size-4"
+	},
+	{
+		"args": [
+			"text-emerald-600"
+		],
+		"expected": "text-emerald-600"
+	},
+	{
+		"args": [
+			"text-gold"
+		],
+		"expected": "text-gold"
+	},
+	{
+		"args": [
+			"text-gray-500"
+		],
+		"expected": "text-gray-500"
+	},
+	{
+		"args": [
+			"text-gray-500 underline"
+		],
+		"expected": "text-gray-500 underline"
+	},
+	{
+		"args": [
+			"text-lg font-medium"
+		],
+		"expected": "text-lg font-medium"
+	},
+	{
+		"args": [
+			"text-mono"
+		],
+		"expected": "text-mono"
+	},
+	{
+		"args": [
+			"text-mono mt-8 flex flex-wrap gap-8 font-mono"
+		],
+		"expected": "text-mono mt-8 flex flex-wrap gap-8 font-mono"
+	},
+	{
+		"args": [
+			"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+		],
+		"expected": "text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+	},
+	{
+		"args": [
+			"text-muted"
+		],
+		"expected": "text-muted"
+	},
+	{
+		"args": [
+			"text-muted flex items-center"
+		],
+		"expected": "text-muted flex items-center"
+	},
+	{
+		"args": [
+			"text-muted font-sans text-xs font-normal"
+		],
+		"expected": "text-muted font-sans text-xs font-normal"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong"
+		],
+		"expected": "text-muted hover:text-strong"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong block py-1 cursor-pointer focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent rounded"
+		],
+		"expected": "text-muted hover:text-strong block py-1 cursor-pointer focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent rounded"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong block py-1 rounded focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "text-muted hover:text-strong block py-1 rounded focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong flex items-center gap-1 font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+		],
+		"expected": "text-muted hover:text-strong flex items-center gap-1 font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong flex items-center gap-1 text-left font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+		],
+		"expected": "text-muted hover:text-strong flex items-center gap-1 text-left font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+		],
+		"expected": "text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			"text-muted ml-auto text-xs tracking-widest"
+		],
+		"expected": "text-muted ml-auto text-xs tracking-widest"
+	},
+	{
+		"args": [
+			"text-muted opacity-50"
+		],
+		"expected": "text-muted opacity-50"
+	},
+	{
+		"args": [
+			"text-muted space-y-4 text-sm font-sans"
+		],
+		"expected": "text-muted space-y-4 text-sm font-sans"
+	},
+	{
+		"args": [
+			"text-muted text-sm"
+		],
+		"expected": "text-muted text-sm"
+	},
+	{
+		"args": [
+			"text-muted text-sm font-sans font-medium min-w-36 p-2"
+		],
+		"expected": "text-muted text-sm font-sans font-medium min-w-36 p-2"
+	},
+	{
+		"args": [
+			"text-muted text-xs"
+		],
+		"expected": "text-muted text-xs"
+	},
+	{
+		"args": [
+			"text-muted text-xs font-mono"
+		],
+		"expected": "text-muted text-xs font-mono"
+	},
+	{
+		"args": [
+			"text-muted-foreground font-mono text-xs"
+		],
+		"expected": "text-muted-foreground font-mono text-xs"
+	},
+	{
+		"args": [
+			"text-muted-foreground text-sm gap-2 flex items-center"
+		],
+		"expected": "text-muted-foreground text-sm gap-2 flex items-center"
+	},
+	{
+		"args": [
+			"text-orange-600"
+		],
+		"expected": "text-orange-600"
+	},
+	{
+		"args": [
+			"text-placeholder"
+		],
+		"expected": "text-placeholder"
+	},
+	{
+		"args": [
+			"text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans"
+		],
+		"expected": "text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans"
+	},
+	{
+		"args": [
+			"text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans"
+		],
+		"expected": "text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans"
+	},
+	{
+		"args": [
+			"text-red"
+		],
+		"expected": "text-red"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-base leading-4"
+		],
+		"expected": "text-red mb-2 text-base leading-4"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-base leading-4 text-xl"
+		],
+		"expected": "text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-xl"
+		],
+		"expected": "text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			"text-red-500"
+		],
+		"expected": "text-red-500"
+	},
+	{
+		"args": [
+			"text-red-500 font-medium"
+		],
+		"expected": "text-red-500 font-medium"
+	},
+	{
+		"args": [
+			"text-red-500 px-4"
+		],
+		"expected": "text-red-500 px-4"
+	},
+	{
+		"args": [
+			"text-right"
+		],
+		"expected": "text-right"
+	},
+	{
+		"args": [
+			"text-size-inherit"
+		],
+		"expected": "text-size-inherit"
+	},
+	{
+		"args": [
+			"text-sm"
+		],
+		"expected": "text-sm"
+	},
+	{
+		"args": [
+			"text-sm font-medium"
+		],
+		"expected": "text-sm font-medium"
+	},
+	{
+		"args": [
+			"text-sm pb-16"
+		],
+		"expected": "text-sm pb-16"
+	},
+	{
+		"args": [
+			"text-sm px-1 mb-6"
+		],
+		"expected": "text-sm px-1 mb-6"
+	},
+	{
+		"args": [
+			"text-sm text-muted"
+		],
+		"expected": "text-sm text-muted"
+	},
+	{
+		"args": [
+			"text-sm text-strong"
+		],
+		"expected": "text-sm text-strong"
+	},
+	{
+		"args": [
+			"text-sm text-strong font-medium"
+		],
+		"expected": "text-sm text-strong font-medium"
+	},
+	{
+		"args": [
+			"text-strong"
+		],
+		"expected": "text-strong"
+	},
+	{
+		"args": [
+			"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans"
+		],
+		"expected": "text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans"
+	},
+	{
+		"args": [
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden"
+		],
+		"expected": "text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden"
+	},
+	{
+		"args": [
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none"
+		],
+		"expected": "text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none"
+	},
+	{
+		"args": [
+			"text-strong flex grow flex-col gap-1"
+		],
+		"expected": "text-strong flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			"text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent"
+		],
+		"expected": "text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent"
+	},
+	{
+		"args": [
+			"text-strong leading-none font-semibold tracking-wider uppercase"
+		],
+		"expected": "text-strong leading-none font-semibold tracking-wider uppercase"
+	},
+	{
+		"args": [
+			"text-strong text-base font-medium"
+		],
+		"expected": "text-strong text-base font-medium"
+	},
+	{
+		"args": [
+			"text-strong text-sm font-medium"
+		],
+		"expected": "text-strong text-sm font-medium"
+	},
+	{
+		"args": [
+			"text-strong text-sm font-medium font-sans"
+		],
+		"expected": "text-strong text-sm font-medium font-sans"
+	},
+	{
+		"args": [
+			"text-success-600"
+		],
+		"expected": "text-success-600"
+	},
+	{
+		"args": [
+			"text-success-600 hidden size-4"
+		],
+		"expected": "text-success-600 hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-600 order-last select-none"
+		],
+		"expected": "text-success-600 order-last select-none"
+	},
+	{
+		"args": [
+			"text-success-700 dark-high-contrast:block hidden size-4"
+		],
+		"expected": "text-success-700 dark-high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-700 high-contrast:block hidden size-4"
+		],
+		"expected": "text-success-700 high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-700 hover-hover:block hidden size-4"
+		],
+		"expected": "text-success-700 hover-hover:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-700 hover-none:block hidden size-4"
+		],
+		"expected": "text-success-700 hover-none:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-700 pointer-coarse:block hidden size-4"
+		],
+		"expected": "text-success-700 pointer-coarse:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-700 pointer-fine:block hidden size-4"
+		],
+		"expected": "text-success-700 pointer-fine:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-success-700 pointer-none:block hidden size-4"
+		],
+		"expected": "text-success-700 pointer-none:block hidden size-4"
+	},
+	{
+		"args": [
+			"text-warning-600"
+		],
+		"expected": "text-warning-600"
+	},
+	{
+		"args": [
+			"text-warning-600 order-last select-none"
+		],
+		"expected": "text-warning-600 order-last select-none"
+	},
+	{
+		"args": [
+			"text-xs"
+		],
+		"expected": "text-xs"
+	},
+	{
+		"args": [
+			"text-yellow-600"
+		],
+		"expected": "text-yellow-600"
+	},
+	{
+		"args": [
+			"text/markdown"
+		],
+		"expected": "text/markdown"
+	},
+	{
+		"args": [
+			"tiny-invariant"
+		],
+		"expected": "tiny-invariant"
+	},
+	{
+		"args": [
+			"toast-icon"
+		],
+		"expected": "toast-icon"
+	},
+	{
+		"args": [
+			"tooltip-content"
+		],
+		"expected": "tooltip-content"
+	},
+	{
+		"args": [
+			"tooltip-provider"
+		],
+		"expected": "tooltip-provider"
+	},
+	{
+		"args": [
+			"tooltip-trigger"
+		],
+		"expected": "tooltip-trigger"
+	},
+	{
+		"args": [
+			"top-center"
+		],
+		"expected": "top-center"
+	},
+	{
+		"args": [
+			"traffic-policy"
+		],
+		"expected": "traffic-policy"
+	},
+	{
+		"args": [
+			"translateX(-4px)"
+		],
+		"expected": "translateX(-4px)"
+	},
+	{
+		"args": [
+			"twitter:card"
+		],
+		"expected": "twitter:card"
+	},
+	{
+		"args": [
+			"twitter:description"
+		],
+		"expected": "twitter:description"
+	},
+	{
+		"args": [
+			"twitter:domain"
+		],
+		"expected": "twitter:domain"
+	},
+	{
+		"args": [
+			"twitter:image"
+		],
+		"expected": "twitter:image"
+	},
+	{
+		"args": [
+			"twitter:title"
+		],
+		"expected": "twitter:title"
+	},
+	{
+		"args": [
+			"twitter:url"
+		],
+		"expected": "twitter:url"
+	},
+	{
+		"args": [
+			"underline"
+		],
+		"expected": "underline"
+	},
+	{
+		"args": [
+			"united-states"
+		],
+		"expected": "united-states"
+	},
+	{
+		"args": [
+			"us-cal-1"
+		],
+		"expected": "us-cal-1"
+	},
+	{
+		"args": [
+			"us-ohio-1"
+		],
+		"expected": "us-ohio-1"
+	},
+	{
+		"args": [
+			"utf-8"
+		],
+		"expected": "utf-8"
+	},
+	{
+		"args": [
+			"utilities/mantle-version.server.ts"
+		],
+		"expected": "utilities/mantle-version.server.ts"
+	},
+	{
+		"args": [
+			"utils/"
+		],
+		"expected": "utils/"
+	},
+	{
+		"args": [
+			"utils/color"
+		],
+		"expected": "utils/color"
+	},
+	{
+		"args": [
+			"utils/compose-refs"
+		],
+		"expected": "utils/compose-refs"
+	},
+	{
+		"args": [
+			"utils/cx"
+		],
+		"expected": "utils/cx"
+	},
+	{
+		"args": [
+			"utils/highlight-utils"
+		],
+		"expected": "utils/highlight-utils"
+	},
+	{
+		"args": [
+			"utils/in-view"
+		],
+		"expected": "utils/in-view"
+	},
+	{
+		"args": [
+			"utils/sorting"
+		],
+		"expected": "utils/sorting"
+	},
+	{
+		"args": [
+			"virtual:mdx-doc-component-imports"
+		],
+		"expected": "virtual:mdx-doc-component-imports"
+	},
+	{
+		"args": [
+			"virtual:raw-mdx-docs"
+		],
+		"expected": "virtual:raw-mdx-docs"
+	},
+	{
+		"args": [
+			"w-(--radix-dropdown-menu-trigger-width)"
+		],
+		"expected": "w-(--radix-dropdown-menu-trigger-width)"
+	},
+	{
+		"args": [
+			"w-(--radix-select-trigger-width)"
+		],
+		"expected": "w-(--radix-select-trigger-width)"
+	},
+	{
+		"args": [
+			"w-*"
+		],
+		"expected": "w-*"
+	},
+	{
+		"args": [
+			"w-0 flex-1 pb-[80vh] sm:px-8"
+		],
+		"expected": "w-0 flex-1 pb-[80vh] sm:px-8"
+	},
+	{
+		"args": [
+			"w-25"
+		],
+		"expected": "w-25"
+	},
+	{
+		"args": [
+			"w-4 h-3"
+		],
+		"expected": "w-4 h-3"
+	},
+	{
+		"args": [
+			"w-5 h-3.75"
+		],
+		"expected": "w-5 h-3.75"
+	},
+	{
+		"args": [
+			"w-50"
+		],
+		"expected": "w-50"
+	},
+	{
+		"args": [
+			"w-8 h-6"
+		],
+		"expected": "w-8 h-6"
+	},
+	{
+		"args": [
+			"w-em"
+		],
+		"expected": "w-em"
+	},
+	{
+		"args": [
+			"w-full border-collapse space-y-1"
+		],
+		"expected": "w-full border-collapse space-y-1"
+	},
+	{
+		"args": [
+			"w-full space-y-2.5"
+		],
+		"expected": "w-full space-y-2.5"
+	},
+	{
+		"args": [
+			"w-full space-y-4"
+		],
+		"expected": "w-full space-y-4"
+	},
+	{
+		"args": [
+			"where:block where:size-4 where:p-0"
+		],
+		"expected": "where:block where:size-4 where:p-0"
+	},
+	{
+		"args": [
+			"z-1 absolute -inset-px right-auto w-1.5 rounded-l"
+		],
+		"expected": "z-1 absolute -inset-px right-auto w-1.5 rounded-l"
+	},
+	{
+		"args": [
+			"*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal",
+			"-mx-1 my-1 w-auto"
+		],
+		"expected": "*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal -mx-1 my-1 w-auto"
+	},
+	{
+		"args": [
+			"-inset-y-px",
+			"@headlessui/react"
+		],
+		"expected": "-inset-y-px @headlessui/react"
+	},
+	{
+		"args": [
+			"-mx-1 my-1 h-px w-auto",
+			"@ngrok/mantle/anchor"
+		],
+		"expected": "-mx-1 my-1 h-px w-auto @ngrok/mantle/anchor"
+	},
+	{
+		"args": [
+			"-mx-1 my-1 w-auto",
+			"@ngrok/mantle/code"
+		],
+		"expected": "-mx-1 my-1 w-auto @ngrok/mantle/code"
+	},
+	{
+		"args": [
+			"-mx-1.25 my-1 w-auto",
+			"@ngrok/mantle/empty"
+		],
+		"expected": "-mx-1.25 my-1 w-auto @ngrok/mantle/empty"
+	},
+	{
+		"args": [
+			"-my-0.5",
+			"@ngrok/mantle/label"
+		],
+		"expected": "-my-0.5 @ngrok/mantle/label"
+	},
+	{
+		"args": [
+			"-u",
+			"@ngrok/mantle/package.json"
+		],
+		"expected": "-u @ngrok/mantle/package.json"
+	},
+	{
+		"args": [
+			"2xs:absolute 2xs:left-[44.5%] 2xs:justify-start 2xs:pt-0 2xs:pl-0 bottom-[7%] flex items-center gap-2 pt-4 pl-1.5 font-mono text-xs text-emerald-600 hover:text-emerald-700 min-[27rem]:left-[44.8%] min-[27rem]:text-sm",
+			"@ngrok/mantle/skip-to-main-link"
+		],
+		"expected": "2xs:absolute 2xs:left-[44.5%] 2xs:justify-start 2xs:pt-0 2xs:pl-0 bottom-[7%] flex items-center gap-2 pt-4 pl-1.5 font-mono text-xs text-emerald-600 hover:text-emerald-700 min-[27rem]:left-[44.8%] min-[27rem]:text-sm @ngrok/mantle/skip-to-main-link"
+	},
+	{
+		"args": [
+			"@ariakit/react",
+			"@ngrok/mantle/toast"
+		],
+		"expected": "@ariakit/react @ngrok/mantle/toast"
+	},
+	{
+		"args": [
+			"@changesets/cli",
+			"@phosphor-icons/react/CaretDown"
+		],
+		"expected": "@changesets/cli @phosphor-icons/react/CaretDown"
+	},
+	{
+		"args": [
+			"@headlessui/react",
+			"@phosphor-icons/react/Copy"
+		],
+		"expected": "@headlessui/react @phosphor-icons/react/Copy"
+	},
+	{
+		"args": [
+			"@mdx-js/react",
+			"@phosphor-icons/react/HandPalm"
+		],
+		"expected": "@mdx-js/react @phosphor-icons/react/HandPalm"
+	},
+	{
+		"args": [
+			"@ngrok/mantle",
+			"@phosphor-icons/react/Minus"
+		],
+		"expected": "@ngrok/mantle @phosphor-icons/react/Minus"
+	},
+	{
+		"args": [
+			"@ngrok/mantle-server-syntax-highlighter",
+			"@phosphor-icons/react/SortDescending"
+		],
+		"expected": "@ngrok/mantle-server-syntax-highlighter @phosphor-icons/react/SortDescending"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/*",
+			"@phosphor-icons/react/WarningDiamond"
+		],
+		"expected": "@ngrok/mantle/* @phosphor-icons/react/WarningDiamond"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/alert",
+			"@radix-ui/react-progress"
+		],
+		"expected": "@ngrok/mantle/alert @radix-ui/react-progress"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/alpha",
+			"@react-router/dev/routes"
+		],
+		"expected": "@ngrok/mantle/alpha @react-router/dev/routes"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/anchor",
+			"@testing-library/user-event"
+		],
+		"expected": "@ngrok/mantle/anchor @testing-library/user-event"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/badge",
+			"Content-Disposition"
+		],
+		"expected": "@ngrok/mantle/badge Content-Disposition"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/browser-only",
+			"If-None-Match"
+		],
+		"expected": "@ngrok/mantle/browser-only If-None-Match"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/button",
+			"Sort-time-newest-to-oldest"
+		],
+		"expected": "@ngrok/mantle/button Sort-time-newest-to-oldest"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/calendar",
+			"UTF-8"
+		],
+		"expected": "@ngrok/mantle/calendar UTF-8"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/card",
+			"absolute right-0"
+		],
+		"expected": "@ngrok/mantle/card absolute right-0"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/checkbox",
+			"accordion-heading"
+		],
+		"expected": "@ngrok/mantle/checkbox accordion-heading"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/code",
+			"alert-dialog-overlay"
+		],
+		"expected": "@ngrok/mantle/code alert-dialog-overlay"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/code-block",
+			"api-changelog-json"
+		],
+		"expected": "@ngrok/mantle/code-block api-changelog-json"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/command",
+			"api/changelog.json"
+		],
+		"expected": "@ngrok/mantle/command api/changelog.json"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/cx",
+			"api/utils.json"
+		],
+		"expected": "@ngrok/mantle/cx api/utils.json"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/data-table",
+			"aria-checked:bg-selected-menu-item aria-checked:pr-9"
+		],
+		"expected": "@ngrok/mantle/data-table aria-checked:bg-selected-menu-item aria-checked:pr-9"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/description-list",
+			"aria-errormessage"
+		],
+		"expected": "@ngrok/mantle/description-list aria-errormessage"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/dropdown-menu",
+			"au-syd-1"
+		],
+		"expected": "@ngrok/mantle/dropdown-menu au-syd-1"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/empty",
+			"base/tailwind-variants"
+		],
+		"expected": "@ngrok/mantle/empty base/tailwind-variants"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/field",
+			"bg-accent-400"
+		],
+		"expected": "@ngrok/mantle/field bg-accent-400"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/hooks",
+			"bg-accent-800"
+		],
+		"expected": "@ngrok/mantle/hooks bg-accent-800"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/icon",
+			"bg-amber-50"
+		],
+		"expected": "@ngrok/mantle/icon bg-amber-50"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/icons",
+			"bg-amber-950"
+		],
+		"expected": "@ngrok/mantle/icons bg-amber-950"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/input",
+			"bg-blue-50"
+		],
+		"expected": "@ngrok/mantle/input bg-blue-50"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/kbd",
+			"bg-blue-950"
+		],
+		"expected": "@ngrok/mantle/kbd bg-blue-950"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/label",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-md"
+		],
+		"expected": "@ngrok/mantle/label bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-md"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/main",
+			"bg-cyan-400"
+		],
+		"expected": "@ngrok/mantle/main bg-cyan-400"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/mantle-dark-high-contrast.css?url",
+			"bg-cyan-900"
+		],
+		"expected": "@ngrok/mantle/mantle-dark-high-contrast.css?url bg-cyan-900"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/mantle-dark.css?url",
+			"bg-danger-500"
+		],
+		"expected": "@ngrok/mantle/mantle-dark.css?url bg-danger-500"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/mantle-light-high-contrast.css?url",
+			"bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+		],
+		"expected": "@ngrok/mantle/mantle-light-high-contrast.css?url bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/media-object",
+			"bg-emerald-500/20"
+		],
+		"expected": "@ngrok/mantle/media-object bg-emerald-500/20"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/multi-select",
+			"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4"
+		],
+		"expected": "@ngrok/mantle/multi-select bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/package.json",
+			"bg-fuchsia-500/20"
+		],
+		"expected": "@ngrok/mantle/package.json bg-fuchsia-500/20"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/pagination",
+			"bg-gray-200"
+		],
+		"expected": "@ngrok/mantle/pagination bg-gray-200"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/popover",
+			"bg-gray-700"
+		],
+		"expected": "@ngrok/mantle/popover bg-gray-700"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/progress",
+			"bg-green-400"
+		],
+		"expected": "@ngrok/mantle/progress bg-green-400"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/separator",
+			"bg-green-900"
+		],
+		"expected": "@ngrok/mantle/separator bg-green-900"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/sheet",
+			"bg-indigo-50"
+		],
+		"expected": "@ngrok/mantle/sheet bg-indigo-50"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/skeleton",
+			"bg-indigo-950"
+		],
+		"expected": "@ngrok/mantle/skeleton bg-indigo-950"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/skip-to-main-link",
+			"bg-info-500/20"
+		],
+		"expected": "@ngrok/mantle/skip-to-main-link bg-info-500/20"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/slot",
+			"bg-lime-200"
+		],
+		"expected": "@ngrok/mantle/slot bg-lime-200"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/split-button",
+			"bg-lime-700"
+		],
+		"expected": "@ngrok/mantle/split-button bg-lime-700"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/switch",
+			"bg-neutral-200"
+		],
+		"expected": "@ngrok/mantle/switch bg-neutral-200"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/table",
+			"bg-neutral-700"
+		],
+		"expected": "@ngrok/mantle/table bg-neutral-700"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/text-area",
+			"bg-orange-400"
+		],
+		"expected": "@ngrok/mantle/text-area bg-orange-400"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/theme",
+			"bg-orange-900"
+		],
+		"expected": "@ngrok/mantle/theme bg-orange-900"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/toast",
+			"bg-pink-50"
+		],
+		"expected": "@ngrok/mantle/toast bg-pink-50"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/tooltip",
+			"bg-pink-950"
+		],
+		"expected": "@ngrok/mantle/tooltip bg-pink-950"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/types",
+			"bg-purple-300"
+		],
+		"expected": "@ngrok/mantle/types bg-purple-300"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/utils",
+			"bg-purple-800"
+		],
+		"expected": "@ngrok/mantle/utils bg-purple-800"
+	},
+	{
+		"args": [
+			"@ngrok/mantle/zed",
+			"bg-red-50"
+		],
+		"expected": "@ngrok/mantle/zed bg-red-50"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react",
+			"bg-red-950"
+		],
+		"expected": "@phosphor-icons/react bg-red-950"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Calendar",
+			"bg-rose-500/20"
+		],
+		"expected": "@phosphor-icons/react/Calendar bg-rose-500/20"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretDown",
+			"bg-sky-200"
+		],
+		"expected": "@phosphor-icons/react/CaretDown bg-sky-200"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretLeft",
+			"bg-sky-700"
+		],
+		"expected": "@phosphor-icons/react/CaretLeft bg-sky-700"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretRight",
+			"bg-success-200"
+		],
+		"expected": "@phosphor-icons/react/CaretRight bg-success-200"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CaretUp",
+			"bg-success-700"
+		],
+		"expected": "@phosphor-icons/react/CaretUp bg-success-700"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Check",
+			"bg-teal-400"
+		],
+		"expected": "@phosphor-icons/react/Check bg-teal-400"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CheckCircle",
+			"bg-teal-900"
+		],
+		"expected": "@phosphor-icons/react/CheckCircle bg-teal-900"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/CircleNotch",
+			"bg-violet-400"
+		],
+		"expected": "@phosphor-icons/react/CircleNotch bg-violet-400"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Copy",
+			"bg-violet-900"
+		],
+		"expected": "@phosphor-icons/react/Copy bg-violet-900"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Desktop",
+			"bg-warning-500"
+		],
+		"expected": "@phosphor-icons/react/Desktop bg-warning-500"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/DotsThree",
+			"bg-white border-card flex flex-col items-center justify-center gap-2 rounded border p-6 text-black"
+		],
+		"expected": "@phosphor-icons/react/DotsThree bg-white border-card flex flex-col items-center justify-center gap-2 rounded border p-6 text-black"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Eye",
+			"bg-yellow-500/20"
+		],
+		"expected": "@phosphor-icons/react/Eye bg-yellow-500/20"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/EyeClosed",
+			"blocks/"
+		],
+		"expected": "@phosphor-icons/react/EyeClosed blocks/"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/FileText",
+			"border-card rounded-md border p-2 shadow-md"
+		],
+		"expected": "@phosphor-icons/react/FileText border-card rounded-md border p-2 shadow-md"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Globe",
+			"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600"
+		],
+		"expected": "@phosphor-icons/react/Globe border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/HandPalm",
+			"border-r border-gray-200"
+		],
+		"expected": "@phosphor-icons/react/HandPalm border-r border-gray-200"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Info",
+			"card-body"
+		],
+		"expected": "@phosphor-icons/react/Info card-body"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Link",
+			"checked:border-accent-600 checked:bg-accent-600 checked:bg-checked-icon"
+		],
+		"expected": "@phosphor-icons/react/Link checked:border-accent-600 checked:bg-checked-icon"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/List",
+			"code-block"
+		],
+		"expected": "@phosphor-icons/react/List code-block"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Lock",
+			"color:var(--shiki-token-string-expression)"
+		],
+		"expected": "@phosphor-icons/react/Lock color:var(--shiki-token-string-expression)"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/MagnifyingGlass",
+			"command-item"
+		],
+		"expected": "@phosphor-icons/react/MagnifyingGlass command-item"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Megaphone",
+			"components/alert"
+		],
+		"expected": "@phosphor-icons/react/Megaphone components/alert"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Minus",
+			"components/card"
+		],
+		"expected": "@phosphor-icons/react/Minus components/card"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Moon",
+			"components/data-table"
+		],
+		"expected": "@phosphor-icons/react/Moon components/data-table"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/PencilSimple",
+			"components/hover-card"
+		],
+		"expected": "@phosphor-icons/react/PencilSimple components/hover-card"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Plus",
+			"components/main"
+		],
+		"expected": "@phosphor-icons/react/Plus components/main"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Question",
+			"components/preview/"
+		],
+		"expected": "@phosphor-icons/react/Question components/preview/"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/SmileyMelting",
+			"components/sandboxed-on-click"
+		],
+		"expected": "@phosphor-icons/react/SmileyMelting components/sandboxed-on-click"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/SortAscending",
+			"components/slot"
+		],
+		"expected": "@phosphor-icons/react/SortAscending components/slot"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/SortDescending",
+			"components/toast"
+		],
+		"expected": "@phosphor-icons/react/SortDescending components/toast"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Sparkle",
+			"cursor-*"
+		],
+		"expected": "@phosphor-icons/react/Sparkle cursor-*"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Sun",
+			"cursor-pagination-separator"
+		],
+		"expected": "@phosphor-icons/react/Sun cursor-pagination-separator"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Terminal",
+			"custom-copy-button"
+		],
+		"expected": "@phosphor-icons/react/Terminal custom-copy-button"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Trash",
+			"data-*"
+		],
+		"expected": "@phosphor-icons/react/Trash data-*"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Tray",
+			"data-disabled:opacity-50"
+		],
+		"expected": "@phosphor-icons/react/Tray data-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/Warning",
+			"data-highlighted:bg-active-menu-item"
+		],
+		"expected": "@phosphor-icons/react/Warning data-highlighted:bg-active-menu-item"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/WarningDiamond",
+			"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)"
+		],
+		"expected": "@phosphor-icons/react/WarningDiamond data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)"
+	},
+	{
+		"args": [
+			"@phosphor-icons/react/X",
+			"data-state-closed:slide-out-to-right data-state-open:slide-in-from-right right-0 border-l"
+		],
+		"expected": "@phosphor-icons/react/X data-state-closed:slide-out-to-right data-state-open:slide-in-from-right right-0 border-l"
+	},
+	{
+		"args": [
+			"@radix-ui/react-accordion",
+			"data-table-header-sort-button"
+		],
+		"expected": "@radix-ui/react-accordion data-table-header-sort-button"
+	},
+	{
+		"args": [
+			"@radix-ui/react-dialog",
+			"data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger"
+		],
+		"expected": "@radix-ui/react-dialog data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger"
+	},
+	{
+		"args": [
+			"@radix-ui/react-dropdown-menu",
+			"data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+		],
+		"expected": "@radix-ui/react-dropdown-menu data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+	},
+	{
+		"args": [
+			"@radix-ui/react-hover-card",
+			"data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning"
+		],
+		"expected": "@radix-ui/react-hover-card data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning"
+	},
+	{
+		"args": [
+			"@radix-ui/react-popover",
+			"de-fra-1"
+		],
+		"expected": "@radix-ui/react-popover de-fra-1"
+	},
+	{
+		"args": [
+			"@radix-ui/react-progress",
+			"dialog-trigger"
+		],
+		"expected": "@radix-ui/react-progress dialog-trigger"
+	},
+	{
+		"args": [
+			"@radix-ui/react-select",
+			"dropdown-menu-content"
+		],
+		"expected": "@radix-ui/react-select dropdown-menu-content"
+	},
+	{
+		"args": [
+			"@radix-ui/react-slider",
+			"dropdown-menu-shortcut"
+		],
+		"expected": "@radix-ui/react-slider dropdown-menu-shortcut"
+	},
+	{
+		"args": [
+			"@radix-ui/react-slot",
+			"empty-actions"
+		],
+		"expected": "@radix-ui/react-slot empty-actions"
+	},
+	{
+		"args": [
+			"@radix-ui/react-switch",
+			"family-italic"
+		],
+		"expected": "@radix-ui/react-switch family-italic"
+	},
+	{
+		"args": [
+			"@radix-ui/react-tabs",
+			"field-item"
+		],
+		"expected": "@radix-ui/react-tabs field-item"
+	},
+	{
+		"args": [
+			"@radix-ui/react-tooltip",
+			"first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+		],
+		"expected": "@radix-ui/react-tooltip first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+	},
+	{
+		"args": [
+			"@react-router/dev/routes",
+			"flex flex-col items-center gap-4 px-8 py-6"
+		],
+		"expected": "@react-router/dev/routes flex flex-col items-center gap-4 px-8 py-6"
+	},
+	{
+		"args": [
+			"@react-router/node",
+			"flex grow flex-col gap-1 font-mono"
+		],
+		"expected": "@react-router/node flex grow flex-col gap-1 font-mono"
+	},
+	{
+		"args": [
+			"@tanstack/react-form",
+			"flex items-center gap-2 justify-between"
+		],
+		"expected": "@tanstack/react-form flex items-center gap-2 justify-between"
+	},
+	{
+		"args": [
+			"@tanstack/react-query",
+			"flex justify-center pt-1 relative items-center"
+		],
+		"expected": "@tanstack/react-query flex justify-center pt-1 relative items-center"
+	},
+	{
+		"args": [
+			"@tanstack/react-query-devtools/production",
+			"flex w-full flex-col items-end justify-between gap-6 sm:flex-row"
+		],
+		"expected": "@tanstack/react-query-devtools/production flex w-full flex-col items-end justify-between gap-6 sm:flex-row"
+	},
+	{
+		"args": [
+			"@tanstack/react-table",
+			"flex-row"
+		],
+		"expected": "@tanstack/react-table flex-row"
+	},
+	{
+		"args": [
+			"@testing-library/react",
+			"focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 text-sm outline-hidden"
+		],
+		"expected": "@testing-library/react focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 text-sm outline-hidden"
+	},
+	{
+		"args": [
+			"@testing-library/user-event",
+			"focus:outline-hidden focus:ring-4 aria-expanded:ring-4"
+		],
+		"expected": "@testing-library/user-event focus:outline-hidden focus:ring-4 aria-expanded:ring-4"
+	},
+	{
+		"args": [
+			"Access-Control-Allow-Origin",
+			"font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+		],
+		"expected": "Access-Control-Allow-Origin font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+	},
+	{
+		"args": [
+			"Auto-Theme-Icon",
+			"font-normal"
+		],
+		"expected": "Auto-Theme-Icon font-normal"
+	},
+	{
+		"args": [
+			"BQ-BO",
+			"gap-*"
+		],
+		"expected": "BQ-BO gap-*"
+	},
+	{
+		"args": [
+			"BQ-SA",
+			"gap-4 gap-em"
+		],
+		"expected": "BQ-SA gap-em"
+	},
+	{
+		"args": [
+			"BQ-SE",
+			"grid w-full max-w-2xl grid-cols-2 gap-6 gap-y-12 font-mono text-[0.8125rem] min-[70.625rem]:max-w-none min-[70.625rem]:grid-cols-5"
+		],
+		"expected": "BQ-SE grid w-full max-w-2xl grid-cols-2 gap-6 gap-y-12 font-mono text-[0.8125rem] min-[70.625rem]:max-w-none min-[70.625rem]:grid-cols-5"
+	},
+	{
+		"args": [
+			"Cache-Control",
+			"group-data-validation"
+		],
+		"expected": "Cache-Control group-data-validation"
+	},
+	{
+		"args": [
+			"Content-Disposition",
+			"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm"
+		],
+		"expected": "Content-Disposition group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm"
+	},
+	{
+		"args": [
+			"Content-Type",
+			"h-10 w-full rounded bg-neutral-950/50"
+		],
+		"expected": "Content-Type h-10 w-full rounded bg-neutral-950/50"
+	},
+	{
+		"args": [
+			"GB-ENG",
+			"h-9 text-sm"
+		],
+		"expected": "GB-ENG h-9 text-sm"
+	},
+	{
+		"args": [
+			"GB-NIR",
+			"h-px w-full group-data-horizontal-separator-group:flex-1"
+		],
+		"expected": "GB-NIR h-px w-full group-data-horizontal-separator-group:flex-1"
+	},
+	{
+		"args": [
+			"GB-SCT",
+			"hidden md:flex items-center gap-1"
+		],
+		"expected": "GB-SCT hidden md:flex items-center gap-1"
+	},
+	{
+		"args": [
+			"GB-UKM",
+			"hover-card-content"
+		],
+		"expected": "GB-UKM hover-card-content"
+	},
+	{
+		"args": [
+			"GB-WLS",
+			"hover:text-orange-700"
+		],
+		"expected": "GB-WLS hover:text-orange-700"
+	},
+	{
+		"args": [
+			"If-None-Match",
+			"http://www.sitemaps.org/schemas/sitemap/0.9"
+		],
+		"expected": "If-None-Match http://www.sitemaps.org/schemas/sitemap/0.9"
+	},
+	{
+		"args": [
+			"KN-SK",
+			"https://github.com/ngrok"
+		],
+		"expected": "KN-SK https://github.com/ngrok"
+	},
+	{
+		"args": [
+			"M0,0h10v10h-10zM10,10h10v10h-10z",
+			"https://mantle.ngrok.com/api/package.json"
+		],
+		"expected": "M0,0h10v10h-10zM10,10h10v10h-10z https://mantle.ngrok.com/api/package.json"
+	},
+	{
+		"args": [
+			"M4,0h4v4h-4z",
+			"https://mantle.ngrok.com/hooks.md"
+		],
+		"expected": "M4,0h4v4h-4z https://mantle.ngrok.com/hooks.md"
+	},
+	{
+		"args": [
+			"Set-Cookie",
+			"https://ngrok.com/about"
+		],
+		"expected": "Set-Cookie https://ngrok.com/about"
+	},
+	{
+		"args": [
+			"Sort-alphanumeric-asc",
+			"https://ngrok.com/customers"
+		],
+		"expected": "Sort-alphanumeric-asc https://ngrok.com/customers"
+	},
+	{
+		"args": [
+			"Sort-alphanumeric-desc",
+			"https://ngrok.com/docs/k8s"
+		],
+		"expected": "Sort-alphanumeric-desc https://ngrok.com/docs/k8s"
+	},
+	{
+		"args": [
+			"Sort-time-newest-to-oldest",
+			"https://ngrok.com/docs/universal-gateway/examples/webhook-gateway"
+		],
+		"expected": "Sort-time-newest-to-oldest https://ngrok.com/docs/universal-gateway/examples/webhook-gateway"
+	},
+	{
+		"args": [
+			"Sort-time-oldest-to-newest",
+			"https://ngrok.com/press"
+		],
+		"expected": "Sort-time-oldest-to-newest https://ngrok.com/press"
+	},
+	{
+		"args": [
+			"Theme-Icon-Dark",
+			"https://ngrok.com/use-cases/developer-preview"
+		],
+		"expected": "Theme-Icon-Dark https://ngrok.com/use-cases/developer-preview"
+	},
+	{
+		"args": [
+			"Theme-Icon-Dark-High-Contrast",
+			"https://upstream-service.internal/ping"
+		],
+		"expected": "Theme-Icon-Dark-High-Contrast https://upstream-service.internal/ping"
+	},
+	{
+		"args": [
+			"Theme-Icon-Light",
+			"ignored-by-context"
+		],
+		"expected": "Theme-Icon-Light ignored-by-context"
+	},
+	{
+		"args": [
+			"Theme-Icon-Light-High-Contrast",
+			"indeterminate:border-accent-600 indeterminate:bg-accent-600 indeterminate:bg-indeterminate-icon"
+		],
+		"expected": "Theme-Icon-Light-High-Contrast indeterminate:border-accent-600 indeterminate:bg-indeterminate-icon"
+	},
+	{
+		"args": [
+			"Theme-Icon-System",
+			"inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-strong hover:bg-neutral-500/10 focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent"
+		],
+		"expected": "Theme-Icon-System inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-strong hover:bg-neutral-500/10 focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"UTF-8",
+			"isolate"
+		],
+		"expected": "UTF-8 isolate"
+	},
+	{
+		"args": [
+			"X-Content-Type-Options",
+			"jetbrains-mono-italic"
+		],
+		"expected": "X-Content-Type-Options jetbrains-mono-italic"
+	},
+	{
+		"args": [
+			"X-Robots-Tag",
+			"lang-fake"
+		],
+		"expected": "X-Robots-Tag lang-fake"
+	},
+	{
+		"args": [
+			"a:",
+			"list-none"
+		],
+		"expected": "a: list-none"
+	},
+	{
+		"args": [
+			"absolute inline-flex size-full animate-ping rounded-full",
+			"m-0 flex w-full flex-col list-none p-0"
+		],
+		"expected": "absolute size-full animate-ping rounded-full m-0 flex w-full flex-col list-none p-0"
+	},
+	{
+		"args": [
+			"absolute inset-0 border border-[#000]/10",
+			"mantle-code-line-number"
+		],
+		"expected": "absolute inset-0 border border-[#000]/10 mantle-code-line-number"
+	},
+	{
+		"args": [
+			"absolute left-0",
+			"mantle-light-high-contrast.css"
+		],
+		"expected": "absolute left-0 mantle-light-high-contrast.css"
+	},
+	{
+		"args": [
+			"absolute right-0",
+			"max-w-md"
+		],
+		"expected": "absolute right-0 max-w-md"
+	},
+	{
+		"args": [
+			"absolute right-2 flex h-3.5 w-3.5 items-center justify-center",
+			"mb-4 leading-relaxed text-pretty text-body"
+		],
+		"expected": "absolute right-2 flex h-3.5 w-3.5 items-center justify-center mb-4 leading-relaxed text-pretty text-body"
+	},
+	{
+		"args": [
+			"absolute right-2 flex items-center",
+			"meta-key"
+		],
+		"expected": "absolute right-2 flex items-center meta-key"
+	},
+	{
+		"args": [
+			"absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex",
+			"min-width"
+		],
+		"expected": "absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex min-width"
+	},
+	{
+		"args": [
+			"absolute top-1.5 right-1.5",
+			"mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row"
+		],
+		"expected": "absolute top-1.5 right-1.5 mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row"
+	},
+	{
+		"args": [
+			"accent-600",
+			"multi-select-trigger"
+		],
+		"expected": "accent-600 multi-select-trigger"
+	},
+	{
+		"args": [
+			"accordion-content",
+			"my-2 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] overflow-auto"
+		],
+		"expected": "accordion-content my-2 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] overflow-auto"
+	},
+	{
+		"args": [
+			"accordion-heading",
+			"not-aria-selected:not-disabled:text-accent-600 font-medium not-aria-selected:not-disabled:bg-filled-accent/10 rounded-md"
+		],
+		"expected": "accordion-heading not-aria-selected:not-disabled:text-accent-600 font-medium not-aria-selected:not-disabled:bg-filled-accent/10 rounded-md"
+	},
+	{
+		"args": [
+			"accordion-item",
+			"number[]"
+		],
+		"expected": "accordion-item number[]"
+	},
+	{
+		"args": [
+			"accordion-trigger",
+			"og:url"
+		],
+		"expected": "accordion-trigger og:url"
+	},
+	{
+		"args": [
+			"accordion-trigger-icon",
+			"order-last"
+		],
+		"expected": "accordion-trigger-icon order-last"
+	},
+	{
+		"args": [
+			"admin:secret",
+			"overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+		],
+		"expected": "admin:secret overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+	},
+	{
+		"args": [
+			"alert-content",
+			"p-4 pt-5 pb-6 pr-3 pb-3"
+		],
+		"expected": "alert-content p-4 pt-5 pr-3 pb-3"
+	},
+	{
+		"args": [
+			"alert-description",
+			"pattern-a"
+		],
+		"expected": "alert-description pattern-a"
+	},
+	{
+		"args": [
+			"alert-dialog-overlay",
+			"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden"
+		],
+		"expected": "alert-dialog-overlay peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden"
+	},
+	{
+		"args": [
+			"alert-dialog-trigger",
+			"pointer-coarse:text-base h-9 text-sm"
+		],
+		"expected": "alert-dialog-trigger pointer-coarse:text-base h-9 text-sm"
+	},
+	{
+		"args": [
+			"alert-dismiss-icon-button",
+			"privacy-policy"
+		],
+		"expected": "alert-dismiss-icon-button privacy-policy"
+	},
+	{
+		"args": [
+			"alert-icon",
+			"ps-2.5"
+		],
+		"expected": "alert-icon ps-2.5"
+	},
+	{
+		"args": [
+			"alert-title",
+			"py-6 text-center text-sm"
+		],
+		"expected": "alert-title py-6 text-center text-sm"
+	},
+	{
+		"args": [
+			"animate-spin",
+			"radio-group-item"
+		],
+		"expected": "animate-spin radio-group-item"
+	},
+	{
+		"args": [
+			"animation-duration-[15s]",
+			"react-router"
+		],
+		"expected": "animation-duration-[15s] react-router"
+	},
+	{
+		"args": [
+			"api-changelog-json",
+			"relative flex items-start gap-2 text-sm font-sans"
+		],
+		"expected": "api-changelog-json relative flex items-start gap-2 text-sm font-sans"
+	},
+	{
+		"args": [
+			"api-components-json",
+			"remark-gfm"
+		],
+		"expected": "api-components-json remark-gfm"
+	},
+	{
+		"args": [
+			"api-hooks-json",
+			"rounded"
+		],
+		"expected": "api-hooks-json rounded"
+	},
+	{
+		"args": [
+			"api-package-json",
+			"rounded-xs"
+		],
+		"expected": "api-package-json rounded-xs"
+	},
+	{
+		"args": [
+			"api-schema-json",
+			"scroll-fade-l overflow-x-auto"
+		],
+		"expected": "api-schema-json scroll-fade-l overflow-x-auto"
+	},
+	{
+		"args": [
+			"api-search-index-json",
+			"scroll-fade-y scrollbar sticky top-15 hidden max-h-[calc(100vh-3.75rem)] w-44 overflow-y-auto px-1 pb-4 md:block"
+		],
+		"expected": "api-search-index-json scroll-fade-y scrollbar sticky top-15 hidden max-h-[calc(100vh-3.75rem)] w-44 overflow-y-auto px-1 pb-4 md:block"
+	},
+	{
+		"args": [
+			"api-utils-json",
+			"select-separator"
+		],
+		"expected": "api-utils-json select-separator"
+	},
+	{
+		"args": [
+			"api/changelog.json",
+			"shape-rendering"
+		],
+		"expected": "api/changelog.json shape-rendering"
+	},
+	{
+		"args": [
+			"api/components.json",
+			"shrink-0 size-12 sm:size-16"
+		],
+		"expected": "api/components.json shrink-0 size-12 sm:size-16"
+	},
+	{
+		"args": [
+			"api/hooks.json",
+			"size-3"
+		],
+		"expected": "api/hooks.json size-3"
+	},
+	{
+		"args": [
+			"api/package.json",
+			"size-7"
+		],
+		"expected": "api/package.json size-7"
+	},
+	{
+		"args": [
+			"api/schema.json",
+			"space-y-2"
+		],
+		"expected": "api/schema.json space-y-2"
+	},
+	{
+		"args": [
+			"api/search-index.json",
+			"sr-only"
+		],
+		"expected": "api/search-index.json sr-only"
+	},
+	{
+		"args": [
+			"api/shiki-highlight",
+			"stop-opacity-100 stop-color-current"
+		],
+		"expected": "api/shiki-highlight stop-opacity-100 stop-color-current"
+	},
+	{
+		"args": [
+			"api/utils.json",
+			"tabs-trigger"
+		],
+		"expected": "api/utils.json tabs-trigger"
+	},
+	{
+		"args": [
+			"appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded text-mono leading-none font-mono",
+			"text-[0.75em]"
+		],
+		"expected": "appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded font-mono text-[0.75em]"
+	},
+	{
+		"args": [
+			"apple-touch-icon",
+			"text-area"
+		],
+		"expected": "apple-touch-icon text-area"
+	},
+	{
+		"args": [
+			"application/json",
+			"text-blue-500 px-2 py-2"
+		],
+		"expected": "application/json text-blue-500 px-2 py-2"
+	},
+	{
+		"args": [
+			"application/schema+json",
+			"text-center space-y-1"
+		],
+		"expected": "application/schema+json text-center space-y-1"
+	},
+	{
+		"args": [
+			"aria-*",
+			"text-danger-700 hover-hover:hidden block size-4"
+		],
+		"expected": "aria-* text-danger-700 hover-hover:hidden block size-4"
+	},
+	{
+		"args": [
+			"aria-checked:bg-selected-menu-item",
+			"text-gray-500"
+		],
+		"expected": "aria-checked:bg-selected-menu-item text-gray-500"
+	},
+	{
+		"args": [
+			"aria-checked:bg-selected-menu-item aria-checked:pr-9",
+			"text-muted"
+		],
+		"expected": "aria-checked:bg-selected-menu-item aria-checked:pr-9 text-muted"
+	},
+	{
+		"args": [
+			"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600",
+			"text-muted hover:text-strong flex items-center gap-1 text-left font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+		],
+		"expected": "aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600 text-muted hover:text-strong flex items-center gap-1 text-left font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			"aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600",
+			"text-muted text-xs"
+		],
+		"expected": "aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600 text-muted text-xs"
+	},
+	{
+		"args": [
+			"aria-controls",
+			"text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans"
+		],
+		"expected": "aria-controls text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans"
+	},
+	{
+		"args": [
+			"aria-describedby",
+			"text-red-500 font-medium"
+		],
+		"expected": "aria-describedby text-red-500 font-medium"
+	},
+	{
+		"args": [
+			"aria-disabled",
+			"text-sm pb-16"
+		],
+		"expected": "aria-disabled text-sm pb-16"
+	},
+	{
+		"args": [
+			"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600",
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden"
+		],
+		"expected": "aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden"
+	},
+	{
+		"args": [
+			"aria-errormessage",
+			"text-strong text-sm font-medium font-sans"
+		],
+		"expected": "aria-errormessage text-strong text-sm font-medium font-sans"
+	},
+	{
+		"args": [
+			"aria-expanded",
+			"text-success-700 hover-none:block hidden size-4"
+		],
+		"expected": "aria-expanded text-success-700 hover-none:block hidden size-4"
+	},
+	{
+		"args": [
+			"aria-hidden",
+			"text-yellow-600"
+		],
+		"expected": "aria-hidden text-yellow-600"
+	},
+	{
+		"args": [
+			"aria-invalid",
+			"top-center"
+		],
+		"expected": "aria-invalid top-center"
+	},
+	{
+		"args": [
+			"aria-label",
+			"twitter:title"
+		],
+		"expected": "aria-label twitter:title"
+	},
+	{
+		"args": [
+			"aria-orientation",
+			"utilities/mantle-version.server.ts"
+		],
+		"expected": "aria-orientation utilities/mantle-version.server.ts"
+	},
+	{
+		"args": [
+			"aria-readonly",
+			"utils/sorting"
+		],
+		"expected": "aria-readonly utils/sorting"
+	},
+	{
+		"args": [
+			"au-syd-1",
+			"w-25"
+		],
+		"expected": "au-syd-1 w-25"
+	},
+	{
+		"args": [
+			"autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]",
+			"w-full border-collapse space-y-1"
+		],
+		"expected": "autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)] w-full border-collapse space-y-1"
+	},
+	{
+		"args": [
+			"base/",
+			"-mx-1 my-1 h-px w-auto"
+		],
+		"expected": "base/ -mx-1 my-1 h-px w-auto"
+	},
+	{
+		"args": [
+			"base/breakpoints",
+			"@changesets/cli"
+		],
+		"expected": "base/breakpoints @changesets/cli"
+	},
+	{
+		"args": [
+			"base/colors",
+			"@ngrok/mantle/alpha"
+		],
+		"expected": "base/colors @ngrok/mantle/alpha"
+	},
+	{
+		"args": [
+			"base/scroll-fade",
+			"@ngrok/mantle/checkbox"
+		],
+		"expected": "base/scroll-fade @ngrok/mantle/checkbox"
+	},
+	{
+		"args": [
+			"base/shadows",
+			"@ngrok/mantle/dropdown-menu"
+		],
+		"expected": "base/shadows @ngrok/mantle/dropdown-menu"
+	},
+	{
+		"args": [
+			"base/tailwind-variants",
+			"@ngrok/mantle/kbd"
+		],
+		"expected": "base/tailwind-variants @ngrok/mantle/kbd"
+	},
+	{
+		"args": [
+			"base/typography",
+			"@ngrok/mantle/multi-select"
+		],
+		"expected": "base/typography @ngrok/mantle/multi-select"
+	},
+	{
+		"args": [
+			"bg-*",
+			"@ngrok/mantle/skeleton"
+		],
+		"expected": "bg-* @ngrok/mantle/skeleton"
+	},
+	{
+		"args": [
+			"bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent",
+			"@ngrok/mantle/theme"
+		],
+		"expected": "bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent @ngrok/mantle/theme"
+	},
+	{
+		"args": [
+			"bg-accent-100",
+			"@phosphor-icons/react/Calendar"
+		],
+		"expected": "bg-accent-100 @phosphor-icons/react/Calendar"
+	},
+	{
+		"args": [
+			"bg-accent-200",
+			"@phosphor-icons/react/CircleNotch"
+		],
+		"expected": "bg-accent-200 @phosphor-icons/react/CircleNotch"
+	},
+	{
+		"args": [
+			"bg-accent-300",
+			"@phosphor-icons/react/Globe"
+		],
+		"expected": "bg-accent-300 @phosphor-icons/react/Globe"
+	},
+	{
+		"args": [
+			"bg-accent-400",
+			"@phosphor-icons/react/Megaphone"
+		],
+		"expected": "bg-accent-400 @phosphor-icons/react/Megaphone"
+	},
+	{
+		"args": [
+			"bg-accent-50",
+			"@phosphor-icons/react/SortAscending"
+		],
+		"expected": "bg-accent-50 @phosphor-icons/react/SortAscending"
+	},
+	{
+		"args": [
+			"bg-accent-500",
+			"@phosphor-icons/react/Warning"
+		],
+		"expected": "bg-accent-500 @phosphor-icons/react/Warning"
+	},
+	{
+		"args": [
+			"bg-accent-500/20",
+			"@radix-ui/react-popover"
+		],
+		"expected": "bg-accent-500/20 @radix-ui/react-popover"
+	},
+	{
+		"args": [
+			"bg-accent-600",
+			"@radix-ui/react-tooltip"
+		],
+		"expected": "bg-accent-600 @radix-ui/react-tooltip"
+	},
+	{
+		"args": [
+			"bg-accent-600 h-full w-full flex-1 transition-all",
+			"@testing-library/react"
+		],
+		"expected": "bg-accent-600 h-full w-full flex-1 transition-all @testing-library/react"
+	},
+	{
+		"args": [
+			"bg-accent-700",
+			"Cache-Control"
+		],
+		"expected": "bg-accent-700 Cache-Control"
+	},
+	{
+		"args": [
+			"bg-accent-800",
+			"GB-WLS"
+		],
+		"expected": "bg-accent-800 GB-WLS"
+	},
+	{
+		"args": [
+			"bg-accent-900",
+			"Sort-alphanumeric-desc"
+		],
+		"expected": "bg-accent-900 Sort-alphanumeric-desc"
+	},
+	{
+		"args": [
+			"bg-accent-950",
+			"Theme-Icon-System"
+		],
+		"expected": "bg-accent-950 Theme-Icon-System"
+	},
+	{
+		"args": [
+			"bg-amber-100",
+			"absolute left-0"
+		],
+		"expected": "bg-amber-100 absolute left-0"
+	},
+	{
+		"args": [
+			"bg-amber-200",
+			"accordion-content"
+		],
+		"expected": "bg-amber-200 accordion-content"
+	},
+	{
+		"args": [
+			"bg-amber-300",
+			"alert-description"
+		],
+		"expected": "bg-amber-300 alert-description"
+	},
+	{
+		"args": [
+			"bg-amber-400",
+			"animation-duration-[15s]"
+		],
+		"expected": "bg-amber-400 animation-duration-[15s]"
+	},
+	{
+		"args": [
+			"bg-amber-50",
+			"api-utils-json"
+		],
+		"expected": "bg-amber-50 api-utils-json"
+	},
+	{
+		"args": [
+			"bg-amber-500",
+			"api/shiki-highlight"
+		],
+		"expected": "bg-amber-500 api/shiki-highlight"
+	},
+	{
+		"args": [
+			"bg-amber-500/20",
+			"aria-checked:bg-selected-menu-item"
+		],
+		"expected": "bg-amber-500/20 aria-checked:bg-selected-menu-item"
+	},
+	{
+		"args": [
+			"bg-amber-600",
+			"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600"
+		],
+		"expected": "bg-amber-600 aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600"
+	},
+	{
+		"args": [
+			"bg-amber-700",
+			"aria-readonly"
+		],
+		"expected": "bg-amber-700 aria-readonly"
+	},
+	{
+		"args": [
+			"bg-amber-800",
+			"base/shadows"
+		],
+		"expected": "bg-amber-800 base/shadows"
+	},
+	{
+		"args": [
+			"bg-amber-900",
+			"bg-accent-300"
+		],
+		"expected": "bg-accent-300"
+	},
+	{
+		"args": [
+			"bg-amber-950",
+			"bg-accent-700"
+		],
+		"expected": "bg-accent-700"
+	},
+	{
+		"args": [
+			"bg-base",
+			"bg-amber-400"
+		],
+		"expected": "bg-amber-400"
+	},
+	{
+		"args": [
+			"bg-base-hover dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md",
+			"bg-amber-900"
+		],
+		"expected": "dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md bg-amber-900"
+	},
+	{
+		"args": [
+			"bg-blue-100",
+			"bg-blue-400"
+		],
+		"expected": "bg-blue-400"
+	},
+	{
+		"args": [
+			"bg-blue-200",
+			"bg-blue-900"
+		],
+		"expected": "bg-blue-900"
+	},
+	{
+		"args": [
+			"bg-blue-300",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-lg"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-lg"
+	},
+	{
+		"args": [
+			"bg-blue-400",
+			"bg-cyan-300"
+		],
+		"expected": "bg-cyan-300"
+	},
+	{
+		"args": [
+			"bg-blue-50",
+			"bg-cyan-800"
+		],
+		"expected": "bg-cyan-800"
+	},
+	{
+		"args": [
+			"bg-blue-500",
+			"bg-danger-50"
+		],
+		"expected": "bg-danger-50"
+	},
+	{
+		"args": [
+			"bg-blue-500/20",
+			"bg-danger-950"
+		],
+		"expected": "bg-danger-950"
+	},
+	{
+		"args": [
+			"bg-blue-600",
+			"bg-emerald-500"
+		],
+		"expected": "bg-emerald-500"
+	},
+	{
+		"args": [
+			"bg-blue-700",
+			"bg-filled-accent text-white focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover h-9 border border-transparent px-3 text-sm font-medium"
+		],
+		"expected": "bg-filled-accent text-white focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover h-9 border border-transparent px-3 text-sm font-medium"
+	},
+	{
+		"args": [
+			"bg-blue-800",
+			"bg-fuchsia-500"
+		],
+		"expected": "bg-fuchsia-500"
+	},
+	{
+		"args": [
+			"bg-blue-900",
+			"bg-gray-100"
+		],
+		"expected": "bg-gray-100"
+	},
+	{
+		"args": [
+			"bg-blue-950",
+			"bg-gray-600"
+		],
+		"expected": "bg-gray-600"
+	},
+	{
+		"args": [
+			"bg-card fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden",
+			"bg-green-300"
+		],
+		"expected": "fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden bg-green-300"
+	},
+	{
+		"args": [
+			"bg-card h-full min-h-full overflow-y-scroll scrollbar isolate relative",
+			"bg-green-800"
+		],
+		"expected": "h-full min-h-full overflow-y-scroll scrollbar isolate relative bg-green-800"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow",
+			"bg-indigo-400"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow bg-indigo-400"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-2xl",
+			"bg-indigo-900"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-2xl bg-indigo-900"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-inner",
+			"bg-info-500"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-inner bg-info-500"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-lg",
+			"bg-lime-100"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-lg bg-lime-100"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-md",
+			"bg-lime-600"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-md bg-lime-600"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm",
+			"bg-neutral-100"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm bg-neutral-100"
+	},
+	{
+		"args": [
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-xl",
+			"bg-neutral-600"
+		],
+		"expected": "xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-xl bg-neutral-600"
+	},
+	{
+		"args": [
+			"bg-center bg-no-repeat focus:outline-hidden",
+			"bg-orange-300"
+		],
+		"expected": "bg-center bg-no-repeat focus:outline-hidden bg-orange-300"
+	},
+	{
+		"args": [
+			"bg-cyan-100",
+			"bg-orange-800"
+		],
+		"expected": "bg-orange-800"
+	},
+	{
+		"args": [
+			"bg-cyan-200",
+			"bg-pink-400"
+		],
+		"expected": "bg-pink-400"
+	},
+	{
+		"args": [
+			"bg-cyan-300",
+			"bg-pink-900"
+		],
+		"expected": "bg-pink-900"
+	},
+	{
+		"args": [
+			"bg-cyan-400",
+			"bg-purple-200"
+		],
+		"expected": "bg-purple-200"
+	},
+	{
+		"args": [
+			"bg-cyan-50",
+			"bg-purple-700"
+		],
+		"expected": "bg-purple-700"
+	},
+	{
+		"args": [
+			"bg-cyan-500",
+			"bg-red-400"
+		],
+		"expected": "bg-red-400"
+	},
+	{
+		"args": [
+			"bg-cyan-500/20",
+			"bg-red-900"
+		],
+		"expected": "bg-red-900"
+	},
+	{
+		"args": [
+			"bg-cyan-600",
+			"bg-rose-500"
+		],
+		"expected": "bg-rose-500"
+	},
+	{
+		"args": [
+			"bg-cyan-700",
+			"bg-sky-100"
+		],
+		"expected": "bg-sky-100"
+	},
+	{
+		"args": [
+			"bg-cyan-800",
+			"bg-sky-600"
+		],
+		"expected": "bg-sky-600"
+	},
+	{
+		"args": [
+			"bg-cyan-900",
+			"bg-success-100"
+		],
+		"expected": "bg-success-100"
+	},
+	{
+		"args": [
+			"bg-cyan-950",
+			"bg-success-600"
+		],
+		"expected": "bg-success-600"
+	},
+	{
+		"args": [
+			"bg-danger-100",
+			"bg-teal-300"
+		],
+		"expected": "bg-teal-300"
+	},
+	{
+		"args": [
+			"bg-danger-200",
+			"bg-teal-800"
+		],
+		"expected": "bg-teal-800"
+	},
+	{
+		"args": [
+			"bg-danger-300",
+			"bg-violet-300"
+		],
+		"expected": "bg-violet-300"
+	},
+	{
+		"args": [
+			"bg-danger-400",
+			"bg-violet-800"
+		],
+		"expected": "bg-violet-800"
+	},
+	{
+		"args": [
+			"bg-danger-50",
+			"bg-warning-50"
+		],
+		"expected": "bg-warning-50"
+	},
+	{
+		"args": [
+			"bg-danger-500",
+			"bg-warning-950"
+		],
+		"expected": "bg-warning-950"
+	},
+	{
+		"args": [
+			"bg-danger-500/20",
+			"bg-yellow-500"
+		],
+		"expected": "bg-yellow-500"
+	},
+	{
+		"args": [
+			"bg-danger-600",
+			"block"
+		],
+		"expected": "bg-danger-600 block"
+	},
+	{
+		"args": [
+			"bg-danger-700",
+			"border-card bg-card relative rounded-md border"
+		],
+		"expected": "border-card bg-card relative rounded-md border"
+	},
+	{
+		"args": [
+			"bg-danger-800",
+			"border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent"
+		],
+		"expected": "bg-danger-800 border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent"
+	},
+	{
+		"args": [
+			"bg-danger-900",
+			"border-r"
+		],
+		"expected": "bg-danger-900 border-r"
+	},
+	{
+		"args": [
+			"bg-danger-950",
+			"button/button.tsx"
+		],
+		"expected": "bg-danger-950 button/button.tsx"
+	},
+	{
+		"args": [
+			"bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in",
+			"changelog-mdx"
+		],
+		"expected": "bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in changelog-mdx"
+	},
+	{
+		"args": [
+			"bg-emerald-100",
+			"click-state"
+		],
+		"expected": "bg-emerald-100 click-state"
+	},
+	{
+		"args": [
+			"bg-emerald-200",
+			"color:var(--shiki-token-keyword)"
+		],
+		"expected": "bg-emerald-200 color:var(--shiki-token-keyword)"
+	},
+	{
+		"args": [
+			"bg-emerald-300",
+			"command-input-wrapper"
+		],
+		"expected": "bg-emerald-300 command-input-wrapper"
+	},
+	{
+		"args": [
+			"bg-emerald-400",
+			"components/"
+		],
+		"expected": "bg-emerald-400 components/"
+	},
+	{
+		"args": [
+			"bg-emerald-50",
+			"components/button"
+		],
+		"expected": "bg-emerald-50 components/button"
+	},
+	{
+		"args": [
+			"bg-emerald-500",
+			"components/command"
+		],
+		"expected": "bg-emerald-500 components/command"
+	},
+	{
+		"args": [
+			"bg-emerald-500/20",
+			"components/flag"
+		],
+		"expected": "bg-emerald-500/20 components/flag"
+	},
+	{
+		"args": [
+			"bg-emerald-600",
+			"components/label"
+		],
+		"expected": "bg-emerald-600 components/label"
+	},
+	{
+		"args": [
+			"bg-emerald-700",
+			"components/popover"
+		],
+		"expected": "bg-emerald-700 components/popover"
+	},
+	{
+		"args": [
+			"bg-emerald-800",
+			"components/radio-group"
+		],
+		"expected": "bg-emerald-800 components/radio-group"
+	},
+	{
+		"args": [
+			"bg-emerald-900",
+			"components/slider"
+		],
+		"expected": "bg-emerald-900 components/slider"
+	},
+	{
+		"args": [
+			"bg-emerald-950",
+			"components/theme"
+		],
+		"expected": "bg-emerald-950 components/theme"
+	},
+	{
+		"args": [
+			"bg-filled-accent text-white focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover h-9 border border-transparent px-3 text-sm font-medium",
+			"contents"
+		],
+		"expected": "bg-filled-accent text-white focus-visible:ring-focus-accent not-disabled:hover:bg-filled-accent-hover h-9 border border-transparent px-3 text-sm font-medium contents"
+	},
+	{
+		"args": [
+			"bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4",
+			"cursor-pagination-previous"
+		],
+		"expected": "bg-form relative flex w-full items-center gap-1.5 rounded-md border px-3 py-2 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-within:outline-hidden focus-within:ring-4 cursor-pagination-previous"
+	},
+	{
+		"args": [
+			"bg-fuchsia-100",
+			"custom-class"
+		],
+		"expected": "bg-fuchsia-100 custom-class"
+	},
+	{
+		"args": [
+			"bg-fuchsia-200",
+			"dark-high-contrast:border-green-600 dark-high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "dark-high-contrast:border-green-600 dark-high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"bg-fuchsia-300",
+			"data-disabled:cursor-default data-disabled:opacity-50"
+		],
+		"expected": "bg-fuchsia-300 data-disabled:cursor-default data-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"bg-fuchsia-400",
+			"data-highlighted:aria-checked:bg-active-selected-menu-item!"
+		],
+		"expected": "bg-fuchsia-400 data-highlighted:aria-checked:bg-active-selected-menu-item!"
+	},
+	{
+		"args": [
+			"bg-fuchsia-50",
+			"data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95"
+		],
+		"expected": "bg-fuchsia-50 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95"
+	},
+	{
+		"args": [
+			"bg-fuchsia-500",
+			"data-state-closed:slide-out-to-left data-state-open:slide-in-from-left left-0 border-r"
+		],
+		"expected": "bg-fuchsia-500 data-state-closed:slide-out-to-left data-state-open:slide-in-from-left left-0 border-r"
+	},
+	{
+		"args": [
+			"bg-fuchsia-500/20",
+			"data-table-head"
+		],
+		"expected": "bg-fuchsia-500/20 data-table-head"
+	},
+	{
+		"args": [
+			"bg-fuchsia-600",
+			"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger"
+		],
+		"expected": "bg-fuchsia-600 data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger"
+	},
+	{
+		"args": [
+			"bg-fuchsia-700",
+			"data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success"
+		],
+		"expected": "bg-fuchsia-700 data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success"
+	},
+	{
+		"args": [
+			"bg-fuchsia-800",
+			"data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600"
+		],
+		"expected": "bg-fuchsia-800 data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600"
+	},
+	{
+		"args": [
+			"bg-fuchsia-900",
+			"day-range-middle not-disabled:aria-selected:bg-filled-accent/15 aria-selected:text-strong rounded-none not-disabled:aria-selected:hover:bg-filled-accent/25"
+		],
+		"expected": "bg-fuchsia-900 day-range-middle not-disabled:aria-selected:bg-filled-accent/15 aria-selected:text-strong rounded-none not-disabled:aria-selected:hover:bg-filled-accent/25"
+	},
+	{
+		"args": [
+			"bg-fuchsia-950",
+			"dialog-footer-dom-order-migration"
+		],
+		"expected": "bg-fuchsia-950 dialog-footer-dom-order-migration"
+	},
+	{
+		"args": [
+			"bg-gray-100",
+			"dropdown-menu-checkbox-item"
+		],
+		"expected": "bg-gray-100 dropdown-menu-checkbox-item"
+	},
+	{
+		"args": [
+			"bg-gray-200",
+			"dropdown-menu-separator"
+		],
+		"expected": "bg-gray-200 dropdown-menu-separator"
+	},
+	{
+		"args": [
+			"bg-gray-300",
+			"email-input"
+		],
+		"expected": "bg-gray-300 email-input"
+	},
+	{
+		"args": [
+			"bg-gray-400",
+			"european-union"
+		],
+		"expected": "bg-gray-400 european-union"
+	},
+	{
+		"args": [
+			"bg-gray-50",
+			"field-help-content"
+		],
+		"expected": "bg-gray-50 field-help-content"
+	},
+	{
+		"args": [
+			"bg-gray-500",
+			"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md"
+		],
+		"expected": "bg-gray-500 first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md"
+	},
+	{
+		"args": [
+			"bg-gray-500/20",
+			"flex flex-col gap-3"
+		],
+		"expected": "bg-gray-500/20 flex flex-col gap-3"
+	},
+	{
+		"args": [
+			"bg-gray-600",
+			"flex grow flex-col gap-1"
+		],
+		"expected": "bg-gray-600 flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			"bg-gray-700",
+			"flex items-center gap-2 has-disabled:opacity-50"
+		],
+		"expected": "bg-gray-700 flex items-center gap-2 has-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"bg-gray-800",
+			"flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+		],
+		"expected": "bg-gray-800 flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+	},
+	{
+		"args": [
+			"bg-gray-900",
+			"flex w-full flex-col gap-1.5"
+		],
+		"expected": "bg-gray-900 flex w-full flex-col gap-1.5"
+	},
+	{
+		"args": [
+			"bg-gray-950",
+			"flex-col items-end gap-3.5 self-stretch"
+		],
+		"expected": "bg-gray-950 flex-col items-end gap-3.5 self-stretch"
+	},
+	{
+		"args": [
+			"bg-green-100",
+			"focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4"
+		],
+		"expected": "bg-green-100 focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"bg-green-200",
+			"focus:outline-hidden focus-visible:ring-4"
+		],
+		"expected": "bg-green-200 focus:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"bg-green-300",
+			"font-bold"
+		],
+		"expected": "bg-green-300 font-bold"
+	},
+	{
+		"args": [
+			"bg-green-400",
+			"font-mono text-mono p-4 text-xl"
+		],
+		"expected": "bg-green-400 font-mono p-4 text-xl"
+	},
+	{
+		"args": [
+			"bg-green-50",
+			"from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)]"
+		],
+		"expected": "bg-green-50 from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)]"
+	},
+	{
+		"args": [
+			"bg-green-500",
+			"gap-4"
+		],
+		"expected": "bg-green-500 gap-4"
+	},
+	{
+		"args": [
+			"bg-green-500/20",
+			"grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+		],
+		"expected": "bg-green-500/20 grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+	},
+	{
+		"args": [
+			"bg-green-600",
+			"group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong"
+		],
+		"expected": "bg-green-600 group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong"
+	},
+	{
+		"args": [
+			"bg-green-700",
+			"group/dropdown-menu-radio-item"
+		],
+		"expected": "bg-green-700 group/dropdown-menu-radio-item"
+	},
+	{
+		"args": [
+			"bg-green-800",
+			"h-10 w-full rounded bg-neutral-950"
+		],
+		"expected": "h-10 w-full rounded bg-neutral-950"
+	},
+	{
+		"args": [
+			"bg-green-900",
+			"h-9"
+		],
+		"expected": "bg-green-900 h-9"
+	},
+	{
+		"args": [
+			"bg-green-950",
+			"h-full w-px"
+		],
+		"expected": "bg-green-950 h-full w-px"
+	},
+	{
+		"args": [
+			"bg-important-500/20",
+			"hidden md:flex"
+		],
+		"expected": "bg-important-500/20 hidden md:flex"
+	},
+	{
+		"args": [
+			"bg-indigo-100",
+			"horizontal-separator-group"
+		],
+		"expected": "bg-indigo-100 horizontal-separator-group"
+	},
+	{
+		"args": [
+			"bg-indigo-200",
+			"hover:text-emerald-700"
+		],
+		"expected": "bg-indigo-200 hover:text-emerald-700"
+	},
+	{
+		"args": [
+			"bg-indigo-300",
+			"http://ngrok.com/foo"
+		],
+		"expected": "bg-indigo-300 http://ngrok.com/foo"
+	},
+	{
+		"args": [
+			"bg-indigo-400",
+			"https://foo/bar"
+		],
+		"expected": "bg-indigo-400 https://foo/bar"
+	},
+	{
+		"args": [
+			"bg-indigo-50",
+			"https://mantle.ngrok.com"
+		],
+		"expected": "bg-indigo-50 https://mantle.ngrok.com"
+	},
+	{
+		"args": [
+			"bg-indigo-500",
+			"https://mantle.ngrok.com/hooks"
+		],
+		"expected": "bg-indigo-500 https://mantle.ngrok.com/hooks"
+	},
+	{
+		"args": [
+			"bg-indigo-500/20",
+			"https://ngrok.com"
+		],
+		"expected": "bg-indigo-500/20 https://ngrok.com"
+	},
+	{
+		"args": [
+			"bg-indigo-600",
+			"https://ngrok.com/contact"
+		],
+		"expected": "bg-indigo-600 https://ngrok.com/contact"
+	},
+	{
+		"args": [
+			"bg-indigo-700",
+			"https://ngrok.com/docs/integrations"
+		],
+		"expected": "bg-indigo-700 https://ngrok.com/docs/integrations"
+	},
+	{
+		"args": [
+			"bg-indigo-800",
+			"https://ngrok.com/docs/universal-gateway/examples/minecraft"
+		],
+		"expected": "bg-indigo-800 https://ngrok.com/docs/universal-gateway/examples/minecraft"
+	},
+	{
+		"args": [
+			"bg-indigo-900",
+			"https://ngrok.com/newsletter"
+		],
+		"expected": "bg-indigo-900 https://ngrok.com/newsletter"
+	},
+	{
+		"args": [
+			"bg-indigo-950",
+			"https://ngrok.com/tos"
+		],
+		"expected": "bg-indigo-950 https://ngrok.com/tos"
+	},
+	{
+		"args": [
+			"bg-info-100",
+			"https://trust.ngrok.com/"
+		],
+		"expected": "bg-info-100 https://trust.ngrok.com/"
+	},
+	{
+		"args": [
+			"bg-info-200",
+			"if/fi"
+		],
+		"expected": "bg-info-200 if/fi"
+	},
+	{
+		"args": [
+			"bg-info-300",
+			"in-mum-1"
+		],
+		"expected": "bg-info-300 in-mum-1"
+	},
+	{
+		"args": [
+			"bg-info-400",
+			"inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md"
+		],
+		"expected": "bg-info-400 inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md"
+	},
+	{
+		"args": [
+			"bg-info-50",
+			"input/"
+		],
+		"expected": "bg-info-50 input/"
+	},
+	{
+		"args": [
+			"bg-info-500",
+			"jetbrains-mono"
+		],
+		"expected": "bg-info-500 jetbrains-mono"
+	},
+	{
+		"args": [
+			"bg-info-500/20",
+			"lang-"
+		],
+		"expected": "bg-info-500/20 lang-"
+	},
+	{
+		"args": [
+			"bg-info-600",
+			"line-content"
+		],
+		"expected": "bg-info-600 line-content"
+	},
+	{
+		"args": [
+			"bg-info-700",
+			"m-0"
+		],
+		"expected": "bg-info-700 m-0"
+	},
+	{
+		"args": [
+			"bg-info-800",
+			"mantle-code-line-content"
+		],
+		"expected": "bg-info-800 mantle-code-line-content"
+	},
+	{
+		"args": [
+			"bg-info-900",
+			"mantle-light-high-contrast-styles"
+		],
+		"expected": "bg-info-900 mantle-light-high-contrast-styles"
+	},
+	{
+		"args": [
+			"bg-info-950",
+			"max-w-lg"
+		],
+		"expected": "bg-info-950 max-w-lg"
+	},
+	{
+		"args": [
+			"bg-lime-100",
+			"mb-3 text-xs font-medium uppercase tracking-wider font-mono"
+		],
+		"expected": "bg-lime-100 mb-3 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			"bg-lime-200",
+			"media-object-media"
+		],
+		"expected": "bg-lime-200 media-object-media"
+	},
+	{
+		"args": [
+			"bg-lime-300",
+			"min-w-0 flex-1 has-data-alert-dismiss:pr-6"
+		],
+		"expected": "bg-lime-300 min-w-0 flex-1 has-data-alert-dismiss:pr-6"
+	},
+	{
+		"args": [
+			"bg-lime-400",
+			"mt-2 flex flex-col gap-2 overflow-hidden text-xs md:flex-row"
+		],
+		"expected": "bg-lime-400 mt-2 flex flex-col gap-2 overflow-hidden text-xs md:flex-row"
+	},
+	{
+		"args": [
+			"bg-lime-50",
+			"multi-select-tag"
+		],
+		"expected": "bg-lime-50 multi-select-tag"
+	},
+	{
+		"args": [
+			"bg-lime-500",
+			"mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+		],
+		"expected": "bg-lime-500 mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+	},
+	{
+		"args": [
+			"bg-lime-500/20",
+			"not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50"
+		],
+		"expected": "bg-lime-500/20 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"bg-lime-600",
+			"nth-child(odd)"
+		],
+		"expected": "bg-lime-600 nth-child(odd)"
+	},
+	{
+		"args": [
+			"bg-lime-700",
+			"og:type"
+		],
+		"expected": "bg-lime-700 og:type"
+	},
+	{
+		"args": [
+			"bg-lime-800",
+			"options:"
+		],
+		"expected": "bg-lime-800 options:"
+	},
+	{
+		"args": [
+			"bg-lime-900",
+			"overflow-hidden p-0 relative"
+		],
+		"expected": "bg-lime-900 overflow-hidden p-0 relative"
+	},
+	{
+		"args": [
+			"bg-lime-950",
+			"p-4 pb-6 not-a-tailwind-class pb-3"
+		],
+		"expected": "bg-lime-950 p-4 not-a-tailwind-class pb-3"
+	},
+	{
+		"args": [
+			"bg-linear-to-l to-transparent",
+			"password-input"
+		],
+		"expected": "bg-linear-to-l to-transparent password-input"
+	},
+	{
+		"args": [
+			"bg-muted text-muted pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none",
+			"pe-2.5"
+		],
+		"expected": "bg-muted text-muted pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none pe-2.5"
+	},
+	{
+		"args": [
+			"bg-neutral-100",
+			"pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+		],
+		"expected": "bg-neutral-100 pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+	},
+	{
+		"args": [
+			"bg-neutral-200",
+			"pre[data-lang]"
+		],
+		"expected": "bg-neutral-200 pre[data-lang]"
+	},
+	{
+		"args": [
+			"bg-neutral-300",
+			"ps-1"
+		],
+		"expected": "bg-neutral-300 ps-1"
+	},
+	{
+		"args": [
+			"bg-neutral-400",
+			"py-2"
+		],
+		"expected": "bg-neutral-400 py-2"
+	},
+	{
+		"args": [
+			"bg-neutral-50",
+			"radio-group-input-sandbox"
+		],
+		"expected": "bg-neutral-50 radio-group-input-sandbox"
+	},
+	{
+		"args": [
+			"bg-neutral-500",
+			"react-hotkeys-hook"
+		],
+		"expected": "bg-neutral-500 react-hotkeys-hook"
+	},
+	{
+		"args": [
+			"bg-neutral-500/20",
+			"relative flex items-center rounded-md"
+		],
+		"expected": "bg-neutral-500/20 relative flex items-center rounded-md"
+	},
+	{
+		"args": [
+			"bg-neutral-600",
+			"remark-frontmatter"
+		],
+		"expected": "bg-neutral-600 remark-frontmatter"
+	},
+	{
+		"args": [
+			"bg-neutral-700",
+			"root:"
+		],
+		"expected": "bg-neutral-700 root:"
+	},
+	{
+		"args": [
+			"bg-neutral-800",
+			"rounded-sm col-span-full grid grid-cols-subgrid items-center"
+		],
+		"expected": "bg-neutral-800 rounded-sm col-span-full grid grid-cols-subgrid items-center"
+	},
+	{
+		"args": [
+			"bg-neutral-900",
+			"scroll-fade-b h-44 overflow-y-auto"
+		],
+		"expected": "bg-neutral-900 scroll-fade-b h-44 overflow-y-auto"
+	},
+	{
+		"args": [
+			"bg-neutral-950",
+			"scroll-fade-y scrollbar min-h-0 flex-1 overflow-y-auto pb-4"
+		],
+		"expected": "bg-neutral-950 scroll-fade-y scrollbar min-h-0 flex-1 overflow-y-auto pb-4"
+	},
+	{
+		"args": [
+			"bg-orange-100",
+			"select-none font-mono text-sm text-muted"
+		],
+		"expected": "bg-orange-100 select-none font-mono text-sm text-muted"
+	},
+	{
+		"args": [
+			"bg-orange-200",
+			"shadow-inner"
+		],
+		"expected": "bg-orange-200 shadow-inner"
+	},
+	{
+		"args": [
+			"bg-orange-300",
+			"shrink-0 leading-none"
+		],
+		"expected": "bg-orange-300 shrink-0 leading-none"
+	},
+	{
+		"args": [
+			"bg-orange-400",
+			"size-20 sm:size-28"
+		],
+		"expected": "bg-orange-400 size-20 sm:size-28"
+	},
+	{
+		"args": [
+			"bg-orange-50",
+			"size-64"
+		],
+		"expected": "bg-orange-50 size-64"
+	},
+	{
+		"args": [
+			"bg-orange-500",
+			"space-y-1 border-l border-gray-300"
+		],
+		"expected": "bg-orange-500 space-y-1 border-l border-gray-300"
+	},
+	{
+		"args": [
+			"bg-orange-500/20",
+			"split-button"
+		],
+		"expected": "bg-orange-500/20 split-button"
+	},
+	{
+		"args": [
+			"bg-orange-600",
+			"stop-opacity-0 stop-color-current"
+		],
+		"expected": "bg-orange-600 stop-opacity-0 stop-color-current"
+	},
+	{
+		"args": [
+			"bg-orange-700",
+			"tabs-content"
+		],
+		"expected": "bg-orange-700 tabs-content"
+	},
+	{
+		"args": [
+			"bg-orange-800",
+			"text-4xl font-medium text-strong sm:text-5xl font-family mb-4"
+		],
+		"expected": "bg-orange-800 text-4xl font-medium text-strong sm:text-5xl font-family mb-4"
+	},
+	{
+		"args": [
+			"bg-orange-900",
+			"text-accent-600 text-sm font-medium flex-1"
+		],
+		"expected": "bg-orange-900 text-accent-600 text-sm font-medium flex-1"
+	},
+	{
+		"args": [
+			"bg-orange-950",
+			"text-blue-500 no-underline"
+		],
+		"expected": "bg-orange-950 text-blue-500 no-underline"
+	},
+	{
+		"args": [
+			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs",
+			"text-body w-7 text-[0.8rem] text-center font-normal"
+		],
+		"expected": "bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs text-body w-7 text-[0.8rem] text-center font-normal"
+	},
+	{
+		"args": [
+			"bg-pink-100",
+			"text-danger-700 high-contrast:hidden block size-4"
+		],
+		"expected": "bg-pink-100 text-danger-700 high-contrast:hidden block size-4"
+	},
+	{
+		"args": [
+			"bg-pink-200",
+			"text-gold"
+		],
+		"expected": "bg-pink-200 text-gold"
+	},
+	{
+		"args": [
+			"bg-pink-300",
+			"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+		],
+		"expected": "text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+	},
+	{
+		"args": [
+			"bg-pink-400",
+			"text-muted hover:text-strong flex items-center gap-1 font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+		],
+		"expected": "bg-pink-400 text-muted hover:text-strong flex items-center gap-1 font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			"bg-pink-50",
+			"text-muted text-sm font-sans font-medium min-w-36 p-2"
+		],
+		"expected": "bg-pink-50 text-muted text-sm font-sans font-medium min-w-36 p-2"
+	},
+	{
+		"args": [
+			"bg-pink-500",
+			"text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans"
+		],
+		"expected": "text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans"
+	},
+	{
+		"args": [
+			"bg-pink-500/20",
+			"text-red-500"
+		],
+		"expected": "bg-pink-500/20 text-red-500"
+	},
+	{
+		"args": [
+			"bg-pink-600",
+			"text-sm font-medium"
+		],
+		"expected": "bg-pink-600 text-sm font-medium"
+	},
+	{
+		"args": [
+			"bg-pink-700",
+			"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans"
+		],
+		"expected": "bg-pink-700 text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans"
+	},
+	{
+		"args": [
+			"bg-pink-800",
+			"text-strong text-sm font-medium"
+		],
+		"expected": "bg-pink-800 text-strong text-sm font-medium"
+	},
+	{
+		"args": [
+			"bg-pink-900",
+			"text-success-700 hover-hover:block hidden size-4"
+		],
+		"expected": "bg-pink-900 text-success-700 hover-hover:block hidden size-4"
+	},
+	{
+		"args": [
+			"bg-pink-950",
+			"text-xs"
+		],
+		"expected": "bg-pink-950 text-xs"
+	},
+	{
+		"args": [
+			"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden",
+			"tooltip-trigger"
+		],
+		"expected": "bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden tooltip-trigger"
+	},
+	{
+		"args": [
+			"bg-popover flex h-full w-full flex-col overflow-hidden rounded-md",
+			"twitter:image"
+		],
+		"expected": "bg-popover flex h-full w-full flex-col overflow-hidden rounded-md twitter:image"
+	},
+	{
+		"args": [
+			"bg-popover font-sans",
+			"utf-8"
+		],
+		"expected": "bg-popover font-sans utf-8"
+	},
+	{
+		"args": [
+			"bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg",
+			"utils/in-view"
+		],
+		"expected": "bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg utils/in-view"
+	},
+	{
+		"args": [
+			"bg-purple-100",
+			"w-0 flex-1 pb-[80vh] sm:px-8"
+		],
+		"expected": "bg-purple-100 w-0 flex-1 pb-[80vh] sm:px-8"
+	},
+	{
+		"args": [
+			"bg-purple-200",
+			"w-em"
+		],
+		"expected": "bg-purple-200 w-em"
+	},
+	{
+		"args": [
+			"bg-purple-300",
+			"-inset-y-px"
+		],
+		"expected": "bg-purple-300 -inset-y-px"
+	},
+	{
+		"args": [
+			"bg-purple-400",
+			"@ariakit/react"
+		],
+		"expected": "bg-purple-400 @ariakit/react"
+	},
+	{
+		"args": [
+			"bg-purple-50",
+			"@ngrok/mantle/alert"
+		],
+		"expected": "bg-purple-50 @ngrok/mantle/alert"
+	},
+	{
+		"args": [
+			"bg-purple-500",
+			"@ngrok/mantle/card"
+		],
+		"expected": "bg-purple-500 @ngrok/mantle/card"
+	},
+	{
+		"args": [
+			"bg-purple-500/20",
+			"@ngrok/mantle/description-list"
+		],
+		"expected": "bg-purple-500/20 @ngrok/mantle/description-list"
+	},
+	{
+		"args": [
+			"bg-purple-600",
+			"@ngrok/mantle/input"
+		],
+		"expected": "bg-purple-600 @ngrok/mantle/input"
+	},
+	{
+		"args": [
+			"bg-purple-700",
+			"@ngrok/mantle/media-object"
+		],
+		"expected": "bg-purple-700 @ngrok/mantle/media-object"
+	},
+	{
+		"args": [
+			"bg-purple-800",
+			"@ngrok/mantle/sheet"
+		],
+		"expected": "bg-purple-800 @ngrok/mantle/sheet"
+	},
+	{
+		"args": [
+			"bg-purple-900",
+			"@ngrok/mantle/text-area"
+		],
+		"expected": "bg-purple-900 @ngrok/mantle/text-area"
+	},
+	{
+		"args": [
+			"bg-purple-950",
+			"@phosphor-icons/react"
+		],
+		"expected": "bg-purple-950 @phosphor-icons/react"
+	},
+	{
+		"args": [
+			"bg-red-100",
+			"@phosphor-icons/react/CheckCircle"
+		],
+		"expected": "bg-red-100 @phosphor-icons/react/CheckCircle"
+	},
+	{
+		"args": [
+			"bg-red-200",
+			"@phosphor-icons/react/FileText"
+		],
+		"expected": "bg-red-200 @phosphor-icons/react/FileText"
+	},
+	{
+		"args": [
+			"bg-red-300",
+			"@phosphor-icons/react/MagnifyingGlass"
+		],
+		"expected": "bg-red-300 @phosphor-icons/react/MagnifyingGlass"
+	},
+	{
+		"args": [
+			"bg-red-400",
+			"@phosphor-icons/react/SmileyMelting"
+		],
+		"expected": "bg-red-400 @phosphor-icons/react/SmileyMelting"
+	},
+	{
+		"args": [
+			"bg-red-50",
+			"@phosphor-icons/react/Tray"
+		],
+		"expected": "bg-red-50 @phosphor-icons/react/Tray"
+	},
+	{
+		"args": [
+			"bg-red-500",
+			"@radix-ui/react-hover-card"
+		],
+		"expected": "bg-red-500 @radix-ui/react-hover-card"
+	},
+	{
+		"args": [
+			"bg-red-500/20",
+			"@radix-ui/react-tabs"
+		],
+		"expected": "bg-red-500/20 @radix-ui/react-tabs"
+	},
+	{
+		"args": [
+			"bg-red-600",
+			"@tanstack/react-table"
+		],
+		"expected": "bg-red-600 @tanstack/react-table"
+	},
+	{
+		"args": [
+			"bg-red-700",
+			"BQ-SE"
+		],
+		"expected": "bg-red-700 BQ-SE"
+	},
+	{
+		"args": [
+			"bg-red-800",
+			"GB-UKM"
+		],
+		"expected": "bg-red-800 GB-UKM"
+	},
+	{
+		"args": [
+			"bg-red-900",
+			"Sort-alphanumeric-asc"
+		],
+		"expected": "bg-red-900 Sort-alphanumeric-asc"
+	},
+	{
+		"args": [
+			"bg-red-950",
+			"Theme-Icon-Light-High-Contrast"
+		],
+		"expected": "bg-red-950 Theme-Icon-Light-High-Contrast"
+	},
+	{
+		"args": [
+			"bg-rose-100",
+			"absolute inset-0 border border-[#000]/10"
+		],
+		"expected": "bg-rose-100 absolute inset-0 border border-[#000]/10"
+	},
+	{
+		"args": [
+			"bg-rose-200",
+			"accent-600"
+		],
+		"expected": "bg-rose-200 accent-600"
+	},
+	{
+		"args": [
+			"bg-rose-300",
+			"alert-content"
+		],
+		"expected": "bg-rose-300 alert-content"
+	},
+	{
+		"args": [
+			"bg-rose-400",
+			"animate-spin"
+		],
+		"expected": "bg-rose-400 animate-spin"
+	},
+	{
+		"args": [
+			"bg-rose-50",
+			"api-search-index-json"
+		],
+		"expected": "bg-rose-50 api-search-index-json"
+	},
+	{
+		"args": [
+			"bg-rose-500",
+			"api/search-index.json"
+		],
+		"expected": "bg-rose-500 api/search-index.json"
+	},
+	{
+		"args": [
+			"bg-rose-500/20",
+			"aria-*"
+		],
+		"expected": "bg-rose-500/20 aria-*"
+	},
+	{
+		"args": [
+			"bg-rose-600",
+			"aria-disabled"
+		],
+		"expected": "bg-rose-600 aria-disabled"
+	},
+	{
+		"args": [
+			"bg-rose-700",
+			"aria-orientation"
+		],
+		"expected": "bg-rose-700 aria-orientation"
+	},
+	{
+		"args": [
+			"bg-rose-800",
+			"base/scroll-fade"
+		],
+		"expected": "bg-rose-800 base/scroll-fade"
+	},
+	{
+		"args": [
+			"bg-rose-900",
+			"bg-accent-200"
+		],
+		"expected": "bg-accent-200"
+	},
+	{
+		"args": [
+			"bg-rose-950",
+			"bg-accent-600 h-full w-full flex-1 transition-all"
+		],
+		"expected": "bg-accent-600 h-full w-full flex-1 transition-all"
+	},
+	{
+		"args": [
+			"bg-sky-100",
+			"bg-amber-300"
+		],
+		"expected": "bg-amber-300"
+	},
+	{
+		"args": [
+			"bg-sky-200",
+			"bg-amber-800"
+		],
+		"expected": "bg-amber-800"
+	},
+	{
+		"args": [
+			"bg-sky-300",
+			"bg-blue-300"
+		],
+		"expected": "bg-blue-300"
+	},
+	{
+		"args": [
+			"bg-sky-400",
+			"bg-blue-800"
+		],
+		"expected": "bg-blue-800"
+	},
+	{
+		"args": [
+			"bg-sky-50",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-inner"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-inner"
+	},
+	{
+		"args": [
+			"bg-sky-500",
+			"bg-cyan-200"
+		],
+		"expected": "bg-cyan-200"
+	},
+	{
+		"args": [
+			"bg-sky-500/20",
+			"bg-cyan-700"
+		],
+		"expected": "bg-cyan-700"
+	},
+	{
+		"args": [
+			"bg-sky-600",
+			"bg-danger-400"
+		],
+		"expected": "bg-danger-400"
+	},
+	{
+		"args": [
+			"bg-sky-700",
+			"bg-danger-900"
+		],
+		"expected": "bg-danger-900"
+	},
+	{
+		"args": [
+			"bg-sky-800",
+			"bg-emerald-50"
+		],
+		"expected": "bg-emerald-50"
+	},
+	{
+		"args": [
+			"bg-sky-900",
+			"bg-emerald-950"
+		],
+		"expected": "bg-emerald-950"
+	},
+	{
+		"args": [
+			"bg-sky-950",
+			"bg-fuchsia-50"
+		],
+		"expected": "bg-fuchsia-50"
+	},
+	{
+		"args": [
+			"bg-static-white",
+			"bg-fuchsia-950"
+		],
+		"expected": "bg-fuchsia-950"
+	},
+	{
+		"args": [
+			"bg-strong h-4 w-px animate-pulse",
+			"bg-gray-500/20"
+		],
+		"expected": "h-4 w-px animate-pulse bg-gray-500/20"
+	},
+	{
+		"args": [
+			"bg-success-100",
+			"bg-green-200"
+		],
+		"expected": "bg-green-200"
+	},
+	{
+		"args": [
+			"bg-success-200",
+			"bg-green-700"
+		],
+		"expected": "bg-green-700"
+	},
+	{
+		"args": [
+			"bg-success-300",
+			"bg-indigo-300"
+		],
+		"expected": "bg-indigo-300"
+	},
+	{
+		"args": [
+			"bg-success-400",
+			"bg-indigo-800"
+		],
+		"expected": "bg-indigo-800"
+	},
+	{
+		"args": [
+			"bg-success-50",
+			"bg-info-50"
+		],
+		"expected": "bg-info-50"
+	},
+	{
+		"args": [
+			"bg-success-500",
+			"bg-info-950"
+		],
+		"expected": "bg-info-950"
+	},
+	{
+		"args": [
+			"bg-success-500/20",
+			"bg-lime-500/20"
+		],
+		"expected": "bg-lime-500/20"
+	},
+	{
+		"args": [
+			"bg-success-600",
+			"bg-muted text-muted pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none"
+		],
+		"expected": "bg-muted text-muted pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none"
+	},
+	{
+		"args": [
+			"bg-success-700",
+			"bg-neutral-500/20"
+		],
+		"expected": "bg-neutral-500/20"
+	},
+	{
+		"args": [
+			"bg-success-800",
+			"bg-orange-200"
+		],
+		"expected": "bg-orange-200"
+	},
+	{
+		"args": [
+			"bg-success-900",
+			"bg-orange-700"
+		],
+		"expected": "bg-orange-700"
+	},
+	{
+		"args": [
+			"bg-success-950",
+			"bg-pink-300"
+		],
+		"expected": "bg-pink-300"
+	},
+	{
+		"args": [
+			"bg-teal-100",
+			"bg-pink-800"
+		],
+		"expected": "bg-pink-800"
+	},
+	{
+		"args": [
+			"bg-teal-200",
+			"bg-purple-100"
+		],
+		"expected": "bg-purple-100"
+	},
+	{
+		"args": [
+			"bg-teal-300",
+			"bg-purple-600"
+		],
+		"expected": "bg-purple-600"
+	},
+	{
+		"args": [
+			"bg-teal-400",
+			"bg-red-300"
+		],
+		"expected": "bg-red-300"
+	},
+	{
+		"args": [
+			"bg-teal-50",
+			"bg-red-800"
+		],
+		"expected": "bg-red-800"
+	},
+	{
+		"args": [
+			"bg-teal-500",
+			"bg-rose-50"
+		],
+		"expected": "bg-rose-50"
+	},
+	{
+		"args": [
+			"bg-teal-500/20",
+			"bg-rose-950"
+		],
+		"expected": "bg-rose-950"
+	},
+	{
+		"args": [
+			"bg-teal-600",
+			"bg-sky-500/20"
+		],
+		"expected": "bg-sky-500/20"
+	},
+	{
+		"args": [
+			"bg-teal-700",
+			"bg-strong h-4 w-px animate-pulse"
+		],
+		"expected": "bg-strong h-4 w-px animate-pulse"
+	},
+	{
+		"args": [
+			"bg-teal-800",
+			"bg-success-500/20"
+		],
+		"expected": "bg-success-500/20"
+	},
+	{
+		"args": [
+			"bg-teal-900",
+			"bg-teal-200"
+		],
+		"expected": "bg-teal-200"
+	},
+	{
+		"args": [
+			"bg-teal-950",
+			"bg-teal-700"
+		],
+		"expected": "bg-teal-700"
+	},
+	{
+		"args": [
+			"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow",
+			"bg-violet-200"
+		],
+		"expected": "text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow bg-violet-200"
+	},
+	{
+		"args": [
+			"bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs",
+			"bg-violet-700"
+		],
+		"expected": "z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs bg-violet-700"
+	},
+	{
+		"args": [
+			"bg-violet-100",
+			"bg-warning-400"
+		],
+		"expected": "bg-warning-400"
+	},
+	{
+		"args": [
+			"bg-violet-200",
+			"bg-warning-900"
+		],
+		"expected": "bg-warning-900"
+	},
+	{
+		"args": [
+			"bg-violet-300",
+			"bg-yellow-50"
+		],
+		"expected": "bg-yellow-50"
+	},
+	{
+		"args": [
+			"bg-violet-400",
+			"bg-yellow-950"
+		],
+		"expected": "bg-yellow-950"
+	},
+	{
+		"args": [
+			"bg-violet-50",
+			"border-accent-600 ring-focus-accent ring-4"
+		],
+		"expected": "bg-violet-50 border-accent-600 ring-focus-accent ring-4"
+	},
+	{
+		"args": [
+			"bg-violet-500",
+			"border-form inline-flex items-center rounded-md"
+		],
+		"expected": "bg-violet-500 border-form inline-flex items-center rounded-md"
+	},
+	{
+		"args": [
+			"bg-violet-500/20",
+			"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md"
+		],
+		"expected": "bg-violet-500/20 border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md"
+	},
+	{
+		"args": [
+			"bg-violet-600",
+			"button/"
+		],
+		"expected": "bg-violet-600 button/"
+	},
+	{
+		"args": [
+			"bg-violet-700",
+			"changelog-md"
+		],
+		"expected": "bg-violet-700 changelog-md"
+	},
+	{
+		"args": [
+			"bg-violet-800",
+			"class-variance-authority"
+		],
+		"expected": "bg-violet-800 class-variance-authority"
+	},
+	{
+		"args": [
+			"bg-violet-900",
+			"color:var(--shiki-token-escape, var(--shiki-token-constant))"
+		],
+		"expected": "bg-violet-900 color:var(--shiki-token-escape, var(--shiki-token-constant))"
+	},
+	{
+		"args": [
+			"bg-violet-950",
+			"command-input"
+		],
+		"expected": "bg-violet-950 command-input"
+	},
+	{
+		"args": [
+			"bg-warning-100",
+			"commit-sha"
+		],
+		"expected": "bg-warning-100 commit-sha"
+	},
+	{
+		"args": [
+			"bg-warning-200",
+			"components/browser-only"
+		],
+		"expected": "bg-warning-200 components/browser-only"
+	},
+	{
+		"args": [
+			"bg-warning-300",
+			"components/combobox"
+		],
+		"expected": "bg-warning-300 components/combobox"
+	},
+	{
+		"args": [
+			"bg-warning-400",
+			"components/field"
+		],
+		"expected": "bg-warning-400 components/field"
+	},
+	{
+		"args": [
+			"bg-warning-50",
+			"components/kbd"
+		],
+		"expected": "bg-warning-50 components/kbd"
+	},
+	{
+		"args": [
+			"bg-warning-500",
+			"components/password-input"
+		],
+		"expected": "bg-warning-500 components/password-input"
+	},
+	{
+		"args": [
+			"bg-warning-500/20",
+			"components/qr-code"
+		],
+		"expected": "bg-warning-500/20 components/qr-code"
+	},
+	{
+		"args": [
+			"bg-warning-600",
+			"components/skip-to-main-link"
+		],
+		"expected": "bg-warning-600 components/skip-to-main-link"
+	},
+	{
+		"args": [
+			"bg-warning-700",
+			"components/text-area"
+		],
+		"expected": "bg-warning-700 components/text-area"
+	},
+	{
+		"args": [
+			"bg-warning-800",
+			"content-length"
+		],
+		"expected": "bg-warning-800 content-length"
+	},
+	{
+		"args": [
+			"bg-warning-900",
+			"cursor-pagination-next"
+		],
+		"expected": "bg-warning-900 cursor-pagination-next"
+	},
+	{
+		"args": [
+			"bg-warning-950",
+			"cursor-wait"
+		],
+		"expected": "bg-warning-950 cursor-wait"
+	},
+	{
+		"args": [
+			"bg-white border-card flex flex-col items-center justify-center gap-2 rounded border p-6 text-black",
+			"dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10"
+		],
+		"expected": "border-card flex flex-col items-center justify-center gap-2 border p-6 text-black dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10"
+	},
+	{
+		"args": [
+			"bg-yellow-100",
+			"data-disabled"
+		],
+		"expected": "bg-yellow-100 data-disabled"
+	},
+	{
+		"args": [
+			"bg-yellow-200",
+			"data-folded-regions"
+		],
+		"expected": "bg-yellow-200 data-folded-regions"
+	},
+	{
+		"args": [
+			"bg-yellow-300",
+			"data-priority"
+		],
+		"expected": "bg-yellow-300 data-priority"
+	},
+	{
+		"args": [
+			"bg-yellow-400",
+			"data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4"
+		],
+		"expected": "bg-yellow-400 data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4"
+	},
+	{
+		"args": [
+			"bg-yellow-50",
+			"data-table-empty-row"
+		],
+		"expected": "bg-yellow-50 data-table-empty-row"
+	},
+	{
+		"args": [
+			"bg-yellow-500",
+			"data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+		],
+		"expected": "bg-yellow-500 data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			"bg-yellow-500/20",
+			"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success"
+		],
+		"expected": "bg-yellow-500/20 data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success"
+	},
+	{
+		"args": [
+			"bg-yellow-600",
+			"data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning"
+		],
+		"expected": "bg-yellow-600 data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning"
+	},
+	{
+		"args": [
+			"bg-yellow-700",
+			"day-outside aria-selected:text-on-filled opacity-50 text-muted"
+		],
+		"expected": "bg-yellow-700 day-outside aria-selected:text-on-filled opacity-50 text-muted"
+	},
+	{
+		"args": [
+			"bg-yellow-800",
+			"description-list-value"
+		],
+		"expected": "bg-yellow-800 description-list-value"
+	},
+	{
+		"args": [
+			"bg-yellow-900",
+			"docs-index-md"
+		],
+		"expected": "bg-yellow-900 docs-index-md"
+	},
+	{
+		"args": [
+			"bg-yellow-950",
+			"dropdown-menu-radio-item"
+		],
+		"expected": "bg-yellow-950 dropdown-menu-radio-item"
+	},
+	{
+		"args": [
+			"block",
+			"ease-out"
+		],
+		"expected": "block ease-out"
+	},
+	{
+		"args": [
+			"blocks/",
+			"en-US"
+		],
+		"expected": "blocks/ en-US"
+	},
+	{
+		"args": [
+			"border-0",
+			"field-group"
+		],
+		"expected": "border-0 field-group"
+	},
+	{
+		"args": [
+			"border-accent-600",
+			"first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md"
+		],
+		"expected": "border-accent-600 first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md"
+	},
+	{
+		"args": [
+			"border-accent-600 bg-accent-600",
+			"flex flex-col gap-2"
+		],
+		"expected": "border-accent-600 bg-accent-600 flex flex-col gap-2"
+	},
+	{
+		"args": [
+			"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border px-3 text-sm font-medium",
+			"flex gap-4"
+		],
+		"expected": "border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border px-3 text-sm font-medium flex gap-4"
+	},
+	{
+		"args": [
+			"border-accent-600 ring-focus-accent ring-4",
+			"flex items-center gap-2"
+		],
+		"expected": "border-accent-600 ring-focus-accent ring-4 flex items-center gap-2"
+	},
+	{
+		"args": [
+			"border-card bg-card relative rounded-md border",
+			"flex items-center rounded justify-between gap-4 bg-accent-600/10 p-4 m-1"
+		],
+		"expected": "border-card relative border flex items-center rounded justify-between gap-4 bg-accent-600/10 p-4 m-1"
+	},
+	{
+		"args": [
+			"border-card rounded-md border p-2 shadow-md",
+			"flex min-w-0 flex-1 items-center justify-between gap-2"
+		],
+		"expected": "border-card rounded-md border p-2 shadow-md flex min-w-0 flex-1 items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			"border-card-muted bg-base relative rounded-md border shadow-inner",
+			"flex-col"
+		],
+		"expected": "border-card-muted bg-base relative rounded-md border shadow-inner flex-col"
+	},
+	{
+		"args": [
+			"border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50",
+			"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4"
+		],
+		"expected": "border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50 focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600",
+			"focus:outline-hidden"
+		],
+		"expected": "border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600 focus:outline-hidden"
+	},
+	{
+		"args": [
+			"border-form flex size-4 items-center justify-center rounded-full border shrink-0",
+			"font-body text-body mt-3"
+		],
+		"expected": "border-form flex size-4 items-center justify-center rounded-full border shrink-0 font-body text-body mt-3"
+	},
+	{
+		"args": [
+			"border-form inline-flex items-center rounded-md",
+			"font-mono p-4 text-xl"
+		],
+		"expected": "border-form inline-flex items-center rounded-md font-mono p-4 text-xl"
+	},
+	{
+		"args": [
+			"border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent",
+			"for/done"
+		],
+		"expected": "border-form text-strong focus-within:border-accent-600 focus-within:ring-focus-accent for/done"
+	},
+	{
+		"args": [
+			"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600",
+			"gap-2"
+		],
+		"expected": "border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600 gap-2"
+	},
+	{
+		"args": [
+			"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]",
+			"grid grid-cols-4 gap-2"
+		],
+		"expected": "border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em] grid grid-cols-4 gap-2"
+	},
+	{
+		"args": [
+			"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
+			"group-data-*"
+		],
+		"expected": "border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50 group-data-*"
+	},
+	{
+		"args": [
+			"border-l",
+			"group-hover/tab-trigger:group-enabled/tab-trigger:text-gray-700"
+		],
+		"expected": "border-l group-hover/tab-trigger:group-enabled/tab-trigger:text-gray-700"
+	},
+	{
+		"args": [
+			"border-neutral-500/50 bg-neutral-500/10 text-neutral-700",
+			"h-10 w-full rounded"
+		],
+		"expected": "border-neutral-500/50 bg-neutral-500/10 text-neutral-700 h-10 w-full rounded"
+	},
+	{
+		"args": [
+			"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
+			"h-72 w-full overflow-y-scroll overscroll-contain"
+		],
+		"expected": "border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md h-72 w-full overflow-y-scroll overscroll-contain"
+	},
+	{
+		"args": [
+			"border-r",
+			"h-full w-full block object-cover"
+		],
+		"expected": "border-r h-full w-full block object-cover"
+	},
+	{
+		"args": [
+			"border-r border-gray-200",
+			"hidden"
+		],
+		"expected": "border-r border-gray-200 hidden"
+	},
+	{
+		"args": [
+			"border-x-0 border-t-0 rounded-none z-50 sticky",
+			"highlight-utils"
+		],
+		"expected": "border-x-0 border-t-0 rounded-none z-50 sticky highlight-utils"
+	},
+	{
+		"args": [
+			"br-sao-1",
+			"hover:text-danger-700"
+		],
+		"expected": "br-sao-1 hover:text-danger-700"
+	},
+	{
+		"args": [
+			"build/server/...",
+			"http://localhost:4444"
+		],
+		"expected": "build/server/... http://localhost:4444"
+	},
+	{
+		"args": [
+			"button-group",
+			"https://example.com"
+		],
+		"expected": "button-group https://example.com"
+	},
+	{
+		"args": [
+			"button/",
+			"https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0"
+		],
+		"expected": "button/ https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0"
+	},
+	{
+		"args": [
+			"button/button.tsx",
+			"https://mantle.ngrok.com/components/zed.md"
+		],
+		"expected": "button/button.tsx https://mantle.ngrok.com/components/zed.md"
+	},
+	{
+		"args": [
+			"card-body",
+			"https://ngrok.ai/"
+		],
+		"expected": "card-body https://ngrok.ai/"
+	},
+	{
+		"args": [
+			"card-footer",
+			"https://ngrok.com/careers"
+		],
+		"expected": "card-footer https://ngrok.com/careers"
+	},
+	{
+		"args": [
+			"card-header",
+			"https://ngrok.com/docs/guides/ssh-rdp"
+		],
+		"expected": "card-header https://ngrok.com/docs/guides/ssh-rdp"
+	},
+	{
+		"args": [
+			"card-title",
+			"https://ngrok.com/docs/universal-gateway/examples/ephemeral-workloads"
+		],
+		"expected": "card-title https://ngrok.com/docs/universal-gateway/examples/ephemeral-workloads"
+	},
+	{
+		"args": [
+			"catch-all",
+			"https://ngrok.com/foo"
+		],
+		"expected": "catch-all https://ngrok.com/foo"
+	},
+	{
+		"args": [
+			"changelog-md",
+			"https://ngrok.com/support"
+		],
+		"expected": "changelog-md https://ngrok.com/support"
+	},
+	{
+		"args": [
+			"changelog-mdx",
+			"https://status.ngrok.com/api/v2/status.json"
+		],
+		"expected": "changelog-mdx https://status.ngrok.com/api/v2/status.json"
+	},
+	{
+		"args": [
+			"checked:border-accent-600 checked:bg-accent-600 checked:bg-checked-icon",
+			"icon-search"
+		],
+		"expected": "checked:border-accent-600 checked:bg-checked-icon icon-search"
+	},
+	{
+		"args": [
+			"child-class",
+			"ignored-trigger"
+		],
+		"expected": "child-class ignored-trigger"
+	},
+	{
+		"args": [
+			"child-error",
+			"inline-flex items-center justify-between gap-2"
+		],
+		"expected": "child-error inline-flex items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			"child-help",
+			"input-otp"
+		],
+		"expected": "child-help input-otp"
+	},
+	{
+		"args": [
+			"child-only-class",
+			"javascript:…"
+		],
+		"expected": "child-only-class javascript:…"
+	},
+	{
+		"args": [
+			"class-variance-authority",
+			"label-row-child"
+		],
+		"expected": "class-variance-authority label-row-child"
+	},
+	{
+		"args": [
+			"click-state",
+			"light-high-contrast"
+		],
+		"expected": "click-state light-high-contrast"
+	},
+	{
+		"args": [
+			"code-block",
+			"localhost:9090"
+		],
+		"expected": "code-block localhost:9090"
+	},
+	{
+		"args": [
+			"code-block-body",
+			"mantle-code-line"
+		],
+		"expected": "code-block-body mantle-code-line"
+	},
+	{
+		"args": [
+			"code-block-code",
+			"mantle-dark.css"
+		],
+		"expected": "code-block-code mantle-dark.css"
+	},
+	{
+		"args": [
+			"code-block-migration",
+			"max-w-72"
+		],
+		"expected": "code-block-migration max-w-72"
+	},
+	{
+		"args": [
+			"cody-dot-js",
+			"mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+		],
+		"expected": "cody-dot-js mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			"color:var(--shiki-token-escape, var(--shiki-token-constant))",
+			"media-object-content"
+		],
+		"expected": "color:var(--shiki-token-escape, var(--shiki-token-constant)) media-object-content"
+	},
+	{
+		"args": [
+			"color:var(--shiki-token-keyword)",
+			"min-w-0 flex-1"
+		],
+		"expected": "color:var(--shiki-token-keyword) min-w-0 flex-1"
+	},
+	{
+		"args": [
+			"color:var(--shiki-token-string-expression)",
+			"mt-2 flex flex-col"
+		],
+		"expected": "color:var(--shiki-token-string-expression) mt-2 flex flex-col"
+	},
+	{
+		"args": [
+			"combobox-item-value",
+			"mt-8 text-xl font-medium capitalize"
+		],
+		"expected": "combobox-item-value mt-8 text-xl font-medium capitalize"
+	},
+	{
+		"args": [
+			"combobox-separator",
+			"mx-auto max-w-full overflow-x-auto rounded-md bg-gray-100 p-4 text-left text-xs text-body"
+		],
+		"expected": "combobox-separator mx-auto max-w-full overflow-x-auto rounded-md bg-gray-100 p-4 text-left text-xs text-body"
+	},
+	{
+		"args": [
+			"command-empty",
+			"node:stream"
+		],
+		"expected": "command-empty node:stream"
+	},
+	{
+		"args": [
+			"command-group",
+			"not-found"
+		],
+		"expected": "command-group not-found"
+	},
+	{
+		"args": [
+			"command-input",
+			"og:title"
+		],
+		"expected": "command-input og:title"
+	},
+	{
+		"args": [
+			"command-input-wrapper",
+			"opacity-75"
+		],
+		"expected": "command-input-wrapper opacity-75"
+	},
+	{
+		"args": [
+			"command-item",
+			"otp-input-slot"
+		],
+		"expected": "command-item otp-input-slot"
+	},
+	{
+		"args": [
+			"command-list",
+			"p-4 not-a-tailwind-class pb-3"
+		],
+		"expected": "command-list p-4 not-a-tailwind-class pb-3"
+	},
+	{
+		"args": [
+			"command-separator",
+			"packages/mantle/src"
+		],
+		"expected": "command-separator packages/mantle/src"
+	},
+	{
+		"args": [
+			"command-shortcut",
+			"pb-8 pb-6"
+		],
+		"expected": "command-shortcut pb-6"
+	},
+	{
+		"args": [
+			"comment.line.double-slash.js",
+			"pointer-coarse:border-green-600 pointer-coarse:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "comment.line.double-slash.js pointer-coarse:border-green-600 pointer-coarse:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"commit-sha",
+			"pointer-none:border-green-600 pointer-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "commit-sha pointer-none:border-green-600 pointer-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"components/",
+			"progress-donut-indicator"
+		],
+		"expected": "components/ progress-donut-indicator"
+	},
+	{
+		"args": [
+			"components/alert",
+			"py-12 sm:py-20 px-4 flex justify-center"
+		],
+		"expected": "components/alert py-12 sm:py-20 px-4 flex justify-center"
+	},
+	{
+		"args": [
+			"components/alert-dialog",
+			"radio-group-button"
+		],
+		"expected": "components/alert-dialog radio-group-button"
+	},
+	{
+		"args": [
+			"components/alpha",
+			"react-dom/server"
+		],
+		"expected": "components/alpha react-dom/server"
+	},
+	{
+		"args": [
+			"components/anchor",
+			"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden"
+		],
+		"expected": "components/anchor relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden"
+	},
+	{
+		"args": [
+			"components/badge",
+			"relative ml-auto max-w-full"
+		],
+		"expected": "components/badge relative ml-auto max-w-full"
+	},
+	{
+		"args": [
+			"components/browser-only",
+			"robots-txt"
+		],
+		"expected": "components/browser-only robots-txt"
+	},
+	{
+		"args": [
+			"components/button",
+			"rounded-full size-5"
+		],
+		"expected": "components/button rounded-full size-5"
+	},
+	{
+		"args": [
+			"components/card",
+			"scroll-behavior"
+		],
+		"expected": "components/card scroll-behavior"
+	},
+	{
+		"args": [
+			"components/checkbox",
+			"scroll-fade-y scrollbar h-full overflow-auto overscroll-contain px-1"
+		],
+		"expected": "components/checkbox scroll-fade-y scrollbar h-full overflow-auto overscroll-contain px-1"
+	},
+	{
+		"args": [
+			"components/code",
+			"select-item"
+		],
+		"expected": "components/code select-item"
+	},
+	{
+		"args": [
+			"components/code-block",
+			"shadow-2xl"
+		],
+		"expected": "components/code-block shadow-2xl"
+	},
+	{
+		"args": [
+			"components/code-block/folding-by-language",
+			"shrink-0"
+		],
+		"expected": "components/code-block/folding-by-language shrink-0"
+	},
+	{
+		"args": [
+			"components/combobox",
+			"size-2 rounded-full bg-white shrink-0"
+		],
+		"expected": "components/combobox size-2 rounded-full bg-white shrink-0"
+	},
+	{
+		"args": [
+			"components/command",
+			"size-6"
+		],
+		"expected": "components/command size-6"
+	},
+	{
+		"args": [
+			"components/data-table",
+			"space-y-1"
+		],
+		"expected": "components/data-table space-y-1"
+	},
+	{
+		"args": [
+			"components/description-list",
+			"space-y-px"
+		],
+		"expected": "components/description-list space-y-px"
+	},
+	{
+		"args": [
+			"components/dialog",
+			"sticky z-10 right-0 bg-inherit"
+		],
+		"expected": "components/dialog sticky z-10 right-0 bg-inherit"
+	},
+	{
+		"args": [
+			"components/dropdown-menu",
+			"tabs-badge"
+		],
+		"expected": "components/dropdown-menu tabs-badge"
+	},
+	{
+		"args": [
+			"components/empty",
+			"text-4xl font-medium sm:text-5xl font-family"
+		],
+		"expected": "components/empty text-4xl font-medium sm:text-5xl font-family"
+	},
+	{
+		"args": [
+			"components/field",
+			"text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+		],
+		"expected": "components/field text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+	},
+	{
+		"args": [
+			"components/flag",
+			"text-blue-500"
+		],
+		"expected": "components/flag text-blue-500"
+	},
+	{
+		"args": [
+			"components/hover-card",
+			"text-body text-sm leading-4"
+		],
+		"expected": "components/hover-card text-body text-sm leading-4"
+	},
+	{
+		"args": [
+			"components/icon",
+			"text-danger-700 dark-high-contrast:hidden block size-4"
+		],
+		"expected": "components/icon text-danger-700 dark-high-contrast:hidden block size-4"
+	},
+	{
+		"args": [
+			"components/icon-button",
+			"text-emerald-600"
+		],
+		"expected": "components/icon-button text-emerald-600"
+	},
+	{
+		"args": [
+			"components/icons",
+			"text-mono text-base"
+		],
+		"expected": "components/icons text-base"
+	},
+	{
+		"args": [
+			"components/input",
+			"text-muted hover:text-strong block py-1 rounded focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "components/input text-muted hover:text-strong block py-1 rounded focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"components/kbd",
+			"text-muted text-sm"
+		],
+		"expected": "components/kbd text-muted text-sm"
+	},
+	{
+		"args": [
+			"components/label",
+			"text-placeholder"
+		],
+		"expected": "components/label text-placeholder"
+	},
+	{
+		"args": [
+			"components/main",
+			"text-red mb-2 text-xl"
+		],
+		"expected": "components/main text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			"components/media-object",
+			"text-sm"
+		],
+		"expected": "components/media-object text-sm"
+	},
+	{
+		"args": [
+			"components/multi-select",
+			"text-strong"
+		],
+		"expected": "components/multi-select text-strong"
+	},
+	{
+		"args": [
+			"components/otp-input",
+			"text-strong text-base font-medium"
+		],
+		"expected": "components/otp-input text-strong text-base font-medium"
+	},
+	{
+		"args": [
+			"components/pagination",
+			"text-success-700 high-contrast:block hidden size-4"
+		],
+		"expected": "components/pagination text-success-700 high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			"components/password-input",
+			"text-warning-600 order-last select-none"
+		],
+		"expected": "components/password-input text-warning-600 order-last select-none"
+	},
+	{
+		"args": [
+			"components/popover",
+			"tooltip-provider"
+		],
+		"expected": "components/popover tooltip-provider"
+	},
+	{
+		"args": [
+			"components/preview/",
+			"twitter:domain"
+		],
+		"expected": "components/preview/ twitter:domain"
+	},
+	{
+		"args": [
+			"components/preview/accordion",
+			"us-ohio-1"
+		],
+		"expected": "components/preview/accordion us-ohio-1"
+	},
+	{
+		"args": [
+			"components/preview/calendar",
+			"utils/highlight-utils"
+		],
+		"expected": "components/preview/calendar utils/highlight-utils"
+	},
+	{
+		"args": [
+			"components/progress-bar",
+			"w-*"
+		],
+		"expected": "components/progress-bar w-*"
+	},
+	{
+		"args": [
+			"components/progress-donut",
+			"w-8 h-6"
+		],
+		"expected": "components/progress-donut w-8 h-6"
+	},
+	{
+		"args": [
+			"components/qr-code",
+			"*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+		],
+		"expected": "components/qr-code *:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+	},
+	{
+		"args": [
+			"components/radio-group",
+			"2xs:absolute 2xs:left-[44.5%] 2xs:justify-start 2xs:pt-0 2xs:pl-0 bottom-[7%] flex items-center gap-2 pt-4 pl-1.5 font-mono text-xs text-emerald-600 hover:text-emerald-700 min-[27rem]:left-[44.8%] min-[27rem]:text-sm"
+		],
+		"expected": "components/radio-group 2xs:absolute 2xs:left-[44.5%] 2xs:justify-start 2xs:pt-0 2xs:pl-0 bottom-[7%] flex items-center gap-2 pt-4 pl-1.5 font-mono text-xs text-emerald-600 hover:text-emerald-700 min-[27rem]:left-[44.8%] min-[27rem]:text-sm"
+	},
+	{
+		"args": [
+			"components/sandboxed-on-click",
+			"@ngrok/mantle/*"
+		],
+		"expected": "components/sandboxed-on-click @ngrok/mantle/*"
+	},
+	{
+		"args": [
+			"components/select",
+			"@ngrok/mantle/calendar"
+		],
+		"expected": "components/select @ngrok/mantle/calendar"
+	},
+	{
+		"args": [
+			"components/separator",
+			"@ngrok/mantle/data-table"
+		],
+		"expected": "components/separator @ngrok/mantle/data-table"
+	},
+	{
+		"args": [
+			"components/sheet",
+			"@ngrok/mantle/icons"
+		],
+		"expected": "components/sheet @ngrok/mantle/icons"
+	},
+	{
+		"args": [
+			"components/skeleton",
+			"@ngrok/mantle/mantle-light-high-contrast.css?url"
+		],
+		"expected": "components/skeleton @ngrok/mantle/mantle-light-high-contrast.css?url"
+	},
+	{
+		"args": [
+			"components/skip-to-main-link",
+			"@ngrok/mantle/separator"
+		],
+		"expected": "components/skip-to-main-link @ngrok/mantle/separator"
+	},
+	{
+		"args": [
+			"components/slider",
+			"@ngrok/mantle/table"
+		],
+		"expected": "components/slider @ngrok/mantle/table"
+	},
+	{
+		"args": [
+			"components/slot",
+			"@ngrok/mantle/zed"
+		],
+		"expected": "components/slot @ngrok/mantle/zed"
+	},
+	{
+		"args": [
+			"components/split-button",
+			"@phosphor-icons/react/Check"
+		],
+		"expected": "components/split-button @phosphor-icons/react/Check"
+	},
+	{
+		"args": [
+			"components/switch",
+			"@phosphor-icons/react/EyeClosed"
+		],
+		"expected": "components/switch @phosphor-icons/react/EyeClosed"
+	},
+	{
+		"args": [
+			"components/table",
+			"@phosphor-icons/react/Lock"
+		],
+		"expected": "components/table @phosphor-icons/react/Lock"
+	},
+	{
+		"args": [
+			"components/tabs",
+			"@phosphor-icons/react/Question"
+		],
+		"expected": "components/tabs @phosphor-icons/react/Question"
+	},
+	{
+		"args": [
+			"components/text-area",
+			"@phosphor-icons/react/Trash"
+		],
+		"expected": "components/text-area @phosphor-icons/react/Trash"
+	},
+	{
+		"args": [
+			"components/theme",
+			"@radix-ui/react-dropdown-menu"
+		],
+		"expected": "components/theme @radix-ui/react-dropdown-menu"
+	},
+	{
+		"args": [
+			"components/toast",
+			"@radix-ui/react-switch"
+		],
+		"expected": "components/toast @radix-ui/react-switch"
+	},
+	{
+		"args": [
+			"components/tooltip",
+			"@tanstack/react-query-devtools/production"
+		],
+		"expected": "components/tooltip @tanstack/react-query-devtools/production"
+	},
+	{
+		"args": [
+			"components/well",
+			"BQ-SA"
+		],
+		"expected": "components/well BQ-SA"
+	},
+	{
+		"args": [
+			"components/zed",
+			"GB-SCT"
+		],
+		"expected": "components/zed GB-SCT"
+	},
+	{
+		"args": [
+			"container",
+			"Set-Cookie"
+		],
+		"expected": "container Set-Cookie"
+	},
+	{
+		"args": [
+			"content-length",
+			"Theme-Icon-Light"
+		],
+		"expected": "content-length Theme-Icon-Light"
+	},
+	{
+		"args": [
+			"contents",
+			"absolute inline-flex size-full animate-ping rounded-full"
+		],
+		"expected": "absolute inline-flex size-full animate-ping rounded-full"
+	},
+	{
+		"args": [
+			"cursor-*",
+			"absolute top-1.5 right-1.5"
+		],
+		"expected": "cursor-* absolute top-1.5 right-1.5"
+	},
+	{
+		"args": [
+			"cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal",
+			"admin:secret"
+		],
+		"expected": "cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal admin:secret"
+	},
+	{
+		"args": [
+			"cursor-default opacity-50",
+			"alert-title"
+		],
+		"expected": "cursor-default opacity-50 alert-title"
+	},
+	{
+		"args": [
+			"cursor-pagination",
+			"api-schema-json"
+		],
+		"expected": "cursor-pagination api-schema-json"
+	},
+	{
+		"args": [
+			"cursor-pagination-buttons",
+			"api/schema.json"
+		],
+		"expected": "cursor-pagination-buttons api/schema.json"
+	},
+	{
+		"args": [
+			"cursor-pagination-next",
+			"application/schema+json"
+		],
+		"expected": "cursor-pagination-next application/schema+json"
+	},
+	{
+		"args": [
+			"cursor-pagination-previous",
+			"aria-describedby"
+		],
+		"expected": "cursor-pagination-previous aria-describedby"
+	},
+	{
+		"args": [
+			"cursor-pagination-separator",
+			"aria-label"
+		],
+		"expected": "cursor-pagination-separator aria-label"
+	},
+	{
+		"args": [
+			"cursor-pointer",
+			"base/colors"
+		],
+		"expected": "cursor-pointer base/colors"
+	},
+	{
+		"args": [
+			"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
+			"bg-accent-100"
+		],
+		"expected": "cursor-pointer aria-disabled:cursor-default focus:outline-hidden bg-accent-100"
+	},
+	{
+		"args": [
+			"cursor-pointer rounded bg-transparent text-accent-600 hover:underline focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent",
+			"bg-accent-600"
+		],
+		"expected": "cursor-pointer rounded text-accent-600 hover:underline focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent bg-accent-600"
+	},
+	{
+		"args": [
+			"cursor-text select-none font-sans text-sm",
+			"bg-amber-200"
+		],
+		"expected": "cursor-text select-none font-sans text-sm bg-amber-200"
+	},
+	{
+		"args": [
+			"cursor-wait",
+			"bg-amber-700"
+		],
+		"expected": "cursor-wait bg-amber-700"
+	},
+	{
+		"args": [
+			"custom-class",
+			"bg-blue-200"
+		],
+		"expected": "custom-class bg-blue-200"
+	},
+	{
+		"args": [
+			"custom-copy-button",
+			"bg-blue-700"
+		],
+		"expected": "custom-copy-button bg-blue-700"
+	},
+	{
+		"args": [
+			"custom-group",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-2xl"
+		],
+		"expected": "custom-group bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-2xl"
+	},
+	{
+		"args": [
+			"custom-slot",
+			"bg-cyan-100"
+		],
+		"expected": "custom-slot bg-cyan-100"
+	},
+	{
+		"args": [
+			"dark-high-contrast",
+			"bg-cyan-600"
+		],
+		"expected": "dark-high-contrast bg-cyan-600"
+	},
+	{
+		"args": [
+			"dark-high-contrast:bg-black high-contrast:bg-black bg-gray-500/20 dark:bg-gray-600/20",
+			"bg-danger-300"
+		],
+		"expected": "dark-high-contrast:bg-black high-contrast:bg-black dark:bg-gray-600/20 bg-danger-300"
+	},
+	{
+		"args": [
+			"dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10",
+			"bg-danger-800"
+		],
+		"expected": "dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md dark:bg-gray-950/10 bg-danger-800"
+	},
+	{
+		"args": [
+			"dark-high-contrast:border-green-600 dark-high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"bg-emerald-400"
+		],
+		"expected": "dark-high-contrast:border-green-600 dark-high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 p-4 bg-emerald-400"
+	},
+	{
+		"args": [
+			"data-*",
+			"bg-emerald-900"
+		],
+		"expected": "data-* bg-emerald-900"
+	},
+	{
+		"args": [
+			"data-analytics-id",
+			"bg-fuchsia-400"
+		],
+		"expected": "data-analytics-id bg-fuchsia-400"
+	},
+	{
+		"args": [
+			"data-appearance",
+			"bg-fuchsia-900"
+		],
+		"expected": "data-appearance bg-fuchsia-900"
+	},
+	{
+		"args": [
+			"data-applied-theme",
+			"bg-gray-500"
+		],
+		"expected": "data-applied-theme bg-gray-500"
+	},
+	{
+		"args": [
+			"data-custom",
+			"bg-green-100"
+		],
+		"expected": "data-custom bg-green-100"
+	},
+	{
+		"args": [
+			"data-disabled",
+			"bg-green-600"
+		],
+		"expected": "data-disabled bg-green-600"
+	},
+	{
+		"args": [
+			"data-disabled:cursor-default data-disabled:opacity-50",
+			"bg-indigo-200"
+		],
+		"expected": "data-disabled:cursor-default data-disabled:opacity-50 bg-indigo-200"
+	},
+	{
+		"args": [
+			"data-disabled:opacity-50",
+			"bg-indigo-700"
+		],
+		"expected": "data-disabled:opacity-50 bg-indigo-700"
+	},
+	{
+		"args": [
+			"data-disabled:pointer-events-none data-disabled:opacity-50",
+			"bg-info-400"
+		],
+		"expected": "data-disabled:pointer-events-none data-disabled:opacity-50 bg-info-400"
+	},
+	{
+		"args": [
+			"data-fold-hidden",
+			"bg-info-900"
+		],
+		"expected": "data-fold-hidden bg-info-900"
+	},
+	{
+		"args": [
+			"data-fold-line",
+			"bg-lime-500"
+		],
+		"expected": "data-fold-line bg-lime-500"
+	},
+	{
+		"args": [
+			"data-fold-regions",
+			"bg-linear-to-l to-transparent"
+		],
+		"expected": "data-fold-regions bg-linear-to-l to-transparent"
+	},
+	{
+		"args": [
+			"data-folded-regions",
+			"bg-neutral-500"
+		],
+		"expected": "data-folded-regions bg-neutral-500"
+	},
+	{
+		"args": [
+			"data-highlighted:aria-checked:bg-active-selected-menu-item!",
+			"bg-orange-100"
+		],
+		"expected": "data-highlighted:aria-checked:bg-active-selected-menu-item! bg-orange-100"
+	},
+	{
+		"args": [
+			"data-highlighted:bg-active-menu-item",
+			"bg-orange-600"
+		],
+		"expected": "data-highlighted:bg-active-menu-item bg-orange-600"
+	},
+	{
+		"args": [
+			"data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item",
+			"bg-pink-200"
+		],
+		"expected": "data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item bg-pink-200"
+	},
+	{
+		"args": [
+			"data-line-number",
+			"bg-pink-700"
+		],
+		"expected": "data-line-number bg-pink-700"
+	},
+	{
+		"args": [
+			"data-loading",
+			"bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg"
+		],
+		"expected": "data-loading bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg"
+	},
+	{
+		"args": [
+			"data-otp-state",
+			"bg-purple-500/20"
+		],
+		"expected": "data-otp-state bg-purple-500/20"
+	},
+	{
+		"args": [
+			"data-priority",
+			"bg-red-200"
+		],
+		"expected": "data-priority bg-red-200"
+	},
+	{
+		"args": [
+			"data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95",
+			"bg-red-700"
+		],
+		"expected": "data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 bg-red-700"
+	},
+	{
+		"args": [
+			"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)",
+			"bg-rose-400"
+		],
+		"expected": "data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height) bg-rose-400"
+	},
+	{
+		"args": [
+			"data-slot",
+			"bg-rose-900"
+		],
+		"expected": "data-slot bg-rose-900"
+	},
+	{
+		"args": [
+			"data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400",
+			"bg-sky-500"
+		],
+		"expected": "data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400 bg-sky-500"
+	},
+	{
+		"args": [
+			"data-state-checked:bg-selected-menu-item",
+			"bg-static-white"
+		],
+		"expected": "data-state-checked:bg-selected-menu-item bg-static-white"
+	},
+	{
+		"args": [
+			"data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5",
+			"bg-success-500"
+		],
+		"expected": "data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5 bg-success-500"
+	},
+	{
+		"args": [
+			"data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4",
+			"bg-teal-100"
+		],
+		"expected": "data-state-closed:animate-accordion-up data-state-open:animate-accordion-down overflow-hidden *:first:mt-4 bg-teal-100"
+	},
+	{
+		"args": [
+			"data-state-closed:slide-out-to-left data-state-open:slide-in-from-left left-0 border-r",
+			"bg-teal-600"
+		],
+		"expected": "data-state-closed:slide-out-to-left data-state-open:slide-in-from-left left-0 border-r bg-teal-600"
+	},
+	{
+		"args": [
+			"data-state-closed:slide-out-to-right data-state-open:slide-in-from-right right-0 border-l",
+			"bg-violet-100"
+		],
+		"expected": "data-state-closed:slide-out-to-right data-state-open:slide-in-from-right right-0 border-l bg-violet-100"
+	},
+	{
+		"args": [
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs",
+			"bg-violet-600"
+		],
+		"expected": "data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 fixed inset-0 z-50 backdrop-blur-xs bg-violet-600"
+	},
+	{
+		"args": [
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2",
+			"bg-warning-300"
+		],
+		"expected": "data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 bg-warning-300"
+	},
+	{
+		"args": [
+			"data-table",
+			"bg-warning-800"
+		],
+		"expected": "data-table bg-warning-800"
+	},
+	{
+		"args": [
+			"data-table-action-header-migration",
+			"bg-yellow-400"
+		],
+		"expected": "data-table-action-header-migration bg-yellow-400"
+	},
+	{
+		"args": [
+			"data-table-empty-row",
+			"bg-yellow-900"
+		],
+		"expected": "data-table-empty-row bg-yellow-900"
+	},
+	{
+		"args": [
+			"data-table-head",
+			"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border px-3 text-sm font-medium"
+		],
+		"expected": "data-table-head border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border px-3 text-sm font-medium"
+	},
+	{
+		"args": [
+			"data-table-header-sort-button",
+			"border-form flex size-4 items-center justify-center rounded-full border shrink-0"
+		],
+		"expected": "data-table-header-sort-button border-form flex size-4 items-center justify-center rounded-full border shrink-0"
+	},
+	{
+		"args": [
+			"data-table-row-expand-button",
+			"border-neutral-500/50 bg-neutral-500/10 text-neutral-700"
+		],
+		"expected": "data-table-row-expand-button border-neutral-500/50 bg-neutral-500/10 text-neutral-700"
+	},
+	{
+		"args": [
+			"data-testid",
+			"button-group"
+		],
+		"expected": "data-testid button-group"
+	},
+	{
+		"args": [
+			"data-theme",
+			"catch-all"
+		],
+		"expected": "data-theme catch-all"
+	},
+	{
+		"args": [
+			"data-validation",
+			"child-only-class"
+		],
+		"expected": "data-validation child-only-class"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger",
+			"cody-dot-js"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger cody-dot-js"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger",
+			"command-group"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger command-group"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger",
+			"comment.line.double-slash.js"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger comment.line.double-slash.js"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600",
+			"components/badge"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600 components/badge"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger",
+			"components/code-block/folding-by-language"
+		],
+		"expected": "data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger components/code-block/folding-by-language"
+	},
+	{
+		"args": [
+			"data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger",
+			"components/empty"
+		],
+		"expected": "data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger components/empty"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success",
+			"components/input"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success components/input"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success",
+			"components/pagination"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success components/pagination"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success",
+			"components/progress-donut"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success components/progress-donut"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600",
+			"components/skeleton"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600 components/skeleton"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success",
+			"components/tabs"
+		],
+		"expected": "data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success components/tabs"
+	},
+	{
+		"args": [
+			"data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success",
+			"container"
+		],
+		"expected": "data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success container"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning",
+			"cursor-pagination-buttons"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning cursor-pagination-buttons"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning",
+			"cursor-text select-none font-sans text-sm"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning cursor-text select-none font-sans text-sm"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning",
+			"dark-high-contrast:bg-black high-contrast:bg-black bg-gray-500/20 dark:bg-gray-600/20"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning dark-high-contrast:bg-black high-contrast:bg-black bg-gray-500/20 dark:bg-gray-600/20"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600",
+			"data-custom"
+		],
+		"expected": "data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600 data-custom"
+	},
+	{
+		"args": [
+			"data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning",
+			"data-fold-regions"
+		],
+		"expected": "data-validation-warning:border-warning-600 focus-within:data-validation-warning:border-warning-600 focus-within:data-validation-warning:ring-focus-warning data-fold-regions"
+	},
+	{
+		"args": [
+			"data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning",
+			"data-otp-state"
+		],
+		"expected": "data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning data-otp-state"
+	},
+	{
+		"args": [
+			"data:…",
+			"data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5"
+		],
+		"expected": "data:… data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5"
+	},
+	{
+		"args": [
+			"datetime-local",
+			"data-table-action-header-migration"
+		],
+		"expected": "datetime-local data-table-action-header-migration"
+	},
+	{
+		"args": [
+			"day size-full rounded-md not-aria-selected:not-disabled:hover:bg-filled-accent/15",
+			"data-validation"
+		],
+		"expected": "day size-full rounded-md not-aria-selected:not-disabled:hover:bg-filled-accent/15 data-validation"
+	},
+	{
+		"args": [
+			"day-outside aria-selected:text-on-filled opacity-50 text-muted",
+			"data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success"
+		],
+		"expected": "day-outside aria-selected:text-on-filled opacity-50 text-muted data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"day-range-middle not-disabled:aria-selected:bg-filled-accent/15 aria-selected:text-strong rounded-none not-disabled:aria-selected:hover:bg-filled-accent/25",
+			"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning"
+		],
+		"expected": "day-range-middle not-disabled:aria-selected:bg-filled-accent/15 aria-selected:text-strong rounded-none not-disabled:aria-selected:hover:bg-filled-accent/25 data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning"
+	},
+	{
+		"args": [
+			"de-fra-1",
+			"day size-full rounded-md not-aria-selected:not-disabled:hover:bg-filled-accent/15"
+		],
+		"expected": "de-fra-1 day size-full rounded-md not-aria-selected:not-disabled:hover:bg-filled-accent/15"
+	},
+	{
+		"args": [
+			"deployment-id",
+			"description-list-label"
+		],
+		"expected": "deployment-id description-list-label"
+	},
+	{
+		"args": [
+			"description-list",
+			"docs-changelog"
+		],
+		"expected": "description-list docs-changelog"
+	},
+	{
+		"args": [
+			"description-list-item",
+			"dropdown-menu-radio-group"
+		],
+		"expected": "description-list-item dropdown-menu-radio-group"
+	},
+	{
+		"args": [
+			"description-list-label",
+			"ease-in-out"
+		],
+		"expected": "description-list-label ease-in-out"
+	},
+	{
+		"args": [
+			"description-list-value",
+			"empty-title"
+		],
+		"expected": "description-list-value empty-title"
+	},
+	{
+		"args": [
+			"dialog-footer-dom-order-migration",
+			"field-error-list"
+		],
+		"expected": "dialog-footer-dom-order-migration field-error-list"
+	},
+	{
+		"args": [
+			"dialog-trigger",
+			"first-letter:uppercase"
+		],
+		"expected": "dialog-trigger first-letter:uppercase"
+	},
+	{
+		"args": [
+			"disabled:cursor-default disabled:opacity-50",
+			"flex flex-col"
+		],
+		"expected": "disabled:cursor-default disabled:opacity-50 flex flex-col"
+	},
+	{
+		"args": [
+			"disabled:cursor-not-allowed",
+			"flex flex-wrap items-center gap-3 mb-6"
+		],
+		"expected": "disabled:cursor-not-allowed flex flex-wrap items-center gap-3 mb-6"
+	},
+	{
+		"args": [
+			"dns-prefetch",
+			"flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+		],
+		"expected": "dns-prefetch flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+	},
+	{
+		"args": [
+			"docs-changelog",
+			"flex items-center ml-auto"
+		],
+		"expected": "docs-changelog flex items-center ml-auto"
+	},
+	{
+		"args": [
+			"docs-index-md",
+			"flex min-w-0 flex-1 flex-col"
+		],
+		"expected": "docs-index-md flex min-w-0 flex-1 flex-col"
+	},
+	{
+		"args": [
+			"dropdown-menu-checkbox-item",
+			"flex w-full mt-1"
+		],
+		"expected": "dropdown-menu-checkbox-item flex w-full mt-1"
+	},
+	{
+		"args": [
+			"dropdown-menu-content",
+			"focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "dropdown-menu-content focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"dropdown-menu-group",
+			"focus:data-state-checked:bg-active-selected-menu-item"
+		],
+		"expected": "dropdown-menu-group focus:data-state-checked:bg-active-selected-menu-item"
+	},
+	{
+		"args": [
+			"dropdown-menu-item",
+			"fold-spacer"
+		],
+		"expected": "dropdown-menu-item fold-spacer"
+	},
+	{
+		"args": [
+			"dropdown-menu-label",
+			"font-mono"
+		],
+		"expected": "dropdown-menu-label font-mono"
+	},
+	{
+		"args": [
+			"dropdown-menu-radio-group",
+			"for-ai-agents"
+		],
+		"expected": "dropdown-menu-radio-group for-ai-agents"
+	},
+	{
+		"args": [
+			"dropdown-menu-radio-item",
+			"gap-1.5"
+		],
+		"expected": "dropdown-menu-radio-item gap-1.5"
+	},
+	{
+		"args": [
+			"dropdown-menu-separator",
+			"grid grid-cols-1 gap-2 p-3"
+		],
+		"expected": "dropdown-menu-separator grid grid-cols-1 gap-2 p-3"
+	},
+	{
+		"args": [
+			"dropdown-menu-shortcut",
+			"group-child"
+		],
+		"expected": "dropdown-menu-shortcut group-child"
+	},
+	{
+		"args": [
+			"dropdown-menu-sub-content",
+			"group-data-validation/otp:last:border-r-(--otp-validation-border)"
+		],
+		"expected": "dropdown-menu-sub-content group-data-validation/otp:last:border-r-(--otp-validation-border)"
+	},
+	{
+		"args": [
+			"dropdown-menu-sub-trigger",
+			"h-*"
+		],
+		"expected": "dropdown-menu-sub-trigger h-*"
+	},
+	{
+		"args": [
+			"dropdown-menu-trigger",
+			"h-60"
+		],
+		"expected": "dropdown-menu-trigger h-60"
+	},
+	{
+		"args": [
+			"ease-in-out",
+			"h-full border border-card-muted hover:border-card flex flex-col items-center gap-1 justify-center relative bg-card ring-accent-600 hover:bg-card-hover focus-visible:bg-card-hover group w-full cursor-pointer rounded-md px-4 py-3 focus:outline-hidden focus-visible:ring-2"
+		],
+		"expected": "ease-in-out h-full border border-card-muted hover:border-card flex flex-col items-center gap-1 justify-center relative bg-card ring-accent-600 hover:bg-card-hover focus-visible:bg-card-hover group w-full cursor-pointer rounded-md px-4 py-3 focus:outline-hidden focus-visible:ring-2"
+	},
+	{
+		"args": [
+			"ease-out",
+			"has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4"
+		],
+		"expected": "ease-out has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4"
+	},
+	{
+		"args": [
+			"email-input",
+			"high-contrast:border-green-600 high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "email-input high-contrast:border-green-600 high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"empty-actions",
+			"hover:border-neutral-400"
+		],
+		"expected": "empty-actions hover:border-neutral-400"
+	},
+	{
+		"args": [
+			"empty-description",
+			"http://json-schema.org/draft-07/schema#"
+		],
+		"expected": "empty-description http://json-schema.org/draft-07/schema#"
+	},
+	{
+		"args": [
+			"empty-icon",
+			"https://evil.com/foo"
+		],
+		"expected": "empty-icon https://evil.com/foo"
+	},
+	{
+		"args": [
+			"empty-state",
+			"https://github.com/ngrok/mantle/pull/1167"
+		],
+		"expected": "empty-state https://github.com/ngrok/mantle/pull/1167"
+	},
+	{
+		"args": [
+			"empty-title",
+			"https://mantle.ngrok.com/components/zed"
+		],
+		"expected": "empty-title https://mantle.ngrok.com/components/zed"
+	},
+	{
+		"args": [
+			"en-US",
+			"https://ngrok.ai"
+		],
+		"expected": "en-US https://ngrok.ai"
+	},
+	{
+		"args": [
+			"european-union",
+			"https://ngrok.com/brand"
+		],
+		"expected": "european-union https://ngrok.com/brand"
+	},
+	{
+		"args": [
+			"family-italic",
+			"https://ngrok.com/docs/guides/device-gateway/agent"
+		],
+		"expected": "family-italic https://ngrok.com/docs/guides/device-gateway/agent"
+	},
+	{
+		"args": [
+			"family-regular",
+			"https://ngrok.com/docs/traffic-policy"
+		],
+		"expected": "family-regular https://ngrok.com/docs/traffic-policy"
+	},
+	{
+		"args": [
+			"field-description",
+			"https://ngrok.com/dpa"
+		],
+		"expected": "field-description https://ngrok.com/dpa"
+	},
+	{
+		"args": [
+			"field-error-item",
+			"https://ngrok.com/security"
+		],
+		"expected": "field-error-item https://ngrok.com/security"
+	},
+	{
+		"args": [
+			"field-error-list",
+			"https://status.ngrok.com/"
+		],
+		"expected": "field-error-list https://status.ngrok.com/"
+	},
+	{
+		"args": [
+			"field-group",
+			"icon-button"
+		],
+		"expected": "field-group icon-button"
+	},
+	{
+		"args": [
+			"field-help-content",
+			"ignored-name"
+		],
+		"expected": "field-help-content ignored-name"
+	},
+	{
+		"args": [
+			"field-item",
+			"inline-flex gap-1 items-center pointer-events-none select-none"
+		],
+		"expected": "field-item inline-flex gap-1 items-center pointer-events-none select-none"
+	},
+	{
+		"args": [
+			"field-label-text",
+			"input-capture"
+		],
+		"expected": "field-label-text input-capture"
+	},
+	{
+		"args": [
+			"field-legend",
+			"javascript:alert(1)"
+		],
+		"expected": "field-legend javascript:alert(1)"
+	},
+	{
+		"args": [
+			"field-set",
+			"justify-end"
+		],
+		"expected": "field-set justify-end"
+	},
+	{
+		"args": [
+			"first-letter:uppercase",
+			"language-tsx"
+		],
+		"expected": "first-letter:uppercase language-tsx"
+	},
+	{
+		"args": [
+			"first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md",
+			"localhost:8080"
+		],
+		"expected": "first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md localhost:8080"
+	},
+	{
+		"args": [
+			"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
+			"mantle-code-fold-toggle"
+		],
+		"expected": "first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md mantle-code-fold-toggle"
+	},
+	{
+		"args": [
+			"first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md",
+			"mantle-dark-styles"
+		],
+		"expected": "first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md mantle-dark-styles"
+	},
+	{
+		"args": [
+			"flex",
+			"max-w-"
+		],
+		"expected": "flex max-w-"
+	},
+	{
+		"args": [
+			"flex absolute right-2.5 top-2.5 z-10 rounded bg-filled-success text-on-filled hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success w-auto gap-1 border-transparent items-center pl-2 pr-1.5 hover:border-transparent",
+			"mb-2 text-blue text-xl leading-5"
+		],
+		"expected": "flex absolute right-2.5 top-2.5 z-10 rounded bg-filled-success hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success w-auto gap-1 border-transparent items-center pl-2 pr-1.5 hover:border-transparent mb-2 text-blue text-xl leading-5"
+	},
+	{
+		"args": [
+			"flex cursor-default items-center justify-center py-1",
+			"media-object"
+		],
+		"expected": "flex cursor-default items-center justify-center py-1 media-object"
+	},
+	{
+		"args": [
+			"flex flex-col",
+			"min-w-0"
+		],
+		"expected": "flex flex-col min-w-0"
+	},
+	{
+		"args": [
+			"flex flex-col gap-2",
+			"mt-2"
+		],
+		"expected": "flex flex-col gap-2 mt-2"
+	},
+	{
+		"args": [
+			"flex flex-col gap-3",
+			"mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+		],
+		"expected": "flex flex-col gap-3 mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+	},
+	{
+		"args": [
+			"flex flex-col items-center gap-4 px-8 py-6",
+			"mx-auto flex max-w-lg flex-col items-center p-6 text-center"
+		],
+		"expected": "gap-4 mx-auto flex max-w-lg flex-col items-center p-6 text-center"
+	},
+	{
+		"args": [
+			"flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0 relative max-w-min",
+			"node:path"
+		],
+		"expected": "flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0 relative max-w-min node:path"
+	},
+	{
+		"args": [
+			"flex flex-row gap-2 min-[70.625rem]:flex-col",
+			"not-focus:sr-only bg-card fixed top-2 left-2 z-max px-4 py-2 shadow-lg"
+		],
+		"expected": "flex flex-row gap-2 min-[70.625rem]:flex-col not-focus:sr-only bg-card fixed top-2 left-2 z-max px-4 py-2 shadow-lg"
+	},
+	{
+		"args": [
+			"flex flex-wrap items-center gap-2",
+			"og:site_name"
+		],
+		"expected": "flex flex-wrap items-center gap-2 og:site_name"
+	},
+	{
+		"args": [
+			"flex flex-wrap items-center gap-3 mb-6",
+			"opacity-50"
+		],
+		"expected": "flex flex-wrap items-center gap-3 mb-6 opacity-50"
+	},
+	{
+		"args": [
+			"flex gap-4",
+			"otp-input-separator"
+		],
+		"expected": "flex gap-4 otp-input-separator"
+	},
+	{
+		"args": [
+			"flex grow flex-col gap-1",
+			"p-3 pl-3.75"
+		],
+		"expected": "flex grow flex-col gap-1 p-3 pl-3.75"
+	},
+	{
+		"args": [
+			"flex grow flex-col gap-1 font-mono",
+			"packages/mantle/CHANGELOG.md"
+		],
+		"expected": "flex grow flex-col gap-1 font-mono packages/mantle/CHANGELOG.md"
+	},
+	{
+		"args": [
+			"flex h-28 w-64 items-center justify-center rounded-xl border-2 font-mono text-sm transition-all duration-500",
+			"pb-8"
+		],
+		"expected": "flex h-28 w-64 items-center justify-center rounded-xl border-2 font-mono text-sm transition-all duration-500 pb-8"
+	},
+	{
+		"args": [
+			"flex h-9 items-center gap-2 border-b border-popover px-3",
+			"placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden"
+		],
+		"expected": "flex h-9 items-center gap-2 border-b border-popover px-3 placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden"
+	},
+	{
+		"args": [
+			"flex items-center",
+			"pointer-fine:border-green-600 pointer-fine:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "pointer-fine:border-green-600 pointer-fine:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10",
+			"progress-bar-indicator"
+		],
+		"expected": "flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10 progress-bar-indicator"
+	},
+	{
+		"args": [
+			"flex items-center gap-2",
+			"px-6 py-3 border-t border-card-muted first:border-t-0"
+		],
+		"expected": "flex items-center gap-2 px-6 py-3 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			"flex items-center gap-2 has-disabled:opacity-50",
+			"qr-code-pattern"
+		],
+		"expected": "flex items-center gap-2 has-disabled:opacity-50 qr-code-pattern"
+	},
+	{
+		"args": [
+			"flex items-center gap-2 justify-between",
+			"react-dom/client"
+		],
+		"expected": "flex items-center gap-2 justify-between react-dom/client"
+	},
+	{
+		"args": [
+			"flex items-center gap-2 rounded font-mono text-xl leading-8 text-strong/90 hover:text-strong focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent",
+			"relative flex flex-col items-center gap-8"
+		],
+		"expected": "rounded font-mono text-xl leading-8 text-strong/90 hover:text-strong focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent relative flex flex-col items-center gap-8"
+	},
+	{
+		"args": [
+			"flex items-center justify-between",
+			"relative inline-flex size-2 rounded-full"
+		],
+		"expected": "items-center justify-between relative inline-flex size-2 rounded-full"
+	},
+	{
+		"args": [
+			"flex items-center justify-center rounded-lg rounded-b-none border border-b-0 border-gray-300 p-4 md:p-16",
+			"right-1.5 top-1.5 absolute"
+		],
+		"expected": "flex items-center justify-center rounded-lg rounded-b-none border border-b-0 border-gray-300 p-4 md:p-16 right-1.5 top-1.5 absolute"
+	},
+	{
+		"args": [
+			"flex items-center ml-auto",
+			"rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600"
+		],
+		"expected": "flex items-center ml-auto rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600"
+	},
+	{
+		"args": [
+			"flex items-center rounded justify-between gap-4 bg-accent-600/10 p-4 m-1",
+			"script:ld+json"
+		],
+		"expected": "flex items-center rounded justify-between gap-4 bg-accent-600/10 p-4 m-1 script:ld+json"
+	},
+	{
+		"args": [
+			"flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row",
+			"scroll-fade-x flex-row items-center overflow-x-auto overscroll-x-none w-full min-w-0 pt-1 -mt-1 px-1 -mx-1"
+		],
+		"expected": "flex sm:items-center gap-x-2 gap-y-1 sm:flex-row scroll-fade-x flex-row items-center overflow-x-auto overscroll-x-none w-full min-w-0 pt-1 -mt-1 px-1 -mx-1"
+	},
+	{
+		"args": [
+			"flex justify-center pt-1 relative items-center",
+			"select-content"
+		],
+		"expected": "flex justify-center pt-1 relative items-center select-content"
+	},
+	{
+		"args": [
+			"flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted",
+			"sg-sin-1"
+		],
+		"expected": "flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted sg-sin-1"
+	},
+	{
+		"args": [
+			"flex md:hidden",
+			"should-not-typecheck"
+		],
+		"expected": "flex md:hidden should-not-typecheck"
+	},
+	{
+		"args": [
+			"flex min-h-full flex-col",
+			"size-12 sm:size-16"
+		],
+		"expected": "flex min-h-full flex-col size-12 sm:size-16"
+	},
+	{
+		"args": [
+			"flex min-w-0 flex-1 flex-col",
+			"size-5 shrink-0 opacity-50"
+		],
+		"expected": "flex min-w-0 flex-1 flex-col size-5 shrink-0 opacity-50"
+	},
+	{
+		"args": [
+			"flex min-w-0 flex-1 items-center justify-between gap-2",
+			"sm:max-w-[560px]"
+		],
+		"expected": "flex min-w-0 flex-1 items-center justify-between gap-2 sm:max-w-[560px]"
+	},
+	{
+		"args": [
+			"flex w-full flex-col gap-1.5",
+			"space-y-4 text-center"
+		],
+		"expected": "flex w-full flex-col gap-1.5 space-y-4 text-center"
+	},
+	{
+		"args": [
+			"flex w-full flex-col items-end justify-between gap-6 sm:flex-row",
+			"sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4"
+		],
+		"expected": "items-end justify-between gap-6 sm:flex-row sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4"
+	},
+	{
+		"args": [
+			"flex w-full max-w-270 flex-col items-center",
+			"table"
+		],
+		"expected": "w-full max-w-270 flex-col items-center table"
+	},
+	{
+		"args": [
+			"flex w-full max-w-lg flex-col gap-1.5",
+			"text-2xl"
+		],
+		"expected": "flex w-full max-w-lg flex-col gap-1.5 text-2xl"
+	},
+	{
+		"args": [
+			"flex w-full min-w-0 flex-col gap-4 border-0 p-0",
+			"text-accent-600 hover:text-accent-600 font-medium high-contrast:bg-filled-accent high-contrast:text-on-filled high-contrast:hover:text-on-filled high-contrast:rounded-md high-contrast:px-2 high-contrast:-ml-2"
+		],
+		"expected": "flex w-full min-w-0 flex-col gap-4 border-0 p-0 text-accent-600 hover:text-accent-600 font-medium high-contrast:bg-filled-accent high-contrast:text-on-filled high-contrast:hover:text-on-filled high-contrast:rounded-md high-contrast:px-2 high-contrast:-ml-2"
+	},
+	{
+		"args": [
+			"flex w-full mt-1",
+			"text-blue"
+		],
+		"expected": "flex w-full mt-1 text-blue"
+	},
+	{
+		"args": [
+			"flex-col",
+			"text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
+		],
+		"expected": "flex-col text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
+	},
+	{
+		"args": [
+			"flex-col items-end gap-3.5 self-stretch",
+			"text-danger-600 order-last select-none"
+		],
+		"expected": "flex-col items-end gap-3.5 self-stretch text-danger-600 order-last select-none"
+	},
+	{
+		"args": [
+			"flex-row",
+			"text-danger-700 pointer-none:hidden block size-4"
+		],
+		"expected": "flex-row text-danger-700 pointer-none:hidden block size-4"
+	},
+	{
+		"args": [
+			"flex-wrap gap-4",
+			"text-mono mt-8 flex flex-wrap gap-8 font-mono"
+		],
+		"expected": "text-mono mt-8 flex flex-wrap gap-8 font-mono"
+	},
+	{
+		"args": [
+			"fmt:check",
+			"text-muted hover:text-strong block py-1 cursor-pointer focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent rounded"
+		],
+		"expected": "fmt:check text-muted hover:text-strong block py-1 cursor-pointer focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent rounded"
+	},
+	{
+		"args": [
+			"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4",
+			"text-muted space-y-4 text-sm font-sans"
+		],
+		"expected": "focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4 text-muted space-y-4 text-sm font-sans"
+	},
+	{
+		"args": [
+			"focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent",
+			"text-orange-600"
+		],
+		"expected": "focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent text-orange-600"
+	},
+	{
+		"args": [
+			"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
+			"text-red mb-2 text-base leading-4 text-xl"
+		],
+		"expected": "focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4 text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			"focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4",
+			"text-size-inherit text-base"
+		],
+		"expected": "focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4 text-base"
+	},
+	{
+		"args": [
+			"focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 text-sm outline-hidden",
+			"text-sm text-strong font-medium"
+		],
+		"expected": "focus:bg-accent data-state-open:bg-accent relative flex select-none items-center rounded-md py-1.5 pl-2 pr-9 outline-hidden text-sm text-strong font-medium"
+	},
+	{
+		"args": [
+			"focus:bg-accent focus:text-accent-foreground",
+			"text-strong leading-none font-semibold tracking-wider uppercase"
+		],
+		"expected": "focus:bg-accent focus:text-accent-foreground text-strong leading-none font-semibold tracking-wider uppercase"
+	},
+	{
+		"args": [
+			"focus:bg-active-menu-item",
+			"text-success-700 dark-high-contrast:block hidden size-4"
+		],
+		"expected": "focus:bg-active-menu-item text-success-700 dark-high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent",
+			"text-warning-600"
+		],
+		"expected": "focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent text-warning-600"
+	},
+	{
+		"args": [
+			"focus:data-state-checked:bg-active-selected-menu-item",
+			"tooltip-content"
+		],
+		"expected": "focus:data-state-checked:bg-active-selected-menu-item tooltip-content"
+	},
+	{
+		"args": [
+			"focus:outline-hidden",
+			"twitter:description"
+		],
+		"expected": "focus:outline-hidden twitter:description"
+	},
+	{
+		"args": [
+			"focus:outline-hidden focus-visible:ring-4",
+			"us-cal-1"
+		],
+		"expected": "focus:outline-hidden focus-visible:ring-4 us-cal-1"
+	},
+	{
+		"args": [
+			"focus:outline-hidden focus:ring-4 aria-expanded:ring-4",
+			"utils/cx"
+		],
+		"expected": "focus:outline-hidden focus:ring-4 aria-expanded:ring-4 utils/cx"
+	},
+	{
+		"args": [
+			"fold%20%22one%22%20region",
+			"w-(--radix-select-trigger-width)"
+		],
+		"expected": "fold%20%22one%22%20region w-(--radix-select-trigger-width)"
+	},
+	{
+		"args": [
+			"fold-ellipsis",
+			"w-50"
+		],
+		"expected": "fold-ellipsis w-50"
+	},
+	{
+		"args": [
+			"fold-runtime",
+			"z-1 absolute -inset-px right-auto w-1.5 rounded-l"
+		],
+		"expected": "fold-runtime z-1 absolute -inset-px right-auto w-1.5 rounded-l"
+	},
+	{
+		"args": [
+			"fold-spacer",
+			"-u"
+		],
+		"expected": "fold-spacer -u"
+	},
+	{
+		"args": [
+			"font-body text-body mt-3",
+			"@ngrok/mantle-server-syntax-highlighter"
+		],
+		"expected": "font-body text-body mt-3 @ngrok/mantle-server-syntax-highlighter"
+	},
+	{
+		"args": [
+			"font-bold",
+			"@ngrok/mantle/button"
+		],
+		"expected": "font-bold @ngrok/mantle/button"
+	},
+	{
+		"args": [
+			"font-family text-strong max-w-xl text-5xl leading-none md:text-6xl",
+			"@ngrok/mantle/cx"
+		],
+		"expected": "font-family text-strong max-w-xl text-5xl leading-none md:text-6xl @ngrok/mantle/cx"
+	},
+	{
+		"args": [
+			"font-family text-strong text-8xl leading-none md:text-9xl",
+			"@ngrok/mantle/icon"
+		],
+		"expected": "font-family text-strong text-8xl leading-none md:text-9xl @ngrok/mantle/icon"
+	},
+	{
+		"args": [
+			"font-medium",
+			"@ngrok/mantle/mantle-dark.css?url"
+		],
+		"expected": "font-medium @ngrok/mantle/mantle-dark.css?url"
+	},
+	{
+		"args": [
+			"font-medium text-strong group-hover:text-accent-600",
+			"@ngrok/mantle/progress"
+		],
+		"expected": "font-medium text-strong group-hover:text-accent-600 @ngrok/mantle/progress"
+	},
+	{
+		"args": [
+			"font-mono",
+			"@ngrok/mantle/switch"
+		],
+		"expected": "font-mono @ngrok/mantle/switch"
+	},
+	{
+		"args": [
+			"font-mono p-4 text-xl",
+			"@ngrok/mantle/utils"
+		],
+		"expected": "font-mono p-4 text-xl @ngrok/mantle/utils"
+	},
+	{
+		"args": [
+			"font-mono text-mono p-4 text-xl",
+			"@phosphor-icons/react/CaretUp"
+		],
+		"expected": "font-mono p-4 text-xl @phosphor-icons/react/CaretUp"
+	},
+	{
+		"args": [
+			"font-normal",
+			"@phosphor-icons/react/Eye"
+		],
+		"expected": "font-normal @phosphor-icons/react/Eye"
+	},
+	{
+		"args": [
+			"font-sans",
+			"@phosphor-icons/react/List"
+		],
+		"expected": "font-sans @phosphor-icons/react/List"
+	},
+	{
+		"args": [
+			"font-size",
+			"@phosphor-icons/react/Plus"
+		],
+		"expected": "font-size @phosphor-icons/react/Plus"
+	},
+	{
+		"args": [
+			"font/woff2",
+			"@phosphor-icons/react/Terminal"
+		],
+		"expected": "font/woff2 @phosphor-icons/react/Terminal"
+	},
+	{
+		"args": [
+			"for-ai-agents",
+			"@radix-ui/react-dialog"
+		],
+		"expected": "for-ai-agents @radix-ui/react-dialog"
+	},
+	{
+		"args": [
+			"for/done",
+			"@radix-ui/react-slot"
+		],
+		"expected": "for/done @radix-ui/react-slot"
+	},
+	{
+		"args": [
+			"from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)]",
+			"@tanstack/react-query"
+		],
+		"expected": "from-[color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent)] @tanstack/react-query"
+	},
+	{
+		"args": [
+			"gap-*",
+			"BQ-BO"
+		],
+		"expected": "gap-* BQ-BO"
+	},
+	{
+		"args": [
+			"gap-0.5",
+			"GB-NIR"
+		],
+		"expected": "gap-0.5 GB-NIR"
+	},
+	{
+		"args": [
+			"gap-1",
+			"M4,0h4v4h-4z"
+		],
+		"expected": "gap-1 M4,0h4v4h-4z"
+	},
+	{
+		"args": [
+			"gap-1 pb-1 -mb-1",
+			"Theme-Icon-Dark-High-Contrast"
+		],
+		"expected": "gap-1 pb-1 -mb-1 Theme-Icon-Dark-High-Contrast"
+	},
+	{
+		"args": [
+			"gap-1.5",
+			"a:"
+		],
+		"expected": "gap-1.5 a:"
+	},
+	{
+		"args": [
+			"gap-2",
+			"absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex"
+		],
+		"expected": "gap-2 absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex"
+	},
+	{
+		"args": [
+			"gap-4",
+			"accordion-trigger-icon"
+		],
+		"expected": "gap-4 accordion-trigger-icon"
+	},
+	{
+		"args": [
+			"gap-4 gap-em",
+			"alert-icon"
+		],
+		"expected": "gap-em alert-icon"
+	},
+	{
+		"args": [
+			"gap-6",
+			"api-package-json"
+		],
+		"expected": "gap-6 api-package-json"
+	},
+	{
+		"args": [
+			"gap-em",
+			"api/package.json"
+		],
+		"expected": "gap-em api/package.json"
+	},
+	{
+		"args": [
+			"grid gap-4 md:grid-cols-2 lg:grid-cols-3",
+			"application/json"
+		],
+		"expected": "grid gap-4 md:grid-cols-2 lg:grid-cols-3 application/json"
+	},
+	{
+		"args": [
+			"grid grid-cols-1 gap-2 p-3",
+			"aria-controls"
+		],
+		"expected": "grid grid-cols-1 gap-2 p-3 aria-controls"
+	},
+	{
+		"args": [
+			"grid grid-cols-4 gap-2",
+			"aria-invalid"
+		],
+		"expected": "grid grid-cols-4 gap-2 aria-invalid"
+	},
+	{
+		"args": [
+			"grid w-full grid-cols-1 gap-6 sm:grid-cols-2",
+			"base/breakpoints"
+		],
+		"expected": "grid w-full grid-cols-1 gap-6 sm:grid-cols-2 base/breakpoints"
+	},
+	{
+		"args": [
+			"grid w-full max-w-2xl grid-cols-2 gap-6 gap-y-12 font-mono text-[0.8125rem] min-[70.625rem]:max-w-none min-[70.625rem]:grid-cols-5",
+			"bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent"
+		],
+		"expected": "grid w-full max-w-2xl grid-cols-2 gap-6 gap-y-12 font-mono text-[0.8125rem] min-[70.625rem]:max-w-none min-[70.625rem]:grid-cols-5 bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent"
+	},
+	{
+		"args": [
+			"group",
+			"bg-accent-500/20"
+		],
+		"expected": "group bg-accent-500/20"
+	},
+	{
+		"args": [
+			"group block rounded py-4 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent",
+			"bg-amber-100"
+		],
+		"expected": "group block rounded py-4 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent bg-amber-100"
+	},
+	{
+		"args": [
+			"group flex items-center gap-1.5",
+			"bg-amber-600"
+		],
+		"expected": "group flex items-center gap-1.5 bg-amber-600"
+	},
+	{
+		"args": [
+			"group-child",
+			"bg-blue-100"
+		],
+		"expected": "group-child bg-blue-100"
+	},
+	{
+		"args": [
+			"group-data-*",
+			"bg-blue-600"
+		],
+		"expected": "group-data-* bg-blue-600"
+	},
+	{
+		"args": [
+			"group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow"
+		],
+		"expected": "group-data-state-active/tab-trigger:bg-neutral-950/10 group-data-state-active/tab-trigger:text-strong group-hover/tab-trigger:group-enabled/tab-trigger:group-data-state-active/tab-trigger:text-strong bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow"
+	},
+	{
+		"args": [
+			"group-data-validation",
+			"bg-center bg-no-repeat focus:outline-hidden"
+		],
+		"expected": "group-data-validation bg-center bg-no-repeat focus:outline-hidden"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:border-y-(--otp-validation-border)",
+			"bg-cyan-500/20"
+		],
+		"expected": "group-data-validation/otp:border-y-(--otp-validation-border) bg-cyan-500/20"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:first:border-l-(--otp-validation-border)",
+			"bg-danger-200"
+		],
+		"expected": "group-data-validation/otp:first:border-l-(--otp-validation-border) bg-danger-200"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)",
+			"bg-danger-700"
+		],
+		"expected": "group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring) bg-danger-700"
+	},
+	{
+		"args": [
+			"group-data-validation/otp:last:border-r-(--otp-validation-border)",
+			"bg-emerald-300"
+		],
+		"expected": "group-data-validation/otp:last:border-r-(--otp-validation-border) bg-emerald-300"
+	},
+	{
+		"args": [
+			"group-hover/tab-trigger:group-enabled/tab-trigger:text-gray-700",
+			"bg-emerald-800"
+		],
+		"expected": "group-hover/tab-trigger:group-enabled/tab-trigger:text-gray-700 bg-emerald-800"
+	},
+	{
+		"args": [
+			"group/dropdown-menu-radio-item",
+			"bg-fuchsia-300"
+		],
+		"expected": "group/dropdown-menu-radio-item bg-fuchsia-300"
+	},
+	{
+		"args": [
+			"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm",
+			"bg-fuchsia-800"
+		],
+		"expected": "group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm bg-fuchsia-800"
+	},
+	{
+		"args": [
+			"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm",
+			"bg-gray-50"
+		],
+		"expected": "group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm bg-gray-50"
+	},
+	{
+		"args": [
+			"group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden",
+			"bg-gray-950"
+		],
+		"expected": "group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden bg-gray-950"
+	},
+	{
+		"args": [
+			"h-(--radix-select-trigger-height) w-full",
+			"bg-green-500/20"
+		],
+		"expected": "h-(--radix-select-trigger-height) w-full bg-green-500/20"
+	},
+	{
+		"args": [
+			"h-*",
+			"bg-indigo-100"
+		],
+		"expected": "h-* bg-indigo-100"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded",
+			"bg-indigo-600"
+		],
+		"expected": "h-10 w-full rounded bg-indigo-600"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950",
+			"bg-info-300"
+		],
+		"expected": "h-10 w-full rounded bg-info-300"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950/50",
+			"bg-info-800"
+		],
+		"expected": "h-10 w-full rounded bg-info-800"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950/60",
+			"bg-lime-50"
+		],
+		"expected": "h-10 w-full rounded bg-lime-50"
+	},
+	{
+		"args": [
+			"h-10 w-full rounded bg-neutral-950/75",
+			"bg-lime-950"
+		],
+		"expected": "h-10 w-full rounded bg-lime-950"
+	},
+	{
+		"args": [
+			"h-6",
+			"bg-neutral-50"
+		],
+		"expected": "h-6 bg-neutral-50"
+	},
+	{
+		"args": [
+			"h-60",
+			"bg-neutral-950"
+		],
+		"expected": "h-60 bg-neutral-950"
+	},
+	{
+		"args": [
+			"h-72 w-full overflow-y-scroll overscroll-contain",
+			"bg-orange-500/20"
+		],
+		"expected": "h-72 w-full overflow-y-scroll overscroll-contain bg-orange-500/20"
+	},
+	{
+		"args": [
+			"h-9",
+			"bg-pink-100"
+		],
+		"expected": "h-9 bg-pink-100"
+	},
+	{
+		"args": [
+			"h-9 text-sm",
+			"bg-pink-600"
+		],
+		"expected": "h-9 text-sm bg-pink-600"
+	},
+	{
+		"args": [
+			"h-auto w-full max-w-126 text-neutral-200",
+			"bg-popover font-sans"
+		],
+		"expected": "h-auto w-full max-w-126 text-neutral-200 bg-popover font-sans"
+	},
+	{
+		"args": [
+			"h-em h-6",
+			"bg-purple-500"
+		],
+		"expected": "h-6 bg-purple-500"
+	},
+	{
+		"args": [
+			"h-full",
+			"bg-red-100"
+		],
+		"expected": "h-full bg-red-100"
+	},
+	{
+		"args": [
+			"h-full border border-card-muted hover:border-card flex flex-col items-center gap-1 justify-center relative bg-card ring-accent-600 hover:bg-card-hover focus-visible:bg-card-hover group w-full cursor-pointer rounded-md px-4 py-3 focus:outline-hidden focus-visible:ring-2",
+			"bg-red-600"
+		],
+		"expected": "h-full border border-card-muted hover:border-card flex flex-col items-center gap-1 justify-center relative ring-accent-600 hover:bg-card-hover focus-visible:bg-card-hover group w-full cursor-pointer rounded-md px-4 py-3 focus:outline-hidden focus-visible:ring-2 bg-red-600"
+	},
+	{
+		"args": [
+			"h-full w-full block object-cover",
+			"bg-rose-300"
+		],
+		"expected": "h-full w-full block object-cover bg-rose-300"
+	},
+	{
+		"args": [
+			"h-full w-px",
+			"bg-rose-800"
+		],
+		"expected": "h-full w-px bg-rose-800"
+	},
+	{
+		"args": [
+			"h-px w-full group-data-horizontal-separator-group:flex-1",
+			"bg-sky-50"
+		],
+		"expected": "h-px w-full group-data-horizontal-separator-group:flex-1 bg-sky-50"
+	},
+	{
+		"args": [
+			"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2",
+			"bg-sky-950"
+		],
+		"expected": "has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2 bg-sky-950"
+	},
+	{
+		"args": [
+			"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4",
+			"bg-success-50"
+		],
+		"expected": "has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4 bg-success-50"
+	},
+	{
+		"args": [
+			"has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent",
+			"bg-success-950"
+		],
+		"expected": "has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent bg-success-950"
+	},
+	{
+		"args": [
+			"has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4",
+			"bg-teal-500/20"
+		],
+		"expected": "has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4 bg-teal-500/20"
+	},
+	{
+		"args": [
+			"hidden",
+			"bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs"
+		],
+		"expected": "hidden bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs"
+	},
+	{
+		"args": [
+			"hidden md:flex",
+			"bg-violet-500/20"
+		],
+		"expected": "hidden md:flex bg-violet-500/20"
+	},
+	{
+		"args": [
+			"hidden md:flex items-center gap-1",
+			"bg-warning-200"
+		],
+		"expected": "hidden md:flex items-center gap-1 bg-warning-200"
+	},
+	{
+		"args": [
+			"hidden md:inline-flex",
+			"bg-warning-700"
+		],
+		"expected": "hidden md:inline-flex bg-warning-700"
+	},
+	{
+		"args": [
+			"hidden min-[70.625rem]:block",
+			"bg-yellow-300"
+		],
+		"expected": "hidden min-[70.625rem]:block bg-yellow-300"
+	},
+	{
+		"args": [
+			"hidden w-40 xl:block",
+			"bg-yellow-800"
+		],
+		"expected": "hidden w-40 xl:block bg-yellow-800"
+	},
+	{
+		"args": [
+			"high-contrast:border-green-600 high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"border-accent-600 bg-accent-600"
+		],
+		"expected": "high-contrast:border-green-600 high-contrast:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border p-4 border-accent-600 bg-accent-600"
+	},
+	{
+		"args": [
+			"highlight-utils",
+			"border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600"
+		],
+		"expected": "highlight-utils border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600"
+	},
+	{
+		"args": [
+			"horizontal-separator-group",
+			"border-l"
+		],
+		"expected": "horizontal-separator-group border-l"
+	},
+	{
+		"args": [
+			"hover-card-content",
+			"build/server/..."
+		],
+		"expected": "hover-card-content build/server/..."
+	},
+	{
+		"args": [
+			"hover-card-trigger",
+			"card-title"
+		],
+		"expected": "hover-card-trigger card-title"
+	},
+	{
+		"args": [
+			"hover-hover:border-green-600 hover-hover:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"child-help"
+		],
+		"expected": "hover-hover:border-green-600 hover-hover:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4 child-help"
+	},
+	{
+		"args": [
+			"hover-none:border-green-600 hover-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"code-block-migration"
+		],
+		"expected": "hover-none:border-green-600 hover-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4 code-block-migration"
+	},
+	{
+		"args": [
+			"hover:border-neutral-400",
+			"command-empty"
+		],
+		"expected": "hover:border-neutral-400 command-empty"
+	},
+	{
+		"args": [
+			"hover:text-danger-700",
+			"command-shortcut"
+		],
+		"expected": "hover:text-danger-700 command-shortcut"
+	},
+	{
+		"args": [
+			"hover:text-emerald-700",
+			"components/anchor"
+		],
+		"expected": "hover:text-emerald-700 components/anchor"
+	},
+	{
+		"args": [
+			"hover:text-orange-700",
+			"components/code-block"
+		],
+		"expected": "hover:text-orange-700 components/code-block"
+	},
+	{
+		"args": [
+			"hover:text-strong",
+			"components/dropdown-menu"
+		],
+		"expected": "hover:text-strong components/dropdown-menu"
+	},
+	{
+		"args": [
+			"hover:text-yellow-700",
+			"components/icons"
+		],
+		"expected": "hover:text-yellow-700 components/icons"
+	},
+	{
+		"args": [
+			"http-request",
+			"components/otp-input"
+		],
+		"expected": "http-request components/otp-input"
+	},
+	{
+		"args": [
+			"http://json-schema.org/draft-07/schema#",
+			"components/progress-bar"
+		],
+		"expected": "http://json-schema.org/draft-07/schema# components/progress-bar"
+	},
+	{
+		"args": [
+			"http://localhost:4444",
+			"components/sheet"
+		],
+		"expected": "http://localhost:4444 components/sheet"
+	},
+	{
+		"args": [
+			"http://ngrok.com/foo",
+			"components/table"
+		],
+		"expected": "http://ngrok.com/foo components/table"
+	},
+	{
+		"args": [
+			"http://www.sitemaps.org/schemas/sitemap/0.9",
+			"components/zed"
+		],
+		"expected": "http://www.sitemaps.org/schemas/sitemap/0.9 components/zed"
+	},
+	{
+		"args": [
+			"https:",
+			"cursor-pagination"
+		],
+		"expected": "https: cursor-pagination"
+	},
+	{
+		"args": [
+			"https://assets.ngrok.com",
+			"cursor-pointer rounded bg-transparent text-accent-600 hover:underline focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "https://assets.ngrok.com cursor-pointer rounded bg-transparent text-accent-600 hover:underline focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"https://bsky.app/profile/ngrok.com",
+			"dark-high-contrast"
+		],
+		"expected": "https://bsky.app/profile/ngrok.com dark-high-contrast"
+	},
+	{
+		"args": [
+			"https://evil.com/foo",
+			"data-applied-theme"
+		],
+		"expected": "https://evil.com/foo data-applied-theme"
+	},
+	{
+		"args": [
+			"https://example.com",
+			"data-fold-line"
+		],
+		"expected": "https://example.com data-fold-line"
+	},
+	{
+		"args": [
+			"https://foo/bar",
+			"data-loading"
+		],
+		"expected": "https://foo/bar data-loading"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok",
+			"data-state-checked:bg-selected-menu-item"
+		],
+		"expected": "https://github.com/ngrok data-state-checked:bg-selected-menu-item"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle",
+			"data-table"
+		],
+		"expected": "https://github.com/ngrok/mantle data-table"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/commit/abcdef0",
+			"data-theme"
+		],
+		"expected": "https://github.com/ngrok/mantle/commit/abcdef0 data-theme"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5",
+			"data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+		],
+		"expected": "https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5 data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/pull/1167",
+			"data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+		],
+		"expected": "https://github.com/ngrok/mantle/pull/1167 data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+	},
+	{
+		"args": [
+			"https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0",
+			"datetime-local"
+		],
+		"expected": "https://github.com/ngrok/mantle/releases/tag/%40ngrok%2Fmantle%400.69.0 datetime-local"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com",
+			"description-list-item"
+		],
+		"expected": "https://mantle.ngrok.com description-list-item"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/api/package.json",
+			"dns-prefetch"
+		],
+		"expected": "https://mantle.ngrok.com/api/package.json dns-prefetch"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/api/schema.json",
+			"dropdown-menu-label"
+		],
+		"expected": "https://mantle.ngrok.com/api/schema.json dropdown-menu-label"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/alpha",
+			"dropdown-menu-trigger"
+		],
+		"expected": "https://mantle.ngrok.com/components/alpha dropdown-menu-trigger"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/alpha.md",
+			"empty-state"
+		],
+		"expected": "https://mantle.ngrok.com/components/alpha.md empty-state"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/zed",
+			"field-error-item"
+		],
+		"expected": "https://mantle.ngrok.com/components/zed field-error-item"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/components/zed.md",
+			"field-set"
+		],
+		"expected": "https://mantle.ngrok.com/components/zed.md field-set"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/hooks",
+			"flex cursor-default items-center justify-center py-1"
+		],
+		"expected": "https://mantle.ngrok.com/hooks flex cursor-default items-center justify-center py-1"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/hooks.md",
+			"flex flex-wrap items-center gap-2"
+		],
+		"expected": "https://mantle.ngrok.com/hooks.md flex flex-wrap items-center gap-2"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/utils/gamma",
+			"flex items-center"
+		],
+		"expected": "https://mantle.ngrok.com/utils/gamma flex items-center"
+	},
+	{
+		"args": [
+			"https://mantle.ngrok.com/utils/gamma.md",
+			"flex items-center justify-center rounded-lg rounded-b-none border border-b-0 border-gray-300 p-4 md:p-16"
+		],
+		"expected": "https://mantle.ngrok.com/utils/gamma.md flex items-center justify-center rounded-lg rounded-b-none border border-b-0 border-gray-300 p-4 md:p-16"
+	},
+	{
+		"args": [
+			"https://ngrok-mantle-pr-123.vercel.app",
+			"flex min-h-full flex-col"
+		],
+		"expected": "https://ngrok-mantle-pr-123.vercel.app flex min-h-full flex-col"
+	},
+	{
+		"args": [
+			"https://ngrok.ai",
+			"flex w-full min-w-0 flex-col gap-4 border-0 p-0"
+		],
+		"expected": "https://ngrok.ai flex w-full min-w-0 flex-col gap-4 border-0 p-0"
+	},
+	{
+		"args": [
+			"https://ngrok.ai/",
+			"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+		],
+		"expected": "https://ngrok.ai/ focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			"https://ngrok.com",
+			"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent"
+		],
+		"expected": "https://ngrok.com focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent"
+	},
+	{
+		"args": [
+			"https://ngrok.com/about",
+			"fold-runtime"
+		],
+		"expected": "https://ngrok.com/about fold-runtime"
+	},
+	{
+		"args": [
+			"https://ngrok.com/abuse",
+			"font-medium text-strong group-hover:text-accent-600"
+		],
+		"expected": "https://ngrok.com/abuse font-medium text-strong group-hover:text-accent-600"
+	},
+	{
+		"args": [
+			"https://ngrok.com/blog",
+			"font/woff2"
+		],
+		"expected": "https://ngrok.com/blog font/woff2"
+	},
+	{
+		"args": [
+			"https://ngrok.com/blog/rss.xml",
+			"gap-1 pb-1 -mb-1"
+		],
+		"expected": "https://ngrok.com/blog/rss.xml gap-1 pb-1 -mb-1"
+	},
+	{
+		"args": [
+			"https://ngrok.com/brand",
+			"grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+		],
+		"expected": "https://ngrok.com/brand grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+	},
+	{
+		"args": [
+			"https://ngrok.com/careers",
+			"group flex items-center gap-1.5"
+		],
+		"expected": "https://ngrok.com/careers group flex items-center gap-1.5"
+	},
+	{
+		"args": [
+			"https://ngrok.com/contact",
+			"group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)"
+		],
+		"expected": "https://ngrok.com/contact group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)"
+	},
+	{
+		"args": [
+			"https://ngrok.com/customers",
+			"h-(--radix-select-trigger-height) w-full"
+		],
+		"expected": "https://ngrok.com/customers h-(--radix-select-trigger-height) w-full"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/agent/overview",
+			"h-6"
+		],
+		"expected": "https://ngrok.com/docs/agent/overview h-6"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides",
+			"h-full"
+		],
+		"expected": "https://ngrok.com/docs/guides h-full"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides/api-gateway/get-started",
+			"has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent"
+		],
+		"expected": "https://ngrok.com/docs/guides/api-gateway/get-started has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides/device-gateway/agent",
+			"hidden w-40 xl:block"
+		],
+		"expected": "https://ngrok.com/docs/guides/device-gateway/agent hidden w-40 xl:block"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/guides/ssh-rdp",
+			"hover-none:border-green-600 hover-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "https://ngrok.com/docs/guides/ssh-rdp hover-none:border-green-600 hover-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/integrations",
+			"http-request"
+		],
+		"expected": "https://ngrok.com/docs/integrations http-request"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/k8s",
+			"https://bsky.app/profile/ngrok.com"
+		],
+		"expected": "https://ngrok.com/docs/k8s https://bsky.app/profile/ngrok.com"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/k8s/guides/local-projection",
+			"https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5"
+		],
+		"expected": "https://ngrok.com/docs/k8s/guides/local-projection https://github.com/ngrok/mantle/commit/acd0c55527fefdf410e28858db2eaf90a9f5d2f5"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/obs",
+			"https://mantle.ngrok.com/components/alpha.md"
+		],
+		"expected": "https://ngrok.com/docs/obs https://mantle.ngrok.com/components/alpha.md"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/start",
+			"https://ngrok-mantle-pr-123.vercel.app"
+		],
+		"expected": "https://ngrok.com/docs/start https://ngrok-mantle-pr-123.vercel.app"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/traffic-policy",
+			"https://ngrok.com/blog/rss.xml"
+		],
+		"expected": "https://ngrok.com/docs/traffic-policy https://ngrok.com/blog/rss.xml"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/examples/ephemeral-workloads",
+			"https://ngrok.com/docs/guides/api-gateway/get-started"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/examples/ephemeral-workloads https://ngrok.com/docs/guides/api-gateway/get-started"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/examples/minecraft",
+			"https://ngrok.com/docs/start"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/examples/minecraft https://ngrok.com/docs/start"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/examples/webhook-gateway",
+			"https://ngrok.com/download"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/examples/webhook-gateway https://ngrok.com/download"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/universal-gateway/overview",
+			"https://ngrok.com/privacy-preferences"
+		],
+		"expected": "https://ngrok.com/docs/universal-gateway/overview https://ngrok.com/privacy-preferences"
+	},
+	{
+		"args": [
+			"https://ngrok.com/docs/using-ngrok-with/using-mcp",
+			"https://schema.org"
+		],
+		"expected": "https://ngrok.com/docs/using-ngrok-with/using-mcp https://schema.org"
+	},
+	{
+		"args": [
+			"https://ngrok.com/download",
+			"https://x.com/ngrokHQ"
+		],
+		"expected": "https://ngrok.com/download https://x.com/ngrokHQ"
+	},
+	{
+		"args": [
+			"https://ngrok.com/dpa",
+			"ignored-input"
+		],
+		"expected": "https://ngrok.com/dpa ignored-input"
+	},
+	{
+		"args": [
+			"https://ngrok.com/foo",
+			"inline-flex"
+		],
+		"expected": "https://ngrok.com/foo inline-flex"
+	},
+	{
+		"args": [
+			"https://ngrok.com/newsletter",
+			"inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 font-medium text-xs font-sans"
+		],
+		"expected": "https://ngrok.com/newsletter inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 font-medium text-xs font-sans"
+	},
+	{
+		"args": [
+			"https://ngrok.com/press",
+			"items-start"
+		],
+		"expected": "https://ngrok.com/press items-start"
+	},
+	{
+		"args": [
+			"https://ngrok.com/pricing",
+			"justify-between gap-4"
+		],
+		"expected": "https://ngrok.com/pricing justify-between gap-4"
+	},
+	{
+		"args": [
+			"https://ngrok.com/privacy",
+			"language-fake"
+		],
+		"expected": "https://ngrok.com/privacy language-fake"
+	},
+	{
+		"args": [
+			"https://ngrok.com/privacy-preferences",
+			"llms-txt"
+		],
+		"expected": "https://ngrok.com/privacy-preferences llms-txt"
+	},
+	{
+		"args": [
+			"https://ngrok.com/security",
+			"mantle-code-fold-ellipsis"
+		],
+		"expected": "https://ngrok.com/security mantle-code-fold-ellipsis"
+	},
+	{
+		"args": [
+			"https://ngrok.com/support",
+			"mantle-dark-high-contrast.css"
+		],
+		"expected": "https://ngrok.com/support mantle-dark-high-contrast.css"
+	},
+	{
+		"args": [
+			"https://ngrok.com/tos",
+			"max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+		],
+		"expected": "https://ngrok.com/tos max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+	},
+	{
+		"args": [
+			"https://ngrok.com/use-cases/developer-preview",
+			"mb-1.5"
+		],
+		"expected": "https://ngrok.com/use-cases/developer-preview mb-1.5"
+	},
+	{
+		"args": [
+			"https://ngrok.com/use-cases/site-to-site-connectivity",
+			"md:hidden"
+		],
+		"expected": "https://ngrok.com/use-cases/site-to-site-connectivity md:hidden"
+	},
+	{
+		"args": [
+			"https://ngrok.com/use-cases/webhook-testing",
+			"min-h-5"
+		],
+		"expected": "https://ngrok.com/use-cases/webhook-testing min-h-5"
+	},
+	{
+		"args": [
+			"https://schema.org",
+			"mt-1 text-sm leading-relaxed text-body"
+		],
+		"expected": "https://schema.org mt-1 text-sm leading-relaxed text-body"
+	},
+	{
+		"args": [
+			"https://status.ngrok.com/",
+			"mt-8 flex flex-wrap gap-4 font-mono text-xs"
+		],
+		"expected": "https://status.ngrok.com/ mt-8 flex flex-wrap gap-4 font-mono text-xs"
+	},
+	{
+		"args": [
+			"https://status.ngrok.com/api/v2/status.json",
+			"mx-auto flex h-15 w-full max-w-7xl items-center gap-3 px-4 md:gap-4"
+		],
+		"expected": "https://status.ngrok.com/api/v2/status.json mx-auto flex h-15 w-full max-w-7xl items-center gap-3 px-4 md:gap-4"
+	},
+	{
+		"args": [
+			"https://trust.ngrok.com/",
+			"node:crypto"
+		],
+		"expected": "https://trust.ngrok.com/ node:crypto"
+	},
+	{
+		"args": [
+			"https://upstream-service.internal/ping",
+			"not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color)"
+		],
+		"expected": "https://upstream-service.internal/ping not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color)"
+	},
+	{
+		"args": [
+			"https://www.linkedin.com/company/ngrok/",
+			"og:locale"
+		],
+		"expected": "https://www.linkedin.com/company/ngrok/ og:locale"
+	},
+	{
+		"args": [
+			"https://www.youtube.com/@ngrokHQ",
+			"oldest-to-newest"
+		],
+		"expected": "https://www.youtube.com/@ngrokHQ oldest-to-newest"
+	},
+	{
+		"args": [
+			"https://x.com/ngrokHQ",
+			"otp-input-group"
+		],
+		"expected": "https://x.com/ngrokHQ otp-input-group"
+	},
+	{
+		"args": [
+			"icon-button",
+			"p-2"
+		],
+		"expected": "icon-button p-2"
+	},
+	{
+		"args": [
+			"icon-search",
+			"p-em p-2"
+		],
+		"expected": "icon-search p-2"
+	},
+	{
+		"args": [
+			"if/fi",
+			"pb-6 pb-8"
+		],
+		"expected": "if/fi pb-8"
+	},
+	{
+		"args": [
+			"ignored-by-context",
+			"placeholder:text-placeholder data-drag-over:border-dashed"
+		],
+		"expected": "ignored-by-context placeholder:text-placeholder data-drag-over:border-dashed"
+	},
+	{
+		"args": [
+			"ignored-description",
+			"pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform"
+		],
+		"expected": "ignored-description pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform"
+	},
+	{
+		"args": [
+			"ignored-error",
+			"progress-bar"
+		],
+		"expected": "ignored-error progress-bar"
+	},
+	{
+		"args": [
+			"ignored-input",
+			"px-4"
+		],
+		"expected": "ignored-input px-4"
+	},
+	{
+		"args": [
+			"ignored-name",
+			"qr-code-overlay"
+		],
+		"expected": "ignored-name qr-code-overlay"
+	},
+	{
+		"args": [
+			"ignored-trigger",
+			"react-dom"
+		],
+		"expected": "ignored-trigger react-dom"
+	},
+	{
+		"args": [
+			"in-mum-1",
+			"relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors"
+		],
+		"expected": "in-mum-1 relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors"
+	},
+	{
+		"args": [
+			"indeterminate:border-accent-600 indeterminate:bg-accent-600 indeterminate:bg-indeterminate-icon",
+			"relative flex w-full gap-1.5 rounded-md border p-2.5 text-sm font-sans"
+		],
+		"expected": "indeterminate:border-accent-600 indeterminate:bg-indeterminate-icon relative flex w-full gap-1.5 rounded-md border p-2.5 text-sm font-sans"
+	},
+	{
+		"args": [
+			"inline-block ml-1.5",
+			"remark-stringify"
+		],
+		"expected": "inline-block ml-1.5 remark-stringify"
+	},
+	{
+		"args": [
+			"inline-block mr-1.5",
+			"rounded-[0.09375rem]"
+		],
+		"expected": "inline-block mr-1.5 rounded-[0.09375rem]"
+	},
+	{
+		"args": [
+			"inline-flex",
+			"scale-95 border-card-muted bg-gray-50 text-muted opacity-30"
+		],
+		"expected": "inline-flex scale-95 border-card-muted bg-gray-50 text-muted opacity-30"
+	},
+	{
+		"args": [
+			"inline-flex gap-1 items-center pointer-events-none select-none",
+			"scroll-fade-x"
+		],
+		"expected": "inline-flex gap-1 items-center pointer-events-none select-none scroll-fade-x"
+	},
+	{
+		"args": [
+			"inline-flex items-center justify-between gap-2",
+			"scroll-smooth"
+		],
+		"expected": "inline-flex items-center justify-between gap-2 scroll-smooth"
+	},
+	{
+		"args": [
+			"inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md",
+			"server:"
+		],
+		"expected": "inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md server:"
+	},
+	{
+		"args": [
+			"inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-strong hover:bg-neutral-500/10 focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent",
+			"sheet-overlay"
+		],
+		"expected": "inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium text-strong hover:bg-neutral-500/10 focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent sheet-overlay"
+	},
+	{
+		"args": [
+			"inline-flex md:hidden",
+			"size-10"
+		],
+		"expected": "inline-flex md:hidden size-10"
+	},
+	{
+		"args": [
+			"inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border",
+			"size-5"
+		],
+		"expected": "inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border size-5"
+	},
+	{
+		"args": [
+			"inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 font-medium text-xs font-sans",
+			"slot-only-class"
+		],
+		"expected": "inline-flex w-fit shrink-0 cursor-default items-center gap-1 rounded px-1.5 py-0.5 font-medium text-xs font-sans slot-only-class"
+	},
+	{
+		"args": [
+			"input-capture",
+			"space-y-4 mb-4"
+		],
+		"expected": "input-capture space-y-4 mb-4"
+	},
+	{
+		"args": [
+			"input-otp",
+			"sticky top-0 z-30 bg-card"
+		],
+		"expected": "input-otp sticky top-0 z-30 bg-card"
+	},
+	{
+		"args": [
+			"input/",
+			"svg-only"
+		],
+		"expected": "input/ svg-only"
+	},
+	{
+		"args": [
+			"isolate",
+			"text-(--alert-dismiss-icon-color)"
+		],
+		"expected": "isolate text-(--alert-dismiss-icon-color)"
+	},
+	{
+		"args": [
+			"item-child",
+			"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group/button-link border-transparent"
+		],
+		"expected": "item-child text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group/button-link border-transparent"
+	},
+	{
+		"args": [
+			"items-center",
+			"text-base text-size-inherit"
+		],
+		"expected": "items-center text-size-inherit"
+	},
+	{
+		"args": [
+			"items-start",
+			"text-body font-mono text-mono py-2 px-3"
+		],
+		"expected": "items-start text-body font-mono text-mono py-2 px-3"
+	},
+	{
+		"args": [
+			"javascript:alert(1)",
+			"text-danger-600 flex items-center gap-2"
+		],
+		"expected": "javascript:alert(1) text-danger-600 flex items-center gap-2"
+	},
+	{
+		"args": [
+			"javascript:…",
+			"text-danger-700 pointer-fine:hidden block size-4"
+		],
+		"expected": "javascript:… text-danger-700 pointer-fine:hidden block size-4"
+	},
+	{
+		"args": [
+			"jetbrains-mono",
+			"text-mono"
+		],
+		"expected": "jetbrains-mono text-mono"
+	},
+	{
+		"args": [
+			"jetbrains-mono-italic",
+			"text-muted hover:text-strong"
+		],
+		"expected": "jetbrains-mono-italic text-muted hover:text-strong"
+	},
+	{
+		"args": [
+			"jp-tokyo-1",
+			"text-muted opacity-50"
+		],
+		"expected": "jp-tokyo-1 text-muted opacity-50"
+	},
+	{
+		"args": [
+			"json-raw",
+			"text-muted-foreground text-sm gap-2 flex items-center"
+		],
+		"expected": "json-raw text-muted-foreground text-sm gap-2 flex items-center"
+	},
+	{
+		"args": [
+			"justify-between gap-4",
+			"text-red mb-2 text-base leading-4 text-blue text-xl leading-5"
+		],
+		"expected": "justify-between gap-4 mb-2 text-blue text-xl leading-5"
+	},
+	{
+		"args": [
+			"justify-end",
+			"text-size-inherit"
+		],
+		"expected": "justify-end text-size-inherit"
+	},
+	{
+		"args": [
+			"label-row-child",
+			"text-sm text-strong"
+		],
+		"expected": "label-row-child text-sm text-strong"
+	},
+	{
+		"args": [
+			"lang-",
+			"text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent"
+		],
+		"expected": "lang- text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent"
+	},
+	{
+		"args": [
+			"lang-fake",
+			"text-success-600 order-last select-none"
+		],
+		"expected": "lang-fake text-success-600 order-last select-none"
+	},
+	{
+		"args": [
+			"lang-tsx",
+			"text-success-700 pointer-none:block hidden size-4"
+		],
+		"expected": "lang-tsx text-success-700 pointer-none:block hidden size-4"
+	},
+	{
+		"args": [
+			"language-",
+			"toast-icon"
+		],
+		"expected": "language- toast-icon"
+	},
+	{
+		"args": [
+			"language-fake",
+			"twitter:card"
+		],
+		"expected": "language-fake twitter:card"
+	},
+	{
+		"args": [
+			"language-tsx",
+			"united-states"
+		],
+		"expected": "language-tsx united-states"
+	},
+	{
+		"args": [
+			"light-high-contrast",
+			"utils/compose-refs"
+		],
+		"expected": "light-high-contrast utils/compose-refs"
+	},
+	{
+		"args": [
+			"line-content",
+			"w-(--radix-dropdown-menu-trigger-width)"
+		],
+		"expected": "line-content w-(--radix-dropdown-menu-trigger-width)"
+	},
+	{
+		"args": [
+			"list-none",
+			"w-5 h-3.75"
+		],
+		"expected": "list-none w-5 h-3.75"
+	},
+	{
+		"args": [
+			"llms-full-txt",
+			"where:block where:size-4 where:p-0"
+		],
+		"expected": "llms-full-txt where:block where:size-4 where:p-0"
+	},
+	{
+		"args": [
+			"llms-full.txt",
+			"-my-0.5"
+		],
+		"expected": "llms-full.txt -my-0.5"
+	},
+	{
+		"args": [
+			"llms-txt",
+			"@ngrok/mantle"
+		],
+		"expected": "llms-txt @ngrok/mantle"
+	},
+	{
+		"args": [
+			"localhost:8080",
+			"@ngrok/mantle/browser-only"
+		],
+		"expected": "localhost:8080 @ngrok/mantle/browser-only"
+	},
+	{
+		"args": [
+			"localhost:9090",
+			"@ngrok/mantle/command"
+		],
+		"expected": "localhost:9090 @ngrok/mantle/command"
+	},
+	{
+		"args": [
+			"m-0",
+			"@ngrok/mantle/hooks"
+		],
+		"expected": "m-0 @ngrok/mantle/hooks"
+	},
+	{
+		"args": [
+			"m-0 flex w-full flex-col list-none p-0",
+			"@ngrok/mantle/mantle-dark-high-contrast.css?url"
+		],
+		"expected": "m-0 flex w-full flex-col list-none p-0 @ngrok/mantle/mantle-dark-high-contrast.css?url"
+	},
+	{
+		"args": [
+			"mailto:foo@bar.com",
+			"@ngrok/mantle/popover"
+		],
+		"expected": "mailto:foo@bar.com @ngrok/mantle/popover"
+	},
+	{
+		"args": [
+			"mailto:…",
+			"@ngrok/mantle/split-button"
+		],
+		"expected": "mailto:… @ngrok/mantle/split-button"
+	},
+	{
+		"args": [
+			"mantle-code-fold-ellipsis",
+			"@ngrok/mantle/types"
+		],
+		"expected": "mantle-code-fold-ellipsis @ngrok/mantle/types"
+	},
+	{
+		"args": [
+			"mantle-code-fold-toggle",
+			"@phosphor-icons/react/CaretRight"
+		],
+		"expected": "mantle-code-fold-toggle @phosphor-icons/react/CaretRight"
+	},
+	{
+		"args": [
+			"mantle-code-line",
+			"@phosphor-icons/react/DotsThree"
+		],
+		"expected": "mantle-code-line @phosphor-icons/react/DotsThree"
+	},
+	{
+		"args": [
+			"mantle-code-line-content",
+			"@phosphor-icons/react/Link"
+		],
+		"expected": "mantle-code-line-content @phosphor-icons/react/Link"
+	},
+	{
+		"args": [
+			"mantle-code-line-number",
+			"@phosphor-icons/react/PencilSimple"
+		],
+		"expected": "mantle-code-line-number @phosphor-icons/react/PencilSimple"
+	},
+	{
+		"args": [
+			"mantle-css-variables",
+			"@phosphor-icons/react/Sun"
+		],
+		"expected": "mantle-css-variables @phosphor-icons/react/Sun"
+	},
+	{
+		"args": [
+			"mantle-dark-high-contrast-styles",
+			"@radix-ui/react-accordion"
+		],
+		"expected": "mantle-dark-high-contrast-styles @radix-ui/react-accordion"
+	},
+	{
+		"args": [
+			"mantle-dark-high-contrast.css",
+			"@radix-ui/react-slider"
+		],
+		"expected": "mantle-dark-high-contrast.css @radix-ui/react-slider"
+	},
+	{
+		"args": [
+			"mantle-dark-styles",
+			"@tanstack/react-form"
+		],
+		"expected": "mantle-dark-styles @tanstack/react-form"
+	},
+	{
+		"args": [
+			"mantle-dark.css",
+			"Auto-Theme-Icon"
+		],
+		"expected": "mantle-dark.css Auto-Theme-Icon"
+	},
+	{
+		"args": [
+			"mantle-light-high-contrast-styles",
+			"GB-ENG"
+		],
+		"expected": "mantle-light-high-contrast-styles GB-ENG"
+	},
+	{
+		"args": [
+			"mantle-light-high-contrast.css",
+			"M0,0h10v10h-10zM10,10h10v10h-10z"
+		],
+		"expected": "mantle-light-high-contrast.css M0,0h10v10h-10zM10,10h10v10h-10z"
+	},
+	{
+		"args": [
+			"mantle-ui-theme",
+			"Theme-Icon-Dark"
+		],
+		"expected": "mantle-ui-theme Theme-Icon-Dark"
+	},
+	{
+		"args": [
+			"match-sorter",
+			"X-Robots-Tag"
+		],
+		"expected": "match-sorter X-Robots-Tag"
+	},
+	{
+		"args": [
+			"max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar",
+			"absolute right-2 flex items-center"
+		],
+		"expected": "max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar absolute right-2 flex items-center"
+	},
+	{
+		"args": [
+			"max-w-",
+			"accordion-trigger"
+		],
+		"expected": "max-w- accordion-trigger"
+	},
+	{
+		"args": [
+			"max-w-72",
+			"alert-dismiss-icon-button"
+		],
+		"expected": "max-w-72 alert-dismiss-icon-button"
+	},
+	{
+		"args": [
+			"max-w-lg",
+			"api-hooks-json"
+		],
+		"expected": "max-w-lg api-hooks-json"
+	},
+	{
+		"args": [
+			"max-w-md",
+			"api/hooks.json"
+		],
+		"expected": "max-w-md api/hooks.json"
+	},
+	{
+		"args": [
+			"mb-*",
+			"apple-touch-icon"
+		],
+		"expected": "mb-* apple-touch-icon"
+	},
+	{
+		"args": [
+			"mb-1 size-10 text-neutral-400",
+			"aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600"
+		],
+		"expected": "mb-1 size-10 text-neutral-400 aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600"
+	},
+	{
+		"args": [
+			"mb-1.5",
+			"aria-hidden"
+		],
+		"expected": "mb-1.5 aria-hidden"
+	},
+	{
+		"args": [
+			"mb-2 text-blue text-xl leading-5",
+			"base/"
+		],
+		"expected": "mb-2 text-blue text-xl leading-5 base/"
+	},
+	{
+		"args": [
+			"mb-2 text-xs font-medium uppercase tracking-wider font-mono",
+			"bg-*"
+		],
+		"expected": "mb-2 text-xs font-medium uppercase tracking-wider font-mono bg-*"
+	},
+	{
+		"args": [
+			"mb-3 text-xs font-medium uppercase tracking-wider font-mono",
+			"bg-accent-500"
+		],
+		"expected": "mb-3 text-xs font-medium uppercase tracking-wider font-mono bg-accent-500"
+	},
+	{
+		"args": [
+			"mb-4 leading-relaxed text-pretty text-body",
+			"bg-accent-950"
+		],
+		"expected": "mb-4 leading-relaxed text-pretty text-body bg-accent-950"
+	},
+	{
+		"args": [
+			"mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0",
+			"bg-amber-500/20"
+		],
+		"expected": "mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0 bg-amber-500/20"
+	},
+	{
+		"args": [
+			"mb-6",
+			"bg-base-hover dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md"
+		],
+		"expected": "mb-6 bg-base-hover dark:bg-base shadow-inner relative h-3 w-full overflow-hidden rounded-md"
+	},
+	{
+		"args": [
+			"md:hidden",
+			"bg-blue-500/20"
+		],
+		"expected": "md:hidden bg-blue-500/20"
+	},
+	{
+		"args": [
+			"media-object",
+			"bg-card h-full min-h-full overflow-y-scroll scrollbar isolate relative"
+		],
+		"expected": "media-object bg-card h-full min-h-full overflow-y-scroll scrollbar isolate relative"
+	},
+	{
+		"args": [
+			"media-object-content",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-xl"
+		],
+		"expected": "media-object-content bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-xl"
+	},
+	{
+		"args": [
+			"media-object-media",
+			"bg-cyan-500"
+		],
+		"expected": "media-object-media bg-cyan-500"
+	},
+	{
+		"args": [
+			"meta-key",
+			"bg-danger-100"
+		],
+		"expected": "meta-key bg-danger-100"
+	},
+	{
+		"args": [
+			"mfa-qr",
+			"bg-danger-600"
+		],
+		"expected": "mfa-qr bg-danger-600"
+	},
+	{
+		"args": [
+			"migrations/",
+			"bg-emerald-200"
+		],
+		"expected": "migrations/ bg-emerald-200"
+	},
+	{
+		"args": [
+			"min-h-5",
+			"bg-emerald-700"
+		],
+		"expected": "min-h-5 bg-emerald-700"
+	},
+	{
+		"args": [
+			"min-w-0",
+			"bg-fuchsia-200"
+		],
+		"expected": "min-w-0 bg-fuchsia-200"
+	},
+	{
+		"args": [
+			"min-w-0 flex-1",
+			"bg-fuchsia-700"
+		],
+		"expected": "min-w-0 flex-1 bg-fuchsia-700"
+	},
+	{
+		"args": [
+			"min-w-0 flex-1 has-data-alert-dismiss:pr-6",
+			"bg-gray-400"
+		],
+		"expected": "min-w-0 flex-1 has-data-alert-dismiss:pr-6 bg-gray-400"
+	},
+	{
+		"args": [
+			"min-width",
+			"bg-gray-900"
+		],
+		"expected": "min-width bg-gray-900"
+	},
+	{
+		"args": [
+			"ml-auto text-xs tracking-widest opacity-60",
+			"bg-green-500"
+		],
+		"expected": "ml-auto text-xs tracking-widest opacity-60 bg-green-500"
+	},
+	{
+		"args": [
+			"msg:",
+			"bg-important-500/20"
+		],
+		"expected": "msg: bg-important-500/20"
+	},
+	{
+		"args": [
+			"mt-1 text-sm leading-relaxed text-body",
+			"bg-indigo-500/20"
+		],
+		"expected": "mt-1 text-sm leading-relaxed text-body bg-indigo-500/20"
+	},
+	{
+		"args": [
+			"mt-2",
+			"bg-info-200"
+		],
+		"expected": "mt-2 bg-info-200"
+	},
+	{
+		"args": [
+			"mt-2 flex flex-col",
+			"bg-info-700"
+		],
+		"expected": "mt-2 flex flex-col bg-info-700"
+	},
+	{
+		"args": [
+			"mt-2 flex flex-col gap-2 overflow-hidden text-xs md:flex-row",
+			"bg-lime-400"
+		],
+		"expected": "mt-2 flex flex-col gap-2 overflow-hidden text-xs md:flex-row bg-lime-400"
+	},
+	{
+		"args": [
+			"mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row",
+			"bg-lime-900"
+		],
+		"expected": "mt-3 flex flex-col gap-4 overflow-hidden text-xs md:flex-row bg-lime-900"
+	},
+	{
+		"args": [
+			"mt-4 flex items-center gap-2",
+			"bg-neutral-400"
+		],
+		"expected": "mt-4 flex items-center gap-2 bg-neutral-400"
+	},
+	{
+		"args": [
+			"mt-6 text-xs font-medium uppercase tracking-wider font-mono",
+			"bg-neutral-900"
+		],
+		"expected": "mt-6 text-xs font-medium uppercase tracking-wider font-mono bg-neutral-900"
+	},
+	{
+		"args": [
+			"mt-8 flex flex-wrap gap-4 font-mono text-xs",
+			"bg-orange-500"
+		],
+		"expected": "mt-8 flex flex-wrap gap-4 font-mono text-xs bg-orange-500"
+	},
+	{
+		"args": [
+			"mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300",
+			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs"
+		],
+		"expected": "mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300 bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-40 backdrop-blur-xs"
+	},
+	{
+		"args": [
+			"mt-8 text-xl font-medium capitalize",
+			"bg-pink-500/20"
+		],
+		"expected": "mt-8 text-xl font-medium capitalize bg-pink-500/20"
+	},
+	{
+		"args": [
+			"multi-select-tag",
+			"bg-popover flex h-full w-full flex-col overflow-hidden rounded-md"
+		],
+		"expected": "multi-select-tag bg-popover flex h-full w-full flex-col overflow-hidden rounded-md"
+	},
+	{
+		"args": [
+			"multi-select-trigger",
+			"bg-purple-50"
+		],
+		"expected": "multi-select-trigger bg-purple-50"
+	},
+	{
+		"args": [
+			"mx-1 h-5 md:hidden",
+			"bg-purple-950"
+		],
+		"expected": "mx-1 h-5 md:hidden bg-purple-950"
+	},
+	{
+		"args": [
+			"mx-3 h-5 hidden md:block",
+			"bg-red-500/20"
+		],
+		"expected": "mx-3 h-5 hidden md:block bg-red-500/20"
+	},
+	{
+		"args": [
+			"mx-auto flex h-15 w-full max-w-7xl items-center gap-3 px-4 md:gap-4",
+			"bg-rose-200"
+		],
+		"expected": "mx-auto flex h-15 w-full max-w-7xl items-center gap-3 px-4 md:gap-4 bg-rose-200"
+	},
+	{
+		"args": [
+			"mx-auto flex max-w-lg flex-col items-center p-6 text-center",
+			"bg-rose-700"
+		],
+		"expected": "mx-auto flex max-w-lg flex-col items-center p-6 text-center bg-rose-700"
+	},
+	{
+		"args": [
+			"mx-auto max-w-full overflow-x-auto rounded-md bg-gray-100 p-4 text-left text-xs text-body",
+			"bg-sky-400"
+		],
+		"expected": "mx-auto max-w-full overflow-x-auto rounded-md p-4 text-left text-xs text-body bg-sky-400"
+	},
+	{
+		"args": [
+			"mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20",
+			"bg-sky-900"
+		],
+		"expected": "mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20 bg-sky-900"
+	},
+	{
+		"args": [
+			"my-2 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] overflow-auto",
+			"bg-success-400"
+		],
+		"expected": "my-2 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] overflow-auto bg-success-400"
+	},
+	{
+		"args": [
+			"newest-to-oldest",
+			"bg-success-900"
+		],
+		"expected": "newest-to-oldest bg-success-900"
+	},
+	{
+		"args": [
+			"no-underline",
+			"bg-teal-500"
+		],
+		"expected": "no-underline bg-teal-500"
+	},
+	{
+		"args": [
+			"node:crypto",
+			"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow"
+		],
+		"expected": "node:crypto bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow"
+	},
+	{
+		"args": [
+			"node:path",
+			"bg-violet-500"
+		],
+		"expected": "node:path bg-violet-500"
+	},
+	{
+		"args": [
+			"node:stream",
+			"bg-warning-100"
+		],
+		"expected": "node:stream bg-warning-100"
+	},
+	{
+		"args": [
+			"not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50",
+			"bg-warning-600"
+		],
+		"expected": "not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50 bg-warning-600"
+	},
+	{
+		"args": [
+			"not-aria-selected:not-disabled:text-accent-600 font-medium not-aria-selected:not-disabled:bg-filled-accent/10 rounded-md",
+			"bg-yellow-200"
+		],
+		"expected": "not-aria-selected:not-disabled:text-accent-600 font-medium not-aria-selected:not-disabled:bg-filled-accent/10 rounded-md bg-yellow-200"
+	},
+	{
+		"args": [
+			"not-disabled:active:scale-97 ease-out transition-transform duration-150",
+			"bg-yellow-700"
+		],
+		"expected": "not-disabled:active:scale-97 ease-out transition-transform duration-150 bg-yellow-700"
+	},
+	{
+		"args": [
+			"not-disabled:bg-filled-accent text-on-filled not-disabled:hover:bg-filled-accent",
+			"border-accent-600"
+		],
+		"expected": "not-disabled:bg-filled-accent text-on-filled not-disabled:hover:bg-filled-accent border-accent-600"
+	},
+	{
+		"args": [
+			"not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color)",
+			"border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50"
+		],
+		"expected": "not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color) border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50"
+	},
+	{
+		"args": [
+			"not-focus:sr-only bg-card fixed top-2 left-2 z-max px-4 py-2 shadow-lg",
+			"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+		],
+		"expected": "not-focus:sr-only fixed top-2 left-2 z-max shadow-lg border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+	},
+	{
+		"args": [
+			"not-found",
+			"br-sao-1"
+		],
+		"expected": "not-found br-sao-1"
+	},
+	{
+		"args": [
+			"nth-child(odd)",
+			"card-header"
+		],
+		"expected": "nth-child(odd) card-header"
+	},
+	{
+		"args": [
+			"number[]",
+			"child-error"
+		],
+		"expected": "number[] child-error"
+	},
+	{
+		"args": [
+			"og:description",
+			"code-block-code"
+		],
+		"expected": "og:description code-block-code"
+	},
+	{
+		"args": [
+			"og:image",
+			"combobox-separator"
+		],
+		"expected": "og:image combobox-separator"
+	},
+	{
+		"args": [
+			"og:locale",
+			"command-separator"
+		],
+		"expected": "og:locale command-separator"
+	},
+	{
+		"args": [
+			"og:site_name",
+			"components/alpha"
+		],
+		"expected": "og:site_name components/alpha"
+	},
+	{
+		"args": [
+			"og:title",
+			"components/code"
+		],
+		"expected": "og:title components/code"
+	},
+	{
+		"args": [
+			"og:type",
+			"components/dialog"
+		],
+		"expected": "og:type components/dialog"
+	},
+	{
+		"args": [
+			"og:url",
+			"components/icon-button"
+		],
+		"expected": "og:url components/icon-button"
+	},
+	{
+		"args": [
+			"ok-on-element-form",
+			"components/multi-select"
+		],
+		"expected": "ok-on-element-form components/multi-select"
+	},
+	{
+		"args": [
+			"old-etag",
+			"components/preview/calendar"
+		],
+		"expected": "old-etag components/preview/calendar"
+	},
+	{
+		"args": [
+			"oldest-to-newest",
+			"components/separator"
+		],
+		"expected": "oldest-to-newest components/separator"
+	},
+	{
+		"args": [
+			"opacity-50",
+			"components/switch"
+		],
+		"expected": "opacity-50 components/switch"
+	},
+	{
+		"args": [
+			"opacity-75",
+			"components/well"
+		],
+		"expected": "opacity-75 components/well"
+	},
+	{
+		"args": [
+			"options:",
+			"cursor-default opacity-50"
+		],
+		"expected": "options: cursor-default opacity-50"
+	},
+	{
+		"args": [
+			"order-last",
+			"cursor-pointer aria-disabled:cursor-default focus:outline-hidden"
+		],
+		"expected": "order-last cursor-pointer aria-disabled:cursor-default focus:outline-hidden"
+	},
+	{
+		"args": [
+			"order-last -mt-4 self-start sm:order-first sm:mt-0 sm:self-auto",
+			"custom-slot"
+		],
+		"expected": "order-last -mt-4 self-start sm:order-first sm:mt-0 sm:self-auto custom-slot"
+	},
+	{
+		"args": [
+			"otp-input",
+			"data-appearance"
+		],
+		"expected": "otp-input data-appearance"
+	},
+	{
+		"args": [
+			"otp-input-group",
+			"data-fold-hidden"
+		],
+		"expected": "otp-input-group data-fold-hidden"
+	},
+	{
+		"args": [
+			"otp-input-separator",
+			"data-line-number"
+		],
+		"expected": "otp-input-separator data-line-number"
+	},
+	{
+		"args": [
+			"otp-input-slot",
+			"data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400"
+		],
+		"expected": "otp-input-slot data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400"
+	},
+	{
+		"args": [
+			"overflow-hidden p-0 relative",
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2"
+		],
+		"expected": "overflow-hidden p-0 relative data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2"
+	},
+	{
+		"args": [
+			"overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md",
+			"data-testid"
+		],
+		"expected": "overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md data-testid"
+	},
+	{
+		"args": [
+			"p-0",
+			"data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger"
+		],
+		"expected": "p-0 data-validation-error:border-danger-600 focus-within:data-validation-error:border-danger-600 focus-within:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			"p-1 space-y-px",
+			"data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success"
+		],
+		"expected": "p-1 space-y-px data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"p-2",
+			"data:…"
+		],
+		"expected": "p-2 data:…"
+	},
+	{
+		"args": [
+			"p-3 pl-3.75",
+			"description-list"
+		],
+		"expected": "p-3 pl-3.75 description-list"
+	},
+	{
+		"args": [
+			"p-4 not-a-tailwind-class pb-3",
+			"disabled:cursor-not-allowed"
+		],
+		"expected": "p-4 not-a-tailwind-class pb-3 disabled:cursor-not-allowed"
+	},
+	{
+		"args": [
+			"p-4 pb-6 not-a-tailwind-class pb-3",
+			"dropdown-menu-item"
+		],
+		"expected": "p-4 not-a-tailwind-class pb-3 dropdown-menu-item"
+	},
+	{
+		"args": [
+			"p-4 pt-5 pb-6 pr-3 pb-3",
+			"dropdown-menu-sub-trigger"
+		],
+		"expected": "p-4 pt-5 pr-3 pb-3 dropdown-menu-sub-trigger"
+	},
+	{
+		"args": [
+			"p-4 pt-5 pr-3 pb-3",
+			"empty-icon"
+		],
+		"expected": "p-4 pt-5 pr-3 pb-3 empty-icon"
+	},
+	{
+		"args": [
+			"p-6 border-t border-card-muted first:border-t-0",
+			"field-description"
+		],
+		"expected": "p-6 border-t border-card-muted first:border-t-0 field-description"
+	},
+	{
+		"args": [
+			"p-em p-2",
+			"field-legend"
+		],
+		"expected": "p-2 field-legend"
+	},
+	{
+		"args": [
+			"packages/mantle/CHANGELOG.md",
+			"flex absolute right-2.5 top-2.5 z-10 rounded bg-filled-success text-on-filled hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success w-auto gap-1 border-transparent items-center pl-2 pr-1.5 hover:border-transparent"
+		],
+		"expected": "packages/mantle/CHANGELOG.md flex absolute right-2.5 top-2.5 z-10 rounded bg-filled-success text-on-filled hover:bg-filled-success focus:bg-filled-success focus-visible:border-success-600 focus-visible:ring-focus-success w-auto gap-1 border-transparent items-center pl-2 pr-1.5 hover:border-transparent"
+	},
+	{
+		"args": [
+			"packages/mantle/src",
+			"flex flex-row gap-2 min-[70.625rem]:flex-col"
+		],
+		"expected": "packages/mantle/src flex flex-row gap-2 min-[70.625rem]:flex-col"
+	},
+	{
+		"args": [
+			"password-input",
+			"flex h-9 items-center gap-2 border-b border-popover px-3"
+		],
+		"expected": "password-input flex h-9 items-center gap-2 border-b border-popover px-3"
+	},
+	{
+		"args": [
+			"pattern-a",
+			"flex items-center justify-between"
+		],
+		"expected": "pattern-a flex items-center justify-between"
+	},
+	{
+		"args": [
+			"pattern-b",
+			"flex md:hidden"
+		],
+		"expected": "pattern-b flex md:hidden"
+	},
+	{
+		"args": [
+			"pb-6",
+			"flex w-full max-w-lg flex-col gap-1.5"
+		],
+		"expected": "pb-6 flex w-full max-w-lg flex-col gap-1.5"
+	},
+	{
+		"args": [
+			"pb-6 pb-8",
+			"fmt:check"
+		],
+		"expected": "pb-8 fmt:check"
+	},
+	{
+		"args": [
+			"pb-8",
+			"focus:bg-active-menu-item"
+		],
+		"expected": "pb-8 focus:bg-active-menu-item"
+	},
+	{
+		"args": [
+			"pb-8 pb-6",
+			"fold-ellipsis"
+		],
+		"expected": "pb-6 fold-ellipsis"
+	},
+	{
+		"args": [
+			"pe-2.5",
+			"font-medium"
+		],
+		"expected": "pe-2.5 font-medium"
+	},
+	{
+		"args": [
+			"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden",
+			"font-size"
+		],
+		"expected": "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden font-size"
+	},
+	{
+		"args": [
+			"pl-8",
+			"gap-1"
+		],
+		"expected": "pl-8 gap-1"
+	},
+	{
+		"args": [
+			"placeholder:text-muted flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+			"gap-em"
+		],
+		"expected": "placeholder:text-muted flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50 gap-em"
+	},
+	{
+		"args": [
+			"placeholder:text-placeholder data-drag-over:border-dashed",
+			"group block rounded py-4 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "placeholder:text-placeholder data-drag-over:border-dashed group block rounded py-4 focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden",
+			"group-data-validation/otp:first:border-l-(--otp-validation-border)"
+		],
+		"expected": "placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden group-data-validation/otp:first:border-l-(--otp-validation-border)"
+	},
+	{
+		"args": [
+			"pointer-coarse:border-green-600 pointer-coarse:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden"
+		],
+		"expected": "pointer-coarse:border-green-600 pointer-coarse:bg-green-600/10 items-center justify-between rounded-lg border border-red-600 bg-red-600/10 p-4 group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden"
+	},
+	{
+		"args": [
+			"pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]",
+			"h-10 w-full rounded bg-neutral-950/75"
+		],
+		"expected": "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem] h-10 w-full rounded bg-neutral-950/75"
+	},
+	{
+		"args": [
+			"pointer-coarse:text-base h-9 text-sm",
+			"h-em h-6"
+		],
+		"expected": "pointer-coarse:text-base text-sm h-6"
+	},
+	{
+		"args": [
+			"pointer-events-none",
+			"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4"
+		],
+		"expected": "pointer-events-none has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4"
+	},
+	{
+		"args": [
+			"pointer-events-none absolute inset-0 flex items-center justify-center",
+			"hidden min-[70.625rem]:block"
+		],
+		"expected": "pointer-events-none absolute inset-0 items-center justify-center hidden min-[70.625rem]:block"
+	},
+	{
+		"args": [
+			"pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform",
+			"hover-hover:border-green-600 hover-hover:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+		],
+		"expected": "pointer-events-none size-4 shadow-md ring-0 transition-transform hover-hover:border-green-600 hover-hover:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4"
+	},
+	{
+		"args": [
+			"pointer-fine:border-green-600 pointer-fine:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"hover:text-yellow-700"
+		],
+		"expected": "pointer-fine:border-green-600 pointer-fine:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4 hover:text-yellow-700"
+	},
+	{
+		"args": [
+			"pointer-none:border-green-600 pointer-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4",
+			"https://assets.ngrok.com"
+		],
+		"expected": "pointer-none:border-green-600 pointer-none:bg-green-600/10 flex items-center justify-between gap-1 rounded-lg border border-red-600 bg-red-600/10 p-4 https://assets.ngrok.com"
+	},
+	{
+		"args": [
+			"pre[data-lang]",
+			"https://github.com/ngrok/mantle/commit/abcdef0"
+		],
+		"expected": "pre[data-lang] https://github.com/ngrok/mantle/commit/abcdef0"
+	},
+	{
+		"args": [
+			"privacy-policy",
+			"https://mantle.ngrok.com/components/alpha"
+		],
+		"expected": "privacy-policy https://mantle.ngrok.com/components/alpha"
+	},
+	{
+		"args": [
+			"profile-card",
+			"https://mantle.ngrok.com/utils/gamma.md"
+		],
+		"expected": "profile-card https://mantle.ngrok.com/utils/gamma.md"
+	},
+	{
+		"args": [
+			"profile-name",
+			"https://ngrok.com/blog"
+		],
+		"expected": "profile-name https://ngrok.com/blog"
+	},
+	{
+		"args": [
+			"progress-bar",
+			"https://ngrok.com/docs/guides"
+		],
+		"expected": "progress-bar https://ngrok.com/docs/guides"
+	},
+	{
+		"args": [
+			"progress-bar-indicator",
+			"https://ngrok.com/docs/obs"
+		],
+		"expected": "progress-bar-indicator https://ngrok.com/docs/obs"
+	},
+	{
+		"args": [
+			"progress-donut-indicator",
+			"https://ngrok.com/docs/using-ngrok-with/using-mcp"
+		],
+		"expected": "progress-donut-indicator https://ngrok.com/docs/using-ngrok-with/using-mcp"
+	},
+	{
+		"args": [
+			"ps-1",
+			"https://ngrok.com/privacy"
+		],
+		"expected": "ps-1 https://ngrok.com/privacy"
+	},
+	{
+		"args": [
+			"ps-2.5",
+			"https://ngrok.com/use-cases/webhook-testing"
+		],
+		"expected": "ps-2.5 https://ngrok.com/use-cases/webhook-testing"
+	},
+	{
+		"args": [
+			"px-2",
+			"https://www.youtube.com/@ngrokHQ"
+		],
+		"expected": "px-2 https://www.youtube.com/@ngrokHQ"
+	},
+	{
+		"args": [
+			"px-2 py-1.5 text-sm font-medium",
+			"ignored-error"
+		],
+		"expected": "px-2 py-1.5 text-sm font-medium ignored-error"
+	},
+	{
+		"args": [
+			"px-4",
+			"inline-block mr-1.5"
+		],
+		"expected": "px-4 inline-block mr-1.5"
+	},
+	{
+		"args": [
+			"px-6 py-3 border-t border-card-muted first:border-t-0",
+			"inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border"
+		],
+		"expected": "px-6 py-3 border-card-muted first:border-t-0 inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border"
+	},
+	{
+		"args": [
+			"py-12 sm:py-20 px-4 flex justify-center",
+			"items-center"
+		],
+		"expected": "py-12 sm:py-20 px-4 flex justify-center items-center"
+	},
+	{
+		"args": [
+			"py-2",
+			"json-raw"
+		],
+		"expected": "py-2 json-raw"
+	},
+	{
+		"args": [
+			"py-6 text-center text-sm",
+			"language-"
+		],
+		"expected": "py-6 text-center text-sm language-"
+	},
+	{
+		"args": [
+			"qr-code",
+			"llms-full.txt"
+		],
+		"expected": "qr-code llms-full.txt"
+	},
+	{
+		"args": [
+			"qr-code-frame",
+			"mailto:…"
+		],
+		"expected": "qr-code-frame mailto:…"
+	},
+	{
+		"args": [
+			"qr-code-overlay",
+			"mantle-dark-high-contrast-styles"
+		],
+		"expected": "qr-code-overlay mantle-dark-high-contrast-styles"
+	},
+	{
+		"args": [
+			"qr-code-pattern",
+			"match-sorter"
+		],
+		"expected": "qr-code-pattern match-sorter"
+	},
+	{
+		"args": [
+			"radio-group-button",
+			"mb-1 size-10 text-neutral-400"
+		],
+		"expected": "radio-group-button mb-1 size-10 text-neutral-400"
+	},
+	{
+		"args": [
+			"radio-group-input-sandbox",
+			"mb-6"
+		],
+		"expected": "radio-group-input-sandbox mb-6"
+	},
+	{
+		"args": [
+			"radio-group-item",
+			"migrations/"
+		],
+		"expected": "radio-group-item migrations/"
+	},
+	{
+		"args": [
+			"radio-group-list-item",
+			"msg:"
+		],
+		"expected": "radio-group-list-item msg:"
+	},
+	{
+		"args": [
+			"react-day-picker",
+			"mt-6 text-xs font-medium uppercase tracking-wider font-mono"
+		],
+		"expected": "react-day-picker mt-6 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			"react-dom",
+			"mx-3 h-5 hidden md:block"
+		],
+		"expected": "react-dom mx-3 h-5 hidden md:block"
+	},
+	{
+		"args": [
+			"react-dom/client",
+			"no-underline"
+		],
+		"expected": "react-dom/client no-underline"
+	},
+	{
+		"args": [
+			"react-dom/server",
+			"not-disabled:bg-filled-accent text-on-filled not-disabled:hover:bg-filled-accent"
+		],
+		"expected": "react-dom/server not-disabled:bg-filled-accent text-on-filled not-disabled:hover:bg-filled-accent"
+	},
+	{
+		"args": [
+			"react-hotkeys-hook",
+			"og:image"
+		],
+		"expected": "react-hotkeys-hook og:image"
+	},
+	{
+		"args": [
+			"react-router",
+			"old-etag"
+		],
+		"expected": "react-router old-etag"
+	},
+	{
+		"args": [
+			"react-router/dom",
+			"otp-input"
+		],
+		"expected": "react-router/dom otp-input"
+	},
+	{
+		"args": [
+			"relative",
+			"p-1 space-y-px"
+		],
+		"expected": "relative p-1 space-y-px"
+	},
+	{
+		"args": [
+			"relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors",
+			"p-6 border-t border-card-muted first:border-t-0"
+		],
+		"expected": "relative flex cursor-pointer select-none items-center rounded-md text-strong text-sm font-normal outline-hidden transition-colors p-6 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			"relative flex flex-col items-center gap-8",
+			"pb-6"
+		],
+		"expected": "relative flex flex-col items-center gap-8 pb-6"
+	},
+	{
+		"args": [
+			"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden",
+			"placeholder:text-muted flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+		],
+		"expected": "relative gap-2 cursor-pointer select-none items-center pl-2 pr-8 text-strong placeholder:text-muted flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+	},
+	{
+		"args": [
+			"relative flex items-center rounded-md",
+			"pointer-events-none absolute inset-0 flex items-center justify-center"
+		],
+		"expected": "rounded-md pointer-events-none absolute inset-0 flex items-center justify-center"
+	},
+	{
+		"args": [
+			"relative flex items-start gap-2 text-sm font-sans",
+			"profile-name"
+		],
+		"expected": "relative flex items-start gap-2 text-sm font-sans profile-name"
+	},
+	{
+		"args": [
+			"relative flex min-h-[70vh] flex-col items-center justify-center px-4 py-12 text-center md:py-20",
+			"px-2 py-1.5 text-sm font-medium"
+		],
+		"expected": "relative flex min-h-[70vh] flex-col items-center justify-center text-center md:py-20 px-2 py-1.5 text-sm font-medium"
+	},
+	{
+		"args": [
+			"relative flex size-2",
+			"qr-code-frame"
+		],
+		"expected": "relative flex size-2 qr-code-frame"
+	},
+	{
+		"args": [
+			"relative flex w-full gap-1.5 rounded-md border p-2.5 text-sm font-sans",
+			"react-day-picker"
+		],
+		"expected": "relative flex w-full gap-1.5 rounded-md border p-2.5 text-sm font-sans react-day-picker"
+	},
+	{
+		"args": [
+			"relative inline-flex size-2 rounded-full",
+			"relative"
+		],
+		"expected": "inline-flex size-2 rounded-full relative"
+	},
+	{
+		"args": [
+			"relative ml-auto max-w-full",
+			"relative flex size-2"
+		],
+		"expected": "ml-auto max-w-full relative flex size-2"
+	},
+	{
+		"args": [
+			"remark-frontmatter",
+			"remark-parse"
+		],
+		"expected": "remark-frontmatter remark-parse"
+	},
+	{
+		"args": [
+			"remark-gfm",
+			"rounded-[0.0625rem]"
+		],
+		"expected": "remark-gfm rounded-[0.0625rem]"
+	},
+	{
+		"args": [
+			"remark-mdx",
+			"scale-100 border-accent-600 bg-accent-600/10 text-accent-600 opacity-100"
+		],
+		"expected": "remark-mdx scale-100 border-accent-600 bg-accent-600/10 text-accent-600 opacity-100"
+	},
+	{
+		"args": [
+			"remark-parse",
+			"scroll-fade-t h-44 overflow-y-auto"
+		],
+		"expected": "remark-parse scroll-fade-t h-44 overflow-y-auto"
+	},
+	{
+		"args": [
+			"remark-stringify",
+			"scroll-my-6"
+		],
+		"expected": "remark-stringify scroll-my-6"
+	},
+	{
+		"args": [
+			"right-1.5 top-1.5 absolute",
+			"server-error"
+		],
+		"expected": "right-1.5 top-1.5 absolute server-error"
+	},
+	{
+		"args": [
+			"robots-txt",
+			"sheet-async-user"
+		],
+		"expected": "robots-txt sheet-async-user"
+	},
+	{
+		"args": [
+			"root:",
+			"sitemap-xml"
+		],
+		"expected": "root: sitemap-xml"
+	},
+	{
+		"args": [
+			"rounded",
+			"size-4 text-accent-600"
+		],
+		"expected": "rounded size-4 text-accent-600"
+	},
+	{
+		"args": [
+			"rounded-*",
+			"slot-class"
+		],
+		"expected": "rounded-* slot-class"
+	},
+	{
+		"args": [
+			"rounded-[0.0625rem]",
+			"space-y-4"
+		],
+		"expected": "rounded-[0.0625rem] space-y-4"
+	},
+	{
+		"args": [
+			"rounded-[0.09375rem]",
+			"start-end"
+		],
+		"expected": "rounded-[0.09375rem] start-end"
+	},
+	{
+		"args": [
+			"rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600",
+			"submit-state"
+		],
+		"expected": "rounded-full bg-neutral-500/20 px-1.5 text-xs font-medium text-gray-600 submit-state"
+	},
+	{
+		"args": [
+			"rounded-full size-5",
+			"terms-of-service"
+		],
+		"expected": "rounded-full size-5 terms-of-service"
+	},
+	{
+		"args": [
+			"rounded-sm col-span-full grid grid-cols-subgrid items-center",
+			"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border border-transparent px-3 text-sm font-medium"
+		],
+		"expected": "rounded-sm col-span-full grid grid-cols-subgrid items-center text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border border-transparent px-3 text-sm font-medium"
+	},
+	{
+		"args": [
+			"rounded-xs",
+			"text-base text-mono"
+		],
+		"expected": "rounded-xs text-mono"
+	},
+	{
+		"args": [
+			"row-1",
+			"text-body -my-0.5"
+		],
+		"expected": "row-1 text-body -my-0.5"
+	},
+	{
+		"args": [
+			"scale-100 border-accent-600 bg-accent-600/10 text-accent-600 opacity-100",
+			"text-danger-600 block size-4"
+		],
+		"expected": "scale-100 border-accent-600 bg-accent-600/10 opacity-100 text-danger-600 block size-4"
+	},
+	{
+		"args": [
+			"scale-95 border-card-muted bg-gray-50 text-muted opacity-30",
+			"text-danger-700 pointer-coarse:hidden block size-4"
+		],
+		"expected": "scale-95 border-card-muted bg-gray-50 opacity-30 text-danger-700 pointer-coarse:hidden block size-4"
+	},
+	{
+		"args": [
+			"script:ld+json",
+			"text-lg font-medium"
+		],
+		"expected": "script:ld+json text-lg font-medium"
+	},
+	{
+		"args": [
+			"scroll-behavior",
+			"text-muted font-sans text-xs font-normal"
+		],
+		"expected": "scroll-behavior text-muted font-sans text-xs font-normal"
+	},
+	{
+		"args": [
+			"scroll-fade-b h-44 overflow-y-auto",
+			"text-muted ml-auto text-xs tracking-widest"
+		],
+		"expected": "scroll-fade-b h-44 overflow-y-auto text-muted ml-auto text-xs tracking-widest"
+	},
+	{
+		"args": [
+			"scroll-fade-l overflow-x-auto",
+			"text-muted-foreground font-mono text-xs"
+		],
+		"expected": "scroll-fade-l overflow-x-auto text-muted-foreground font-mono text-xs"
+	},
+	{
+		"args": [
+			"scroll-fade-r overflow-x-auto",
+			"text-red mb-2 text-base leading-4"
+		],
+		"expected": "scroll-fade-r overflow-x-auto text-red mb-2 text-base leading-4"
+	},
+	{
+		"args": [
+			"scroll-fade-t h-44 overflow-y-auto",
+			"text-right"
+		],
+		"expected": "scroll-fade-t h-44 overflow-y-auto text-right"
+	},
+	{
+		"args": [
+			"scroll-fade-x",
+			"text-sm text-muted"
+		],
+		"expected": "scroll-fade-x text-sm text-muted"
+	},
+	{
+		"args": [
+			"scroll-fade-x flex-row items-center overflow-x-auto overscroll-x-none w-full min-w-0 pt-1 -mt-1 px-1 -mx-1",
+			"text-strong flex grow flex-col gap-1"
+		],
+		"expected": "scroll-fade-x items-center overflow-x-auto overscroll-x-none w-full min-w-0 pt-1 -mt-1 px-1 -mx-1 text-strong flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			"scroll-fade-y scrollbar h-full overflow-auto overscroll-contain px-1",
+			"text-success-600 hidden size-4"
+		],
+		"expected": "scroll-fade-y scrollbar overflow-auto overscroll-contain px-1 text-success-600 hidden size-4"
+	},
+	{
+		"args": [
+			"scroll-fade-y scrollbar min-h-0 flex-1 overflow-y-auto pb-4",
+			"text-success-700 pointer-fine:block hidden size-4"
+		],
+		"expected": "scroll-fade-y scrollbar min-h-0 flex-1 overflow-y-auto pb-4 text-success-700 pointer-fine:block hidden size-4"
+	},
+	{
+		"args": [
+			"scroll-fade-y scrollbar sticky top-15 hidden max-h-[calc(100vh-3.75rem)] w-44 overflow-y-auto px-1 pb-4 md:block",
+			"tiny-invariant"
+		],
+		"expected": "scroll-fade-y scrollbar sticky top-15 hidden max-h-[calc(100vh-3.75rem)] w-44 overflow-y-auto px-1 pb-4 md:block tiny-invariant"
+	},
+	{
+		"args": [
+			"scroll-mt-24",
+			"translateX(-4px)"
+		],
+		"expected": "scroll-mt-24 translateX(-4px)"
+	},
+	{
+		"args": [
+			"scroll-my-6",
+			"underline"
+		],
+		"expected": "scroll-my-6 underline"
+	},
+	{
+		"args": [
+			"scroll-smooth",
+			"utils/color"
+		],
+		"expected": "scroll-smooth utils/color"
+	},
+	{
+		"args": [
+			"select-content",
+			"virtual:raw-mdx-docs"
+		],
+		"expected": "select-content virtual:raw-mdx-docs"
+	},
+	{
+		"args": [
+			"select-item",
+			"w-4 w-em"
+		],
+		"expected": "select-item w-em"
+	},
+	{
+		"args": [
+			"select-none font-mono text-sm text-muted",
+			"w-full space-y-4"
+		],
+		"expected": "select-none font-mono text-sm text-muted w-full space-y-4"
+	},
+	{
+		"args": [
+			"select-separator",
+			"-mx-1.25 my-1 w-auto"
+		],
+		"expected": "select-separator -mx-1.25 my-1 w-auto"
+	},
+	{
+		"args": [
+			"select-trigger",
+			"@mdx-js/react"
+		],
+		"expected": "select-trigger @mdx-js/react"
+	},
+	{
+		"args": [
+			"server-error",
+			"@ngrok/mantle/badge"
+		],
+		"expected": "server-error @ngrok/mantle/badge"
+	},
+	{
+		"args": [
+			"server:",
+			"@ngrok/mantle/code-block"
+		],
+		"expected": "server: @ngrok/mantle/code-block"
+	},
+	{
+		"args": [
+			"sg-sin-1",
+			"@ngrok/mantle/field"
+		],
+		"expected": "sg-sin-1 @ngrok/mantle/field"
+	},
+	{
+		"args": [
+			"shadow-2xl",
+			"@ngrok/mantle/main"
+		],
+		"expected": "shadow-2xl @ngrok/mantle/main"
+	},
+	{
+		"args": [
+			"shadow-inner",
+			"@ngrok/mantle/pagination"
+		],
+		"expected": "shadow-inner @ngrok/mantle/pagination"
+	},
+	{
+		"args": [
+			"shape-rendering",
+			"@ngrok/mantle/slot"
+		],
+		"expected": "shape-rendering @ngrok/mantle/slot"
+	},
+	{
+		"args": [
+			"sheet-async",
+			"@ngrok/mantle/tooltip"
+		],
+		"expected": "sheet-async @ngrok/mantle/tooltip"
+	},
+	{
+		"args": [
+			"sheet-async-user",
+			"@phosphor-icons/react/CaretLeft"
+		],
+		"expected": "sheet-async-user @phosphor-icons/react/CaretLeft"
+	},
+	{
+		"args": [
+			"sheet-overlay",
+			"@phosphor-icons/react/Desktop"
+		],
+		"expected": "sheet-overlay @phosphor-icons/react/Desktop"
+	},
+	{
+		"args": [
+			"should-not-typecheck",
+			"@phosphor-icons/react/Info"
+		],
+		"expected": "should-not-typecheck @phosphor-icons/react/Info"
+	},
+	{
+		"args": [
+			"shrink-0",
+			"@phosphor-icons/react/Moon"
+		],
+		"expected": "shrink-0 @phosphor-icons/react/Moon"
+	},
+	{
+		"args": [
+			"shrink-0 leading-none",
+			"@phosphor-icons/react/Sparkle"
+		],
+		"expected": "shrink-0 leading-none @phosphor-icons/react/Sparkle"
+	},
+	{
+		"args": [
+			"shrink-0 size-12 sm:size-16",
+			"@phosphor-icons/react/X"
+		],
+		"expected": "shrink-0 size-12 sm:size-16 @phosphor-icons/react/X"
+	},
+	{
+		"args": [
+			"shrink-0 size-20 sm:size-28",
+			"@radix-ui/react-select"
+		],
+		"expected": "shrink-0 size-20 sm:size-28 @radix-ui/react-select"
+	},
+	{
+		"args": [
+			"sitemap-xml",
+			"@react-router/node"
+		],
+		"expected": "sitemap-xml @react-router/node"
+	},
+	{
+		"args": [
+			"size-10",
+			"Access-Control-Allow-Origin"
+		],
+		"expected": "size-10 Access-Control-Allow-Origin"
+	},
+	{
+		"args": [
+			"size-12 sm:size-16",
+			"Content-Type"
+		],
+		"expected": "size-12 sm:size-16 Content-Type"
+	},
+	{
+		"args": [
+			"size-2 rounded-full bg-white shrink-0",
+			"KN-SK"
+		],
+		"expected": "size-2 rounded-full bg-white shrink-0 KN-SK"
+	},
+	{
+		"args": [
+			"size-20 sm:size-28",
+			"Sort-time-oldest-to-newest"
+		],
+		"expected": "size-20 sm:size-28 Sort-time-oldest-to-newest"
+	},
+	{
+		"args": [
+			"size-3",
+			"X-Content-Type-Options"
+		],
+		"expected": "size-3 X-Content-Type-Options"
+	},
+	{
+		"args": [
+			"size-4",
+			"absolute right-2 flex h-3.5 w-3.5 items-center justify-center"
+		],
+		"expected": "size-4 absolute right-2 flex h-3.5 w-3.5 items-center justify-center"
+	},
+	{
+		"args": [
+			"size-4 text-accent-600",
+			"accordion-item"
+		],
+		"expected": "size-4 text-accent-600 accordion-item"
+	},
+	{
+		"args": [
+			"size-5",
+			"alert-dialog-trigger"
+		],
+		"expected": "size-5 alert-dialog-trigger"
+	},
+	{
+		"args": [
+			"size-5 shrink-0 opacity-50",
+			"api-components-json"
+		],
+		"expected": "size-5 shrink-0 opacity-50 api-components-json"
+	},
+	{
+		"args": [
+			"size-6",
+			"api/components.json"
+		],
+		"expected": "size-6 api/components.json"
+	},
+	{
+		"args": [
+			"size-64",
+			"appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded text-mono leading-none font-mono"
+		],
+		"expected": "appearance-none tabular-nums inline-grid place-items-center size-5 bg-neutral-500/15 px-1 rounded text-mono leading-none font-mono"
+	},
+	{
+		"args": [
+			"size-7",
+			"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600"
+		],
+		"expected": "size-7 aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600"
+	},
+	{
+		"args": [
+			"size-9",
+			"aria-expanded"
+		],
+		"expected": "size-9 aria-expanded"
+	},
+	{
+		"args": [
+			"slot-class",
+			"autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]"
+		],
+		"expected": "slot-class autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] has-autofill:bg-blue-50 has-autofill:[-webkit-text-fill-color:var(--text-color-strong)]"
+	},
+	{
+		"args": [
+			"slot-only-class",
+			"base/typography"
+		],
+		"expected": "slot-only-class base/typography"
+	},
+	{
+		"args": [
+			"sm:max-w-[560px]",
+			"bg-accent-50"
+		],
+		"expected": "sm:max-w-[560px] bg-accent-50"
+	},
+	{
+		"args": [
+			"space-y-1",
+			"bg-accent-900"
+		],
+		"expected": "space-y-1 bg-accent-900"
+	},
+	{
+		"args": [
+			"space-y-1 border-l border-gray-300",
+			"bg-amber-500"
+		],
+		"expected": "space-y-1 border-l border-gray-300 bg-amber-500"
+	},
+	{
+		"args": [
+			"space-y-2",
+			"bg-base"
+		],
+		"expected": "space-y-2 bg-base"
+	},
+	{
+		"args": [
+			"space-y-3",
+			"bg-blue-500"
+		],
+		"expected": "space-y-3 bg-blue-500"
+	},
+	{
+		"args": [
+			"space-y-4",
+			"bg-card fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden"
+		],
+		"expected": "space-y-4 bg-card fixed bottom-0 left-0 right-0 top-15 z-50 p-4 md:hidden"
+	},
+	{
+		"args": [
+			"space-y-4 mb-4",
+			"bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+		],
+		"expected": "space-y-4 mb-4 bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+	},
+	{
+		"args": [
+			"space-y-4 text-center",
+			"bg-cyan-50"
+		],
+		"expected": "space-y-4 text-center bg-cyan-50"
+	},
+	{
+		"args": [
+			"space-y-px",
+			"bg-cyan-950"
+		],
+		"expected": "space-y-px bg-cyan-950"
+	},
+	{
+		"args": [
+			"split-button",
+			"bg-danger-500/20"
+		],
+		"expected": "split-button bg-danger-500/20"
+	},
+	{
+		"args": [
+			"sr-only",
+			"bg-emerald-100"
+		],
+		"expected": "sr-only bg-emerald-100"
+	},
+	{
+		"args": [
+			"sr-only absolute",
+			"bg-emerald-600"
+		],
+		"expected": "sr-only absolute bg-emerald-600"
+	},
+	{
+		"args": [
+			"start-end",
+			"bg-fuchsia-100"
+		],
+		"expected": "start-end bg-fuchsia-100"
+	},
+	{
+		"args": [
+			"sticky top-0 z-30 bg-card",
+			"bg-fuchsia-600"
+		],
+		"expected": "sticky top-0 z-30 bg-fuchsia-600"
+	},
+	{
+		"args": [
+			"sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4",
+			"bg-gray-300"
+		],
+		"expected": "sticky top-15 flex max-h-[calc(100vh-3.75rem)] w-40 flex-col pt-4 bg-gray-300"
+	},
+	{
+		"args": [
+			"sticky z-10 right-0 bg-inherit",
+			"bg-gray-800"
+		],
+		"expected": "sticky z-10 right-0 bg-gray-800"
+	},
+	{
+		"args": [
+			"stop-opacity-0 stop-color-current",
+			"bg-green-50"
+		],
+		"expected": "stop-opacity-0 stop-color-current bg-green-50"
+	},
+	{
+		"args": [
+			"stop-opacity-100 stop-color-current",
+			"bg-green-950"
+		],
+		"expected": "stop-opacity-100 stop-color-current bg-green-950"
+	},
+	{
+		"args": [
+			"string[]",
+			"bg-indigo-500"
+		],
+		"expected": "string[] bg-indigo-500"
+	},
+	{
+		"args": [
+			"submit-state",
+			"bg-info-100"
+		],
+		"expected": "submit-state bg-info-100"
+	},
+	{
+		"args": [
+			"svg-only",
+			"bg-info-600"
+		],
+		"expected": "svg-only bg-info-600"
+	},
+	{
+		"args": [
+			"table",
+			"bg-lime-300"
+		],
+		"expected": "table bg-lime-300"
+	},
+	{
+		"args": [
+			"tabs-badge",
+			"bg-lime-800"
+		],
+		"expected": "tabs-badge bg-lime-800"
+	},
+	{
+		"args": [
+			"tabs-content",
+			"bg-neutral-300"
+		],
+		"expected": "tabs-content bg-neutral-300"
+	},
+	{
+		"args": [
+			"tabs-trigger",
+			"bg-neutral-800"
+		],
+		"expected": "tabs-trigger bg-neutral-800"
+	},
+	{
+		"args": [
+			"tailwind-merge",
+			"bg-orange-50"
+		],
+		"expected": "tailwind-merge bg-orange-50"
+	},
+	{
+		"args": [
+			"terms-of-service",
+			"bg-orange-950"
+		],
+		"expected": "terms-of-service bg-orange-950"
+	},
+	{
+		"args": [
+			"text-(--alert-dismiss-icon-color)",
+			"bg-pink-500"
+		],
+		"expected": "text-(--alert-dismiss-icon-color) bg-pink-500"
+	},
+	{
+		"args": [
+			"text-2xl",
+			"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden"
+		],
+		"expected": "text-2xl bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden"
+	},
+	{
+		"args": [
+			"text-4xl font-medium sm:text-5xl font-family",
+			"bg-purple-400"
+		],
+		"expected": "text-4xl font-medium sm:text-5xl font-family bg-purple-400"
+	},
+	{
+		"args": [
+			"text-4xl font-medium text-strong sm:text-5xl font-family mb-4",
+			"bg-purple-900"
+		],
+		"expected": "text-4xl font-medium text-strong sm:text-5xl font-family mb-4 bg-purple-900"
+	},
+	{
+		"args": [
+			"text-[0.75em]",
+			"bg-red-500"
+		],
+		"expected": "text-[0.75em] bg-red-500"
+	},
+	{
+		"args": [
+			"text-accent-600",
+			"bg-rose-100"
+		],
+		"expected": "text-accent-600 bg-rose-100"
+	},
+	{
+		"args": [
+			"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border border-transparent px-3 text-sm font-medium",
+			"bg-rose-600"
+		],
+		"expected": "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 h-9 border border-transparent px-3 text-sm font-medium bg-rose-600"
+	},
+	{
+		"args": [
+			"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group/button-link border-transparent",
+			"bg-sky-300"
+		],
+		"expected": "text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:underline group/button-link border-transparent bg-sky-300"
+	},
+	{
+		"args": [
+			"text-accent-600 hover:text-accent-600 font-medium high-contrast:bg-filled-accent high-contrast:text-on-filled high-contrast:hover:text-on-filled high-contrast:rounded-md high-contrast:px-2 high-contrast:-ml-2",
+			"bg-sky-800"
+		],
+		"expected": "text-accent-600 hover:text-accent-600 font-medium high-contrast:bg-filled-accent high-contrast:text-on-filled high-contrast:hover:text-on-filled high-contrast:rounded-md high-contrast:px-2 high-contrast:-ml-2 bg-sky-800"
+	},
+	{
+		"args": [
+			"text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs",
+			"bg-success-300"
+		],
+		"expected": "text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs bg-success-300"
+	},
+	{
+		"args": [
+			"text-accent-600 text-sm font-medium flex-1",
+			"bg-success-800"
+		],
+		"expected": "text-accent-600 text-sm font-medium flex-1 bg-success-800"
+	},
+	{
+		"args": [
+			"text-area",
+			"bg-teal-50"
+		],
+		"expected": "text-area bg-teal-50"
+	},
+	{
+		"args": [
+			"text-base",
+			"bg-teal-950"
+		],
+		"expected": "text-base bg-teal-950"
+	},
+	{
+		"args": [
+			"text-base text-mono",
+			"bg-violet-50"
+		],
+		"expected": "text-mono bg-violet-50"
+	},
+	{
+		"args": [
+			"text-base text-size-inherit",
+			"bg-violet-950"
+		],
+		"expected": "text-size-inherit bg-violet-950"
+	},
+	{
+		"args": [
+			"text-blue",
+			"bg-warning-500/20"
+		],
+		"expected": "text-blue bg-warning-500/20"
+	},
+	{
+		"args": [
+			"text-blue-500",
+			"bg-yellow-100"
+		],
+		"expected": "text-blue-500 bg-yellow-100"
+	},
+	{
+		"args": [
+			"text-blue-500 no-underline",
+			"bg-yellow-600"
+		],
+		"expected": "text-blue-500 no-underline bg-yellow-600"
+	},
+	{
+		"args": [
+			"text-blue-500 px-2 py-2",
+			"border-0"
+		],
+		"expected": "text-blue-500 px-2 py-2 border-0"
+	},
+	{
+		"args": [
+			"text-body",
+			"border-card-muted bg-base relative rounded-md border shadow-inner"
+		],
+		"expected": "text-body border-card-muted bg-base relative rounded-md border shadow-inner"
+	},
+	{
+		"args": [
+			"text-body -my-0.5",
+			"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]"
+		],
+		"expected": "text-body -my-0.5 border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]"
+	},
+	{
+		"args": [
+			"text-body font-mono text-mono py-2 px-3",
+			"border-x-0 border-t-0 rounded-none z-50 sticky"
+		],
+		"expected": "text-body font-mono text-mono py-2 px-3 border-x-0 border-t-0 rounded-none z-50 sticky"
+	},
+	{
+		"args": [
+			"text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0",
+			"card-footer"
+		],
+		"expected": "text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0 card-footer"
+	},
+	{
+		"args": [
+			"text-body text-sm leading-4",
+			"child-class"
+		],
+		"expected": "text-body text-sm leading-4 child-class"
+	},
+	{
+		"args": [
+			"text-body w-7 text-[0.8rem] text-center font-normal",
+			"code-block-body"
+		],
+		"expected": "text-body w-7 text-[0.8rem] text-center font-normal code-block-body"
+	},
+	{
+		"args": [
+			"text-center space-y-1",
+			"combobox-item-value"
+		],
+		"expected": "text-center space-y-1 combobox-item-value"
+	},
+	{
+		"args": [
+			"text-danger-600",
+			"command-list"
+		],
+		"expected": "text-danger-600 command-list"
+	},
+	{
+		"args": [
+			"text-danger-600 block size-4",
+			"components/alert-dialog"
+		],
+		"expected": "text-danger-600 block size-4 components/alert-dialog"
+	},
+	{
+		"args": [
+			"text-danger-600 flex items-center gap-2",
+			"components/checkbox"
+		],
+		"expected": "text-danger-600 flex items-center gap-2 components/checkbox"
+	},
+	{
+		"args": [
+			"text-danger-600 order-last select-none",
+			"components/description-list"
+		],
+		"expected": "text-danger-600 order-last select-none components/description-list"
+	},
+	{
+		"args": [
+			"text-danger-700 dark-high-contrast:hidden block size-4",
+			"components/icon"
+		],
+		"expected": "text-danger-700 dark-high-contrast:hidden block size-4 components/icon"
+	},
+	{
+		"args": [
+			"text-danger-700 high-contrast:hidden block size-4",
+			"components/media-object"
+		],
+		"expected": "text-danger-700 high-contrast:hidden block size-4 components/media-object"
+	},
+	{
+		"args": [
+			"text-danger-700 hover-hover:hidden block size-4",
+			"components/preview/accordion"
+		],
+		"expected": "text-danger-700 hover-hover:hidden block size-4 components/preview/accordion"
+	},
+	{
+		"args": [
+			"text-danger-700 hover-none:hidden block size-4",
+			"components/select"
+		],
+		"expected": "text-danger-700 hover-none:hidden block size-4 components/select"
+	},
+	{
+		"args": [
+			"text-danger-700 pointer-coarse:hidden block size-4",
+			"components/split-button"
+		],
+		"expected": "text-danger-700 pointer-coarse:hidden block size-4 components/split-button"
+	},
+	{
+		"args": [
+			"text-danger-700 pointer-fine:hidden block size-4",
+			"components/tooltip"
+		],
+		"expected": "text-danger-700 pointer-fine:hidden block size-4 components/tooltip"
+	},
+	{
+		"args": [
+			"text-danger-700 pointer-none:hidden block size-4",
+			"cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal"
+		],
+		"expected": "pointer-none:hidden size-4 cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal"
+	},
+	{
+		"args": [
+			"text-emerald-600",
+			"cursor-pointer"
+		],
+		"expected": "text-emerald-600 cursor-pointer"
+	},
+	{
+		"args": [
+			"text-gold",
+			"custom-group"
+		],
+		"expected": "text-gold custom-group"
+	},
+	{
+		"args": [
+			"text-gray-500",
+			"data-analytics-id"
+		],
+		"expected": "text-gray-500 data-analytics-id"
+	},
+	{
+		"args": [
+			"text-gray-500 underline",
+			"data-disabled:pointer-events-none data-disabled:opacity-50"
+		],
+		"expected": "text-gray-500 underline data-disabled:pointer-events-none data-disabled:opacity-50"
+	},
+	{
+		"args": [
+			"text-lg font-medium",
+			"data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item"
+		],
+		"expected": "text-lg font-medium data-highlighted:bg-active-menu-item data-state-open:bg-active-menu-item"
+	},
+	{
+		"args": [
+			"text-mono",
+			"data-slot"
+		],
+		"expected": "text-mono data-slot"
+	},
+	{
+		"args": [
+			"text-mono mt-8 flex flex-wrap gap-8 font-mono",
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs"
+		],
+		"expected": "text-mono mt-8 flex flex-wrap gap-8 font-mono data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs"
+	},
+	{
+		"args": [
+			"text-mono text-base",
+			"data-table-row-expand-button"
+		],
+		"expected": "text-base data-table-row-expand-button"
+	},
+	{
+		"args": [
+			"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono",
+			"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600"
+		],
+		"expected": "text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600"
+	},
+	{
+		"args": [
+			"text-muted",
+			"data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success"
+		],
+		"expected": "text-muted data-validation-success:border-success-600 focus-within:data-validation-success:border-success-600 focus-within:data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"text-muted flex items-center",
+			"data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+		],
+		"expected": "text-muted flex items-center data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning"
+	},
+	{
+		"args": [
+			"text-muted font-sans text-xs font-normal",
+			"deployment-id"
+		],
+		"expected": "text-muted font-sans text-xs font-normal deployment-id"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong",
+			"disabled:cursor-default disabled:opacity-50"
+		],
+		"expected": "text-muted hover:text-strong disabled:cursor-default disabled:opacity-50"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong block py-1 cursor-pointer focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent rounded",
+			"dropdown-menu-group"
+		],
+		"expected": "text-muted hover:text-strong block py-1 cursor-pointer focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent rounded dropdown-menu-group"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong block py-1 rounded focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent",
+			"dropdown-menu-sub-content"
+		],
+		"expected": "text-muted hover:text-strong block py-1 rounded focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent dropdown-menu-sub-content"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong flex items-center gap-1 font-mono text-[0.8125rem] leading-[1.5em] font-medium",
+			"empty-description"
+		],
+		"expected": "text-muted hover:text-strong flex items-center gap-1 font-mono text-[0.8125rem] leading-[1.5em] font-medium empty-description"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong flex items-center gap-1 text-left font-mono text-[0.8125rem] leading-[1.5em] font-medium",
+			"family-regular"
+		],
+		"expected": "text-muted hover:text-strong flex items-center gap-1 text-left font-mono text-[0.8125rem] leading-[1.5em] font-medium family-regular"
+	},
+	{
+		"args": [
+			"text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium",
+			"field-label-text"
+		],
+		"expected": "text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium field-label-text"
+	},
+	{
+		"args": [
+			"text-muted ml-auto text-xs tracking-widest",
+			"flex"
+		],
+		"expected": "text-muted ml-auto text-xs tracking-widest flex"
+	},
+	{
+		"args": [
+			"text-muted opacity-50",
+			"flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0 relative max-w-min"
+		],
+		"expected": "text-muted opacity-50 flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0 relative max-w-min"
+	},
+	{
+		"args": [
+			"text-muted space-y-4 text-sm font-sans",
+			"flex h-28 w-64 items-center justify-center rounded-xl border-2 font-mono text-sm transition-all duration-500"
+		],
+		"expected": "text-muted space-y-4 flex h-28 w-64 items-center justify-center rounded-xl border-2 font-mono text-sm transition-all duration-500"
+	},
+	{
+		"args": [
+			"text-muted text-sm",
+			"flex items-center gap-2 rounded font-mono text-xl leading-8 text-strong/90 hover:text-strong focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+		],
+		"expected": "flex items-center gap-2 rounded font-mono text-xl leading-8 text-strong/90 hover:text-strong focus:outline-hidden focus-visible:ring-3 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"text-muted text-sm font-sans font-medium min-w-36 p-2",
+			"flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted"
+		],
+		"expected": "text-sm font-sans font-medium min-w-36 p-2 flex justify-start w-full h-full rounded-none not-disabled:active:scale-none text-muted"
+	},
+	{
+		"args": [
+			"text-muted text-xs",
+			"flex w-full max-w-270 flex-col items-center"
+		],
+		"expected": "text-muted text-xs flex w-full max-w-270 flex-col items-center"
+	},
+	{
+		"args": [
+			"text-muted text-xs font-mono",
+			"flex-wrap gap-4"
+		],
+		"expected": "text-muted text-xs font-mono flex-wrap gap-4"
+	},
+	{
+		"args": [
+			"text-muted-foreground font-mono text-xs",
+			"focus:bg-accent focus:text-accent-foreground"
+		],
+		"expected": "text-muted-foreground font-mono text-xs focus:bg-accent focus:text-accent-foreground"
+	},
+	{
+		"args": [
+			"text-muted-foreground text-sm gap-2 flex items-center",
+			"fold%20%22one%22%20region"
+		],
+		"expected": "text-muted-foreground text-sm gap-2 flex items-center fold%20%22one%22%20region"
+	},
+	{
+		"args": [
+			"text-orange-600",
+			"font-family text-strong text-8xl leading-none md:text-9xl"
+		],
+		"expected": "font-family text-strong text-8xl leading-none md:text-9xl"
+	},
+	{
+		"args": [
+			"text-placeholder",
+			"font-sans"
+		],
+		"expected": "text-placeholder font-sans"
+	},
+	{
+		"args": [
+			"text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans",
+			"gap-0.5"
+		],
+		"expected": "text-popover-foreground border-popover bg-popover p-1.25 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl space-y-px font-sans gap-0.5"
+	},
+	{
+		"args": [
+			"text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans",
+			"gap-6"
+		],
+		"expected": "text-popover-foreground border-popover bg-popover p-1.25 z-50 min-w-32 overflow-hidden rounded-md border shadow-xl outline-hidden space-y-px font-sans gap-6"
+	},
+	{
+		"args": [
+			"text-red",
+			"group"
+		],
+		"expected": "text-red group"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-base leading-4",
+			"group-data-validation/otp:border-y-(--otp-validation-border)"
+		],
+		"expected": "text-red mb-2 text-base leading-4 group-data-validation/otp:border-y-(--otp-validation-border)"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-base leading-4 text-blue text-xl leading-5",
+			"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm"
+		],
+		"expected": "mb-2 text-blue group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-base leading-4 text-xl",
+			"h-10 w-full rounded bg-neutral-950/60"
+		],
+		"expected": "text-red mb-2 text-xl h-10 w-full rounded bg-neutral-950/60"
+	},
+	{
+		"args": [
+			"text-red mb-2 text-xl",
+			"h-auto w-full max-w-126 text-neutral-200"
+		],
+		"expected": "mb-2 text-xl h-auto w-full max-w-126 text-neutral-200"
+	},
+	{
+		"args": [
+			"text-red-500",
+			"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2"
+		],
+		"expected": "text-red-500 has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2"
+	},
+	{
+		"args": [
+			"text-red-500 font-medium",
+			"hidden md:inline-flex"
+		],
+		"expected": "text-red-500 font-medium hidden md:inline-flex"
+	},
+	{
+		"args": [
+			"text-red-500 px-4",
+			"hover-card-trigger"
+		],
+		"expected": "text-red-500 px-4 hover-card-trigger"
+	},
+	{
+		"args": [
+			"text-right",
+			"hover:text-strong"
+		],
+		"expected": "text-right hover:text-strong"
+	},
+	{
+		"args": [
+			"text-size-inherit",
+			"https:"
+		],
+		"expected": "text-size-inherit https:"
+	},
+	{
+		"args": [
+			"text-size-inherit text-base",
+			"https://github.com/ngrok/mantle"
+		],
+		"expected": "text-base https://github.com/ngrok/mantle"
+	},
+	{
+		"args": [
+			"text-sm",
+			"https://mantle.ngrok.com/api/schema.json"
+		],
+		"expected": "text-sm https://mantle.ngrok.com/api/schema.json"
+	},
+	{
+		"args": [
+			"text-sm font-medium",
+			"https://mantle.ngrok.com/utils/gamma"
+		],
+		"expected": "text-sm font-medium https://mantle.ngrok.com/utils/gamma"
+	},
+	{
+		"args": [
+			"text-sm pb-16",
+			"https://ngrok.com/abuse"
+		],
+		"expected": "text-sm pb-16 https://ngrok.com/abuse"
+	},
+	{
+		"args": [
+			"text-sm px-1 mb-6",
+			"https://ngrok.com/docs/agent/overview"
+		],
+		"expected": "text-sm px-1 mb-6 https://ngrok.com/docs/agent/overview"
+	},
+	{
+		"args": [
+			"text-sm text-muted",
+			"https://ngrok.com/docs/k8s/guides/local-projection"
+		],
+		"expected": "text-sm text-muted https://ngrok.com/docs/k8s/guides/local-projection"
+	},
+	{
+		"args": [
+			"text-sm text-strong",
+			"https://ngrok.com/docs/universal-gateway/overview"
+		],
+		"expected": "text-sm text-strong https://ngrok.com/docs/universal-gateway/overview"
+	},
+	{
+		"args": [
+			"text-sm text-strong font-medium",
+			"https://ngrok.com/pricing"
+		],
+		"expected": "text-sm text-strong font-medium https://ngrok.com/pricing"
+	},
+	{
+		"args": [
+			"text-strong",
+			"https://ngrok.com/use-cases/site-to-site-connectivity"
+		],
+		"expected": "text-strong https://ngrok.com/use-cases/site-to-site-connectivity"
+	},
+	{
+		"args": [
+			"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans",
+			"https://www.linkedin.com/company/ngrok/"
+		],
+		"expected": "text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans https://www.linkedin.com/company/ngrok/"
+	},
+	{
+		"args": [
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden",
+			"ignored-description"
+		],
+		"expected": "text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden ignored-description"
+	},
+	{
+		"args": [
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none",
+			"inline-block ml-1.5"
+		],
+		"expected": "text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none inline-block ml-1.5"
+	},
+	{
+		"args": [
+			"text-strong flex grow flex-col gap-1",
+			"inline-flex md:hidden"
+		],
+		"expected": "text-strong grow flex-col gap-1 inline-flex md:hidden"
+	},
+	{
+		"args": [
+			"text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent",
+			"item-child"
+		],
+		"expected": "text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent item-child"
+	},
+	{
+		"args": [
+			"text-strong leading-none font-semibold tracking-wider uppercase",
+			"jp-tokyo-1"
+		],
+		"expected": "text-strong leading-none font-semibold tracking-wider uppercase jp-tokyo-1"
+	},
+	{
+		"args": [
+			"text-strong text-base font-medium",
+			"lang-tsx"
+		],
+		"expected": "text-strong text-base font-medium lang-tsx"
+	},
+	{
+		"args": [
+			"text-strong text-sm font-medium",
+			"llms-full-txt"
+		],
+		"expected": "text-strong text-sm font-medium llms-full-txt"
+	},
+	{
+		"args": [
+			"text-strong text-sm font-medium font-sans",
+			"mailto:foo@bar.com"
+		],
+		"expected": "text-strong text-sm font-medium font-sans mailto:foo@bar.com"
+	},
+	{
+		"args": [
+			"text-success-600",
+			"mantle-css-variables"
+		],
+		"expected": "text-success-600 mantle-css-variables"
+	},
+	{
+		"args": [
+			"text-success-600 hidden size-4",
+			"mantle-ui-theme"
+		],
+		"expected": "text-success-600 hidden size-4 mantle-ui-theme"
+	},
+	{
+		"args": [
+			"text-success-600 order-last select-none",
+			"mb-*"
+		],
+		"expected": "text-success-600 order-last select-none mb-*"
+	},
+	{
+		"args": [
+			"text-success-700 dark-high-contrast:block hidden size-4",
+			"mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0"
+		],
+		"expected": "text-success-700 dark-high-contrast:block hidden size-4 mb-4 sm:absolute sm:right-0 sm:top-0 sm:z-10 sm:mb-0"
+	},
+	{
+		"args": [
+			"text-success-700 high-contrast:block hidden size-4",
+			"mfa-qr"
+		],
+		"expected": "text-success-700 high-contrast:block hidden size-4 mfa-qr"
+	},
+	{
+		"args": [
+			"text-success-700 hover-hover:block hidden size-4",
+			"ml-auto text-xs tracking-widest opacity-60"
+		],
+		"expected": "text-success-700 hover-hover:block hidden size-4 ml-auto text-xs tracking-widest opacity-60"
+	},
+	{
+		"args": [
+			"text-success-700 hover-none:block hidden size-4",
+			"mt-4 flex items-center gap-2"
+		],
+		"expected": "text-success-700 hover-none:block size-4 mt-4 flex items-center gap-2"
+	},
+	{
+		"args": [
+			"text-success-700 pointer-coarse:block hidden size-4",
+			"mx-1 h-5 md:hidden"
+		],
+		"expected": "text-success-700 pointer-coarse:block hidden size-4 mx-1 h-5 md:hidden"
+	},
+	{
+		"args": [
+			"text-success-700 pointer-fine:block hidden size-4",
+			"newest-to-oldest"
+		],
+		"expected": "text-success-700 pointer-fine:block hidden size-4 newest-to-oldest"
+	},
+	{
+		"args": [
+			"text-success-700 pointer-none:block hidden size-4",
+			"not-disabled:active:scale-97 ease-out transition-transform duration-150"
+		],
+		"expected": "text-success-700 pointer-none:block hidden size-4 not-disabled:active:scale-97 ease-out transition-transform duration-150"
+	},
+	{
+		"args": [
+			"text-warning-600",
+			"og:description"
+		],
+		"expected": "text-warning-600 og:description"
+	},
+	{
+		"args": [
+			"text-warning-600 order-last select-none",
+			"ok-on-element-form"
+		],
+		"expected": "text-warning-600 order-last select-none ok-on-element-form"
+	},
+	{
+		"args": [
+			"text-xs",
+			"order-last -mt-4 self-start sm:order-first sm:mt-0 sm:self-auto"
+		],
+		"expected": "text-xs order-last -mt-4 self-start sm:order-first sm:mt-0 sm:self-auto"
+	},
+	{
+		"args": [
+			"text-yellow-600",
+			"p-0"
+		],
+		"expected": "text-yellow-600 p-0"
+	},
+	{
+		"args": [
+			"text/markdown",
+			"p-4 pt-5 pr-3 pb-3"
+		],
+		"expected": "text/markdown p-4 pt-5 pr-3 pb-3"
+	},
+	{
+		"args": [
+			"tiny-invariant",
+			"pattern-b"
+		],
+		"expected": "tiny-invariant pattern-b"
+	},
+	{
+		"args": [
+			"toast-icon",
+			"pl-8"
+		],
+		"expected": "toast-icon pl-8"
+	},
+	{
+		"args": [
+			"tooltip-content",
+			"pointer-events-none"
+		],
+		"expected": "tooltip-content pointer-events-none"
+	},
+	{
+		"args": [
+			"tooltip-provider",
+			"profile-card"
+		],
+		"expected": "tooltip-provider profile-card"
+	},
+	{
+		"args": [
+			"tooltip-trigger",
+			"px-2"
+		],
+		"expected": "tooltip-trigger px-2"
+	},
+	{
+		"args": [
+			"top-center",
+			"qr-code"
+		],
+		"expected": "top-center qr-code"
+	},
+	{
+		"args": [
+			"traffic-policy",
+			"radio-group-list-item"
+		],
+		"expected": "traffic-policy radio-group-list-item"
+	},
+	{
+		"args": [
+			"translateX(-4px)",
+			"react-router/dom"
+		],
+		"expected": "translateX(-4px) react-router/dom"
+	},
+	{
+		"args": [
+			"twitter:card",
+			"relative flex min-h-[70vh] flex-col items-center justify-center px-4 py-12 text-center md:py-20"
+		],
+		"expected": "twitter:card relative flex min-h-[70vh] flex-col items-center justify-center px-4 py-12 text-center md:py-20"
+	},
+	{
+		"args": [
+			"twitter:description",
+			"remark-mdx"
+		],
+		"expected": "twitter:description remark-mdx"
+	},
+	{
+		"args": [
+			"twitter:domain",
+			"rounded-*"
+		],
+		"expected": "twitter:domain rounded-*"
+	},
+	{
+		"args": [
+			"twitter:image",
+			"row-1"
+		],
+		"expected": "twitter:image row-1"
+	},
+	{
+		"args": [
+			"twitter:title",
+			"scroll-fade-r overflow-x-auto"
+		],
+		"expected": "twitter:title scroll-fade-r overflow-x-auto"
+	},
+	{
+		"args": [
+			"twitter:url",
+			"scroll-mt-24"
+		],
+		"expected": "twitter:url scroll-mt-24"
+	},
+	{
+		"args": [
+			"underline",
+			"select-trigger"
+		],
+		"expected": "underline select-trigger"
+	},
+	{
+		"args": [
+			"united-states",
+			"sheet-async"
+		],
+		"expected": "united-states sheet-async"
+	},
+	{
+		"args": [
+			"us-cal-1",
+			"shrink-0 size-20 sm:size-28"
+		],
+		"expected": "us-cal-1 shrink-0 size-20 sm:size-28"
+	},
+	{
+		"args": [
+			"us-ohio-1",
+			"size-4"
+		],
+		"expected": "us-ohio-1 size-4"
+	},
+	{
+		"args": [
+			"utf-8",
+			"size-9"
+		],
+		"expected": "utf-8 size-9"
+	},
+	{
+		"args": [
+			"utilities/mantle-version.server.ts",
+			"space-y-3"
+		],
+		"expected": "utilities/mantle-version.server.ts space-y-3"
+	},
+	{
+		"args": [
+			"utils/",
+			"sr-only absolute"
+		],
+		"expected": "utils/ sr-only absolute"
+	},
+	{
+		"args": [
+			"utils/color",
+			"string[]"
+		],
+		"expected": "utils/color string[]"
+	},
+	{
+		"args": [
+			"utils/compose-refs",
+			"tailwind-merge"
+		],
+		"expected": "utils/compose-refs tailwind-merge"
+	},
+	{
+		"args": [
+			"utils/cx",
+			"text-accent-600"
+		],
+		"expected": "utils/cx text-accent-600"
+	},
+	{
+		"args": [
+			"utils/highlight-utils",
+			"text-base"
+		],
+		"expected": "utils/highlight-utils text-base"
+	},
+	{
+		"args": [
+			"utils/in-view",
+			"text-body"
+		],
+		"expected": "utils/in-view text-body"
+	},
+	{
+		"args": [
+			"utils/sorting",
+			"text-danger-600"
+		],
+		"expected": "utils/sorting text-danger-600"
+	},
+	{
+		"args": [
+			"virtual:mdx-doc-component-imports",
+			"text-danger-700 hover-none:hidden block size-4"
+		],
+		"expected": "virtual:mdx-doc-component-imports text-danger-700 hover-none:hidden block size-4"
+	},
+	{
+		"args": [
+			"virtual:raw-mdx-docs",
+			"text-gray-500 underline"
+		],
+		"expected": "virtual:raw-mdx-docs text-gray-500 underline"
+	},
+	{
+		"args": [
+			"w-(--radix-dropdown-menu-trigger-width)",
+			"text-muted flex items-center"
+		],
+		"expected": "w-(--radix-dropdown-menu-trigger-width) text-muted flex items-center"
+	},
+	{
+		"args": [
+			"w-(--radix-select-trigger-width)",
+			"text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+		],
+		"expected": "w-(--radix-select-trigger-width) text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			"w-*",
+			"text-muted text-xs font-mono"
+		],
+		"expected": "w-* text-muted text-xs font-mono"
+	},
+	{
+		"args": [
+			"w-0 flex-1 pb-[80vh] sm:px-8",
+			"text-red"
+		],
+		"expected": "w-0 flex-1 pb-[80vh] sm:px-8 text-red"
+	},
+	{
+		"args": [
+			"w-25",
+			"text-red-500 px-4"
+		],
+		"expected": "w-25 text-red-500 px-4"
+	},
+	{
+		"args": [
+			"w-4 h-3",
+			"text-sm px-1 mb-6"
+		],
+		"expected": "w-4 h-3 text-sm px-1 mb-6"
+	},
+	{
+		"args": [
+			"w-4 w-em",
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none"
+		],
+		"expected": "w-em text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none"
+	},
+	{
+		"args": [
+			"w-5 h-3.75",
+			"text-success-600"
+		],
+		"expected": "w-5 h-3.75 text-success-600"
+	},
+	{
+		"args": [
+			"w-50",
+			"text-success-700 pointer-coarse:block hidden size-4"
+		],
+		"expected": "text-success-700 pointer-coarse:block hidden size-4"
+	},
+	{
+		"args": [
+			"w-8 h-6",
+			"text/markdown"
+		],
+		"expected": "w-8 h-6 text/markdown"
+	},
+	{
+		"args": [
+			"w-em",
+			"traffic-policy"
+		],
+		"expected": "w-em traffic-policy"
+	},
+	{
+		"args": [
+			"w-full border-collapse space-y-1",
+			"twitter:url"
+		],
+		"expected": "w-full border-collapse space-y-1 twitter:url"
+	},
+	{
+		"args": [
+			"w-full space-y-2.5",
+			"utils/"
+		],
+		"expected": "w-full space-y-2.5 utils/"
+	},
+	{
+		"args": [
+			"w-full space-y-4",
+			"virtual:mdx-doc-component-imports"
+		],
+		"expected": "w-full space-y-4 virtual:mdx-doc-component-imports"
+	},
+	{
+		"args": [
+			"where:block where:size-4 where:p-0",
+			"w-4 h-3"
+		],
+		"expected": "where:block where:size-4 where:p-0 w-4 h-3"
+	},
+	{
+		"args": [
+			"z-1 absolute -inset-px right-auto w-1.5 rounded-l",
+			"w-full space-y-2.5"
+		],
+		"expected": "z-1 absolute -inset-px right-auto rounded-l w-full space-y-2.5"
+	},
+	{
+		"args": [
+			"*:data-user-value:font-medium",
+			"flex-1",
+			"shrink-0",
+			"text-strong",
+			"font-normal"
+		],
+		"expected": "*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+	},
+	{
+		"args": [
+			[
+				"*:data-user-value:font-medium",
+				"flex-1",
+				"shrink-0",
+				"text-strong",
+				"font-normal"
+			]
+		],
+		"expected": "*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+	},
+	{
+		"args": [
+			{
+				"*:data-user-value:font-medium": true,
+				"flex-1": true,
+				"shrink-0": true,
+				"text-strong": true,
+				"font-normal": true
+			}
+		],
+		"expected": "*:data-user-value:font-medium flex-1 shrink-0 text-strong font-normal"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"*:data-user-value:font-medium"
+				],
+				false
+			],
+			"flex-1"
+		],
+		"expected": "nested *:data-user-value:font-medium flex-1"
+	},
+	{
+		"args": [
+			"bg-card",
+			"xs:size-36",
+			"flex",
+			"h-36",
+			"w-full",
+			"shrink-0",
+			"items-center",
+			"justify-center",
+			"rounded-lg",
+			"shadow-sm"
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+	},
+	{
+		"args": [
+			[
+				"bg-card",
+				"xs:size-36",
+				"flex",
+				"h-36",
+				"w-full",
+				"shrink-0",
+				"items-center",
+				"justify-center",
+				"rounded-lg",
+				"shadow-sm"
+			]
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+	},
+	{
+		"args": [
+			{
+				"bg-card": true,
+				"xs:size-36": true,
+				"flex": true,
+				"h-36": true,
+				"w-full": true,
+				"shrink-0": true,
+				"items-center": true,
+				"justify-center": true,
+				"rounded-lg": true,
+				"shadow-sm": true
+			}
+		],
+		"expected": "bg-card xs:size-36 flex h-36 w-full shrink-0 items-center justify-center rounded-lg shadow-sm"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"bg-card"
+				],
+				false
+			],
+			"xs:size-36"
+		],
+		"expected": "nested bg-card xs:size-36"
+	},
+	{
+		"args": [
+			"bg-dialog",
+			"border-dialog",
+			"inset-y-0",
+			"h-full",
+			"w-full",
+			"fixed",
+			"z-40",
+			"flex",
+			"flex-col",
+			"shadow-lg",
+			"outline-hidden",
+			"transition",
+			"ease-in-out",
+			"focus-within:outline-hidden",
+			"data-state-closed:duration-100",
+			"data-state-closed:animate-out",
+			"data-state-open:duration-100",
+			"data-state-open:animate-in"
+		],
+		"expected": "bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+	},
+	{
+		"args": [
+			[
+				"bg-dialog",
+				"border-dialog",
+				"inset-y-0",
+				"h-full",
+				"w-full",
+				"fixed",
+				"z-40",
+				"flex",
+				"flex-col",
+				"shadow-lg",
+				"outline-hidden",
+				"transition",
+				"ease-in-out",
+				"focus-within:outline-hidden",
+				"data-state-closed:duration-100",
+				"data-state-closed:animate-out",
+				"data-state-open:duration-100",
+				"data-state-open:animate-in"
+			]
+		],
+		"expected": "bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+	},
+	{
+		"args": [
+			{
+				"bg-dialog": true,
+				"border-dialog": true,
+				"inset-y-0": true,
+				"h-full": true,
+				"w-full": true,
+				"fixed": true,
+				"z-40": true,
+				"flex": true,
+				"flex-col": true,
+				"shadow-lg": true,
+				"outline-hidden": true,
+				"transition": true,
+				"ease-in-out": true,
+				"focus-within:outline-hidden": true,
+				"data-state-closed:duration-100": true,
+				"data-state-closed:animate-out": true,
+				"data-state-open:duration-100": true,
+				"data-state-open:animate-in": true
+			}
+		],
+		"expected": "bg-dialog border-dialog inset-y-0 h-full w-full fixed z-40 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"bg-dialog"
+				],
+				false
+			],
+			"border-dialog"
+		],
+		"expected": "nested bg-dialog border-dialog"
+	},
+	{
+		"args": [
+			"bg-strong",
+			"h-4",
+			"w-px",
+			"animate-pulse"
+		],
+		"expected": "bg-strong h-4 w-px animate-pulse"
+	},
+	{
+		"args": [
+			[
+				"bg-strong",
+				"h-4",
+				"w-px",
+				"animate-pulse"
+			]
+		],
+		"expected": "bg-strong h-4 w-px animate-pulse"
+	},
+	{
+		"args": [
+			{
+				"bg-strong": true,
+				"h-4": true,
+				"w-px": true,
+				"animate-pulse": true
+			}
+		],
+		"expected": "bg-strong h-4 w-px animate-pulse"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"bg-strong"
+				],
+				false
+			],
+			"h-4"
+		],
+		"expected": "nested bg-strong h-4"
+	},
+	{
+		"args": [
+			"border-card",
+			"rounded-md",
+			"border",
+			"p-2",
+			"shadow-md"
+		],
+		"expected": "border-card rounded-md border p-2 shadow-md"
+	},
+	{
+		"args": [
+			[
+				"border-card",
+				"rounded-md",
+				"border",
+				"p-2",
+				"shadow-md"
+			]
+		],
+		"expected": "border-card rounded-md border p-2 shadow-md"
+	},
+	{
+		"args": [
+			{
+				"border-card": true,
+				"rounded-md": true,
+				"border": true,
+				"p-2": true,
+				"shadow-md": true
+			}
+		],
+		"expected": "border-card rounded-md border p-2 shadow-md"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"border-card"
+				],
+				false
+			],
+			"rounded-md"
+		],
+		"expected": "nested border-card rounded-md"
+	},
+	{
+		"args": [
+			"border-input",
+			"bg-form",
+			"data-drag-over:border-dashed",
+			"data-drag-over:ring-4",
+			"pointer-coarse:py-[calc(theme(spacing[2.5])-1px)]",
+			"pointer-coarse:text-base",
+			"flex",
+			"min-h-24",
+			"w-full",
+			"rounded-md",
+			"border",
+			"px-3",
+			"py-[calc(theme(spacing[2])-1px)]",
+			"focus-visible:outline-hidden",
+			"focus-visible:ring-4",
+			"disabled:pointer-events-none",
+			"disabled:opacity-50"
+		],
+		"expected": "border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+	},
+	{
+		"args": [
+			[
+				"border-input",
+				"bg-form",
+				"data-drag-over:border-dashed",
+				"data-drag-over:ring-4",
+				"pointer-coarse:py-[calc(theme(spacing[2.5])-1px)]",
+				"pointer-coarse:text-base",
+				"flex",
+				"min-h-24",
+				"w-full",
+				"rounded-md",
+				"border",
+				"px-3",
+				"py-[calc(theme(spacing[2])-1px)]",
+				"focus-visible:outline-hidden",
+				"focus-visible:ring-4",
+				"disabled:pointer-events-none",
+				"disabled:opacity-50"
+			]
+		],
+		"expected": "border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+	},
+	{
+		"args": [
+			{
+				"border-input": true,
+				"bg-form": true,
+				"data-drag-over:border-dashed": true,
+				"data-drag-over:ring-4": true,
+				"pointer-coarse:py-[calc(theme(spacing[2.5])-1px)]": true,
+				"pointer-coarse:text-base": true,
+				"flex": true,
+				"min-h-24": true,
+				"w-full": true,
+				"rounded-md": true,
+				"border": true,
+				"px-3": true,
+				"py-[calc(theme(spacing[2])-1px)]": true,
+				"focus-visible:outline-hidden": true,
+				"focus-visible:ring-4": true,
+				"disabled:pointer-events-none": true,
+				"disabled:opacity-50": true
+			}
+		],
+		"expected": "border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"border-input"
+				],
+				false
+			],
+			"bg-form"
+		],
+		"expected": "nested border-input bg-form"
+	},
+	{
+		"args": [
+			"data-validation-error:border-danger-600",
+			"data-validation-error:checked:bg-danger-600",
+			"data-validation-error:indeterminate:bg-danger-600",
+			"focus-visible:data-validation-error:border-danger-600",
+			"focus-visible:data-validation-error:ring-focus-danger"
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			[
+				"data-validation-error:border-danger-600",
+				"data-validation-error:checked:bg-danger-600",
+				"data-validation-error:indeterminate:bg-danger-600",
+				"focus-visible:data-validation-error:border-danger-600",
+				"focus-visible:data-validation-error:ring-focus-danger"
+			]
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			{
+				"data-validation-error:border-danger-600": true,
+				"data-validation-error:checked:bg-danger-600": true,
+				"data-validation-error:indeterminate:bg-danger-600": true,
+				"focus-visible:data-validation-error:border-danger-600": true,
+				"focus-visible:data-validation-error:ring-focus-danger": true
+			}
+		],
+		"expected": "data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"data-validation-error:border-danger-600"
+				],
+				false
+			],
+			"data-validation-error:checked:bg-danger-600"
+		],
+		"expected": "nested data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600"
+	},
+	{
+		"args": [
+			"data-validation-success:border-success-600",
+			"data-validation-success:ring-focus-success",
+			"data-validation-success:focus-visible:border-success-600",
+			"data-validation-success:data-drag-over:border-success-600"
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+	},
+	{
+		"args": [
+			[
+				"data-validation-success:border-success-600",
+				"data-validation-success:ring-focus-success",
+				"data-validation-success:focus-visible:border-success-600",
+				"data-validation-success:data-drag-over:border-success-600"
+			]
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+	},
+	{
+		"args": [
+			{
+				"data-validation-success:border-success-600": true,
+				"data-validation-success:ring-focus-success": true,
+				"data-validation-success:focus-visible:border-success-600": true,
+				"data-validation-success:data-drag-over:border-success-600": true
+			}
+		],
+		"expected": "data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"data-validation-success:border-success-600"
+				],
+				false
+			],
+			"data-validation-success:ring-focus-success"
+		],
+		"expected": "nested data-validation-success:border-success-600 data-validation-success:ring-focus-success"
+	},
+	{
+		"args": [
+			"first:has-aria-selected:rounded-l-md",
+			"last:has-aria-selected:rounded-r-md"
+		],
+		"expected": "first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+	},
+	{
+		"args": [
+			[
+				"first:has-aria-selected:rounded-l-md",
+				"last:has-aria-selected:rounded-r-md"
+			]
+		],
+		"expected": "first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+	},
+	{
+		"args": [
+			{
+				"first:has-aria-selected:rounded-l-md": true,
+				"last:has-aria-selected:rounded-r-md": true
+			}
+		],
+		"expected": "first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"first:has-aria-selected:rounded-l-md"
+				],
+				false
+			],
+			"last:has-aria-selected:rounded-r-md"
+		],
+		"expected": "nested first:has-aria-selected:rounded-l-md last:has-aria-selected:rounded-r-md"
+	},
+	{
+		"args": [
+			"flex",
+			"flex-row",
+			"gap-2",
+			"min-[70.625rem]:flex-col"
+		],
+		"expected": "flex flex-row gap-2 min-[70.625rem]:flex-col"
+	},
+	{
+		"args": [
+			[
+				"flex",
+				"flex-row",
+				"gap-2",
+				"min-[70.625rem]:flex-col"
+			]
+		],
+		"expected": "flex flex-row gap-2 min-[70.625rem]:flex-col"
+	},
+	{
+		"args": [
+			{
+				"flex": true,
+				"flex-row": true,
+				"gap-2": true,
+				"min-[70.625rem]:flex-col": true
+			}
+		],
+		"expected": "flex flex-row gap-2 min-[70.625rem]:flex-col"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"flex"
+				],
+				false
+			],
+			"flex-row"
+		],
+		"expected": "nested flex flex-row"
+	},
+	{
+		"args": [
+			"flex",
+			"items-center",
+			"absolute",
+			"inset-x-0",
+			"top-1",
+			"h-5",
+			"justify-between",
+			"z-10"
+		],
+		"expected": "flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+	},
+	{
+		"args": [
+			[
+				"flex",
+				"items-center",
+				"absolute",
+				"inset-x-0",
+				"top-1",
+				"h-5",
+				"justify-between",
+				"z-10"
+			]
+		],
+		"expected": "flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+	},
+	{
+		"args": [
+			{
+				"flex": true,
+				"items-center": true,
+				"absolute": true,
+				"inset-x-0": true,
+				"top-1": true,
+				"h-5": true,
+				"justify-between": true,
+				"z-10": true
+			}
+		],
+		"expected": "flex items-center absolute inset-x-0 top-1 h-5 justify-between z-10"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"flex"
+				],
+				false
+			],
+			"items-center"
+		],
+		"expected": "nested flex items-center"
+	},
+	{
+		"args": [
+			"flex",
+			"items-start",
+			"sm:items-center",
+			"gap-x-2",
+			"gap-y-1",
+			"flex-col",
+			"sm:flex-row"
+		],
+		"expected": "flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+	},
+	{
+		"args": [
+			[
+				"flex",
+				"items-start",
+				"sm:items-center",
+				"gap-x-2",
+				"gap-y-1",
+				"flex-col",
+				"sm:flex-row"
+			]
+		],
+		"expected": "flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+	},
+	{
+		"args": [
+			{
+				"flex": true,
+				"items-start": true,
+				"sm:items-center": true,
+				"gap-x-2": true,
+				"gap-y-1": true,
+				"flex-col": true,
+				"sm:flex-row": true
+			}
+		],
+		"expected": "flex items-start sm:items-center gap-x-2 gap-y-1 flex-col sm:flex-row"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"flex"
+				],
+				false
+			],
+			"items-start"
+		],
+		"expected": "nested flex items-start"
+	},
+	{
+		"args": [
+			"flex",
+			"w-full",
+			"max-w-270",
+			"flex-col",
+			"items-center"
+		],
+		"expected": "flex w-full max-w-270 flex-col items-center"
+	},
+	{
+		"args": [
+			[
+				"flex",
+				"w-full",
+				"max-w-270",
+				"flex-col",
+				"items-center"
+			]
+		],
+		"expected": "flex w-full max-w-270 flex-col items-center"
+	},
+	{
+		"args": [
+			{
+				"flex": true,
+				"w-full": true,
+				"max-w-270": true,
+				"flex-col": true,
+				"items-center": true
+			}
+		],
+		"expected": "flex w-full max-w-270 flex-col items-center"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"flex"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested flex w-full"
+	},
+	{
+		"args": [
+			"focus-visible:border-accent-600",
+			"focus-visible:ring-focus-accent",
+			"focus-visible:outline-hidden",
+			"focus-visible:ring-4"
+		],
+		"expected": "focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			[
+				"focus-visible:border-accent-600",
+				"focus-visible:ring-focus-accent",
+				"focus-visible:outline-hidden",
+				"focus-visible:ring-4"
+			]
+		],
+		"expected": "focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			{
+				"focus-visible:border-accent-600": true,
+				"focus-visible:ring-focus-accent": true,
+				"focus-visible:outline-hidden": true,
+				"focus-visible:ring-4": true
+			}
+		],
+		"expected": "focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"focus-visible:border-accent-600"
+				],
+				false
+			],
+			"focus-visible:ring-focus-accent"
+		],
+		"expected": "nested focus-visible:border-accent-600 focus-visible:ring-focus-accent"
+	},
+	{
+		"args": [
+			"font-family",
+			"text-strong",
+			"max-w-xl",
+			"text-5xl",
+			"leading-none",
+			"md:text-6xl"
+		],
+		"expected": "font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+	},
+	{
+		"args": [
+			[
+				"font-family",
+				"text-strong",
+				"max-w-xl",
+				"text-5xl",
+				"leading-none",
+				"md:text-6xl"
+			]
+		],
+		"expected": "font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+	},
+	{
+		"args": [
+			{
+				"font-family": true,
+				"text-strong": true,
+				"max-w-xl": true,
+				"text-5xl": true,
+				"leading-none": true,
+				"md:text-6xl": true
+			}
+		],
+		"expected": "font-family text-strong max-w-xl text-5xl leading-none md:text-6xl"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"font-family"
+				],
+				false
+			],
+			"text-strong"
+		],
+		"expected": "nested font-family text-strong"
+	},
+	{
+		"args": [
+			"grid",
+			"w-full",
+			"grid-cols-1",
+			"gap-6",
+			"sm:grid-cols-2"
+		],
+		"expected": "grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+	},
+	{
+		"args": [
+			[
+				"grid",
+				"w-full",
+				"grid-cols-1",
+				"gap-6",
+				"sm:grid-cols-2"
+			]
+		],
+		"expected": "grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+	},
+	{
+		"args": [
+			{
+				"grid": true,
+				"w-full": true,
+				"grid-cols-1": true,
+				"gap-6": true,
+				"sm:grid-cols-2": true
+			}
+		],
+		"expected": "grid w-full grid-cols-1 gap-6 sm:grid-cols-2"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"grid"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested grid w-full"
+	},
+	{
+		"args": [
+			"h-(--radix-select-trigger-height)",
+			"w-full"
+		],
+		"expected": "h-(--radix-select-trigger-height) w-full"
+	},
+	{
+		"args": [
+			[
+				"h-(--radix-select-trigger-height)",
+				"w-full"
+			]
+		],
+		"expected": "h-(--radix-select-trigger-height) w-full"
+	},
+	{
+		"args": [
+			{
+				"h-(--radix-select-trigger-height)": true,
+				"w-full": true
+			}
+		],
+		"expected": "h-(--radix-select-trigger-height) w-full"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"h-(--radix-select-trigger-height)"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested h-(--radix-select-trigger-height) w-full"
+	},
+	{
+		"args": [
+			"h-72",
+			"w-full",
+			"overflow-y-scroll",
+			"overscroll-contain"
+		],
+		"expected": "h-72 w-full overflow-y-scroll overscroll-contain"
+	},
+	{
+		"args": [
+			[
+				"h-72",
+				"w-full",
+				"overflow-y-scroll",
+				"overscroll-contain"
+			]
+		],
+		"expected": "h-72 w-full overflow-y-scroll overscroll-contain"
+	},
+	{
+		"args": [
+			{
+				"h-72": true,
+				"w-full": true,
+				"overflow-y-scroll": true,
+				"overscroll-contain": true
+			}
+		],
+		"expected": "h-72 w-full overflow-y-scroll overscroll-contain"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"h-72"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested h-72 w-full"
+	},
+	{
+		"args": [
+			"h-px",
+			"w-full",
+			"group-data-horizontal-separator-group:flex-1"
+		],
+		"expected": "h-px w-full group-data-horizontal-separator-group:flex-1"
+	},
+	{
+		"args": [
+			[
+				"h-px",
+				"w-full",
+				"group-data-horizontal-separator-group:flex-1"
+			]
+		],
+		"expected": "h-px w-full group-data-horizontal-separator-group:flex-1"
+	},
+	{
+		"args": [
+			{
+				"h-px": true,
+				"w-full": true,
+				"group-data-horizontal-separator-group:flex-1": true
+			}
+		],
+		"expected": "h-px w-full group-data-horizontal-separator-group:flex-1"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"h-px"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested h-px w-full"
+	},
+	{
+		"args": [
+			"hidden",
+			"min-[70.625rem]:block"
+		],
+		"expected": "hidden min-[70.625rem]:block"
+	},
+	{
+		"args": [
+			[
+				"hidden",
+				"min-[70.625rem]:block"
+			]
+		],
+		"expected": "hidden min-[70.625rem]:block"
+	},
+	{
+		"args": [
+			{
+				"hidden": true,
+				"min-[70.625rem]:block": true
+			}
+		],
+		"expected": "hidden min-[70.625rem]:block"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"hidden"
+				],
+				false
+			],
+			"min-[70.625rem]:block"
+		],
+		"expected": "nested hidden min-[70.625rem]:block"
+	},
+	{
+		"args": [
+			"inline-flex",
+			"items-center",
+			"justify-between",
+			"gap-2"
+		],
+		"expected": "inline-flex items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			[
+				"inline-flex",
+				"items-center",
+				"justify-between",
+				"gap-2"
+			]
+		],
+		"expected": "inline-flex items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			{
+				"inline-flex": true,
+				"items-center": true,
+				"justify-between": true,
+				"gap-2": true
+			}
+		],
+		"expected": "inline-flex items-center justify-between gap-2"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"inline-flex"
+				],
+				false
+			],
+			"items-center"
+		],
+		"expected": "nested inline-flex items-center"
+	},
+	{
+		"args": [
+			"max-h-75",
+			"scroll-py-1",
+			"overflow-x-hidden",
+			"overflow-y-auto",
+			"scrollbar"
+		],
+		"expected": "max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+	},
+	{
+		"args": [
+			[
+				"max-h-75",
+				"scroll-py-1",
+				"overflow-x-hidden",
+				"overflow-y-auto",
+				"scrollbar"
+			]
+		],
+		"expected": "max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+	},
+	{
+		"args": [
+			{
+				"max-h-75": true,
+				"scroll-py-1": true,
+				"overflow-x-hidden": true,
+				"overflow-y-auto": true,
+				"scrollbar": true
+			}
+		],
+		"expected": "max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"max-h-75"
+				],
+				false
+			],
+			"scroll-py-1"
+		],
+		"expected": "nested max-h-75 scroll-py-1"
+	},
+	{
+		"args": [
+			"mb-2",
+			"text-xs",
+			"font-medium",
+			"uppercase",
+			"tracking-wider",
+			"font-mono"
+		],
+		"expected": "mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			[
+				"mb-2",
+				"text-xs",
+				"font-medium",
+				"uppercase",
+				"tracking-wider",
+				"font-mono"
+			]
+		],
+		"expected": "mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			{
+				"mb-2": true,
+				"text-xs": true,
+				"font-medium": true,
+				"uppercase": true,
+				"tracking-wider": true,
+				"font-mono": true
+			}
+		],
+		"expected": "mb-2 text-xs font-medium uppercase tracking-wider font-mono"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"mb-2"
+				],
+				false
+			],
+			"text-xs"
+		],
+		"expected": "nested mb-2 text-xs"
+	},
+	{
+		"args": [
+			"mt-8",
+			"max-w-3xl",
+			"divide-y",
+			"divide-gray-300",
+			"border-y",
+			"border-gray-300"
+		],
+		"expected": "mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+	},
+	{
+		"args": [
+			[
+				"mt-8",
+				"max-w-3xl",
+				"divide-y",
+				"divide-gray-300",
+				"border-y",
+				"border-gray-300"
+			]
+		],
+		"expected": "mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+	},
+	{
+		"args": [
+			{
+				"mt-8": true,
+				"max-w-3xl": true,
+				"divide-y": true,
+				"divide-gray-300": true,
+				"border-y": true,
+				"border-gray-300": true
+			}
+		],
+		"expected": "mt-8 max-w-3xl divide-y divide-gray-300 border-y border-gray-300"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"mt-8"
+				],
+				false
+			],
+			"max-w-3xl"
+		],
+		"expected": "nested mt-8 max-w-3xl"
+	},
+	{
+		"args": [
+			"mx-auto",
+			"w-full",
+			"max-w-7xl",
+			"flex-1",
+			"px-4",
+			"pt-4",
+			"md:pt-20"
+		],
+		"expected": "mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+	},
+	{
+		"args": [
+			[
+				"mx-auto",
+				"w-full",
+				"max-w-7xl",
+				"flex-1",
+				"px-4",
+				"pt-4",
+				"md:pt-20"
+			]
+		],
+		"expected": "mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+	},
+	{
+		"args": [
+			{
+				"mx-auto": true,
+				"w-full": true,
+				"max-w-7xl": true,
+				"flex-1": true,
+				"px-4": true,
+				"pt-4": true,
+				"md:pt-20": true
+			}
+		],
+		"expected": "mx-auto w-full max-w-7xl flex-1 px-4 pt-4 md:pt-20"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"mx-auto"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested mx-auto w-full"
+	},
+	{
+		"args": [
+			"not-disabled:active:scale-97",
+			"ease-out",
+			"transition-transform",
+			"duration-150"
+		],
+		"expected": "not-disabled:active:scale-97 ease-out transition-transform duration-150"
+	},
+	{
+		"args": [
+			[
+				"not-disabled:active:scale-97",
+				"ease-out",
+				"transition-transform",
+				"duration-150"
+			]
+		],
+		"expected": "not-disabled:active:scale-97 ease-out transition-transform duration-150"
+	},
+	{
+		"args": [
+			{
+				"not-disabled:active:scale-97": true,
+				"ease-out": true,
+				"transition-transform": true,
+				"duration-150": true
+			}
+		],
+		"expected": "not-disabled:active:scale-97 ease-out transition-transform duration-150"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"not-disabled:active:scale-97"
+				],
+				false
+			],
+			"ease-out"
+		],
+		"expected": "nested not-disabled:active:scale-97 ease-out"
+	},
+	{
+		"args": [
+			"overflow-hidden",
+			"text-center",
+			"text-sm",
+			"p-0",
+			"relative",
+			"focus-within:relative",
+			"focus-within:z-20",
+			"size-7",
+			"rounded-md"
+		],
+		"expected": "overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+	},
+	{
+		"args": [
+			[
+				"overflow-hidden",
+				"text-center",
+				"text-sm",
+				"p-0",
+				"relative",
+				"focus-within:relative",
+				"focus-within:z-20",
+				"size-7",
+				"rounded-md"
+			]
+		],
+		"expected": "overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+	},
+	{
+		"args": [
+			{
+				"overflow-hidden": true,
+				"text-center": true,
+				"text-sm": true,
+				"p-0": true,
+				"relative": true,
+				"focus-within:relative": true,
+				"focus-within:z-20": true,
+				"size-7": true,
+				"rounded-md": true
+			}
+		],
+		"expected": "overflow-hidden text-center text-sm p-0 relative focus-within:relative focus-within:z-20 size-7 rounded-md"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"overflow-hidden"
+				],
+				false
+			],
+			"text-center"
+		],
+		"expected": "nested overflow-hidden text-center"
+	},
+	{
+		"args": [
+			"p-6",
+			"border-t",
+			"border-card-muted",
+			"first:border-t-0"
+		],
+		"expected": "p-6 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			[
+				"p-6",
+				"border-t",
+				"border-card-muted",
+				"first:border-t-0"
+			]
+		],
+		"expected": "p-6 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			{
+				"p-6": true,
+				"border-t": true,
+				"border-card-muted": true,
+				"first:border-t-0": true
+			}
+		],
+		"expected": "p-6 border-t border-card-muted first:border-t-0"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"p-6"
+				],
+				false
+			],
+			"border-t"
+		],
+		"expected": "nested p-6 border-t"
+	},
+	{
+		"args": [
+			"pointer-coarse:text-[0.9375rem]",
+			"font-mono",
+			"text-[0.8125rem]"
+		],
+		"expected": "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+	},
+	{
+		"args": [
+			[
+				"pointer-coarse:text-[0.9375rem]",
+				"font-mono",
+				"text-[0.8125rem]"
+			]
+		],
+		"expected": "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+	},
+	{
+		"args": [
+			{
+				"pointer-coarse:text-[0.9375rem]": true,
+				"font-mono": true,
+				"text-[0.8125rem]": true
+			}
+		],
+		"expected": "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"pointer-coarse:text-[0.9375rem]"
+				],
+				false
+			],
+			"font-mono"
+		],
+		"expected": "nested pointer-coarse:text-[0.9375rem] font-mono"
+	},
+	{
+		"args": [
+			"relative",
+			"flex",
+			"size-2"
+		],
+		"expected": "relative flex size-2"
+	},
+	{
+		"args": [
+			[
+				"relative",
+				"flex",
+				"size-2"
+			]
+		],
+		"expected": "relative flex size-2"
+	},
+	{
+		"args": [
+			{
+				"relative": true,
+				"flex": true,
+				"size-2": true
+			}
+		],
+		"expected": "relative flex size-2"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"relative"
+				],
+				false
+			],
+			"flex"
+		],
+		"expected": "nested relative flex"
+	},
+	{
+		"args": [
+			"right-1.5",
+			"top-1.5",
+			"absolute"
+		],
+		"expected": "right-1.5 top-1.5 absolute"
+	},
+	{
+		"args": [
+			[
+				"right-1.5",
+				"top-1.5",
+				"absolute"
+			]
+		],
+		"expected": "right-1.5 top-1.5 absolute"
+	},
+	{
+		"args": [
+			{
+				"right-1.5": true,
+				"top-1.5": true,
+				"absolute": true
+			}
+		],
+		"expected": "right-1.5 top-1.5 absolute"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"right-1.5"
+				],
+				false
+			],
+			"top-1.5"
+		],
+		"expected": "nested right-1.5 top-1.5"
+	},
+	{
+		"args": [
+			"rounded-sm",
+			"col-span-full",
+			"grid",
+			"grid-cols-subgrid",
+			"items-center"
+		],
+		"expected": "rounded-sm col-span-full grid grid-cols-subgrid items-center"
+	},
+	{
+		"args": [
+			[
+				"rounded-sm",
+				"col-span-full",
+				"grid",
+				"grid-cols-subgrid",
+				"items-center"
+			]
+		],
+		"expected": "rounded-sm col-span-full grid grid-cols-subgrid items-center"
+	},
+	{
+		"args": [
+			{
+				"rounded-sm": true,
+				"col-span-full": true,
+				"grid": true,
+				"grid-cols-subgrid": true,
+				"items-center": true
+			}
+		],
+		"expected": "rounded-sm col-span-full grid grid-cols-subgrid items-center"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"rounded-sm"
+				],
+				false
+			],
+			"col-span-full"
+		],
+		"expected": "nested rounded-sm col-span-full"
+	},
+	{
+		"args": [
+			"scroll-fade-r",
+			"overflow-x-auto"
+		],
+		"expected": "scroll-fade-r overflow-x-auto"
+	},
+	{
+		"args": [
+			[
+				"scroll-fade-r",
+				"overflow-x-auto"
+			]
+		],
+		"expected": "scroll-fade-r overflow-x-auto"
+	},
+	{
+		"args": [
+			{
+				"scroll-fade-r": true,
+				"overflow-x-auto": true
+			}
+		],
+		"expected": "scroll-fade-r overflow-x-auto"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"scroll-fade-r"
+				],
+				false
+			],
+			"overflow-x-auto"
+		],
+		"expected": "nested scroll-fade-r overflow-x-auto"
+	},
+	{
+		"args": [
+			"shrink-0",
+			"size-12",
+			"sm:size-16"
+		],
+		"expected": "shrink-0 size-12 sm:size-16"
+	},
+	{
+		"args": [
+			[
+				"shrink-0",
+				"size-12",
+				"sm:size-16"
+			]
+		],
+		"expected": "shrink-0 size-12 sm:size-16"
+	},
+	{
+		"args": [
+			{
+				"shrink-0": true,
+				"size-12": true,
+				"sm:size-16": true
+			}
+		],
+		"expected": "shrink-0 size-12 sm:size-16"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"shrink-0"
+				],
+				false
+			],
+			"size-12"
+		],
+		"expected": "nested shrink-0 size-12"
+	},
+	{
+		"args": [
+			"size-4",
+			"text-accent-600"
+		],
+		"expected": "size-4 text-accent-600"
+	},
+	{
+		"args": [
+			[
+				"size-4",
+				"text-accent-600"
+			]
+		],
+		"expected": "size-4 text-accent-600"
+	},
+	{
+		"args": [
+			{
+				"size-4": true,
+				"text-accent-600": true
+			}
+		],
+		"expected": "size-4 text-accent-600"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"size-4"
+				],
+				false
+			],
+			"text-accent-600"
+		],
+		"expected": "nested size-4 text-accent-600"
+	},
+	{
+		"args": [
+			"text-accent-600",
+			"mr-2",
+			"shrink-0",
+			"whitespace-nowrap",
+			"text-xs"
+		],
+		"expected": "text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+	},
+	{
+		"args": [
+			[
+				"text-accent-600",
+				"mr-2",
+				"shrink-0",
+				"whitespace-nowrap",
+				"text-xs"
+			]
+		],
+		"expected": "text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+	},
+	{
+		"args": [
+			{
+				"text-accent-600": true,
+				"mr-2": true,
+				"shrink-0": true,
+				"whitespace-nowrap": true,
+				"text-xs": true
+			}
+		],
+		"expected": "text-accent-600 mr-2 shrink-0 whitespace-nowrap text-xs"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-accent-600"
+				],
+				false
+			],
+			"mr-2"
+		],
+		"expected": "nested text-accent-600 mr-2"
+	},
+	{
+		"args": [
+			"text-blue-500",
+			"px-2",
+			"py-2"
+		],
+		"expected": "text-blue-500 px-2 py-2"
+	},
+	{
+		"args": [
+			[
+				"text-blue-500",
+				"px-2",
+				"py-2"
+			]
+		],
+		"expected": "text-blue-500 px-2 py-2"
+	},
+	{
+		"args": [
+			{
+				"text-blue-500": true,
+				"px-2": true,
+				"py-2": true
+			}
+		],
+		"expected": "text-blue-500 px-2 py-2"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-blue-500"
+				],
+				false
+			],
+			"px-2"
+		],
+		"expected": "nested text-blue-500 px-2"
+	},
+	{
+		"args": [
+			"text-danger-600",
+			"block",
+			"size-4"
+		],
+		"expected": "text-danger-600 block size-4"
+	},
+	{
+		"args": [
+			[
+				"text-danger-600",
+				"block",
+				"size-4"
+			]
+		],
+		"expected": "text-danger-600 block size-4"
+	},
+	{
+		"args": [
+			{
+				"text-danger-600": true,
+				"block": true,
+				"size-4": true
+			}
+		],
+		"expected": "text-danger-600 block size-4"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-danger-600"
+				],
+				false
+			],
+			"block"
+		],
+		"expected": "nested text-danger-600 block"
+	},
+	{
+		"args": [
+			"text-danger-700",
+			"pointer-none:hidden",
+			"block",
+			"size-4"
+		],
+		"expected": "text-danger-700 pointer-none:hidden block size-4"
+	},
+	{
+		"args": [
+			[
+				"text-danger-700",
+				"pointer-none:hidden",
+				"block",
+				"size-4"
+			]
+		],
+		"expected": "text-danger-700 pointer-none:hidden block size-4"
+	},
+	{
+		"args": [
+			{
+				"text-danger-700": true,
+				"pointer-none:hidden": true,
+				"block": true,
+				"size-4": true
+			}
+		],
+		"expected": "text-danger-700 pointer-none:hidden block size-4"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-danger-700"
+				],
+				false
+			],
+			"pointer-none:hidden"
+		],
+		"expected": "nested text-danger-700 pointer-none:hidden"
+	},
+	{
+		"args": [
+			"text-mono",
+			"w-full",
+			"overflow-hidden",
+			"rounded-md",
+			"border",
+			"border-gray-300",
+			"bg-card",
+			"font-mono"
+		],
+		"expected": "text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+	},
+	{
+		"args": [
+			[
+				"text-mono",
+				"w-full",
+				"overflow-hidden",
+				"rounded-md",
+				"border",
+				"border-gray-300",
+				"bg-card",
+				"font-mono"
+			]
+		],
+		"expected": "text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+	},
+	{
+		"args": [
+			{
+				"text-mono": true,
+				"w-full": true,
+				"overflow-hidden": true,
+				"rounded-md": true,
+				"border": true,
+				"border-gray-300": true,
+				"bg-card": true,
+				"font-mono": true
+			}
+		],
+		"expected": "text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-mono"
+				],
+				false
+			],
+			"w-full"
+		],
+		"expected": "nested text-mono w-full"
+	},
+	{
+		"args": [
+			"text-muted",
+			"hover:text-strong",
+			"font-mono",
+			"text-[0.8125rem]",
+			"leading-[1.5em]",
+			"font-medium"
+		],
+		"expected": "text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			[
+				"text-muted",
+				"hover:text-strong",
+				"font-mono",
+				"text-[0.8125rem]",
+				"leading-[1.5em]",
+				"font-medium"
+			]
+		],
+		"expected": "text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			{
+				"text-muted": true,
+				"hover:text-strong": true,
+				"font-mono": true,
+				"text-[0.8125rem]": true,
+				"leading-[1.5em]": true,
+				"font-medium": true
+			}
+		],
+		"expected": "text-muted hover:text-strong font-mono text-[0.8125rem] leading-[1.5em] font-medium"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-muted"
+				],
+				false
+			],
+			"hover:text-strong"
+		],
+		"expected": "nested text-muted hover:text-strong"
+	},
+	{
+		"args": [
+			"text-muted-foreground",
+			"text-sm",
+			"gap-2",
+			"flex",
+			"items-center"
+		],
+		"expected": "text-muted-foreground text-sm gap-2 flex items-center"
+	},
+	{
+		"args": [
+			[
+				"text-muted-foreground",
+				"text-sm",
+				"gap-2",
+				"flex",
+				"items-center"
+			]
+		],
+		"expected": "text-muted-foreground text-sm gap-2 flex items-center"
+	},
+	{
+		"args": [
+			{
+				"text-muted-foreground": true,
+				"text-sm": true,
+				"gap-2": true,
+				"flex": true,
+				"items-center": true
+			}
+		],
+		"expected": "text-muted-foreground text-sm gap-2 flex items-center"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-muted-foreground"
+				],
+				false
+			],
+			"text-sm"
+		],
+		"expected": "nested text-muted-foreground text-sm"
+	},
+	{
+		"args": [
+			"text-red",
+			"mb-2",
+			"text-xl"
+		],
+		"expected": "text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			[
+				"text-red",
+				"mb-2",
+				"text-xl"
+			]
+		],
+		"expected": "text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			{
+				"text-red": true,
+				"mb-2": true,
+				"text-xl": true
+			}
+		],
+		"expected": "text-red mb-2 text-xl"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-red"
+				],
+				false
+			],
+			"mb-2"
+		],
+		"expected": "nested text-red mb-2"
+	},
+	{
+		"args": [
+			"text-sm",
+			"pb-16"
+		],
+		"expected": "text-sm pb-16"
+	},
+	{
+		"args": [
+			[
+				"text-sm",
+				"pb-16"
+			]
+		],
+		"expected": "text-sm pb-16"
+	},
+	{
+		"args": [
+			{
+				"text-sm": true,
+				"pb-16": true
+			}
+		],
+		"expected": "text-sm pb-16"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-sm"
+				],
+				false
+			],
+			"pb-16"
+		],
+		"expected": "nested text-sm pb-16"
+	},
+	{
+		"args": [
+			"text-strong",
+			"flex",
+			"grow",
+			"flex-col",
+			"gap-1"
+		],
+		"expected": "text-strong flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			[
+				"text-strong",
+				"flex",
+				"grow",
+				"flex-col",
+				"gap-1"
+			]
+		],
+		"expected": "text-strong flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			{
+				"text-strong": true,
+				"flex": true,
+				"grow": true,
+				"flex-col": true,
+				"gap-1": true
+			}
+		],
+		"expected": "text-strong flex grow flex-col gap-1"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-strong"
+				],
+				false
+			],
+			"flex"
+		],
+		"expected": "nested text-strong flex"
+	},
+	{
+		"args": [
+			"text-success-700",
+			"dark-high-contrast:block",
+			"hidden",
+			"size-4"
+		],
+		"expected": "text-success-700 dark-high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			[
+				"text-success-700",
+				"dark-high-contrast:block",
+				"hidden",
+				"size-4"
+			]
+		],
+		"expected": "text-success-700 dark-high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			{
+				"text-success-700": true,
+				"dark-high-contrast:block": true,
+				"hidden": true,
+				"size-4": true
+			}
+		],
+		"expected": "text-success-700 dark-high-contrast:block hidden size-4"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"text-success-700"
+				],
+				false
+			],
+			"dark-high-contrast:block"
+		],
+		"expected": "nested text-success-700 dark-high-contrast:block"
+	},
+	{
+		"args": [
+			"w-full",
+			"space-y-4"
+		],
+		"expected": "w-full space-y-4"
+	},
+	{
+		"args": [
+			[
+				"w-full",
+				"space-y-4"
+			]
+		],
+		"expected": "w-full space-y-4"
+	},
+	{
+		"args": [
+			{
+				"w-full": true,
+				"space-y-4": true
+			}
+		],
+		"expected": "w-full space-y-4"
+	},
+	{
+		"args": [
+			[
+				"nested",
+				[
+					"w-full"
+				],
+				false
+			],
+			"space-y-4"
+		],
+		"expected": "nested w-full space-y-4"
+	}
+]

--- a/packages/mantle/src/utils/cx/clsx.test.ts
+++ b/packages/mantle/src/utils/cx/clsx.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { clsx } from "./index.js";
+
+describe("clsx", () => {
+	test("joins string arguments with single spaces", () => {
+		expect(clsx("a", "b", "c")).toBe("a b c");
+	});
+
+	test("ignores falsy values", () => {
+		// oxlint-disable-next-line no-constant-binary-expression
+		expect(clsx("a", false, null, undefined, 0, "", true && "b")).toBe("a b");
+	});
+
+	test("supports object syntax (truthy keys only)", () => {
+		expect(clsx({ a: true, b: false, c: 1 })).toBe("a c");
+	});
+
+	test("flattens arrays recursively", () => {
+		expect(clsx(["a", ["b", ["c", false]]], "d")).toBe("a b c d");
+	});
+
+	test("does NOT resolve Tailwind conflicts (unlike cx)", () => {
+		// clsx is a plain join: conflicting utilities are both kept.
+		expect(clsx("p-4", "p-8")).toBe("p-4 p-8");
+	});
+
+	test("plain space-join for non-class text, skipping falsy (input.tsx use case)", () => {
+		const name: string | undefined = undefined;
+		expect(clsx("The value entered for the", name, "input has failed validation.")).toBe(
+			"The value entered for the input has failed validation.",
+		);
+	});
+});

--- a/packages/mantle/src/utils/cx/clsx.ts
+++ b/packages/mantle/src/utils/cx/clsx.ts
@@ -1,0 +1,16 @@
+import { type ClassValue, clsx as vendorClsx } from "./vendor/clsx.js";
+
+/**
+ * Conditionally join class names into a single space-separated string, with falsy
+ * values ignored — **without** Tailwind conflict resolution.
+ *
+ * Vendored `clsx`. Prefer {@link cx} for composing a `className` (it also resolves
+ * Tailwind conflicts); reach for `clsx` only when you need a plain space-join that
+ * must not be run through the Tailwind merge engine (e.g. assembling a sentence).
+ *
+ * @example
+ * clsx("base", isActive && "active", { disabled: isDisabled }); // → "base active"
+ */
+export const clsx: typeof vendorClsx = vendorClsx;
+
+export type { ClassValue };

--- a/packages/mantle/src/utils/cx/cx.browser.test.ts
+++ b/packages/mantle/src/utils/cx/cx.browser.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import { cx } from "./cx.js";
+
+/**
+ * Real-browser (Chromium/V8) profiling for `cx`. `cx` layers three caches over the vendored
+ * merge engine — a whole-string result cache (`./vendor/lib/tw-merge.ts`), a per-call-site
+ * cache for the tagged-template form (`./vendor/lib/merge-template.ts`), and a V8-only
+ * arg-sequence cache (in `./cx.ts`) — so we validate the speedups against a cold merge in a
+ * real browser rather than happy-dom. These assert the *relative* claims (cache hits beat a
+ * cold full merge) and log ops/sec so the run doubles as a profile. They are intentionally
+ * generous to stay non-flaky in CI.
+ */
+
+// Realistic, conflict-bearing class lists in the spirit of mantle components.
+const SAMPLES = [
+	"flex items-center justify-between gap-2 rounded border px-4 py-2 text-sm font-medium",
+	"bg-blue-500 text-white hover:bg-blue-600 focus-visible:ring-2 focus-visible:ring-blue-400",
+	"absolute inset-0 z-10 grid place-items-center bg-black/50 p-4 p-6",
+	"text-red-500 text-blue-500 mb-2 text-base leading-4 text-xl leading-5",
+	"p-4 pt-5 pb-6 pr-3 pb-3 m-2 mx-4 mt-1",
+	"w-4 w-em h-em h-6 size-4 size-em gap-4 gap-em",
+	"rounded-md rounded-lg shadow shadow-md border border-2 border-form",
+	"transition-colors duration-150 ease-in-out hover:opacity-80 disabled:opacity-50",
+];
+
+type BenchResult = { label: string; opsPerSec: number; elapsedMs: number };
+
+/** Time `fn` over `iterations` calls after a warmup, returning ops/sec. */
+function bench(label: string, iterations: number, fn: (index: number) => string): BenchResult {
+	const warmup = Math.min(iterations, 10_000);
+	for (let index = 0; index < warmup; index++) {
+		fn(index);
+	}
+	const start = performance.now();
+	for (let index = 0; index < iterations; index++) {
+		fn(index);
+	}
+	const elapsedMs = performance.now() - start;
+	return { label, opsPerSec: (iterations / elapsedMs) * 1000, elapsedMs };
+}
+
+describe("cx — browser correctness (real V8)", () => {
+	test("resolves conflicts and mantle overrides in a real browser", () => {
+		expect(cx("p-4 p-8")).toBe("p-8");
+		expect(cx("text-mono text-base")).toBe("text-base");
+		expect(cx("w-4 w-em")).toBe("w-em");
+		expect(cx`px-2 px-4 ${"bg-blue-500"}`).toBe("px-4 bg-blue-500");
+		expect(cx("bg-blue-500", "bg-red-500")).toBe("bg-red-500");
+	});
+});
+
+describe("cx — performance profile (real V8)", () => {
+	test("cache hits and tagged templates beat a cold merge", () => {
+		// Cold: a large pool of distinct strings, cycled so the whole-string LRU mostly misses
+		// and each call pays a full split + conflict resolution.
+		const coldPool: string[] = [];
+		for (let index = 0; index < 3000; index++) {
+			coldPool.push(`${SAMPLES[index % SAMPLES.length]} mt-${index} pb-${index % 97}`);
+		}
+		const cold = bench("cold (unique strings, full merge)", 150_000, (index) =>
+			cx(coldPool[index % coldPool.length]),
+		);
+
+		// Cached: the same string every call — whole-string cache hits after the first.
+		const cachedInput = SAMPLES[0];
+		const cached = bench("cached (repeated string)", 1_000_000, () => cx(cachedInput));
+
+		// Variadic component-style call: stable base classes + a couple of toggled variants,
+		// exercising the V8 arg-sequence cache (no re-hash of the joined string).
+		const variadic = bench("variadic (stable args, arg cache)", 1_000_000, (index) =>
+			cx("flex items-center px-4 py-2", index % 2 === 0 && "bg-blue-500", "text-sm"),
+		);
+
+		// Tagged template: a single stable call site cycling a boolean — call-site cache hits.
+		const template = bench(
+			"template (stable call site)",
+			1_000_000,
+			(index) => cx`flex items-center px-4 py-2 ${index % 2 === 0 && "bg-blue-500"} text-sm`,
+		);
+
+		const results = [cold, cached, variadic, template];
+		const fmt = (value: number) => `${(value / 1000).toFixed(0)}k ops/s`;
+		// Surfaced in the reporter output as the in-browser profile (console.log forwards
+		// from the browser; console.table does not).
+		console.log("=== cx in-browser profile (Chromium/V8) ===");
+		for (const result of results) {
+			console.log(
+				`${result.label.padEnd(36)} ${fmt(result.opsPerSec).padStart(12)}  ${(result.opsPerSec / cold.opsPerSec).toFixed(1)}x vs cold`,
+			);
+		}
+
+		// Relative claims (generous margins to stay non-flaky):
+		expect(cached.opsPerSec).toBeGreaterThan(cold.opsPerSec);
+		expect(variadic.opsPerSec).toBeGreaterThan(cold.opsPerSec);
+		expect(template.opsPerSec).toBeGreaterThan(cold.opsPerSec);
+		// Cache hits should be dramatically faster than a cold merge.
+		expect(cached.opsPerSec).toBeGreaterThan(cold.opsPerSec * 3);
+	});
+});

--- a/packages/mantle/src/utils/cx/cx.parity.test.ts
+++ b/packages/mantle/src/utils/cx/cx.parity.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { type ClassValue, cx } from "./cx.js";
+import fixtureData from "./__fixtures__/parity.json" with { type: "json" };
+
+type ParityCase = { args: ClassValue[]; expected: string };
+
+// `expected` was frozen by running the PREVIOUS implementation (clsx + extendTailwindMerge)
+// over a corpus harvested from this repo plus curated edge cases — the byte-for-byte oracle
+// the vendored engine must reproduce. See ./vendor/README.md.
+const fixture: ParityCase[] = fixtureData;
+
+describe("cx — parity with the previous clsx + extendTailwindMerge implementation", () => {
+	test("fixture is non-trivial", () => {
+		expect(fixture.length).toBeGreaterThan(3000);
+	});
+
+	test("produces byte-identical output for every fixture case", () => {
+		const mismatches: Array<{ args: ClassValue[]; expected: string; actual: string }> = [];
+		for (const { args, expected } of fixture) {
+			const actual = cx(...args);
+			if (actual !== expected) {
+				mismatches.push({ args, expected, actual });
+			}
+		}
+
+		expect(
+			mismatches.slice(0, 10),
+			`${mismatches.length} of ${fixture.length} cases diverged from the oracle`,
+		).toEqual([]);
+	});
+});
+
+describe("cx — type compatibility with the historical contract", () => {
+	// The contract documented at apps/www/app/docs/utils/cx.mdx and shipped before vendoring.
+	type LegacyCx = (...inputs: ClassValue[]) => string;
+
+	test("cx is assignable to (...inputs: ClassValue[]) => string", () => {
+		// Compile-time proof (checked by `tsc`): an incompatible signature fails to assign.
+		const legacy: LegacyCx = cx;
+		expect(typeof legacy).toBe("function");
+		expect(legacy("p-4", "p-8")).toBe("p-8");
+	});
+
+	test("Parameters<typeof cx> is exactly ClassValue[]", () => {
+		// If the variadic parameter type changed, this annotation would fail to typecheck.
+		const params: Parameters<typeof cx> = [
+			"flex",
+			{ active: true },
+			["px-4", false],
+			null,
+			undefined,
+			1,
+		];
+		expect(cx(...params)).toBe("flex active px-4 1");
+	});
+
+	test("ReturnType<typeof cx> is exactly string", () => {
+		const result: ReturnType<typeof cx> = cx("p-4");
+		const asString: string = result;
+		expect(asString).toBe("p-4");
+	});
+});

--- a/packages/mantle/src/utils/cx/cx.test.ts
+++ b/packages/mantle/src/utils/cx/cx.test.ts
@@ -85,3 +85,176 @@ describe("cx", () => {
 		expect(cx("gap-4 gap-em")).toBe("gap-em");
 	});
 });
+
+describe("cx — mantle overrides (no extendTailwindMerge call)", () => {
+	test("text-mono and text-size-inherit conflict (font-size group)", () => {
+		expect(cx("text-mono text-size-inherit")).toBe("text-size-inherit");
+		expect(cx("text-size-inherit text-mono")).toBe("text-mono");
+	});
+
+	test("text-mono / text-size-inherit conflict with tshirt sizes", () => {
+		expect(cx("text-xl text-mono")).toBe("text-mono");
+		expect(cx("text-mono text-2xl")).toBe("text-2xl");
+		expect(cx("text-size-inherit text-sm")).toBe("text-sm");
+	});
+
+	test("em is a recognized spacing value across spacing utilities", () => {
+		expect(cx("m-em m-4")).toBe("m-4");
+		expect(cx("px-2 px-em")).toBe("px-em");
+		expect(cx("mt-em mt-4")).toBe("mt-4");
+		expect(cx("size-4 size-em")).toBe("size-em");
+	});
+
+	test("em utilities still merge per-axis like other spacing", () => {
+		// p-em sets all sides; a later pt-2 overrides only the top
+		expect(cx("p-em pt-2")).toBe("p-em pt-2");
+		expect(cx("px-em pl-4")).toBe("px-em pl-4");
+	});
+});
+
+describe("cx — value shapes (clsx parity)", () => {
+	test("object syntax includes truthy keys, drops falsy", () => {
+		expect(cx({ "p-4": true, "p-8": false, "m-2": true })).toBe("p-4 m-2");
+	});
+
+	test("object syntax resolves conflicts left-to-right by insertion order", () => {
+		expect(cx({ "p-4": true, "p-8": true })).toBe("p-8");
+	});
+
+	test("arrays are flattened recursively", () => {
+		expect(cx(["px-4", ["py-2", ["text-sm"]]])).toBe("px-4 py-2 text-sm");
+	});
+
+	test("falsy values are ignored (false, null, undefined, 0, '')", () => {
+		expect(cx("base", false, null, undefined, 0, "")).toBe("base");
+	});
+
+	test("numbers are coerced to strings", () => {
+		expect(cx(1, "px-4")).toBe("1 px-4");
+	});
+
+	test("mixed strings, arrays, objects, and conditionals", () => {
+		const isActive = true;
+		const isDisabled = false;
+		expect(
+			cx("flex items-center", ["gap-2", isActive && "bg-blue-500"], {
+				"opacity-50": isDisabled,
+				rounded: true,
+			}),
+		).toBe("flex items-center gap-2 bg-blue-500 rounded");
+	});
+
+	test("consumer className overrides component defaults (prop-override use case)", () => {
+		const className = "bg-red-500";
+		expect(cx("bg-blue-500 text-white px-4 py-2 rounded", className)).toBe(
+			"text-white px-4 py-2 rounded bg-red-500",
+		);
+	});
+});
+
+describe("cx — modifiers, important, postfix, arbitrary", () => {
+	test("variant modifiers scope conflicts", () => {
+		expect(cx("hover:bg-red-500 hover:bg-blue-500")).toBe("hover:bg-blue-500");
+		expect(cx("md:p-4 md:p-8")).toBe("md:p-8");
+		// different modifiers do not conflict
+		expect(cx("p-4 hover:p-8")).toBe("p-4 hover:p-8");
+	});
+
+	test("important modifier (Tailwind v4 trailing and legacy leading)", () => {
+		expect(cx("p-4! p-8!")).toBe("p-8!");
+		expect(cx("!p-4 !p-8")).toBe("!p-8");
+		// important and non-important are distinct conflict keys
+		expect(cx("p-4 p-8!")).toBe("p-4 p-8!");
+	});
+
+	test("postfix (opacity) modifier", () => {
+		expect(cx("bg-red-500/50 bg-red-500/75")).toBe("bg-red-500/75");
+		expect(cx("text-black/50 text-black/80")).toBe("text-black/80");
+	});
+
+	test("arbitrary values conflict within their group", () => {
+		expect(cx("w-[10px] w-[20px]")).toBe("w-[20px]");
+		expect(cx("p-[3px] p-[5px]")).toBe("p-[5px]");
+		expect(cx("w-4 w-[20px]")).toBe("w-[20px]");
+	});
+
+	test("arbitrary properties conflict by property name", () => {
+		expect(cx("[mask-type:luminance] [mask-type:alpha]")).toBe("[mask-type:alpha]");
+		expect(cx("[r:var(--radius)] origin-center")).toBe("[r:var(--radius)] origin-center");
+	});
+
+	test("negative values", () => {
+		expect(cx("-mt-2 -mt-4")).toBe("-mt-4");
+		expect(cx("-z-10 z-20")).toBe("z-20");
+	});
+});
+
+describe("cx — tagged-template form", () => {
+	test("merges a static template", () => {
+		expect(cx`px-2 px-4`).toBe("px-4");
+	});
+
+	test("merges with a truthy interpolation", () => {
+		const active = true;
+		expect(cx`px-2 px-4 ${active && "bg-blue-500"}`).toBe("px-4 bg-blue-500");
+	});
+
+	test("falsy interpolations are dropped", () => {
+		const active = false;
+		expect(cx`px-2 ${active && "bg-blue-500"} py-1`).toBe("px-2 py-1");
+	});
+
+	test("interpolation participates in conflict resolution", () => {
+		const override = "text-blue-500";
+		expect(cx`text-red-500 ${override}`).toBe("text-blue-500");
+	});
+
+	test("object interpolation resolves like the variadic form", () => {
+		expect(cx`p-2 ${{ "p-8": true }}`).toBe("p-8");
+	});
+
+	test("repeated identical calls return identical output (cache-stable)", () => {
+		const render = (active: boolean) => cx`px-2 px-4 ${active && "bg-blue-500"}`;
+		expect(render(true)).toBe("px-4 bg-blue-500");
+		expect(render(true)).toBe("px-4 bg-blue-500");
+		expect(render(false)).toBe("px-4");
+		expect(render(true)).toBe("px-4 bg-blue-500");
+	});
+
+	test("mutated object interpolation is not wrongly cached", () => {
+		const dynamic: Record<string, boolean> = { "p-4": true };
+		expect(cx`base ${dynamic}`).toBe("base p-4");
+		dynamic["p-4"] = false;
+		dynamic["p-8"] = true;
+		expect(cx`base ${dynamic}`).toBe("base p-8");
+	});
+});
+
+describe("cx — caching correctness", () => {
+	test("same first arg, different rest args do not cross-contaminate", () => {
+		expect(cx("p-4", "p-8")).toBe("p-8");
+		expect(cx("p-4", "p-2")).toBe("p-2");
+		expect(cx("p-4", "p-8")).toBe("p-8");
+		expect(cx("p-4", "m-2")).toBe("p-4 m-2");
+	});
+
+	test("repeated variadic calls are stable", () => {
+		for (let index = 0; index < 1000; index++) {
+			expect(cx("flex", "p-4", "p-8", index % 2 === 0 && "text-red-500")).toBe(
+				index % 2 === 0 ? "flex p-8 text-red-500" : "flex p-8",
+			);
+		}
+	});
+
+	test("mutated object arg is reflected, not stale-cached", () => {
+		const dynamic: Record<string, boolean> = { "p-4": true };
+		expect(cx("base", dynamic)).toBe("base p-4");
+		dynamic["p-4"] = false;
+		dynamic["p-8"] = true;
+		expect(cx("base", dynamic)).toBe("base p-8");
+	});
+
+	test("single truthy string among falsy args", () => {
+		expect(cx(false, "p-4 p-8", null)).toBe("p-8");
+	});
+});

--- a/packages/mantle/src/utils/cx/cx.ts
+++ b/packages/mantle/src/utils/cx/cx.ts
@@ -1,22 +1,208 @@
-import { type ClassValue, clsx } from "clsx";
-import { extendTailwindMerge } from "tailwind-merge";
+import { type ClassValue, resolveClassValue } from "./vendor/clsx.js";
+import { mergeTemplate } from "./vendor/lib/merge-template.js";
+import { twMerge } from "./vendor/lib/tw-merge.js";
 
-const twMerge = extendTailwindMerge({
-	extend: {
-		classGroups: {
-			"font-size": ["text-mono", "text-size-inherit"],
-		},
-		theme: {
-			spacing: ["em"],
-		},
-	},
-});
+export type { ClassValue };
 
 /**
- * Conditionally add Tailwind (and other) CSS classes.
- *
- * Allows for tailwind overrides in LTR-specificity-like order of applied classes.
+ * The two ways `cx` can be called: as a normal variadic function, or as a tagged
+ * template literal.
  */
-export function cx(...inputs: ClassValue[]) {
-	return twMerge(clsx(inputs));
-}
+type ClassNameFunction = {
+	(strings: TemplateStringsArray, ...values: ClassValue[]): string;
+	(...inputs: ClassValue[]): string;
+};
+
+/**
+ * A tagged template passes a frozen `TemplateStringsArray` (an array carrying a `.raw`
+ * array) as the first argument, which is what distinguishes ``cx`...` `` from `cx(...)`.
+ */
+const isTemplateStringsArray = (
+	value: TemplateStringsArray | ClassValue,
+): value is TemplateStringsArray => Array.isArray(value) && "raw" in value;
+
+/**
+ * Whether the runtime is V8 (Chrome/Edge/Node/Deno/Electron). V8 caches a string's hash on
+ * the object it first hashed, so the whole-string merge cache pays a full O(length) re-hash
+ * on every repeated multi-arg call (the join is a fresh string each render). The arg cache
+ * below avoids that by keying on the stable individual argument strings instead. JavaScriptCore
+ * (Safari/Bun) and SpiderMonkey (Firefox) hash fresh strings cheaply, so the extra layer is
+ * pure overhead there — hence the gate. V8 `Error`s expose neither JSC's `line` nor
+ * SpiderMonkey's `lineNumber`, a deterministic, allocation-free signal evaluated once.
+ */
+const isV8 = (() => {
+	const error = new Error();
+	return !("line" in error) && !("lineNumber" in error);
+})();
+
+type ArgCacheEntry = {
+	/** The truthy string args after the first, in order; the bucket key is the first. */
+	rest: string[];
+	result: string;
+};
+
+/** Max distinct rest-sequences kept per first-arg bucket before the oldest is dropped. */
+const ARG_CACHE_BUCKET_SIZE = 64;
+/** First-arg buckets kept before a generation rotates into `previousArgCache`. */
+const ARG_CACHE_GENERATION_SIZE = 500;
+
+// Two-generation LRU. The merged output of `cx("a", cond && "b", …)` depends only on which
+// string args are truthy and their order, and JSX class literals keep a stable identity across
+// renders — so an identical arg sequence always yields an identical result and can be cached
+// against the args by identity, with no re-hash of the joined string.
+let argCache = new Map<string, ArgCacheEntry[]>();
+let previousArgCache = new Map<string, ArgCacheEntry[]>();
+let argCacheCount = 0;
+
+/**
+ * Variadic merge with the V8 arg-sequence cache. Only caches when every truthy arg is a
+ * string (immutable, so identity guarantees identical output); a truthy object/array arg is
+ * mutable, so those calls always recompute.
+ */
+const mergeVariadicCached = (inputs: ClassValue[]): string => {
+	let firstKey = "";
+	let hasFirstKey = false;
+	let truthyStringCount = 0;
+	let everyTruthyIsString = true;
+	for (const input of inputs) {
+		if (!input) {
+			continue;
+		}
+		if (typeof input !== "string") {
+			everyTruthyIsString = false;
+			break;
+		}
+		if (!hasFirstKey) {
+			firstKey = input;
+			hasFirstKey = true;
+		}
+		truthyStringCount += 1;
+	}
+
+	if (!everyTruthyIsString) {
+		return twMerge.mergeString(resolveClassValue(inputs));
+	}
+	if (!hasFirstKey) {
+		return "";
+	}
+	// A lone truthy string behaves like the single-arg path: its hash is already cached, so the
+	// whole-string cache is cheap without a separate arg-cache entry.
+	if (truthyStringCount === 1) {
+		return twMerge.mergeString(firstKey);
+	}
+
+	// Identity-compare the remaining truthy args against each cached entry — no string hashing.
+	const bucket = argCache.get(firstKey) ?? previousArgCache.get(firstKey);
+	if (bucket != null) {
+		for (const entry of bucket) {
+			if (entry.rest.length !== truthyStringCount - 1) {
+				continue;
+			}
+			let restIndex = 0;
+			let sawFirst = false;
+			let isMatch = true;
+			for (const input of inputs) {
+				if (!input) {
+					continue;
+				}
+				if (!sawFirst) {
+					sawFirst = true;
+					continue;
+				}
+				if (input !== entry.rest[restIndex]) {
+					isMatch = false;
+					break;
+				}
+				restIndex += 1;
+			}
+			if (isMatch) {
+				return entry.result;
+			}
+		}
+	}
+
+	// Miss: build the join once, merge, and store it keyed on the stable arg strings.
+	let joined = firstKey;
+	let sawFirst = false;
+	const rest: string[] = [];
+	for (const input of inputs) {
+		if (!input || typeof input !== "string") {
+			continue;
+		}
+		if (!sawFirst) {
+			sawFirst = true;
+			continue;
+		}
+		joined += " " + input;
+		rest.push(input);
+	}
+	const result = twMerge.mergeString(joined);
+
+	let target = argCache.get(firstKey);
+	if (target == null) {
+		target = [];
+		argCache.set(firstKey, target);
+	}
+	if (target.length >= ARG_CACHE_BUCKET_SIZE) {
+		target.shift();
+	}
+	target.push({ rest, result });
+
+	argCacheCount += 1;
+	if (argCacheCount > ARG_CACHE_GENERATION_SIZE) {
+		argCacheCount = 0;
+		previousArgCache = argCache;
+		argCache = new Map();
+	}
+
+	return result;
+};
+
+/**
+ * Conditionally compose class names and resolve Tailwind CSS conflicts, so later
+ * classes override earlier ones (the same precedence model as inline styles).
+ *
+ * Accepts the same inputs as `clsx` — strings, numbers, arrays, and
+ * `{ [className]: boolean }` objects, with falsy values ignored — then resolves
+ * Tailwind utility conflicts so the rightmost class in each conflicting group wins.
+ * This makes `cx` safe for prop overrides: `cx("bg-blue-500", className)` lets a
+ * consumer's `className` win.
+ *
+ * Conflict resolution uses a vendored, byte-for-byte port of `tailwind-merge` (see
+ * `./vendor`) with mantle's overrides baked into the default config: the `em` spacing
+ * scale (`w-em`, `p-em`, …) and the `text-mono` / `text-size-inherit` font-size
+ * utilities are conflict-aware with no `extendTailwindMerge` call. Results are cached so
+ * repeated calls with the same arguments — the common case across re-renders — are cheap.
+ *
+ * Also callable as a tagged template, which caches by call-site identity for hot
+ * re-rendering paths: `` cx`px-2 px-4 ${active && "bg-blue-500"}` ``.
+ *
+ * @example
+ * // Conditional + object syntax; later class wins on conflict
+ * cx("px-4 py-2", isActive && "bg-blue-500", { "text-red-500": hasError });
+ * // → "px-4 py-2 bg-blue-500 text-red-500"  (when isActive && hasError)
+ *
+ * @example
+ * cx("text-red-500", "text-blue-500"); // → "text-blue-500"
+ */
+export const cx: ClassNameFunction = (
+	first?: TemplateStringsArray | ClassValue,
+	...rest: ClassValue[]
+): string => {
+	if (isTemplateStringsArray(first)) {
+		return mergeTemplate(first, rest);
+	}
+
+	// Single-arg fast path (the most common call shape): the whole-string cache already keys
+	// on this stable string, so no arg-cache bookkeeping is needed.
+	if (rest.length === 0) {
+		return twMerge.mergeString(resolveClassValue(first));
+	}
+
+	const inputs = [first, ...rest];
+	// The arg cache only helps on V8; elsewhere fresh strings hash cheaply, so skip it.
+	if (isV8) {
+		return mergeVariadicCached(inputs);
+	}
+	return twMerge.mergeString(resolveClassValue(inputs));
+};

--- a/packages/mantle/src/utils/cx/index.ts
+++ b/packages/mantle/src/utils/cx/index.ts
@@ -1,4 +1,3 @@
-export {
-	//,
-	cx,
-} from "./cx.js";
+export { clsx } from "./clsx.js";
+export { cx } from "./cx.js";
+export type { ClassValue } from "./cx.js";

--- a/packages/mantle/src/utils/cx/vendor/LICENSE
+++ b/packages/mantle/src/utils/cx/vendor/LICENSE
@@ -1,0 +1,34 @@
+MIT License
+
+Copyright (c) 2026 Aiden Bai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+cnfast bundles and adapts code from the following MIT-licensed projects:
+
+clsx — Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+https://github.com/lukeed/clsx
+
+tailwind-merge — Copyright (c) 2021 Dany Castillo
+https://github.com/dcastil/tailwind-merge
+
+Both are distributed under the MIT License, the full text of which is identical
+to the license above (with their respective copyright holders).

--- a/packages/mantle/src/utils/cx/vendor/README.md
+++ b/packages/mantle/src/utils/cx/vendor/README.md
@@ -1,0 +1,54 @@
+# `cx` vendored engine
+
+This directory vendors the class-merge **engine** from [`cnfast@0.0.8`](https://github.com/aidenybai/cnfast)
+(MIT) — itself a faster, byte-for-byte port of [`clsx`](https://github.com/lukeed/clsx)
+(Luke Edwards) + [`tailwind-merge`](https://github.com/dcastil/tailwind-merge) (Dany
+Castillo) — replacing the former runtime dependencies on `clsx` and `tailwind-merge`. The
+`cx` function itself lives in [`../cx.ts`](../cx.ts) (our code) and calls into this engine.
+
+It is **excluded from oxlint and oxfmt** (see `.oxlintrc.json#ignorePatterns` and
+`.prettierignore`) so it stays close to upstream and re-syncable. Treat it as read-only:
+do not refactor it to match repo conventions.
+
+## Layout
+
+Mirrors `cnfast/packages/cnfast/src` so internal import paths stay identical to upstream:
+
+- `clsx.ts` — upstream `src/clsx.ts` (`resolveClassValue` / `clsx`).
+- `lib/*` — upstream `src/lib/*` (the tailwind-merge engine + the baked default config).
+  `../cx.ts` calls `lib/tw-merge.ts` (whole-string result cache) and `lib/merge-template.ts`
+  (tagged-template call-site cache) directly.
+
+Upstream's `cn` dispatcher (`src/index.ts`) is intentionally **not** vendored — `../cx.ts`
+reimplements that small variadic/tagged-template dispatch as ordinary mantle code. The CLI
+(`src/cli`), benchmarks, and scripts are not vendored either.
+
+## Mantle overrides
+
+The only hand-edits to upstream live in [`lib/default-config.ts`](./lib/default-config.ts),
+marked with `--- mantle override ---`. They bake in what `cx` previously did via
+`extendTailwindMerge`, so no extend call is needed:
+
+1. **`em` spacing scale** — `em` is appended to `theme.spacing`, so `w-em`, `h-em`, `p-em`,
+   `gap-em`, … are recognized spacing utilities and conflict-resolve against `w-4`, `p-2`, ….
+2. **`text-mono` / `text-size-inherit`** — appended to the `font-size` class group, so they
+   conflict-resolve against `text-base`, `text-xl`, ….
+
+## Normalization applied on vendoring
+
+Upstream source is copied verbatim except:
+
+1. A one-line provenance header is prepended to each file.
+2. Relative import specifiers get explicit `.js` extensions (required by the package's
+   `NodeNext` module resolution).
+3. Type-only imports are rewritten to `import type` / inline `type` (required by
+   `verbatimModuleSyntax`).
+4. The two `default-config.ts` overrides above.
+
+## Re-syncing to a newer cnfast
+
+1. Download `packages/cnfast/src/{index.ts,clsx.ts,lib/*}` from the target tag.
+2. Re-apply steps 1–3 above (deterministic: see `scripts` history / the original vendoring
+   commit), then re-apply the two `default-config.ts` overrides.
+3. Run `cx`'s parity suite (`pnpm -w run test -F @ngrok/mantle cx`): the `parity.json` fixture
+   asserts byte-identical output against the behavior frozen at vendoring time.

--- a/packages/mantle/src/utils/cx/vendor/clsx.ts
+++ b/packages/mantle/src/utils/cx/vendor/clsx.ts
@@ -1,0 +1,65 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ./README.md for sync steps.
+
+export interface ClassDictionary {
+  // Mirrors clsx's `Record<string, any>`: `unknown` here would reject render-function
+  // classNames (e.g. Base UI / Radix `className={(state) => ...}`) that structurally
+  // satisfy `any` but not an `unknown`-valued index signature, breaking drop-in parity.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional clsx type parity
+  [className: string]: any;
+}
+
+export type ClassValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | ClassValue[]
+  | ClassDictionary;
+
+// Hoist the global builtin to a module-scope binding (oveo "hoist globals"): turns a
+// repeated global-object property load into a plain variable load on the join hot path.
+const isArray = Array.isArray;
+
+// Exported for `cn`, which passes its collected rest-args array straight in to avoid
+// a second spread + array allocation that `clsx(...inputs)` would incur per call.
+export const resolveClassValue = (value: ClassValue): string => {
+  if (!value) return "";
+
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return "" + value;
+
+  let result = "";
+
+  if (isArray(value)) {
+    const length = value.length;
+    for (let index = 0; index < length; index++) {
+      const item = value[index];
+      // Skip falsy items (null/false/undefined/0/"") without a recursive call, and take the
+      // string fast path directly: most arguments to `cn`/`clsx` are plain class strings.
+      if (!item) continue;
+      const resolved = typeof item === "string" ? item : resolveClassValue(item);
+      if (resolved) {
+        if (result) result += " ";
+        result += resolved;
+      }
+    }
+    return result;
+  }
+
+  if (typeof value === "object") {
+    for (const key in value) {
+      if (value[key]) {
+        if (result) result += " ";
+        result += key;
+      }
+    }
+  }
+
+  return result;
+};
+
+export const clsx = (...inputs: ClassValue[]): string => resolveClassValue(inputs);

--- a/packages/mantle/src/utils/cx/vendor/lib/class-group-utils.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/class-group-utils.ts
@@ -1,0 +1,275 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import type {
+  AnyClassGroupIds,
+  AnyConfig,
+  AnyThemeGroupIds,
+  ClassGroup,
+  ClassValidator,
+  Config,
+  ThemeGetter,
+  ThemeObject,
+} from "./types.js";
+import { concatArrays } from "./utils.js";
+
+export interface ClassPartObject {
+  nextPart: Map<string, ClassPartObject>;
+  validators: ClassValidatorObject[] | null;
+  classGroupId: AnyClassGroupIds | undefined; // Always define optional props for consistent shape
+}
+
+interface ClassValidatorObject {
+  classGroupId: AnyClassGroupIds;
+  validator: ClassValidator;
+}
+
+// Factory function ensures consistent object shapes
+const createClassValidatorObject = (
+  classGroupId: AnyClassGroupIds,
+  validator: ClassValidator,
+): ClassValidatorObject => ({
+  classGroupId,
+  validator,
+});
+
+// Factory ensures consistent ClassPartObject shape
+const createClassPartObject = (
+  nextPart: Map<string, ClassPartObject> = new Map(),
+  validators: ClassValidatorObject[] | null = null,
+  classGroupId?: AnyClassGroupIds,
+): ClassPartObject => ({
+  nextPart,
+  validators,
+  classGroupId,
+});
+
+const CLASS_PART_SEPARATOR = "-";
+
+const EMPTY_CONFLICTS: readonly AnyClassGroupIds[] = [];
+// I use two dots here because one dot is used as prefix for class groups in plugins
+const ARBITRARY_PROPERTY_PREFIX = "arbitrary..";
+
+export const createClassGroupUtils = (config: AnyConfig) => {
+  const classMap = createClassMap(config);
+  const { conflictingClassGroups, conflictingClassGroupModifiers } = config;
+
+  const getClassGroupId = (className: string) => {
+    if (className[0] === "[" && className[className.length - 1] === "]") {
+      return getGroupIdForArbitraryProperty(className);
+    }
+
+    const classParts = className.split(CLASS_PART_SEPARATOR);
+    // Classes like `-inset-1` produce an empty string as first classPart. We assume that classes for negative values are used correctly and skip it.
+    const startIndex = classParts[0] === "" && classParts.length > 1 ? 1 : 0;
+    return getGroupRecursive(classParts, startIndex, classMap);
+  };
+
+  const getConflictingClassGroupIds = (
+    classGroupId: AnyClassGroupIds,
+    hasPostfixModifier: boolean,
+  ): readonly AnyClassGroupIds[] => {
+    if (hasPostfixModifier) {
+      const modifierConflicts = conflictingClassGroupModifiers[classGroupId];
+      const baseConflicts = conflictingClassGroups[classGroupId];
+
+      if (modifierConflicts) {
+        if (baseConflicts) {
+          return concatArrays(baseConflicts, modifierConflicts);
+        }
+        return modifierConflicts;
+      }
+      return baseConflicts || EMPTY_CONFLICTS;
+    }
+
+    return conflictingClassGroups[classGroupId] || EMPTY_CONFLICTS;
+  };
+
+  return {
+    getClassGroupId,
+    getConflictingClassGroupIds,
+  };
+};
+
+const getGroupRecursive = (
+  classParts: string[],
+  startIndex: number,
+  classPartObject: ClassPartObject,
+): AnyClassGroupIds | undefined => {
+  const classPathsLength = classParts.length - startIndex;
+  if (classPathsLength === 0) {
+    return classPartObject.classGroupId;
+  }
+
+  const currentClassPart = classParts[startIndex]!;
+  const nextClassPartObject = classPartObject.nextPart.get(currentClassPart);
+
+  if (nextClassPartObject) {
+    const result = getGroupRecursive(classParts, startIndex + 1, nextClassPartObject);
+    if (result) return result;
+  }
+
+  const validators = classPartObject.validators;
+  if (validators === null) {
+    return undefined;
+  }
+
+  const classRest =
+    startIndex === 0
+      ? classParts.join(CLASS_PART_SEPARATOR)
+      : classParts.slice(startIndex).join(CLASS_PART_SEPARATOR);
+  const validatorsLength = validators.length;
+
+  for (let index = 0; index < validatorsLength; index++) {
+    const validatorObject = validators[index]!;
+    if (validatorObject.validator(classRest)) {
+      return validatorObject.classGroupId;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Get the class group ID for an arbitrary property.
+ *
+ * @param className - The class name to get the group ID for. Is expected to be string starting with `[` and ending with `]`.
+ */
+const getGroupIdForArbitraryProperty = (className: string): AnyClassGroupIds | undefined => {
+  const content = className.slice(1, -1);
+  const colonIndex = content.indexOf(":");
+  if (colonIndex === -1) {
+    return undefined;
+  }
+  const property = content.slice(0, colonIndex);
+  return property ? ARBITRARY_PROPERTY_PREFIX + property : undefined;
+};
+
+/**
+ * Exported for testing only
+ */
+export const createClassMap = (config: Config<AnyClassGroupIds, AnyThemeGroupIds>) => {
+  const { theme, classGroups } = config;
+  return processClassGroups(classGroups, theme);
+};
+
+// Split into separate functions to maintain monomorphic call sites
+const processClassGroups = (
+  classGroups: Record<AnyClassGroupIds, ClassGroup<AnyThemeGroupIds>>,
+  theme: ThemeObject<AnyThemeGroupIds>,
+): ClassPartObject => {
+  const classMap = createClassPartObject();
+
+  for (const classGroupId in classGroups) {
+    const group = classGroups[classGroupId]!;
+    processClassesRecursively(group, classMap, classGroupId, theme);
+  }
+
+  return classMap;
+};
+
+const processClassesRecursively = (
+  classGroup: ClassGroup<AnyThemeGroupIds>,
+  classPartObject: ClassPartObject,
+  classGroupId: AnyClassGroupIds,
+  theme: ThemeObject<AnyThemeGroupIds>,
+) => {
+  const length = classGroup.length;
+  for (let index = 0; index < length; index++) {
+    const classDefinition = classGroup[index]!;
+    processClassDefinition(classDefinition, classPartObject, classGroupId, theme);
+  }
+};
+
+// Split into separate functions for each type to maintain monomorphic call sites
+const processClassDefinition = (
+  classDefinition: ClassGroup<AnyThemeGroupIds>[number],
+  classPartObject: ClassPartObject,
+  classGroupId: AnyClassGroupIds,
+  theme: ThemeObject<AnyThemeGroupIds>,
+) => {
+  if (typeof classDefinition === "string") {
+    processStringDefinition(classDefinition, classPartObject, classGroupId);
+    return;
+  }
+
+  if (typeof classDefinition === "function") {
+    processFunctionDefinition(classDefinition, classPartObject, classGroupId, theme);
+    return;
+  }
+
+  processObjectDefinition(
+    classDefinition as Record<string, ClassGroup<AnyThemeGroupIds>>,
+    classPartObject,
+    classGroupId,
+    theme,
+  );
+};
+
+const processStringDefinition = (
+  classDefinition: string,
+  classPartObject: ClassPartObject,
+  classGroupId: AnyClassGroupIds,
+) => {
+  const classPartObjectToEdit =
+    classDefinition === "" ? classPartObject : getPart(classPartObject, classDefinition);
+  classPartObjectToEdit.classGroupId = classGroupId;
+};
+
+const processFunctionDefinition = (
+  classDefinition: ClassValidator | ThemeGetter,
+  classPartObject: ClassPartObject,
+  classGroupId: AnyClassGroupIds,
+  theme: ThemeObject<AnyThemeGroupIds>,
+) => {
+  if (isThemeGetter(classDefinition)) {
+    processClassesRecursively(classDefinition(theme), classPartObject, classGroupId, theme);
+    return;
+  }
+
+  if (classPartObject.validators === null) {
+    classPartObject.validators = [];
+  }
+  classPartObject.validators.push(
+    createClassValidatorObject(classGroupId, classDefinition as ClassValidator),
+  );
+};
+
+const processObjectDefinition = (
+  classDefinition: Record<string, ClassGroup<AnyThemeGroupIds>>,
+  classPartObject: ClassPartObject,
+  classGroupId: AnyClassGroupIds,
+  theme: ThemeObject<AnyThemeGroupIds>,
+) => {
+  const entries = Object.entries(classDefinition);
+  const length = entries.length;
+  for (let index = 0; index < length; index++) {
+    const [key, value] = entries[index]!;
+    processClassesRecursively(value, getPart(classPartObject, key), classGroupId, theme);
+  }
+};
+
+const getPart = (classPartObject: ClassPartObject, path: string): ClassPartObject => {
+  let current = classPartObject;
+  const parts = path.split(CLASS_PART_SEPARATOR);
+  const length = parts.length;
+
+  for (let index = 0; index < length; index++) {
+    const part = parts[index]!;
+
+    let next = current.nextPart.get(part);
+    if (!next) {
+      next = createClassPartObject();
+      current.nextPart.set(part, next);
+    }
+    current = next;
+  }
+
+  return current;
+};
+
+const isThemeGetter = (
+  classDefinition: ClassValidator | ThemeGetter,
+): classDefinition is ThemeGetter =>
+  "isThemeGetter" in classDefinition && (classDefinition as ThemeGetter).isThemeGetter === true;

--- a/packages/mantle/src/utils/cx/vendor/lib/config-utils.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/config-utils.ts
@@ -1,0 +1,343 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import { createClassGroupUtils } from "./class-group-utils.js";
+import { IMPORTANT_MODIFIER, parseClassName } from "./parse-class-name.js";
+import { createSortModifiers } from "./sort-modifiers.js";
+import type { AnyClassGroupIds, AnyConfig } from "./types.js";
+
+export type ConfigUtils = ReturnType<typeof createConfigUtils>;
+
+/**
+ * Precomputed, cacheable result of analysing a single class name. Because parsing,
+ * class-group lookup and conflict resolution are deterministic per class string, we
+ * memoize this descriptor per unique token and amortize the work across every call
+ * that reuses the token (tailwind-merge only caches whole class strings).
+ */
+export interface ClassDescriptor {
+  isExternal: boolean;
+  /** Interned integer ID of this class's conflict key `{modifierId}{classGroupId}`. */
+  classId: number;
+  /** Interned integer IDs of the conflict keys `{modifierId}{conflictGroupId}` this class overrides. */
+  conflictIds: number[];
+}
+
+const EXTERNAL_DESCRIPTOR: ClassDescriptor = { isExternal: true, classId: -1, conflictIds: [] };
+
+/**
+ * Per-token descriptor cache capacity (entries). Larger than the whole-string LRU because
+ * individual tokens are far more numerous but cheap to store; the LRU bound prevents
+ * unbounded growth when callers pass dynamically generated arbitrary values (e.g. `w-[123px]`).
+ */
+const DESCRIPTOR_CACHE_SIZE = 4096;
+
+/**
+ * Upper bound on distinct interned conflict keys before the registry (and the descriptor caches that
+ * reference its IDs) are reset. A conflict key's `modifierId` can be an arbitrary variant such as
+ * `data-[id=123]:`, so an app generating unbounded distinct variants would otherwise grow the
+ * registry forever. Sized well above the distinct `(modifier, group)` pairs a real app produces, so
+ * the reset never fires in normal use and only caps pathological, dynamically generated variants.
+ */
+const MAX_CONFLICT_KEYS = 16384;
+
+export const createConfigUtils = (config: AnyConfig) => {
+  const sortModifiers = createSortModifiers(config);
+  const postfixLookupClassGroupIds = createPostfixLookupClassGroupIds(config);
+  const { getClassGroupId, getConflictingClassGroupIds } = createClassGroupUtils(config);
+
+  // Descriptor cache is the hottest lookup in the engine (once per token in `mergeClassList`).
+  // It inlines a two-generation null-prototype LRU directly here (no get/set abstraction) so the
+  // merge loop avoids an extra method-call hop per token.
+  let descriptorCache: Record<string, ClassDescriptor> = Object.create(null);
+  let previousDescriptorCache: Record<string, ClassDescriptor> = Object.create(null);
+  let descriptorCacheSize = 0;
+
+  // `mergeClassList` compares interned integer IDs instead of hashing conflict-key strings on
+  // every token. `internConflictKey` assigns each `{modifierId}{classGroupId}` pair a dense
+  // integer and holds it until the registry is reset. Most apps reuse a small, fixed set of pairs,
+  // so a key keeps its ID for the session. But `modifierId` can be an arbitrary variant
+  // (`data-[id=123]:`), so dynamically generated variants WOULD grow the registry without bound;
+  // `mergeClassList` caps that by resetting the registry (and the descriptor caches that hold its
+  // IDs) once `nextConflictKeyId` passes `MAX_CONFLICT_KEYS`, keeping memory bounded.
+  //
+  // Claimed keys are tracked by stamping a reusable `Int32Array` (indexed by conflict-key ID)
+  // with a per-merge generation counter, instead of allocating a fresh `Set<number>` per call:
+  // starting a pass is one integer bump, with no allocation and no per-element reset. The array
+  // is grown when a new ID is interned, so the merge loop's index ops need no bounds checks.
+  let claimedGeneration = new Int32Array(256);
+  let currentGeneration = 0;
+
+  // Reused "keep this token" flag buffer, indexed by token position, so the merge loop needs no
+  // per-call `kept` array. Grown on demand for unusually long class lists; every slot up to the
+  // token count is overwritten each pass, so no reset is needed.
+  let keepFlags = new Uint8Array(64);
+
+  // Set by `splitClassList` when a run of whitespace contains a non-space character (tab/LF/etc).
+  // The no-op shortcut in `mergeClassList` can only return the raw input when every separator is a
+  // plain space, since the rebuild always joins with `" "`.
+  let splitSawNonSpaceWhitespace = false;
+
+  // Splits on runs of ASCII whitespace (space, tab, LF, VT, FF, CR) the same way `/\s+/` does for
+  // any realistic class string, while skipping leading/trailing runs so no separate `trim()` pass
+  // (and its string allocation) is needed. Tailwind class tokens are ASCII, so this never diverges
+  // from the reference on real input; the parity + fuzz suites guard against regressions.
+  const splitClassList = (classList: string): string[] => {
+    const tokens: string[] = [];
+    const length = classList.length;
+    let tokenStart = -1;
+    splitSawNonSpaceWhitespace = false;
+
+    for (let index = 0; index < length; index++) {
+      const charCode = classList.charCodeAt(index);
+
+      if (charCode === 32) {
+        if (tokenStart !== -1) {
+          tokens.push(classList.slice(tokenStart, index));
+          tokenStart = -1;
+        }
+      } else if (charCode >= 9 && charCode <= 13) {
+        splitSawNonSpaceWhitespace = true;
+        if (tokenStart !== -1) {
+          tokens.push(classList.slice(tokenStart, index));
+          tokenStart = -1;
+        }
+      } else if (tokenStart === -1) {
+        tokenStart = index;
+      }
+    }
+
+    if (tokenStart !== -1) {
+      tokens.push(classList.slice(tokenStart));
+    }
+
+    return tokens;
+  };
+
+  const conflictKeyIds = new Map<string, number>();
+  let nextConflictKeyId = 0;
+  const internConflictKey = (conflictKey: string): number => {
+    let id = conflictKeyIds.get(conflictKey);
+    if (id === undefined) {
+      id = nextConflictKeyId++;
+      conflictKeyIds.set(conflictKey, id);
+      if (id >= claimedGeneration.length) {
+        const grown = new Int32Array(claimedGeneration.length * 2);
+        grown.set(claimedGeneration);
+        claimedGeneration = grown;
+      }
+    }
+    return id;
+  };
+
+  const computeClassDescriptor = (originalClassName: string): ClassDescriptor => {
+    const {
+      isExternal,
+      modifiers,
+      hasImportantModifier,
+      baseClassName,
+      maybePostfixModifierPosition,
+    } = parseClassName(originalClassName);
+
+    if (isExternal) {
+      return EXTERNAL_DESCRIPTOR;
+    }
+
+    let hasPostfixModifier = Boolean(maybePostfixModifierPosition);
+    let classGroupId: ReturnType<typeof getClassGroupId>;
+
+    if (hasPostfixModifier) {
+      const baseClassNameWithoutPostfix = baseClassName.substring(0, maybePostfixModifierPosition);
+      classGroupId = getClassGroupId(baseClassNameWithoutPostfix);
+
+      const classGroupIdWithPostfix =
+        classGroupId && postfixLookupClassGroupIds[classGroupId]
+          ? getClassGroupId(baseClassName)
+          : undefined;
+      if (classGroupIdWithPostfix && classGroupIdWithPostfix !== classGroupId) {
+        classGroupId = classGroupIdWithPostfix;
+        hasPostfixModifier = false;
+      }
+    } else {
+      classGroupId = getClassGroupId(baseClassName);
+    }
+
+    if (!classGroupId) {
+      if (!hasPostfixModifier) {
+        return EXTERNAL_DESCRIPTOR;
+      }
+
+      classGroupId = getClassGroupId(baseClassName);
+
+      if (!classGroupId) {
+        return EXTERNAL_DESCRIPTOR;
+      }
+
+      hasPostfixModifier = false;
+    }
+
+    const variantModifier =
+      modifiers.length === 0
+        ? ""
+        : modifiers.length === 1
+          ? modifiers[0]!
+          : sortModifiers(modifiers).join(":");
+
+    const modifierId = hasImportantModifier
+      ? variantModifier + IMPORTANT_MODIFIER
+      : variantModifier;
+
+    const conflictGroups = getConflictingClassGroupIds(classGroupId, hasPostfixModifier);
+    const conflictIds: number[] = [];
+    for (let index = 0; index < conflictGroups.length; index++) {
+      conflictIds.push(internConflictKey(modifierId + conflictGroups[index]!));
+    }
+
+    return {
+      isExternal: false,
+      classId: internConflictKey(modifierId + classGroupId),
+      conflictIds,
+    };
+  };
+
+  const getClassDescriptor = (originalClassName: string): ClassDescriptor => {
+    let descriptor = descriptorCache[originalClassName];
+    if (descriptor !== undefined) {
+      return descriptor;
+    }
+
+    descriptor = previousDescriptorCache[originalClassName];
+    if (descriptor === undefined) {
+      descriptor = computeClassDescriptor(originalClassName);
+    }
+
+    descriptorCache[originalClassName] = descriptor;
+    if (++descriptorCacheSize > DESCRIPTOR_CACHE_SIZE) {
+      descriptorCacheSize = 0;
+      previousDescriptorCache = descriptorCache;
+      descriptorCache = Object.create(null);
+    }
+    return descriptor;
+  };
+
+  // Resolves conflicts in a joined class string, keeping the last (rightmost) class per group.
+  // Lives inside this closure so the conflict tracker is touched as direct `Int32Array` index ops
+  // (no `claim`/`check`/`begin` closure calls per token). `claimedGeneration` is read fresh on
+  // every access, so a mid-loop `getClassDescriptor` miss that grows the array stays correct.
+  const mergeClassList = (classList: string): string => {
+    const classNames = splitClassList(classList);
+    const classCount = classNames.length;
+
+    // A single token cannot conflict with itself, so it is always kept verbatim. ~60% of real class
+    // lists reduce to one token, and this skips descriptor resolution (including a full compute on a
+    // cache miss), conflict tracking, and the rebuild for all of them. Empty input (`classCount` 0)
+    // falls through: the loops below no-op and the rebuild returns "".
+    if (classCount === 1) {
+      return classNames[0]!;
+    }
+
+    // Keep the conflict-key registry bounded. It never evicts on its own, and arbitrary variants can
+    // make distinct keys unbounded, so reset it once it passes `MAX_CONFLICT_KEYS`. The reset runs
+    // here (between merges, never mid-pass) so interned IDs stay consistent within a single pass, and
+    // the descriptor caches are flushed alongside it because their descriptors hold these IDs. The
+    // monotonic generation counter means reused IDs never read a stale claim from a prior merge.
+    if (nextConflictKeyId > MAX_CONFLICT_KEYS) {
+      conflictKeyIds.clear();
+      nextConflictKeyId = 0;
+      descriptorCache = Object.create(null);
+      previousDescriptorCache = Object.create(null);
+      descriptorCacheSize = 0;
+    }
+
+    currentGeneration = (currentGeneration + 1) | 0;
+    // Generation 0 is the array's initialized value; skip it so a fresh pass never reads stale
+    // zero-stamps as "claimed" after the int32 counter wraps.
+    if (currentGeneration === 0) currentGeneration = 1;
+    const generation = currentGeneration;
+
+    if (classCount > keepFlags.length) {
+      let capacity = keepFlags.length;
+      while (capacity < classCount) capacity *= 2;
+      keepFlags = new Uint8Array(capacity);
+    }
+
+    // Pass 1, right-to-left: the rightmost class per conflict group wins, so a token is kept unless
+    // a later class already claimed one of its conflict keys. Decisions land in `keepFlags`.
+    // `tokenCharCount` accumulates every token's length (kept or dropped) so the no-op shortcut
+    // below can tell whether the input was already normalized without a second scan.
+    let didDrop = false;
+    let tokenCharCount = 0;
+    for (let index = classCount - 1; index >= 0; index -= 1) {
+      const className = classNames[index]!;
+      tokenCharCount += className.length;
+      const descriptor = getClassDescriptor(className);
+
+      if (descriptor.isExternal) {
+        keepFlags[index] = 1;
+        continue;
+      }
+
+      const classId = descriptor.classId;
+      if (claimedGeneration[classId] === generation) {
+        keepFlags[index] = 0;
+        didDrop = true;
+        continue;
+      }
+
+      claimedGeneration[classId] = generation;
+      const conflictIds = descriptor.conflictIds;
+      for (let conflictIndex = 0; conflictIndex < conflictIds.length; conflictIndex++) {
+        claimedGeneration[conflictIds[conflictIndex]!] = generation;
+      }
+
+      keepFlags[index] = 1;
+    }
+
+    // No-op shortcut: when nothing was dropped and the input is already space-normalized, the
+    // rebuild would just recreate `classList`, so return it directly and skip the rebuild
+    // allocation. The length equality holds iff whitespace is exactly `classCount - 1` separators
+    // (no leading, trailing, or doubled runs); combined with "no non-space whitespace" that means
+    // the input is byte-identical to `tokens.join(" ")`. `cn`'s clsx step always feeds such strings.
+    if (
+      !didDrop &&
+      !splitSawNonSpaceWhitespace &&
+      classList.length === tokenCharCount + classCount - 1
+    ) {
+      return classList;
+    }
+
+    // Pass 2, left-to-right: emit kept tokens in source order (no reversal needed).
+    let result = "";
+    for (let index = 0; index < classCount; index++) {
+      if (keepFlags[index] === 1) {
+        if (result) result += " ";
+        result += classNames[index];
+      }
+    }
+
+    return result;
+  };
+
+  return {
+    parseClassName,
+    sortModifiers,
+    postfixLookupClassGroupIds,
+    getClassGroupId,
+    getConflictingClassGroupIds,
+    getClassDescriptor,
+    mergeClassList,
+  };
+};
+
+const createPostfixLookupClassGroupIds = (config: AnyConfig) => {
+  const lookup: Partial<Record<AnyClassGroupIds, true>> = Object.create(null);
+  const classGroupIds = config.postfixLookupClassGroups;
+
+  if (classGroupIds) {
+    for (let index = 0; index < classGroupIds.length; index++) {
+      lookup[classGroupIds[index]!] = true;
+    }
+  }
+
+  return lookup;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/create-tailwind-merge.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/create-tailwind-merge.ts
@@ -1,0 +1,73 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import { createConfigUtils } from "./config-utils.js";
+import { type ClassNameValue, twJoin } from "./tw-join.js";
+import type { AnyConfig } from "./types.js";
+
+type ConfigUtils = ReturnType<typeof createConfigUtils>;
+
+export interface TailwindMerge {
+  (...classLists: ClassNameValue[]): string;
+  /**
+   * Merge an already-joined, space-separated class string, skipping the `twJoin` pass.
+   * Used by `cn`, whose `clsx` step already produces a single string.
+   */
+  mergeString(classList: string): string;
+}
+
+/**
+ * Whole-string result cache capacity. Matches tailwind-merge's default; cnfast ships a single,
+ * non-configurable config so it is baked in rather than exposed as an option.
+ */
+const MERGE_CACHE_SIZE = 500;
+
+export const createTailwindMerge = (createConfig: () => AnyConfig): TailwindMerge => {
+  let configUtils: ConfigUtils;
+  let mergeClassList: ConfigUtils["mergeClassList"];
+
+  // Whole-string result cache, hit once per `cn` call. Inlined as a two-generation null-prototype
+  // LRU directly in `tailwindMerge` (rather than behind a `get`/`set` abstraction) so the hottest
+  // path has no per-call closure hop. A full generation rotates into `previousCache` instead of
+  // evicting entries individually, keeping the write path allocation-free in the common case.
+  let cache: Record<string, string> = Object.create(null);
+  let previousCache: Record<string, string> = Object.create(null);
+  let cacheSize = 0;
+
+  // Lazy init that self-patches `merge.mergeString` to `tailwindMerge` so every call after the
+  // first skips both the init check and a wrapper-closure hop. Hot callers (`cn`) reach the
+  // merge through `twMerge.mergeString(...)`, a monomorphic property load that V8 inline-caches.
+  const initTailwindMerge = (classList: string) => {
+    configUtils = createConfigUtils(createConfig());
+    mergeClassList = configUtils.mergeClassList;
+    merge.mergeString = tailwindMerge;
+
+    return tailwindMerge(classList);
+  };
+
+  const tailwindMerge = (classList: string) => {
+    let result = cache[classList];
+    if (result !== undefined) {
+      return result;
+    }
+
+    result = previousCache[classList];
+    if (result === undefined) {
+      result = mergeClassList(classList);
+    }
+
+    cache[classList] = result;
+    if (++cacheSize > MERGE_CACHE_SIZE) {
+      cacheSize = 0;
+      previousCache = cache;
+      cache = Object.create(null);
+    }
+
+    return result;
+  };
+
+  const merge: TailwindMerge = (...args: ClassNameValue[]) => merge.mergeString(twJoin(...args));
+  merge.mergeString = initTailwindMerge;
+  return merge;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/default-config.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/default-config.ts
@@ -1,0 +1,2543 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import { fromTheme } from "./from-theme.js";
+import type { Config, DefaultClassGroupIds, DefaultThemeGroupIds } from "./types.js";
+import {
+  isAny,
+  isAnyNonArbitrary,
+  isArbitraryFamilyName,
+  isArbitraryImage,
+  isArbitraryLength,
+  isArbitraryNumber,
+  isArbitraryPosition,
+  isArbitraryShadow,
+  isArbitrarySize,
+  isArbitraryValue,
+  isArbitraryVariable,
+  isArbitraryVariableFamilyName,
+  isArbitraryVariableImage,
+  isArbitraryVariableLength,
+  isArbitraryVariablePosition,
+  isArbitraryVariableShadow,
+  isArbitraryVariableSize,
+  isArbitraryVariableWeight,
+  isArbitraryWeight,
+  isFraction,
+  isInteger,
+  isNamedContainerQuery,
+  isNumber,
+  isPercent,
+  isTshirtSize,
+} from "./validators.js";
+
+export const getDefaultConfig = () => {
+  /**
+   * Theme getters for theme variable namespaces
+   * @see https://tailwindcss.com/docs/theme#theme-variable-namespaces
+   */
+  /***/
+
+  const themeColor = fromTheme("color");
+  const themeFont = fromTheme("font");
+  const themeText = fromTheme("text");
+  const themeFontWeight = fromTheme("font-weight");
+  const themeTracking = fromTheme("tracking");
+  const themeLeading = fromTheme("leading");
+  const themeBreakpoint = fromTheme("breakpoint");
+  const themeContainer = fromTheme("container");
+  const themeSpacing = fromTheme("spacing");
+  const themeRadius = fromTheme("radius");
+  const themeShadow = fromTheme("shadow");
+  const themeInsetShadow = fromTheme("inset-shadow");
+  const themeTextShadow = fromTheme("text-shadow");
+  const themeDropShadow = fromTheme("drop-shadow");
+  const themeBlur = fromTheme("blur");
+  const themePerspective = fromTheme("perspective");
+  const themeAspect = fromTheme("aspect");
+  const themeEase = fromTheme("ease");
+  const themeAnimate = fromTheme("animate");
+
+  /**
+   * Helpers to avoid repeating the same scales
+   *
+   * We use functions that create a new array every time they're called instead of static arrays.
+   * This ensures that users who modify any scale by mutating the array (e.g. with `array.push(element)`) don't accidentally mutate arrays in other parts of the config.
+   */
+  /***/
+
+  const scaleBreak = () =>
+    ["auto", "avoid", "all", "avoid-page", "page", "left", "right", "column"] as const;
+  const scalePosition = () =>
+    [
+      "center",
+      "top",
+      "bottom",
+      "left",
+      "right",
+      "top-left",
+      // Deprecated since Tailwind CSS v4.1.0, see https://github.com/tailwindlabs/tailwindcss/pull/17378
+      "left-top",
+      "top-right",
+      // Deprecated since Tailwind CSS v4.1.0, see https://github.com/tailwindlabs/tailwindcss/pull/17378
+      "right-top",
+      "bottom-right",
+      // Deprecated since Tailwind CSS v4.1.0, see https://github.com/tailwindlabs/tailwindcss/pull/17378
+      "right-bottom",
+      "bottom-left",
+      // Deprecated since Tailwind CSS v4.1.0, see https://github.com/tailwindlabs/tailwindcss/pull/17378
+      "left-bottom",
+    ] as const;
+  const scalePositionWithArbitrary = () =>
+    [...scalePosition(), isArbitraryVariable, isArbitraryValue] as const;
+  const scaleOverflow = () => ["auto", "hidden", "clip", "visible", "scroll"] as const;
+  const scaleOverscroll = () => ["auto", "contain", "none"] as const;
+  const scaleUnambiguousSpacing = () =>
+    [isArbitraryVariable, isArbitraryValue, themeSpacing] as const;
+  const scaleInset = () => [isFraction, "full", "auto", ...scaleUnambiguousSpacing()] as const;
+  const scaleGridTemplateColsRows = () =>
+    [isInteger, "none", "subgrid", isArbitraryVariable, isArbitraryValue] as const;
+  const scaleGridColRowStartAndEnd = () =>
+    [
+      "auto",
+      { span: ["full", isInteger, isArbitraryVariable, isArbitraryValue] },
+      isInteger,
+      isArbitraryVariable,
+      isArbitraryValue,
+    ] as const;
+  const scaleGridColRowStartOrEnd = () =>
+    [isInteger, "auto", isArbitraryVariable, isArbitraryValue] as const;
+  const scaleGridAutoColsRows = () =>
+    ["auto", "min", "max", "fr", isArbitraryVariable, isArbitraryValue] as const;
+  const scaleAlignPrimaryAxis = () =>
+    [
+      "start",
+      "end",
+      "center",
+      "between",
+      "around",
+      "evenly",
+      "stretch",
+      "baseline",
+      "center-safe",
+      "end-safe",
+    ] as const;
+  const scaleAlignSecondaryAxis = () =>
+    ["start", "end", "center", "stretch", "center-safe", "end-safe"] as const;
+  const scaleMargin = () => ["auto", ...scaleUnambiguousSpacing()] as const;
+  const scaleSizing = () =>
+    [
+      isFraction,
+      "auto",
+      "full",
+      "dvw",
+      "dvh",
+      "lvw",
+      "lvh",
+      "svw",
+      "svh",
+      "min",
+      "max",
+      "fit",
+      ...scaleUnambiguousSpacing(),
+    ] as const;
+  const scaleSizingInline = () =>
+    [
+      isFraction,
+      "screen",
+      "full",
+      "dvw",
+      "lvw",
+      "svw",
+      "min",
+      "max",
+      "fit",
+      ...scaleUnambiguousSpacing(),
+    ] as const;
+  const scaleSizingBlock = () =>
+    [
+      isFraction,
+      "screen",
+      "full",
+      "lh",
+      "dvh",
+      "lvh",
+      "svh",
+      "min",
+      "max",
+      "fit",
+      ...scaleUnambiguousSpacing(),
+    ] as const;
+  const scaleColor = () => [themeColor, isArbitraryVariable, isArbitraryValue] as const;
+  const scaleBgPosition = () =>
+    [
+      ...scalePosition(),
+      isArbitraryVariablePosition,
+      isArbitraryPosition,
+      { position: [isArbitraryVariable, isArbitraryValue] },
+    ] as const;
+  const scaleBgRepeat = () => ["no-repeat", { repeat: ["", "x", "y", "space", "round"] }] as const;
+  const scaleBgSize = () =>
+    [
+      "auto",
+      "cover",
+      "contain",
+      isArbitraryVariableSize,
+      isArbitrarySize,
+      { size: [isArbitraryVariable, isArbitraryValue] },
+    ] as const;
+  const scaleGradientStopPosition = () =>
+    [isPercent, isArbitraryVariableLength, isArbitraryLength] as const;
+  const scaleRadius = () =>
+    [
+      // Deprecated since Tailwind CSS v4.0.0
+      "",
+      "none",
+      "full",
+      themeRadius,
+      isArbitraryVariable,
+      isArbitraryValue,
+    ] as const;
+  const scaleBorderWidth = () =>
+    ["", isNumber, isArbitraryVariableLength, isArbitraryLength] as const;
+  const scaleLineStyle = () => ["solid", "dashed", "dotted", "double"] as const;
+  const scaleBlendMode = () =>
+    [
+      "normal",
+      "multiply",
+      "screen",
+      "overlay",
+      "darken",
+      "lighten",
+      "color-dodge",
+      "color-burn",
+      "hard-light",
+      "soft-light",
+      "difference",
+      "exclusion",
+      "hue",
+      "saturation",
+      "color",
+      "luminosity",
+    ] as const;
+  const scaleMaskImagePosition = () =>
+    [isNumber, isPercent, isArbitraryVariablePosition, isArbitraryPosition] as const;
+  const scaleBlur = () =>
+    [
+      // Deprecated since Tailwind CSS v4.0.0
+      "",
+      "none",
+      themeBlur,
+      isArbitraryVariable,
+      isArbitraryValue,
+    ] as const;
+  const scaleRotate = () => ["none", isNumber, isArbitraryVariable, isArbitraryValue] as const;
+  const scaleScale = () => ["none", isNumber, isArbitraryVariable, isArbitraryValue] as const;
+  const scaleSkew = () => [isNumber, isArbitraryVariable, isArbitraryValue] as const;
+  const scaleTranslate = () => [isFraction, "full", ...scaleUnambiguousSpacing()] as const;
+
+  return {
+    theme: {
+      animate: ["spin", "ping", "pulse", "bounce"],
+      aspect: ["video"],
+      blur: [isTshirtSize],
+      breakpoint: [isTshirtSize],
+      color: [isAny],
+      container: [isTshirtSize],
+      "drop-shadow": [isTshirtSize],
+      ease: ["in", "out", "in-out"],
+      font: [isAnyNonArbitrary],
+      "font-weight": [
+        "thin",
+        "extralight",
+        "light",
+        "normal",
+        "medium",
+        "semibold",
+        "bold",
+        "extrabold",
+        "black",
+      ],
+      "inset-shadow": [isTshirtSize],
+      leading: ["none", "tight", "snug", "normal", "relaxed", "loose"],
+      perspective: ["dramatic", "near", "normal", "midrange", "distant", "none"],
+      radius: [isTshirtSize],
+      shadow: [isTshirtSize],
+      // --- mantle override --- : `em` joins the spacing scale so `w-em`, `h-em`, `p-em`,
+      // `gap-em`, … are recognized spacing utilities and conflict-resolve against `w-4`, `p-2`, …
+      // Replaces the former `extendTailwindMerge({ extend: { theme: { spacing: ["em"] } } })`.
+      spacing: ["px", isNumber, "em"],
+      text: [isTshirtSize],
+      "text-shadow": [isTshirtSize],
+      tracking: ["tighter", "tight", "normal", "wide", "wider", "widest"],
+    },
+    classGroups: {
+      // --------------
+      // --- Layout ---
+      // --------------
+
+      /**
+       * Aspect Ratio
+       * @see https://tailwindcss.com/docs/aspect-ratio
+       */
+      aspect: [
+        {
+          aspect: [
+            "auto",
+            "square",
+            isFraction,
+            isArbitraryValue,
+            isArbitraryVariable,
+            themeAspect,
+          ],
+        },
+      ],
+      /**
+       * Container
+       * @see https://tailwindcss.com/docs/container
+       * @deprecated since Tailwind CSS v4.0.0
+       */
+      container: ["container"],
+      /**
+       * Container Type
+       * @see https://tailwindcss.com/docs/responsive-design#container-queries
+       */
+      "container-type": [
+        { "@container": ["", "normal", "size", isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Container Name
+       * @see https://tailwindcss.com/docs/responsive-design#named-containers
+       */
+      "container-named": [isNamedContainerQuery],
+      /**
+       * Columns
+       * @see https://tailwindcss.com/docs/columns
+       */
+      columns: [{ columns: [isNumber, isArbitraryValue, isArbitraryVariable, themeContainer] }],
+      /**
+       * Break After
+       * @see https://tailwindcss.com/docs/break-after
+       */
+      "break-after": [{ "break-after": scaleBreak() }],
+      /**
+       * Break Before
+       * @see https://tailwindcss.com/docs/break-before
+       */
+      "break-before": [{ "break-before": scaleBreak() }],
+      /**
+       * Break Inside
+       * @see https://tailwindcss.com/docs/break-inside
+       */
+      "break-inside": [{ "break-inside": ["auto", "avoid", "avoid-page", "avoid-column"] }],
+      /**
+       * Box Decoration Break
+       * @see https://tailwindcss.com/docs/box-decoration-break
+       */
+      "box-decoration": [{ "box-decoration": ["slice", "clone"] }],
+      /**
+       * Box Sizing
+       * @see https://tailwindcss.com/docs/box-sizing
+       */
+      box: [{ box: ["border", "content"] }],
+      /**
+       * Display
+       * @see https://tailwindcss.com/docs/display
+       */
+      display: [
+        "block",
+        "inline-block",
+        "inline",
+        "flex",
+        "inline-flex",
+        "table",
+        "inline-table",
+        "table-caption",
+        "table-cell",
+        "table-column",
+        "table-column-group",
+        "table-footer-group",
+        "table-header-group",
+        "table-row-group",
+        "table-row",
+        "flow-root",
+        "grid",
+        "inline-grid",
+        "contents",
+        "list-item",
+        "hidden",
+      ],
+      /**
+       * Screen Reader Only
+       * @see https://tailwindcss.com/docs/display#screen-reader-only
+       */
+      sr: ["sr-only", "not-sr-only"],
+      /**
+       * Floats
+       * @see https://tailwindcss.com/docs/float
+       */
+      float: [{ float: ["right", "left", "none", "start", "end"] }],
+      /**
+       * Clear
+       * @see https://tailwindcss.com/docs/clear
+       */
+      clear: [{ clear: ["left", "right", "both", "none", "start", "end"] }],
+      /**
+       * Isolation
+       * @see https://tailwindcss.com/docs/isolation
+       */
+      isolation: ["isolate", "isolation-auto"],
+      /**
+       * Object Fit
+       * @see https://tailwindcss.com/docs/object-fit
+       */
+      "object-fit": [{ object: ["contain", "cover", "fill", "none", "scale-down"] }],
+      /**
+       * Object Position
+       * @see https://tailwindcss.com/docs/object-position
+       */
+      "object-position": [{ object: scalePositionWithArbitrary() }],
+      /**
+       * Overflow
+       * @see https://tailwindcss.com/docs/overflow
+       */
+      overflow: [{ overflow: scaleOverflow() }],
+      /**
+       * Overflow X
+       * @see https://tailwindcss.com/docs/overflow
+       */
+      "overflow-x": [{ "overflow-x": scaleOverflow() }],
+      /**
+       * Overflow Y
+       * @see https://tailwindcss.com/docs/overflow
+       */
+      "overflow-y": [{ "overflow-y": scaleOverflow() }],
+      /**
+       * Overscroll Behavior
+       * @see https://tailwindcss.com/docs/overscroll-behavior
+       */
+      overscroll: [{ overscroll: scaleOverscroll() }],
+      /**
+       * Overscroll Behavior X
+       * @see https://tailwindcss.com/docs/overscroll-behavior
+       */
+      "overscroll-x": [{ "overscroll-x": scaleOverscroll() }],
+      /**
+       * Overscroll Behavior Y
+       * @see https://tailwindcss.com/docs/overscroll-behavior
+       */
+      "overscroll-y": [{ "overscroll-y": scaleOverscroll() }],
+      /**
+       * Position
+       * @see https://tailwindcss.com/docs/position
+       */
+      position: ["static", "fixed", "absolute", "relative", "sticky"],
+      /**
+       * Inset
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      inset: [{ inset: scaleInset() }],
+      /**
+       * Inset Inline
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      "inset-x": [{ "inset-x": scaleInset() }],
+      /**
+       * Inset Block
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      "inset-y": [{ "inset-y": scaleInset() }],
+      /**
+       * Inset Inline Start
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       * @todo class group will be renamed to `inset-s` in next major release
+       */
+      start: [
+        {
+          "inset-s": scaleInset(),
+          /**
+           * @deprecated since Tailwind CSS v4.2.0 in favor of `inset-s-*` utilities.
+           * @see https://github.com/tailwindlabs/tailwindcss/pull/19613
+           */
+          start: scaleInset(),
+        },
+      ],
+      /**
+       * Inset Inline End
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       * @todo class group will be renamed to `inset-e` in next major release
+       */
+      end: [
+        {
+          "inset-e": scaleInset(),
+          /**
+           * @deprecated since Tailwind CSS v4.2.0 in favor of `inset-e-*` utilities.
+           * @see https://github.com/tailwindlabs/tailwindcss/pull/19613
+           */
+          end: scaleInset(),
+        },
+      ],
+      /**
+       * Inset Block Start
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      "inset-bs": [{ "inset-bs": scaleInset() }],
+      /**
+       * Inset Block End
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      "inset-be": [{ "inset-be": scaleInset() }],
+      /**
+       * Top
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      top: [{ top: scaleInset() }],
+      /**
+       * Right
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      right: [{ right: scaleInset() }],
+      /**
+       * Bottom
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      bottom: [{ bottom: scaleInset() }],
+      /**
+       * Left
+       * @see https://tailwindcss.com/docs/top-right-bottom-left
+       */
+      left: [{ left: scaleInset() }],
+      /**
+       * Visibility
+       * @see https://tailwindcss.com/docs/visibility
+       */
+      visibility: ["visible", "invisible", "collapse"],
+      /**
+       * Z-Index
+       * @see https://tailwindcss.com/docs/z-index
+       */
+      z: [{ z: [isInteger, "auto", isArbitraryVariable, isArbitraryValue] }],
+
+      // ------------------------
+      // --- Flexbox and Grid ---
+      // ------------------------
+
+      /**
+       * Flex Basis
+       * @see https://tailwindcss.com/docs/flex-basis
+       */
+      basis: [
+        {
+          basis: [isFraction, "full", "auto", themeContainer, ...scaleUnambiguousSpacing()],
+        },
+      ],
+      /**
+       * Flex Direction
+       * @see https://tailwindcss.com/docs/flex-direction
+       */
+      "flex-direction": [{ flex: ["row", "row-reverse", "col", "col-reverse"] }],
+      /**
+       * Flex Wrap
+       * @see https://tailwindcss.com/docs/flex-wrap
+       */
+      "flex-wrap": [{ flex: ["nowrap", "wrap", "wrap-reverse"] }],
+      /**
+       * Flex
+       * @see https://tailwindcss.com/docs/flex
+       */
+      flex: [{ flex: [isNumber, isFraction, "auto", "initial", "none", isArbitraryValue] }],
+      /**
+       * Flex Grow
+       * @see https://tailwindcss.com/docs/flex-grow
+       */
+      grow: [{ grow: ["", isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Flex Shrink
+       * @see https://tailwindcss.com/docs/flex-shrink
+       */
+      shrink: [{ shrink: ["", isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Order
+       * @see https://tailwindcss.com/docs/order
+       */
+      order: [
+        {
+          order: [isInteger, "first", "last", "none", isArbitraryVariable, isArbitraryValue],
+        },
+      ],
+      /**
+       * Grid Template Columns
+       * @see https://tailwindcss.com/docs/grid-template-columns
+       */
+      "grid-cols": [{ "grid-cols": scaleGridTemplateColsRows() }],
+      /**
+       * Grid Column Start / End
+       * @see https://tailwindcss.com/docs/grid-column
+       */
+      "col-start-end": [{ col: scaleGridColRowStartAndEnd() }],
+      /**
+       * Grid Column Start
+       * @see https://tailwindcss.com/docs/grid-column
+       */
+      "col-start": [{ "col-start": scaleGridColRowStartOrEnd() }],
+      /**
+       * Grid Column End
+       * @see https://tailwindcss.com/docs/grid-column
+       */
+      "col-end": [{ "col-end": scaleGridColRowStartOrEnd() }],
+      /**
+       * Grid Template Rows
+       * @see https://tailwindcss.com/docs/grid-template-rows
+       */
+      "grid-rows": [{ "grid-rows": scaleGridTemplateColsRows() }],
+      /**
+       * Grid Row Start / End
+       * @see https://tailwindcss.com/docs/grid-row
+       */
+      "row-start-end": [{ row: scaleGridColRowStartAndEnd() }],
+      /**
+       * Grid Row Start
+       * @see https://tailwindcss.com/docs/grid-row
+       */
+      "row-start": [{ "row-start": scaleGridColRowStartOrEnd() }],
+      /**
+       * Grid Row End
+       * @see https://tailwindcss.com/docs/grid-row
+       */
+      "row-end": [{ "row-end": scaleGridColRowStartOrEnd() }],
+      /**
+       * Grid Auto Flow
+       * @see https://tailwindcss.com/docs/grid-auto-flow
+       */
+      "grid-flow": [{ "grid-flow": ["row", "col", "dense", "row-dense", "col-dense"] }],
+      /**
+       * Grid Auto Columns
+       * @see https://tailwindcss.com/docs/grid-auto-columns
+       */
+      "auto-cols": [{ "auto-cols": scaleGridAutoColsRows() }],
+      /**
+       * Grid Auto Rows
+       * @see https://tailwindcss.com/docs/grid-auto-rows
+       */
+      "auto-rows": [{ "auto-rows": scaleGridAutoColsRows() }],
+      /**
+       * Gap
+       * @see https://tailwindcss.com/docs/gap
+       */
+      gap: [{ gap: scaleUnambiguousSpacing() }],
+      /**
+       * Gap X
+       * @see https://tailwindcss.com/docs/gap
+       */
+      "gap-x": [{ "gap-x": scaleUnambiguousSpacing() }],
+      /**
+       * Gap Y
+       * @see https://tailwindcss.com/docs/gap
+       */
+      "gap-y": [{ "gap-y": scaleUnambiguousSpacing() }],
+      /**
+       * Justify Content
+       * @see https://tailwindcss.com/docs/justify-content
+       */
+      "justify-content": [{ justify: [...scaleAlignPrimaryAxis(), "normal"] }],
+      /**
+       * Justify Items
+       * @see https://tailwindcss.com/docs/justify-items
+       */
+      "justify-items": [{ "justify-items": [...scaleAlignSecondaryAxis(), "normal"] }],
+      /**
+       * Justify Self
+       * @see https://tailwindcss.com/docs/justify-self
+       */
+      "justify-self": [{ "justify-self": ["auto", ...scaleAlignSecondaryAxis()] }],
+      /**
+       * Align Content
+       * @see https://tailwindcss.com/docs/align-content
+       */
+      "align-content": [{ content: ["normal", ...scaleAlignPrimaryAxis()] }],
+      /**
+       * Align Items
+       * @see https://tailwindcss.com/docs/align-items
+       */
+      "align-items": [{ items: [...scaleAlignSecondaryAxis(), { baseline: ["", "last"] }] }],
+      /**
+       * Align Self
+       * @see https://tailwindcss.com/docs/align-self
+       */
+      "align-self": [{ self: ["auto", ...scaleAlignSecondaryAxis(), { baseline: ["", "last"] }] }],
+      /**
+       * Place Content
+       * @see https://tailwindcss.com/docs/place-content
+       */
+      "place-content": [{ "place-content": scaleAlignPrimaryAxis() }],
+      /**
+       * Place Items
+       * @see https://tailwindcss.com/docs/place-items
+       */
+      "place-items": [{ "place-items": [...scaleAlignSecondaryAxis(), "baseline"] }],
+      /**
+       * Place Self
+       * @see https://tailwindcss.com/docs/place-self
+       */
+      "place-self": [{ "place-self": ["auto", ...scaleAlignSecondaryAxis()] }],
+      // Spacing
+      /**
+       * Padding
+       * @see https://tailwindcss.com/docs/padding
+       */
+      p: [{ p: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Inline
+       * @see https://tailwindcss.com/docs/padding
+       */
+      px: [{ px: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Block
+       * @see https://tailwindcss.com/docs/padding
+       */
+      py: [{ py: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Inline Start
+       * @see https://tailwindcss.com/docs/padding
+       */
+      ps: [{ ps: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Inline End
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pe: [{ pe: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Block Start
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pbs: [{ pbs: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Block End
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pbe: [{ pbe: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Top
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pt: [{ pt: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Right
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pr: [{ pr: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Bottom
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pb: [{ pb: scaleUnambiguousSpacing() }],
+      /**
+       * Padding Left
+       * @see https://tailwindcss.com/docs/padding
+       */
+      pl: [{ pl: scaleUnambiguousSpacing() }],
+      /**
+       * Margin
+       * @see https://tailwindcss.com/docs/margin
+       */
+      m: [{ m: scaleMargin() }],
+      /**
+       * Margin Inline
+       * @see https://tailwindcss.com/docs/margin
+       */
+      mx: [{ mx: scaleMargin() }],
+      /**
+       * Margin Block
+       * @see https://tailwindcss.com/docs/margin
+       */
+      my: [{ my: scaleMargin() }],
+      /**
+       * Margin Inline Start
+       * @see https://tailwindcss.com/docs/margin
+       */
+      ms: [{ ms: scaleMargin() }],
+      /**
+       * Margin Inline End
+       * @see https://tailwindcss.com/docs/margin
+       */
+      me: [{ me: scaleMargin() }],
+      /**
+       * Margin Block Start
+       * @see https://tailwindcss.com/docs/margin
+       */
+      mbs: [{ mbs: scaleMargin() }],
+      /**
+       * Margin Block End
+       * @see https://tailwindcss.com/docs/margin
+       */
+      mbe: [{ mbe: scaleMargin() }],
+      /**
+       * Margin Top
+       * @see https://tailwindcss.com/docs/margin
+       */
+      mt: [{ mt: scaleMargin() }],
+      /**
+       * Margin Right
+       * @see https://tailwindcss.com/docs/margin
+       */
+      mr: [{ mr: scaleMargin() }],
+      /**
+       * Margin Bottom
+       * @see https://tailwindcss.com/docs/margin
+       */
+      mb: [{ mb: scaleMargin() }],
+      /**
+       * Margin Left
+       * @see https://tailwindcss.com/docs/margin
+       */
+      ml: [{ ml: scaleMargin() }],
+      /**
+       * Space Between X
+       * @see https://tailwindcss.com/docs/margin#adding-space-between-children
+       */
+      "space-x": [{ "space-x": scaleUnambiguousSpacing() }],
+      /**
+       * Space Between X Reverse
+       * @see https://tailwindcss.com/docs/margin#adding-space-between-children
+       */
+      "space-x-reverse": ["space-x-reverse"],
+      /**
+       * Space Between Y
+       * @see https://tailwindcss.com/docs/margin#adding-space-between-children
+       */
+      "space-y": [{ "space-y": scaleUnambiguousSpacing() }],
+      /**
+       * Space Between Y Reverse
+       * @see https://tailwindcss.com/docs/margin#adding-space-between-children
+       */
+      "space-y-reverse": ["space-y-reverse"],
+
+      // --------------
+      // --- Sizing ---
+      // --------------
+
+      /**
+       * Size
+       * @see https://tailwindcss.com/docs/width#setting-both-width-and-height
+       */
+      size: [{ size: scaleSizing() }],
+      /**
+       * Inline Size
+       * @see https://tailwindcss.com/docs/width
+       */
+      "inline-size": [{ inline: ["auto", ...scaleSizingInline()] }],
+      /**
+       * Min-Inline Size
+       * @see https://tailwindcss.com/docs/min-width
+       */
+      "min-inline-size": [{ "min-inline": ["auto", ...scaleSizingInline()] }],
+      /**
+       * Max-Inline Size
+       * @see https://tailwindcss.com/docs/max-width
+       */
+      "max-inline-size": [{ "max-inline": ["none", ...scaleSizingInline()] }],
+      /**
+       * Block Size
+       * @see https://tailwindcss.com/docs/height
+       */
+      "block-size": [{ block: ["auto", ...scaleSizingBlock()] }],
+      /**
+       * Min-Block Size
+       * @see https://tailwindcss.com/docs/min-height
+       */
+      "min-block-size": [{ "min-block": ["auto", ...scaleSizingBlock()] }],
+      /**
+       * Max-Block Size
+       * @see https://tailwindcss.com/docs/max-height
+       */
+      "max-block-size": [{ "max-block": ["none", ...scaleSizingBlock()] }],
+      /**
+       * Width
+       * @see https://tailwindcss.com/docs/width
+       */
+      w: [{ w: [themeContainer, "screen", ...scaleSizing()] }],
+      /**
+       * Min-Width
+       * @see https://tailwindcss.com/docs/min-width
+       */
+      "min-w": [
+        {
+          "min-w": [
+            themeContainer,
+            "screen",
+            /** Deprecated. @see https://github.com/tailwindlabs/tailwindcss.com/issues/2027#issuecomment-2620152757 */
+            "none",
+            ...scaleSizing(),
+          ],
+        },
+      ],
+      /**
+       * Max-Width
+       * @see https://tailwindcss.com/docs/max-width
+       */
+      "max-w": [
+        {
+          "max-w": [
+            themeContainer,
+            "screen",
+            "none",
+            /** Deprecated since Tailwind CSS v4.0.0. @see https://github.com/tailwindlabs/tailwindcss.com/issues/2027#issuecomment-2620152757 */
+            "prose",
+            /** Deprecated since Tailwind CSS v4.0.0. @see https://github.com/tailwindlabs/tailwindcss.com/issues/2027#issuecomment-2620152757 */
+            { screen: [themeBreakpoint] },
+            ...scaleSizing(),
+          ],
+        },
+      ],
+      /**
+       * Height
+       * @see https://tailwindcss.com/docs/height
+       */
+      h: [{ h: ["screen", "lh", ...scaleSizing()] }],
+      /**
+       * Min-Height
+       * @see https://tailwindcss.com/docs/min-height
+       */
+      "min-h": [{ "min-h": ["screen", "lh", "none", ...scaleSizing()] }],
+      /**
+       * Max-Height
+       * @see https://tailwindcss.com/docs/max-height
+       */
+      "max-h": [{ "max-h": ["screen", "lh", ...scaleSizing()] }],
+
+      // ------------------
+      // --- Typography ---
+      // ------------------
+
+      /**
+       * Font Size
+       * @see https://tailwindcss.com/docs/font-size
+       */
+      // --- mantle override --- : `text-mono` + `text-size-inherit` join the font-size group so
+      // they conflict-resolve against `text-base`, `text-xl`, … Replaces the former
+      // `extendTailwindMerge({ extend: { classGroups: { "font-size": [...] } } })`.
+      "font-size": [
+        { text: ["base", themeText, isArbitraryVariableLength, isArbitraryLength] },
+        "text-mono",
+        "text-size-inherit",
+      ],
+      /**
+       * Font Smoothing
+       * @see https://tailwindcss.com/docs/font-smoothing
+       */
+      "font-smoothing": ["antialiased", "subpixel-antialiased"],
+      /**
+       * Font Style
+       * @see https://tailwindcss.com/docs/font-style
+       */
+      "font-style": ["italic", "not-italic"],
+      /**
+       * Font Weight
+       * @see https://tailwindcss.com/docs/font-weight
+       */
+      "font-weight": [
+        {
+          font: [themeFontWeight, isArbitraryVariableWeight, isArbitraryWeight],
+        },
+      ],
+      /**
+       * Font Stretch
+       * @see https://tailwindcss.com/docs/font-stretch
+       */
+      "font-stretch": [
+        {
+          "font-stretch": [
+            "ultra-condensed",
+            "extra-condensed",
+            "condensed",
+            "semi-condensed",
+            "normal",
+            "semi-expanded",
+            "expanded",
+            "extra-expanded",
+            "ultra-expanded",
+            isPercent,
+            isArbitraryValue,
+          ],
+        },
+      ],
+      /**
+       * Font Family
+       * @see https://tailwindcss.com/docs/font-family
+       */
+      "font-family": [{ font: [isArbitraryVariableFamilyName, isArbitraryFamilyName, themeFont] }],
+      /**
+       * Font Feature Settings
+       * @see https://tailwindcss.com/docs/font-feature-settings
+       */
+      "font-features": [{ "font-features": [isArbitraryValue] }],
+      /**
+       * Font Variant Numeric
+       * @see https://tailwindcss.com/docs/font-variant-numeric
+       */
+      "fvn-normal": ["normal-nums"],
+      /**
+       * Font Variant Numeric
+       * @see https://tailwindcss.com/docs/font-variant-numeric
+       */
+      "fvn-ordinal": ["ordinal"],
+      /**
+       * Font Variant Numeric
+       * @see https://tailwindcss.com/docs/font-variant-numeric
+       */
+      "fvn-slashed-zero": ["slashed-zero"],
+      /**
+       * Font Variant Numeric
+       * @see https://tailwindcss.com/docs/font-variant-numeric
+       */
+      "fvn-figure": ["lining-nums", "oldstyle-nums"],
+      /**
+       * Font Variant Numeric
+       * @see https://tailwindcss.com/docs/font-variant-numeric
+       */
+      "fvn-spacing": ["proportional-nums", "tabular-nums"],
+      /**
+       * Font Variant Numeric
+       * @see https://tailwindcss.com/docs/font-variant-numeric
+       */
+      "fvn-fraction": ["diagonal-fractions", "stacked-fractions"],
+      /**
+       * Letter Spacing
+       * @see https://tailwindcss.com/docs/letter-spacing
+       */
+      tracking: [{ tracking: [themeTracking, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Line Clamp
+       * @see https://tailwindcss.com/docs/line-clamp
+       */
+      "line-clamp": [{ "line-clamp": [isNumber, "none", isArbitraryVariable, isArbitraryNumber] }],
+      /**
+       * Line Height
+       * @see https://tailwindcss.com/docs/line-height
+       */
+      leading: [
+        {
+          leading: [
+            /** Deprecated since Tailwind CSS v4.0.0. @see https://github.com/tailwindlabs/tailwindcss.com/issues/2027#issuecomment-2620152757 */
+            themeLeading,
+            ...scaleUnambiguousSpacing(),
+          ],
+        },
+      ],
+      /**
+       * List Style Image
+       * @see https://tailwindcss.com/docs/list-style-image
+       */
+      "list-image": [{ "list-image": ["none", isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * List Style Position
+       * @see https://tailwindcss.com/docs/list-style-position
+       */
+      "list-style-position": [{ list: ["inside", "outside"] }],
+      /**
+       * List Style Type
+       * @see https://tailwindcss.com/docs/list-style-type
+       */
+      "list-style-type": [
+        { list: ["disc", "decimal", "none", isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Text Alignment
+       * @see https://tailwindcss.com/docs/text-align
+       */
+      "text-alignment": [{ text: ["left", "center", "right", "justify", "start", "end"] }],
+      /**
+       * Placeholder Color
+       * @deprecated since Tailwind CSS v3.0.0
+       * @see https://v3.tailwindcss.com/docs/placeholder-color
+       */
+      "placeholder-color": [{ placeholder: scaleColor() }],
+      /**
+       * Text Color
+       * @see https://tailwindcss.com/docs/text-color
+       */
+      "text-color": [{ text: scaleColor() }],
+      /**
+       * Text Decoration
+       * @see https://tailwindcss.com/docs/text-decoration
+       */
+      "text-decoration": ["underline", "overline", "line-through", "no-underline"],
+      /**
+       * Text Decoration Style
+       * @see https://tailwindcss.com/docs/text-decoration-style
+       */
+      "text-decoration-style": [{ decoration: [...scaleLineStyle(), "wavy"] }],
+      /**
+       * Text Decoration Thickness
+       * @see https://tailwindcss.com/docs/text-decoration-thickness
+       */
+      "text-decoration-thickness": [
+        {
+          decoration: [isNumber, "from-font", "auto", isArbitraryVariable, isArbitraryLength],
+        },
+      ],
+      /**
+       * Text Decoration Color
+       * @see https://tailwindcss.com/docs/text-decoration-color
+       */
+      "text-decoration-color": [{ decoration: scaleColor() }],
+      /**
+       * Text Underline Offset
+       * @see https://tailwindcss.com/docs/text-underline-offset
+       */
+      "underline-offset": [
+        { "underline-offset": [isNumber, "auto", isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Text Transform
+       * @see https://tailwindcss.com/docs/text-transform
+       */
+      "text-transform": ["uppercase", "lowercase", "capitalize", "normal-case"],
+      /**
+       * Text Overflow
+       * @see https://tailwindcss.com/docs/text-overflow
+       */
+      "text-overflow": ["truncate", "text-ellipsis", "text-clip"],
+      /**
+       * Text Wrap
+       * @see https://tailwindcss.com/docs/text-wrap
+       */
+      "text-wrap": [{ text: ["wrap", "nowrap", "balance", "pretty"] }],
+      /**
+       * Text Indent
+       * @see https://tailwindcss.com/docs/text-indent
+       */
+      indent: [{ indent: scaleUnambiguousSpacing() }],
+      /**
+       * Tab Size
+       * @see https://tailwindcss.com/docs/tab-size
+       */
+      "tab-size": [{ tab: [isInteger, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Vertical Alignment
+       * @see https://tailwindcss.com/docs/vertical-align
+       */
+      "vertical-align": [
+        {
+          align: [
+            "baseline",
+            "top",
+            "middle",
+            "bottom",
+            "text-top",
+            "text-bottom",
+            "sub",
+            "super",
+            isArbitraryVariable,
+            isArbitraryValue,
+          ],
+        },
+      ],
+      /**
+       * Whitespace
+       * @see https://tailwindcss.com/docs/whitespace
+       */
+      whitespace: [
+        { whitespace: ["normal", "nowrap", "pre", "pre-line", "pre-wrap", "break-spaces"] },
+      ],
+      /**
+       * Word Break
+       * @see https://tailwindcss.com/docs/word-break
+       */
+      break: [{ break: ["normal", "words", "all", "keep"] }],
+      /**
+       * Overflow Wrap
+       * @see https://tailwindcss.com/docs/overflow-wrap
+       */
+      wrap: [{ wrap: ["break-word", "anywhere", "normal"] }],
+      /**
+       * Hyphens
+       * @see https://tailwindcss.com/docs/hyphens
+       */
+      hyphens: [{ hyphens: ["none", "manual", "auto"] }],
+      /**
+       * Content
+       * @see https://tailwindcss.com/docs/content
+       */
+      content: [{ content: ["none", isArbitraryVariable, isArbitraryValue] }],
+
+      // -------------------
+      // --- Backgrounds ---
+      // -------------------
+
+      /**
+       * Background Attachment
+       * @see https://tailwindcss.com/docs/background-attachment
+       */
+      "bg-attachment": [{ bg: ["fixed", "local", "scroll"] }],
+      /**
+       * Background Clip
+       * @see https://tailwindcss.com/docs/background-clip
+       */
+      "bg-clip": [{ "bg-clip": ["border", "padding", "content", "text"] }],
+      /**
+       * Background Origin
+       * @see https://tailwindcss.com/docs/background-origin
+       */
+      "bg-origin": [{ "bg-origin": ["border", "padding", "content"] }],
+      /**
+       * Background Position
+       * @see https://tailwindcss.com/docs/background-position
+       */
+      "bg-position": [{ bg: scaleBgPosition() }],
+      /**
+       * Background Repeat
+       * @see https://tailwindcss.com/docs/background-repeat
+       */
+      "bg-repeat": [{ bg: scaleBgRepeat() }],
+      /**
+       * Background Size
+       * @see https://tailwindcss.com/docs/background-size
+       */
+      "bg-size": [{ bg: scaleBgSize() }],
+      /**
+       * Background Image
+       * @see https://tailwindcss.com/docs/background-image
+       */
+      "bg-image": [
+        {
+          bg: [
+            "none",
+            {
+              linear: [
+                { to: ["t", "tr", "r", "br", "b", "bl", "l", "tl"] },
+                isInteger,
+                isArbitraryVariable,
+                isArbitraryValue,
+              ],
+              radial: ["", isArbitraryVariable, isArbitraryValue],
+              conic: [isInteger, isArbitraryVariable, isArbitraryValue],
+            },
+            isArbitraryVariableImage,
+            isArbitraryImage,
+          ],
+        },
+      ],
+      /**
+       * Background Color
+       * @see https://tailwindcss.com/docs/background-color
+       */
+      "bg-color": [{ bg: scaleColor() }],
+      /**
+       * Gradient Color Stops From Position
+       * @see https://tailwindcss.com/docs/gradient-color-stops
+       */
+      "gradient-from-pos": [{ from: scaleGradientStopPosition() }],
+      /**
+       * Gradient Color Stops Via Position
+       * @see https://tailwindcss.com/docs/gradient-color-stops
+       */
+      "gradient-via-pos": [{ via: scaleGradientStopPosition() }],
+      /**
+       * Gradient Color Stops To Position
+       * @see https://tailwindcss.com/docs/gradient-color-stops
+       */
+      "gradient-to-pos": [{ to: scaleGradientStopPosition() }],
+      /**
+       * Gradient Color Stops From
+       * @see https://tailwindcss.com/docs/gradient-color-stops
+       */
+      "gradient-from": [{ from: scaleColor() }],
+      /**
+       * Gradient Color Stops Via
+       * @see https://tailwindcss.com/docs/gradient-color-stops
+       */
+      "gradient-via": [{ via: scaleColor() }],
+      /**
+       * Gradient Color Stops To
+       * @see https://tailwindcss.com/docs/gradient-color-stops
+       */
+      "gradient-to": [{ to: scaleColor() }],
+
+      // ---------------
+      // --- Borders ---
+      // ---------------
+
+      /**
+       * Border Radius
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      rounded: [{ rounded: scaleRadius() }],
+      /**
+       * Border Radius Start
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-s": [{ "rounded-s": scaleRadius() }],
+      /**
+       * Border Radius End
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-e": [{ "rounded-e": scaleRadius() }],
+      /**
+       * Border Radius Top
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-t": [{ "rounded-t": scaleRadius() }],
+      /**
+       * Border Radius Right
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-r": [{ "rounded-r": scaleRadius() }],
+      /**
+       * Border Radius Bottom
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-b": [{ "rounded-b": scaleRadius() }],
+      /**
+       * Border Radius Left
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-l": [{ "rounded-l": scaleRadius() }],
+      /**
+       * Border Radius Start Start
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-ss": [{ "rounded-ss": scaleRadius() }],
+      /**
+       * Border Radius Start End
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-se": [{ "rounded-se": scaleRadius() }],
+      /**
+       * Border Radius End End
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-ee": [{ "rounded-ee": scaleRadius() }],
+      /**
+       * Border Radius End Start
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-es": [{ "rounded-es": scaleRadius() }],
+      /**
+       * Border Radius Top Left
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-tl": [{ "rounded-tl": scaleRadius() }],
+      /**
+       * Border Radius Top Right
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-tr": [{ "rounded-tr": scaleRadius() }],
+      /**
+       * Border Radius Bottom Right
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-br": [{ "rounded-br": scaleRadius() }],
+      /**
+       * Border Radius Bottom Left
+       * @see https://tailwindcss.com/docs/border-radius
+       */
+      "rounded-bl": [{ "rounded-bl": scaleRadius() }],
+      /**
+       * Border Width
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w": [{ border: scaleBorderWidth() }],
+      /**
+       * Border Width Inline
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-x": [{ "border-x": scaleBorderWidth() }],
+      /**
+       * Border Width Block
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-y": [{ "border-y": scaleBorderWidth() }],
+      /**
+       * Border Width Inline Start
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-s": [{ "border-s": scaleBorderWidth() }],
+      /**
+       * Border Width Inline End
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-e": [{ "border-e": scaleBorderWidth() }],
+      /**
+       * Border Width Block Start
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-bs": [{ "border-bs": scaleBorderWidth() }],
+      /**
+       * Border Width Block End
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-be": [{ "border-be": scaleBorderWidth() }],
+      /**
+       * Border Width Top
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-t": [{ "border-t": scaleBorderWidth() }],
+      /**
+       * Border Width Right
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-r": [{ "border-r": scaleBorderWidth() }],
+      /**
+       * Border Width Bottom
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-b": [{ "border-b": scaleBorderWidth() }],
+      /**
+       * Border Width Left
+       * @see https://tailwindcss.com/docs/border-width
+       */
+      "border-w-l": [{ "border-l": scaleBorderWidth() }],
+      /**
+       * Divide Width X
+       * @see https://tailwindcss.com/docs/border-width#between-children
+       */
+      "divide-x": [{ "divide-x": scaleBorderWidth() }],
+      /**
+       * Divide Width X Reverse
+       * @see https://tailwindcss.com/docs/border-width#between-children
+       */
+      "divide-x-reverse": ["divide-x-reverse"],
+      /**
+       * Divide Width Y
+       * @see https://tailwindcss.com/docs/border-width#between-children
+       */
+      "divide-y": [{ "divide-y": scaleBorderWidth() }],
+      /**
+       * Divide Width Y Reverse
+       * @see https://tailwindcss.com/docs/border-width#between-children
+       */
+      "divide-y-reverse": ["divide-y-reverse"],
+      /**
+       * Border Style
+       * @see https://tailwindcss.com/docs/border-style
+       */
+      "border-style": [{ border: [...scaleLineStyle(), "hidden", "none"] }],
+      /**
+       * Divide Style
+       * @see https://tailwindcss.com/docs/border-style#setting-the-divider-style
+       */
+      "divide-style": [{ divide: [...scaleLineStyle(), "hidden", "none"] }],
+      /**
+       * Border Color
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color": [{ border: scaleColor() }],
+      /**
+       * Border Color Inline
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-x": [{ "border-x": scaleColor() }],
+      /**
+       * Border Color Block
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-y": [{ "border-y": scaleColor() }],
+      /**
+       * Border Color Inline Start
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-s": [{ "border-s": scaleColor() }],
+      /**
+       * Border Color Inline End
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-e": [{ "border-e": scaleColor() }],
+      /**
+       * Border Color Block Start
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-bs": [{ "border-bs": scaleColor() }],
+      /**
+       * Border Color Block End
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-be": [{ "border-be": scaleColor() }],
+      /**
+       * Border Color Top
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-t": [{ "border-t": scaleColor() }],
+      /**
+       * Border Color Right
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-r": [{ "border-r": scaleColor() }],
+      /**
+       * Border Color Bottom
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-b": [{ "border-b": scaleColor() }],
+      /**
+       * Border Color Left
+       * @see https://tailwindcss.com/docs/border-color
+       */
+      "border-color-l": [{ "border-l": scaleColor() }],
+      /**
+       * Divide Color
+       * @see https://tailwindcss.com/docs/divide-color
+       */
+      "divide-color": [{ divide: scaleColor() }],
+      /**
+       * Outline Style
+       * @see https://tailwindcss.com/docs/outline-style
+       */
+      "outline-style": [{ outline: [...scaleLineStyle(), "none", "hidden"] }],
+      /**
+       * Outline Offset
+       * @see https://tailwindcss.com/docs/outline-offset
+       */
+      "outline-offset": [{ "outline-offset": [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Outline Width
+       * @see https://tailwindcss.com/docs/outline-width
+       */
+      "outline-w": [{ outline: ["", isNumber, isArbitraryVariableLength, isArbitraryLength] }],
+      /**
+       * Outline Color
+       * @see https://tailwindcss.com/docs/outline-color
+       */
+      "outline-color": [{ outline: scaleColor() }],
+
+      // ---------------
+      // --- Effects ---
+      // ---------------
+
+      /**
+       * Box Shadow
+       * @see https://tailwindcss.com/docs/box-shadow
+       */
+      shadow: [
+        {
+          shadow: [
+            // Deprecated since Tailwind CSS v4.0.0
+            "",
+            "none",
+            themeShadow,
+            isArbitraryVariableShadow,
+            isArbitraryShadow,
+          ],
+        },
+      ],
+      /**
+       * Box Shadow Color
+       * @see https://tailwindcss.com/docs/box-shadow#setting-the-shadow-color
+       */
+      "shadow-color": [{ shadow: scaleColor() }],
+      /**
+       * Inset Box Shadow
+       * @see https://tailwindcss.com/docs/box-shadow#adding-an-inset-shadow
+       */
+      "inset-shadow": [
+        {
+          "inset-shadow": ["none", themeInsetShadow, isArbitraryVariableShadow, isArbitraryShadow],
+        },
+      ],
+      /**
+       * Inset Box Shadow Color
+       * @see https://tailwindcss.com/docs/box-shadow#setting-the-inset-shadow-color
+       */
+      "inset-shadow-color": [{ "inset-shadow": scaleColor() }],
+      /**
+       * Ring Width
+       * @see https://tailwindcss.com/docs/box-shadow#adding-a-ring
+       */
+      "ring-w": [{ ring: scaleBorderWidth() }],
+      /**
+       * Ring Width Inset
+       * @see https://v3.tailwindcss.com/docs/ring-width#inset-rings
+       * @deprecated since Tailwind CSS v4.0.0
+       * @see https://github.com/tailwindlabs/tailwindcss/blob/v4.0.0/packages/tailwindcss/src/utilities.ts#L4158
+       */
+      "ring-w-inset": ["ring-inset"],
+      /**
+       * Ring Color
+       * @see https://tailwindcss.com/docs/box-shadow#setting-the-ring-color
+       */
+      "ring-color": [{ ring: scaleColor() }],
+      /**
+       * Ring Offset Width
+       * @see https://v3.tailwindcss.com/docs/ring-offset-width
+       * @deprecated since Tailwind CSS v4.0.0
+       * @see https://github.com/tailwindlabs/tailwindcss/blob/v4.0.0/packages/tailwindcss/src/utilities.ts#L4158
+       */
+      "ring-offset-w": [{ "ring-offset": [isNumber, isArbitraryLength] }],
+      /**
+       * Ring Offset Color
+       * @see https://v3.tailwindcss.com/docs/ring-offset-color
+       * @deprecated since Tailwind CSS v4.0.0
+       * @see https://github.com/tailwindlabs/tailwindcss/blob/v4.0.0/packages/tailwindcss/src/utilities.ts#L4158
+       */
+      "ring-offset-color": [{ "ring-offset": scaleColor() }],
+      /**
+       * Inset Ring Width
+       * @see https://tailwindcss.com/docs/box-shadow#adding-an-inset-ring
+       */
+      "inset-ring-w": [{ "inset-ring": scaleBorderWidth() }],
+      /**
+       * Inset Ring Color
+       * @see https://tailwindcss.com/docs/box-shadow#setting-the-inset-ring-color
+       */
+      "inset-ring-color": [{ "inset-ring": scaleColor() }],
+      /**
+       * Text Shadow
+       * @see https://tailwindcss.com/docs/text-shadow
+       */
+      "text-shadow": [
+        {
+          "text-shadow": ["none", themeTextShadow, isArbitraryVariableShadow, isArbitraryShadow],
+        },
+      ],
+      /**
+       * Text Shadow Color
+       * @see https://tailwindcss.com/docs/text-shadow#setting-the-shadow-color
+       */
+      "text-shadow-color": [{ "text-shadow": scaleColor() }],
+      /**
+       * Opacity
+       * @see https://tailwindcss.com/docs/opacity
+       */
+      opacity: [{ opacity: [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Mix Blend Mode
+       * @see https://tailwindcss.com/docs/mix-blend-mode
+       */
+      "mix-blend": [{ "mix-blend": [...scaleBlendMode(), "plus-darker", "plus-lighter"] }],
+      /**
+       * Background Blend Mode
+       * @see https://tailwindcss.com/docs/background-blend-mode
+       */
+      "bg-blend": [{ "bg-blend": scaleBlendMode() }],
+      /**
+       * Mask Clip
+       * @see https://tailwindcss.com/docs/mask-clip
+       */
+      "mask-clip": [
+        { "mask-clip": ["border", "padding", "content", "fill", "stroke", "view"] },
+        "mask-no-clip",
+      ],
+      /**
+       * Mask Composite
+       * @see https://tailwindcss.com/docs/mask-composite
+       */
+      "mask-composite": [{ mask: ["add", "subtract", "intersect", "exclude"] }],
+      /**
+       * Mask Image
+       * @see https://tailwindcss.com/docs/mask-image
+       */
+      "mask-image-linear-pos": [{ "mask-linear": [isNumber] }],
+      "mask-image-linear-from-pos": [{ "mask-linear-from": scaleMaskImagePosition() }],
+      "mask-image-linear-to-pos": [{ "mask-linear-to": scaleMaskImagePosition() }],
+      "mask-image-linear-from-color": [{ "mask-linear-from": scaleColor() }],
+      "mask-image-linear-to-color": [{ "mask-linear-to": scaleColor() }],
+      "mask-image-t-from-pos": [{ "mask-t-from": scaleMaskImagePosition() }],
+      "mask-image-t-to-pos": [{ "mask-t-to": scaleMaskImagePosition() }],
+      "mask-image-t-from-color": [{ "mask-t-from": scaleColor() }],
+      "mask-image-t-to-color": [{ "mask-t-to": scaleColor() }],
+      "mask-image-r-from-pos": [{ "mask-r-from": scaleMaskImagePosition() }],
+      "mask-image-r-to-pos": [{ "mask-r-to": scaleMaskImagePosition() }],
+      "mask-image-r-from-color": [{ "mask-r-from": scaleColor() }],
+      "mask-image-r-to-color": [{ "mask-r-to": scaleColor() }],
+      "mask-image-b-from-pos": [{ "mask-b-from": scaleMaskImagePosition() }],
+      "mask-image-b-to-pos": [{ "mask-b-to": scaleMaskImagePosition() }],
+      "mask-image-b-from-color": [{ "mask-b-from": scaleColor() }],
+      "mask-image-b-to-color": [{ "mask-b-to": scaleColor() }],
+      "mask-image-l-from-pos": [{ "mask-l-from": scaleMaskImagePosition() }],
+      "mask-image-l-to-pos": [{ "mask-l-to": scaleMaskImagePosition() }],
+      "mask-image-l-from-color": [{ "mask-l-from": scaleColor() }],
+      "mask-image-l-to-color": [{ "mask-l-to": scaleColor() }],
+      "mask-image-x-from-pos": [{ "mask-x-from": scaleMaskImagePosition() }],
+      "mask-image-x-to-pos": [{ "mask-x-to": scaleMaskImagePosition() }],
+      "mask-image-x-from-color": [{ "mask-x-from": scaleColor() }],
+      "mask-image-x-to-color": [{ "mask-x-to": scaleColor() }],
+      "mask-image-y-from-pos": [{ "mask-y-from": scaleMaskImagePosition() }],
+      "mask-image-y-to-pos": [{ "mask-y-to": scaleMaskImagePosition() }],
+      "mask-image-y-from-color": [{ "mask-y-from": scaleColor() }],
+      "mask-image-y-to-color": [{ "mask-y-to": scaleColor() }],
+      "mask-image-radial": [{ "mask-radial": [isArbitraryVariable, isArbitraryValue] }],
+      "mask-image-radial-from-pos": [{ "mask-radial-from": scaleMaskImagePosition() }],
+      "mask-image-radial-to-pos": [{ "mask-radial-to": scaleMaskImagePosition() }],
+      "mask-image-radial-from-color": [{ "mask-radial-from": scaleColor() }],
+      "mask-image-radial-to-color": [{ "mask-radial-to": scaleColor() }],
+      "mask-image-radial-shape": [{ "mask-radial": ["circle", "ellipse"] }],
+      "mask-image-radial-size": [
+        { "mask-radial": [{ closest: ["side", "corner"], farthest: ["side", "corner"] }] },
+      ],
+      "mask-image-radial-pos": [{ "mask-radial-at": scalePosition() }],
+      "mask-image-conic-pos": [{ "mask-conic": [isNumber] }],
+      "mask-image-conic-from-pos": [{ "mask-conic-from": scaleMaskImagePosition() }],
+      "mask-image-conic-to-pos": [{ "mask-conic-to": scaleMaskImagePosition() }],
+      "mask-image-conic-from-color": [{ "mask-conic-from": scaleColor() }],
+      "mask-image-conic-to-color": [{ "mask-conic-to": scaleColor() }],
+      /**
+       * Mask Mode
+       * @see https://tailwindcss.com/docs/mask-mode
+       */
+      "mask-mode": [{ mask: ["alpha", "luminance", "match"] }],
+      /**
+       * Mask Origin
+       * @see https://tailwindcss.com/docs/mask-origin
+       */
+      "mask-origin": [
+        { "mask-origin": ["border", "padding", "content", "fill", "stroke", "view"] },
+      ],
+      /**
+       * Mask Position
+       * @see https://tailwindcss.com/docs/mask-position
+       */
+      "mask-position": [{ mask: scaleBgPosition() }],
+      /**
+       * Mask Repeat
+       * @see https://tailwindcss.com/docs/mask-repeat
+       */
+      "mask-repeat": [{ mask: scaleBgRepeat() }],
+      /**
+       * Mask Size
+       * @see https://tailwindcss.com/docs/mask-size
+       */
+      "mask-size": [{ mask: scaleBgSize() }],
+      /**
+       * Mask Type
+       * @see https://tailwindcss.com/docs/mask-type
+       */
+      "mask-type": [{ "mask-type": ["alpha", "luminance"] }],
+      /**
+       * Mask Image
+       * @see https://tailwindcss.com/docs/mask-image
+       */
+      "mask-image": [{ mask: ["none", isArbitraryVariable, isArbitraryValue] }],
+
+      // ---------------
+      // --- Filters ---
+      // ---------------
+
+      /**
+       * Filter
+       * @see https://tailwindcss.com/docs/filter
+       */
+      filter: [
+        {
+          filter: [
+            // Deprecated since Tailwind CSS v3.0.0
+            "",
+            "none",
+            isArbitraryVariable,
+            isArbitraryValue,
+          ],
+        },
+      ],
+      /**
+       * Blur
+       * @see https://tailwindcss.com/docs/blur
+       */
+      blur: [{ blur: scaleBlur() }],
+      /**
+       * Brightness
+       * @see https://tailwindcss.com/docs/brightness
+       */
+      brightness: [{ brightness: [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Contrast
+       * @see https://tailwindcss.com/docs/contrast
+       */
+      contrast: [{ contrast: [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Drop Shadow
+       * @see https://tailwindcss.com/docs/drop-shadow
+       */
+      "drop-shadow": [
+        {
+          "drop-shadow": [
+            // Deprecated since Tailwind CSS v4.0.0
+            "",
+            "none",
+            themeDropShadow,
+            isArbitraryVariableShadow,
+            isArbitraryShadow,
+          ],
+        },
+      ],
+      /**
+       * Drop Shadow Color
+       * @see https://tailwindcss.com/docs/filter-drop-shadow#setting-the-shadow-color
+       */
+      "drop-shadow-color": [{ "drop-shadow": scaleColor() }],
+      /**
+       * Grayscale
+       * @see https://tailwindcss.com/docs/grayscale
+       */
+      grayscale: [{ grayscale: ["", isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Hue Rotate
+       * @see https://tailwindcss.com/docs/hue-rotate
+       */
+      "hue-rotate": [{ "hue-rotate": [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Invert
+       * @see https://tailwindcss.com/docs/invert
+       */
+      invert: [{ invert: ["", isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Saturate
+       * @see https://tailwindcss.com/docs/saturate
+       */
+      saturate: [{ saturate: [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Sepia
+       * @see https://tailwindcss.com/docs/sepia
+       */
+      sepia: [{ sepia: ["", isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Backdrop Filter
+       * @see https://tailwindcss.com/docs/backdrop-filter
+       */
+      "backdrop-filter": [
+        {
+          "backdrop-filter": [
+            // Deprecated since Tailwind CSS v3.0.0
+            "",
+            "none",
+            isArbitraryVariable,
+            isArbitraryValue,
+          ],
+        },
+      ],
+      /**
+       * Backdrop Blur
+       * @see https://tailwindcss.com/docs/backdrop-blur
+       */
+      "backdrop-blur": [{ "backdrop-blur": scaleBlur() }],
+      /**
+       * Backdrop Brightness
+       * @see https://tailwindcss.com/docs/backdrop-brightness
+       */
+      "backdrop-brightness": [
+        { "backdrop-brightness": [isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Contrast
+       * @see https://tailwindcss.com/docs/backdrop-contrast
+       */
+      "backdrop-contrast": [
+        { "backdrop-contrast": [isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Grayscale
+       * @see https://tailwindcss.com/docs/backdrop-grayscale
+       */
+      "backdrop-grayscale": [
+        { "backdrop-grayscale": ["", isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Hue Rotate
+       * @see https://tailwindcss.com/docs/backdrop-hue-rotate
+       */
+      "backdrop-hue-rotate": [
+        { "backdrop-hue-rotate": [isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Invert
+       * @see https://tailwindcss.com/docs/backdrop-invert
+       */
+      "backdrop-invert": [
+        { "backdrop-invert": ["", isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Opacity
+       * @see https://tailwindcss.com/docs/backdrop-opacity
+       */
+      "backdrop-opacity": [
+        { "backdrop-opacity": [isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Saturate
+       * @see https://tailwindcss.com/docs/backdrop-saturate
+       */
+      "backdrop-saturate": [
+        { "backdrop-saturate": [isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+      /**
+       * Backdrop Sepia
+       * @see https://tailwindcss.com/docs/backdrop-sepia
+       */
+      "backdrop-sepia": [
+        { "backdrop-sepia": ["", isNumber, isArbitraryVariable, isArbitraryValue] },
+      ],
+
+      // --------------
+      // --- Tables ---
+      // --------------
+
+      /**
+       * Border Collapse
+       * @see https://tailwindcss.com/docs/border-collapse
+       */
+      "border-collapse": [{ border: ["collapse", "separate"] }],
+      /**
+       * Border Spacing
+       * @see https://tailwindcss.com/docs/border-spacing
+       */
+      "border-spacing": [{ "border-spacing": scaleUnambiguousSpacing() }],
+      /**
+       * Border Spacing X
+       * @see https://tailwindcss.com/docs/border-spacing
+       */
+      "border-spacing-x": [{ "border-spacing-x": scaleUnambiguousSpacing() }],
+      /**
+       * Border Spacing Y
+       * @see https://tailwindcss.com/docs/border-spacing
+       */
+      "border-spacing-y": [{ "border-spacing-y": scaleUnambiguousSpacing() }],
+      /**
+       * Table Layout
+       * @see https://tailwindcss.com/docs/table-layout
+       */
+      "table-layout": [{ table: ["auto", "fixed"] }],
+      /**
+       * Caption Side
+       * @see https://tailwindcss.com/docs/caption-side
+       */
+      caption: [{ caption: ["top", "bottom"] }],
+
+      // ---------------------------------
+      // --- Transitions and Animation ---
+      // ---------------------------------
+
+      /**
+       * Transition Property
+       * @see https://tailwindcss.com/docs/transition-property
+       */
+      transition: [
+        {
+          transition: [
+            "",
+            "all",
+            "colors",
+            "opacity",
+            "shadow",
+            "transform",
+            "none",
+            isArbitraryVariable,
+            isArbitraryValue,
+          ],
+        },
+      ],
+      /**
+       * Transition Behavior
+       * @see https://tailwindcss.com/docs/transition-behavior
+       */
+      "transition-behavior": [{ transition: ["normal", "discrete"] }],
+      /**
+       * Transition Duration
+       * @see https://tailwindcss.com/docs/transition-duration
+       */
+      duration: [{ duration: [isNumber, "initial", isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Transition Timing Function
+       * @see https://tailwindcss.com/docs/transition-timing-function
+       */
+      ease: [{ ease: ["linear", "initial", themeEase, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Transition Delay
+       * @see https://tailwindcss.com/docs/transition-delay
+       */
+      delay: [{ delay: [isNumber, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Animation
+       * @see https://tailwindcss.com/docs/animation
+       */
+      animate: [{ animate: ["none", themeAnimate, isArbitraryVariable, isArbitraryValue] }],
+
+      // ------------------
+      // --- Transforms ---
+      // ------------------
+
+      /**
+       * Backface Visibility
+       * @see https://tailwindcss.com/docs/backface-visibility
+       */
+      backface: [{ backface: ["hidden", "visible"] }],
+      /**
+       * Perspective
+       * @see https://tailwindcss.com/docs/perspective
+       */
+      perspective: [{ perspective: [themePerspective, isArbitraryVariable, isArbitraryValue] }],
+      /**
+       * Perspective Origin
+       * @see https://tailwindcss.com/docs/perspective-origin
+       */
+      "perspective-origin": [{ "perspective-origin": scalePositionWithArbitrary() }],
+      /**
+       * Rotate
+       * @see https://tailwindcss.com/docs/rotate
+       */
+      rotate: [{ rotate: scaleRotate() }],
+      /**
+       * Rotate X
+       * @see https://tailwindcss.com/docs/rotate
+       */
+      "rotate-x": [{ "rotate-x": scaleRotate() }],
+      /**
+       * Rotate Y
+       * @see https://tailwindcss.com/docs/rotate
+       */
+      "rotate-y": [{ "rotate-y": scaleRotate() }],
+      /**
+       * Rotate Z
+       * @see https://tailwindcss.com/docs/rotate
+       */
+      "rotate-z": [{ "rotate-z": scaleRotate() }],
+      /**
+       * Scale
+       * @see https://tailwindcss.com/docs/scale
+       */
+      scale: [{ scale: scaleScale() }],
+      /**
+       * Scale X
+       * @see https://tailwindcss.com/docs/scale
+       */
+      "scale-x": [{ "scale-x": scaleScale() }],
+      /**
+       * Scale Y
+       * @see https://tailwindcss.com/docs/scale
+       */
+      "scale-y": [{ "scale-y": scaleScale() }],
+      /**
+       * Scale Z
+       * @see https://tailwindcss.com/docs/scale
+       */
+      "scale-z": [{ "scale-z": scaleScale() }],
+      /**
+       * Scale 3D
+       * @see https://tailwindcss.com/docs/scale
+       */
+      "scale-3d": ["scale-3d"],
+      /**
+       * Skew
+       * @see https://tailwindcss.com/docs/skew
+       */
+      skew: [{ skew: scaleSkew() }],
+      /**
+       * Skew X
+       * @see https://tailwindcss.com/docs/skew
+       */
+      "skew-x": [{ "skew-x": scaleSkew() }],
+      /**
+       * Skew Y
+       * @see https://tailwindcss.com/docs/skew
+       */
+      "skew-y": [{ "skew-y": scaleSkew() }],
+      /**
+       * Transform
+       * @see https://tailwindcss.com/docs/transform
+       */
+      transform: [{ transform: [isArbitraryVariable, isArbitraryValue, "", "none", "gpu", "cpu"] }],
+      /**
+       * Transform Origin
+       * @see https://tailwindcss.com/docs/transform-origin
+       */
+      "transform-origin": [{ origin: scalePositionWithArbitrary() }],
+      /**
+       * Transform Style
+       * @see https://tailwindcss.com/docs/transform-style
+       */
+      "transform-style": [{ transform: ["3d", "flat"] }],
+      /**
+       * Translate
+       * @see https://tailwindcss.com/docs/translate
+       */
+      translate: [{ translate: scaleTranslate() }],
+      /**
+       * Translate X
+       * @see https://tailwindcss.com/docs/translate
+       */
+      "translate-x": [{ "translate-x": scaleTranslate() }],
+      /**
+       * Translate Y
+       * @see https://tailwindcss.com/docs/translate
+       */
+      "translate-y": [{ "translate-y": scaleTranslate() }],
+      /**
+       * Translate Z
+       * @see https://tailwindcss.com/docs/translate
+       */
+      "translate-z": [{ "translate-z": scaleTranslate() }],
+      /**
+       * Translate None
+       * @see https://tailwindcss.com/docs/translate
+       */
+      "translate-none": ["translate-none"],
+      /**
+       * Zoom
+       * @see https://tailwindcss.com/docs/zoom
+       */
+      zoom: [{ zoom: [isInteger, isArbitraryVariable, isArbitraryValue] }],
+
+      // ---------------------
+      // --- Interactivity ---
+      // ---------------------
+
+      /**
+       * Accent Color
+       * @see https://tailwindcss.com/docs/accent-color
+       */
+      accent: [{ accent: scaleColor() }],
+      /**
+       * Appearance
+       * @see https://tailwindcss.com/docs/appearance
+       */
+      appearance: [{ appearance: ["none", "auto"] }],
+      /**
+       * Caret Color
+       * @see https://tailwindcss.com/docs/just-in-time-mode#caret-color-utilities
+       */
+      "caret-color": [{ caret: scaleColor() }],
+      /**
+       * Color Scheme
+       * @see https://tailwindcss.com/docs/color-scheme
+       */
+      "color-scheme": [
+        { scheme: ["normal", "dark", "light", "light-dark", "only-dark", "only-light"] },
+      ],
+      /**
+       * Cursor
+       * @see https://tailwindcss.com/docs/cursor
+       */
+      cursor: [
+        {
+          cursor: [
+            "auto",
+            "default",
+            "pointer",
+            "wait",
+            "text",
+            "move",
+            "help",
+            "not-allowed",
+            "none",
+            "context-menu",
+            "progress",
+            "cell",
+            "crosshair",
+            "vertical-text",
+            "alias",
+            "copy",
+            "no-drop",
+            "grab",
+            "grabbing",
+            "all-scroll",
+            "col-resize",
+            "row-resize",
+            "n-resize",
+            "e-resize",
+            "s-resize",
+            "w-resize",
+            "ne-resize",
+            "nw-resize",
+            "se-resize",
+            "sw-resize",
+            "ew-resize",
+            "ns-resize",
+            "nesw-resize",
+            "nwse-resize",
+            "zoom-in",
+            "zoom-out",
+            isArbitraryVariable,
+            isArbitraryValue,
+          ],
+        },
+      ],
+      /**
+       * Field Sizing
+       * @see https://tailwindcss.com/docs/field-sizing
+       */
+      "field-sizing": [{ "field-sizing": ["fixed", "content"] }],
+      /**
+       * Pointer Events
+       * @see https://tailwindcss.com/docs/pointer-events
+       */
+      "pointer-events": [{ "pointer-events": ["auto", "none"] }],
+      /**
+       * Resize
+       * @see https://tailwindcss.com/docs/resize
+       */
+      resize: [{ resize: ["none", "", "y", "x"] }],
+      /**
+       * Scroll Behavior
+       * @see https://tailwindcss.com/docs/scroll-behavior
+       */
+      "scroll-behavior": [{ scroll: ["auto", "smooth"] }],
+      /**
+       * Scrollbar Thumb Color
+       * @see https://tailwindcss.com/docs/scrollbar-color
+       */
+      "scrollbar-thumb-color": [{ "scrollbar-thumb": scaleColor() }],
+      /**
+       * Scrollbar Track Color
+       * @see https://tailwindcss.com/docs/scrollbar-color
+       */
+      "scrollbar-track-color": [{ "scrollbar-track": scaleColor() }],
+      /**
+       * Scrollbar Gutter
+       * @see https://tailwindcss.com/docs/scrollbar-gutter
+       */
+      "scrollbar-gutter": [{ "scrollbar-gutter": ["auto", "stable", "both"] }],
+      /**
+       * Scrollbar Width
+       * @see https://tailwindcss.com/docs/scrollbar-width
+       */
+      "scrollbar-w": [{ scrollbar: ["auto", "thin", "none"] }],
+      /**
+       * Scroll Margin
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-m": [{ "scroll-m": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Inline
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-mx": [{ "scroll-mx": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Block
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-my": [{ "scroll-my": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Inline Start
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-ms": [{ "scroll-ms": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Inline End
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-me": [{ "scroll-me": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Block Start
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-mbs": [{ "scroll-mbs": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Block End
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-mbe": [{ "scroll-mbe": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Top
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-mt": [{ "scroll-mt": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Right
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-mr": [{ "scroll-mr": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Bottom
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-mb": [{ "scroll-mb": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Margin Left
+       * @see https://tailwindcss.com/docs/scroll-margin
+       */
+      "scroll-ml": [{ "scroll-ml": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-p": [{ "scroll-p": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Inline
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-px": [{ "scroll-px": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Block
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-py": [{ "scroll-py": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Inline Start
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-ps": [{ "scroll-ps": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Inline End
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pe": [{ "scroll-pe": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Block Start
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pbs": [{ "scroll-pbs": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Block End
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pbe": [{ "scroll-pbe": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Top
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pt": [{ "scroll-pt": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Right
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pr": [{ "scroll-pr": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Bottom
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pb": [{ "scroll-pb": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Padding Left
+       * @see https://tailwindcss.com/docs/scroll-padding
+       */
+      "scroll-pl": [{ "scroll-pl": scaleUnambiguousSpacing() }],
+      /**
+       * Scroll Snap Align
+       * @see https://tailwindcss.com/docs/scroll-snap-align
+       */
+      "snap-align": [{ snap: ["start", "end", "center", "align-none"] }],
+      /**
+       * Scroll Snap Stop
+       * @see https://tailwindcss.com/docs/scroll-snap-stop
+       */
+      "snap-stop": [{ snap: ["normal", "always"] }],
+      /**
+       * Scroll Snap Type
+       * @see https://tailwindcss.com/docs/scroll-snap-type
+       */
+      "snap-type": [{ snap: ["none", "x", "y", "both"] }],
+      /**
+       * Scroll Snap Type Strictness
+       * @see https://tailwindcss.com/docs/scroll-snap-type
+       */
+      "snap-strictness": [{ snap: ["mandatory", "proximity"] }],
+      /**
+       * Touch Action
+       * @see https://tailwindcss.com/docs/touch-action
+       */
+      touch: [{ touch: ["auto", "none", "manipulation"] }],
+      /**
+       * Touch Action X
+       * @see https://tailwindcss.com/docs/touch-action
+       */
+      "touch-x": [{ "touch-pan": ["x", "left", "right"] }],
+      /**
+       * Touch Action Y
+       * @see https://tailwindcss.com/docs/touch-action
+       */
+      "touch-y": [{ "touch-pan": ["y", "up", "down"] }],
+      /**
+       * Touch Action Pinch Zoom
+       * @see https://tailwindcss.com/docs/touch-action
+       */
+      "touch-pz": ["touch-pinch-zoom"],
+      /**
+       * User Select
+       * @see https://tailwindcss.com/docs/user-select
+       */
+      select: [{ select: ["none", "text", "all", "auto"] }],
+      /**
+       * Will Change
+       * @see https://tailwindcss.com/docs/will-change
+       */
+      "will-change": [
+        {
+          "will-change": [
+            "auto",
+            "scroll",
+            "contents",
+            "transform",
+            isArbitraryVariable,
+            isArbitraryValue,
+          ],
+        },
+      ],
+
+      // -----------
+      // --- SVG ---
+      // -----------
+
+      /**
+       * Fill
+       * @see https://tailwindcss.com/docs/fill
+       */
+      fill: [{ fill: ["none", ...scaleColor()] }],
+      /**
+       * Stroke Width
+       * @see https://tailwindcss.com/docs/stroke-width
+       */
+      "stroke-w": [
+        {
+          stroke: [isNumber, isArbitraryVariableLength, isArbitraryLength, isArbitraryNumber],
+        },
+      ],
+      /**
+       * Stroke
+       * @see https://tailwindcss.com/docs/stroke
+       */
+      stroke: [{ stroke: ["none", ...scaleColor()] }],
+
+      // ---------------------
+      // --- Accessibility ---
+      // ---------------------
+
+      /**
+       * Forced Color Adjust
+       * @see https://tailwindcss.com/docs/forced-color-adjust
+       */
+      "forced-color-adjust": [{ "forced-color-adjust": ["auto", "none"] }],
+    },
+    conflictingClassGroups: {
+      "container-named": ["container-type"],
+      overflow: ["overflow-x", "overflow-y"],
+      overscroll: ["overscroll-x", "overscroll-y"],
+      inset: [
+        "inset-x",
+        "inset-y",
+        "inset-bs",
+        "inset-be",
+        "start",
+        "end",
+        "top",
+        "right",
+        "bottom",
+        "left",
+      ],
+      "inset-x": ["right", "left"],
+      "inset-y": ["top", "bottom"],
+      flex: ["basis", "grow", "shrink"],
+      gap: ["gap-x", "gap-y"],
+      p: ["px", "py", "ps", "pe", "pbs", "pbe", "pt", "pr", "pb", "pl"],
+      px: ["pr", "pl"],
+      py: ["pt", "pb"],
+      m: ["mx", "my", "ms", "me", "mbs", "mbe", "mt", "mr", "mb", "ml"],
+      mx: ["mr", "ml"],
+      my: ["mt", "mb"],
+      size: ["w", "h"],
+      "font-size": ["leading"],
+      "fvn-normal": [
+        "fvn-ordinal",
+        "fvn-slashed-zero",
+        "fvn-figure",
+        "fvn-spacing",
+        "fvn-fraction",
+      ],
+      "fvn-ordinal": ["fvn-normal"],
+      "fvn-slashed-zero": ["fvn-normal"],
+      "fvn-figure": ["fvn-normal"],
+      "fvn-spacing": ["fvn-normal"],
+      "fvn-fraction": ["fvn-normal"],
+      "line-clamp": ["display", "overflow"],
+      rounded: [
+        "rounded-s",
+        "rounded-e",
+        "rounded-t",
+        "rounded-r",
+        "rounded-b",
+        "rounded-l",
+        "rounded-ss",
+        "rounded-se",
+        "rounded-ee",
+        "rounded-es",
+        "rounded-tl",
+        "rounded-tr",
+        "rounded-br",
+        "rounded-bl",
+      ],
+      "rounded-s": ["rounded-ss", "rounded-es"],
+      "rounded-e": ["rounded-se", "rounded-ee"],
+      "rounded-t": ["rounded-tl", "rounded-tr"],
+      "rounded-r": ["rounded-tr", "rounded-br"],
+      "rounded-b": ["rounded-br", "rounded-bl"],
+      "rounded-l": ["rounded-tl", "rounded-bl"],
+      "border-spacing": ["border-spacing-x", "border-spacing-y"],
+      "border-w": [
+        "border-w-x",
+        "border-w-y",
+        "border-w-s",
+        "border-w-e",
+        "border-w-bs",
+        "border-w-be",
+        "border-w-t",
+        "border-w-r",
+        "border-w-b",
+        "border-w-l",
+      ],
+      "border-w-x": ["border-w-r", "border-w-l"],
+      "border-w-y": ["border-w-t", "border-w-b"],
+      "border-color": [
+        "border-color-x",
+        "border-color-y",
+        "border-color-s",
+        "border-color-e",
+        "border-color-bs",
+        "border-color-be",
+        "border-color-t",
+        "border-color-r",
+        "border-color-b",
+        "border-color-l",
+      ],
+      "border-color-x": ["border-color-r", "border-color-l"],
+      "border-color-y": ["border-color-t", "border-color-b"],
+      translate: ["translate-x", "translate-y", "translate-none"],
+      "translate-none": ["translate", "translate-x", "translate-y", "translate-z"],
+      "scroll-m": [
+        "scroll-mx",
+        "scroll-my",
+        "scroll-ms",
+        "scroll-me",
+        "scroll-mbs",
+        "scroll-mbe",
+        "scroll-mt",
+        "scroll-mr",
+        "scroll-mb",
+        "scroll-ml",
+      ],
+      "scroll-mx": ["scroll-mr", "scroll-ml"],
+      "scroll-my": ["scroll-mt", "scroll-mb"],
+      "scroll-p": [
+        "scroll-px",
+        "scroll-py",
+        "scroll-ps",
+        "scroll-pe",
+        "scroll-pbs",
+        "scroll-pbe",
+        "scroll-pt",
+        "scroll-pr",
+        "scroll-pb",
+        "scroll-pl",
+      ],
+      "scroll-px": ["scroll-pr", "scroll-pl"],
+      "scroll-py": ["scroll-pt", "scroll-pb"],
+      touch: ["touch-x", "touch-y", "touch-pz"],
+      "touch-x": ["touch"],
+      "touch-y": ["touch"],
+      "touch-pz": ["touch"],
+    },
+    conflictingClassGroupModifiers: {
+      "font-size": ["leading"],
+    },
+    postfixLookupClassGroups: ["container-type"],
+    orderSensitiveModifiers: [
+      "*",
+      "**",
+      "after",
+      "backdrop",
+      "before",
+      "details-content",
+      "file",
+      "first-letter",
+      "first-line",
+      "marker",
+      "placeholder",
+      "selection",
+    ],
+  } as const satisfies Config<DefaultClassGroupIds, DefaultThemeGroupIds>;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/from-theme.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/from-theme.ts
@@ -1,0 +1,21 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import type { DefaultThemeGroupIds, NoInfer, ThemeGetter, ThemeObject } from "./types.js";
+
+const fallbackThemeArr: ThemeObject<DefaultThemeGroupIds>[DefaultThemeGroupIds] = [];
+
+export const fromTheme = <
+  AdditionalThemeGroupIds extends string = never,
+  DefaultThemeGroupIdsInner extends string = DefaultThemeGroupIds,
+>(
+  key: NoInfer<DefaultThemeGroupIdsInner | AdditionalThemeGroupIds>,
+): ThemeGetter => {
+  const themeGetter = (theme: ThemeObject<DefaultThemeGroupIdsInner | AdditionalThemeGroupIds>) =>
+    theme[key] || fallbackThemeArr;
+
+  themeGetter.isThemeGetter = true as const;
+
+  return themeGetter;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/merge-template.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/merge-template.ts
@@ -1,0 +1,84 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import { type ClassValue, resolveClassValue } from "../clsx.js";
+import { twMerge } from "./tw-merge.js";
+
+/**
+ * Max distinct interpolation tuples remembered per call site. Real tagged-template sites cycle
+ * through a tiny set of dynamic values (a boolean toggling one class, a small variant union), so
+ * this stays small; the bound only guards a site that interpolates high-cardinality values (e.g. a
+ * live color) from growing its per-site list without limit.
+ */
+const TEMPLATE_SITE_CACHE = 8;
+
+interface TemplateEntry {
+  values: ClassValue[];
+  result: string;
+}
+
+// Per-call-site cache keyed on the template's strings array. A tagged template reuses the SAME
+// frozen strings array object on every evaluation (spec-guaranteed), so its identity is a stable,
+// allocation-free handle for the static part of the class list — something a plain string key can
+// never be (strings are illegal WeakMap keys, and value-keying just re-hashes). On a hit we skip
+// building and hashing the whole joined string, which is the dominant cost the profiler shows.
+const templateCache = new WeakMap<TemplateStringsArray, TemplateEntry[]>();
+
+export const mergeTemplate = (strings: TemplateStringsArray, values: ClassValue[]): string => {
+  const valueCount = values.length;
+
+  // Only cache when every interpolation is a string or falsy: those are immutable, so an identity
+  // match guarantees identical output. An object/array interpolation could be mutated between calls
+  // while keeping the same reference, so such calls always recompute and are never cached.
+  let isCacheable = true;
+  for (let index = 0; index < valueCount; index++) {
+    const value = values[index];
+    if (value && typeof value !== "string") {
+      isCacheable = false;
+      break;
+    }
+  }
+
+  if (isCacheable) {
+    const entries = templateCache.get(strings);
+    if (entries !== undefined) {
+      for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
+        const entry = entries[entryIndex]!;
+        const entryValues = entry.values;
+        let isMatch = true;
+        for (let index = 0; index < valueCount; index++) {
+          if (entryValues[index] !== values[index]) {
+            isMatch = false;
+            break;
+          }
+        }
+        if (isMatch) return entry.result;
+      }
+    }
+  }
+
+  // Interleave the literal spans with the resolved interpolations exactly as written. Spacing is the
+  // author's responsibility (`cn` does not inject spaces between a span and its value), matching how
+  // template literals concatenate; the merge engine normalizes the resulting whitespace.
+  let joined = strings[0]!;
+  for (let index = 0; index < valueCount; index++) {
+    const value = values[index];
+    if (value) joined += typeof value === "string" ? value : resolveClassValue(value);
+    joined += strings[index + 1]!;
+  }
+
+  const result = twMerge.mergeString(joined);
+
+  if (isCacheable) {
+    let entries = templateCache.get(strings);
+    if (entries === undefined) {
+      entries = [];
+      templateCache.set(strings, entries);
+    }
+    if (entries.length >= TEMPLATE_SITE_CACHE) entries.shift();
+    entries.push({ values, result });
+  }
+
+  return result;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/parse-class-name.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/parse-class-name.ts
@@ -1,0 +1,100 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import type { ParsedClassName } from "./types.js";
+
+export const IMPORTANT_MODIFIER = "!";
+
+const CHAR_MODIFIER_SEPARATOR = 58; // ":"
+const CHAR_POSTFIX_SEPARATOR = 47; // "/"
+const CHAR_OPEN_BRACKET = 91; // "["
+const CHAR_CLOSE_BRACKET = 93; // "]"
+const CHAR_OPEN_PAREN = 40; // "("
+const CHAR_CLOSE_PAREN = 41; // ")"
+const CHAR_IMPORTANT = 33; // "!"
+
+// Pre-allocated result object shape for consistency
+const createResultObject = (
+  modifiers: string[],
+  hasImportantModifier: boolean,
+  baseClassName: string,
+  maybePostfixModifierPosition?: number,
+): ParsedClassName => ({
+  modifiers,
+  hasImportantModifier,
+  baseClassName,
+  maybePostfixModifierPosition,
+  isExternal: undefined,
+});
+
+/**
+ * Parse class name into parts.
+ *
+ * Inspired by `splitAtTopLevelOnly` used in Tailwind CSS
+ * @see https://github.com/tailwindlabs/tailwindcss/blob/v3.2.2/src/util/splitAtTopLevelOnly.js
+ */
+export const parseClassName = (className: string): ParsedClassName => {
+  const modifiers: string[] = [];
+
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let modifierStart = 0;
+  let postfixModifierPosition: number | undefined;
+
+  const len = className.length;
+  for (let index = 0; index < len; index++) {
+    const charCode = className.charCodeAt(index);
+
+    if (bracketDepth === 0 && parenDepth === 0) {
+      if (charCode === CHAR_MODIFIER_SEPARATOR) {
+        modifiers.push(className.slice(modifierStart, index));
+        modifierStart = index + 1;
+        continue;
+      }
+
+      if (charCode === CHAR_POSTFIX_SEPARATOR) {
+        postfixModifierPosition = index;
+        continue;
+      }
+    }
+
+    if (charCode === CHAR_OPEN_BRACKET) bracketDepth++;
+    else if (charCode === CHAR_CLOSE_BRACKET) bracketDepth--;
+    else if (charCode === CHAR_OPEN_PAREN) parenDepth++;
+    else if (charCode === CHAR_CLOSE_PAREN) parenDepth--;
+  }
+
+  const baseClassNameWithImportantModifier =
+    modifiers.length === 0 ? className : className.slice(modifierStart);
+
+  let baseClassName = baseClassNameWithImportantModifier;
+  let hasImportantModifier = false;
+
+  const lastIndex = baseClassNameWithImportantModifier.length - 1;
+  if (baseClassNameWithImportantModifier.charCodeAt(lastIndex) === CHAR_IMPORTANT) {
+    baseClassName = baseClassNameWithImportantModifier.slice(0, -1);
+    hasImportantModifier = true;
+  } else if (
+    /**
+     * In Tailwind CSS v3 the important modifier was at the start of the base class name. This is still supported for legacy reasons.
+     * @see https://github.com/dcastil/tailwind-merge/issues/513#issuecomment-2614029864
+     */
+    baseClassNameWithImportantModifier.charCodeAt(0) === CHAR_IMPORTANT
+  ) {
+    baseClassName = baseClassNameWithImportantModifier.slice(1);
+    hasImportantModifier = true;
+  }
+
+  const maybePostfixModifierPosition =
+    postfixModifierPosition && postfixModifierPosition > modifierStart
+      ? postfixModifierPosition - modifierStart
+      : undefined;
+
+  return createResultObject(
+    modifiers,
+    hasImportantModifier,
+    baseClassName,
+    maybePostfixModifierPosition,
+  );
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/sort-modifiers.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/sort-modifiers.ts
@@ -1,0 +1,48 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import type { AnyConfig } from "./types.js";
+
+/**
+ * Sorts modifiers according to following schema:
+ * - Predefined modifiers are sorted alphabetically
+ * - When an arbitrary variant appears, it must be preserved which modifiers are before and after it
+ */
+export const createSortModifiers = (config: AnyConfig) => {
+  const orderSensitiveModifiers = new Set(config.orderSensitiveModifiers);
+
+  return (modifiers: readonly string[]): string[] => {
+    const result: string[] = [];
+    let currentSegment: string[] = [];
+
+    for (let index = 0; index < modifiers.length; index++) {
+      const modifier = modifiers[index]!;
+
+      const isArbitrary = modifier[0] === "[";
+      const isOrderSensitive = orderSensitiveModifiers.has(modifier);
+
+      if (isArbitrary || isOrderSensitive) {
+        if (currentSegment.length > 0) {
+          currentSegment.sort();
+          for (let segmentIndex = 0; segmentIndex < currentSegment.length; segmentIndex++) {
+            result.push(currentSegment[segmentIndex]!);
+          }
+          currentSegment = [];
+        }
+        result.push(modifier);
+      } else {
+        currentSegment.push(modifier);
+      }
+    }
+
+    if (currentSegment.length > 0) {
+      currentSegment.sort();
+      for (let segmentIndex = 0; segmentIndex < currentSegment.length; segmentIndex++) {
+        result.push(currentSegment[segmentIndex]!);
+      }
+    }
+
+    return result;
+  };
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/tw-join.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/tw-join.ts
@@ -1,0 +1,53 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+/**
+ * The code in this file is copied from https://github.com/lukeed/clsx and modified to suit the needs of tailwind-merge better.
+ *
+ * Specifically:
+ * - Runtime code from https://github.com/lukeed/clsx/blob/v1.2.1/src/index.js
+ * - TypeScript types from https://github.com/lukeed/clsx/blob/v1.2.1/clsx.d.ts
+ *
+ * Original code has MIT license: Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+ */
+
+export type ClassNameValue = ClassNameArray | string | null | undefined | 0 | 0n | false;
+type ClassNameArray = readonly ClassNameValue[];
+
+export const twJoin = (...classLists: ClassNameValue[]): string => {
+  let index = 0;
+  let argument: ClassNameValue;
+  let resolvedValue: string;
+  let string = "";
+
+  while (index < classLists.length) {
+    if ((argument = classLists[index++])) {
+      if ((resolvedValue = toValue(argument))) {
+        if (string) string += " ";
+        string += resolvedValue;
+      }
+    }
+  }
+  return string;
+};
+
+const toValue = (value: ClassNameArray | string): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  let resolvedValue: string;
+  let string = "";
+
+  for (let index = 0; index < value.length; index++) {
+    if (value[index]) {
+      if ((resolvedValue = toValue(value[index] as ClassNameArray | string))) {
+        if (string) string += " ";
+        string += resolvedValue;
+      }
+    }
+  }
+
+  return string;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/tw-merge.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/tw-merge.ts
@@ -1,0 +1,8 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+import { createTailwindMerge } from "./create-tailwind-merge.js";
+import { getDefaultConfig } from "./default-config.js";
+
+export const twMerge = createTailwindMerge(getDefaultConfig);

--- a/packages/mantle/src/utils/cx/vendor/lib/types.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/types.ts
@@ -1,0 +1,564 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+/**
+ * Type the baked-in cnfast configuration adheres to.
+ */
+export type Config<ClassGroupIds extends string, ThemeGroupIds extends string> = ConfigGroupsPart<
+  ClassGroupIds,
+  ThemeGroupIds
+>;
+
+/**
+ * Result of parsing a single class name into its parts.
+ */
+export interface ParsedClassName {
+  /**
+   * Whether the class is external and merging logic should be sipped.
+   *
+   * If this is `true`, the class will be treated as if it wasn't a Tailwind class and will be passed through as is.
+   */
+  isExternal?: boolean;
+  /**
+   * Modifiers of the class in the order they appear in the class.
+   *
+   * @example ['hover', 'dark'] // for `hover:dark:bg-gray-100`
+   */
+  modifiers: string[];
+  /**
+   * Whether the class has an `!important` modifier.
+   *
+   * @example true // for `hover:dark:!bg-gray-100`
+   */
+  hasImportantModifier: boolean;
+  /**
+   * Base class without preceding modifiers.
+   *
+   * @example 'bg-gray-100' // for `hover:dark:bg-gray-100`
+   */
+  baseClassName: string;
+  /**
+   * Index position of a possible postfix modifier in the class.
+   * If the class has no postfix modifier, this is `undefined`.
+   *
+   * This property is prefixed with "maybe" because tailwind-merge does not know whether something is a postfix modifier or part of the base class since it's possible to configure Tailwind CSS classes which include a `/` in the base class name.
+   *
+   * If a `maybePostfixModifierPosition` is present, tailwind-merge first tries to match the `baseClassName` without the possible postfix modifier to a class group. If that fails or the matched class group is configured in `postfixLookupClassGroups`, it tries again with the possible postfix modifier.
+   *
+   * @example 11 // for `bg-gray-100/50`
+   */
+  maybePostfixModifierPosition: number | undefined;
+}
+
+/**
+ * The dynamic part of the tailwind-merge configuration. When merging multiple configurations, the user can choose to either override or extend the properties of this interface.
+ */
+interface ConfigGroupsPart<ClassGroupIds extends string, ThemeGroupIds extends string> {
+  /**
+   * Theme scales used in classGroups.
+   *
+   * The keys are the same as in the Tailwind config but the values are sometimes defined more broadly.
+   */
+  theme: NoInfer<ThemeObject<ThemeGroupIds>>;
+  /**
+   * Object with groups of classes.
+   *
+   * @example
+   * {
+   *     // Creates group of classes `group`, `of` and `classes`
+   *     'group-id': ['group', 'of', 'classes'],
+   *     // Creates group of classes `look-at-me-other` and `look-at-me-group`.
+   *     'other-group': [{ 'look-at-me': ['other', 'group']}]
+   * }
+   */
+  classGroups: NoInfer<Record<ClassGroupIds, ClassGroup<ThemeGroupIds>>>;
+  /**
+   * Conflicting classes across groups.
+   *
+   * The key is the ID of a class group which creates a conflict, values are IDs of class groups which receive a conflict. That means if a class from from the key ID is present, all preceding classes from the values are removed.
+   *
+   * A class group ID is the key of a class group in the classGroups object.
+   *
+   * @example { gap: ['gap-x', 'gap-y'] }
+   */
+  conflictingClassGroups: NoInfer<Partial<Record<ClassGroupIds, readonly ClassGroupIds[]>>>;
+  /**
+   * Postfix modifiers conflicting with other class groups.
+   *
+   * A class group ID is the key of a class group in classGroups object.
+   *
+   * @example { 'font-size': ['leading'] }
+   */
+  conflictingClassGroupModifiers: NoInfer<Partial<Record<ClassGroupIds, readonly ClassGroupIds[]>>>;
+  /**
+   * Class group IDs which should be resolved again with their postfix modifier attached.
+   *
+   * This is needed when a slash can make the full class name belong to a different class group than the part before the slash.
+   *
+   * @example ['container-type'] // `@container-size/sidebar` should resolve differently from `@container-size`
+   */
+  postfixLookupClassGroups?: readonly NoInferString<ClassGroupIds>[];
+  /**
+   * Modifiers whose order among multiple modifiers should be preserved because their order changes which element gets targeted.
+   *
+   * tailwind-merge makes sure that classes with these modifiers are not overwritten by classes with the same modifiers with order-sensitive modifiers being in a different position.
+   */
+  orderSensitiveModifiers: string[];
+}
+
+export type ThemeObject<ThemeGroupIds extends string> = Record<
+  ThemeGroupIds,
+  ClassGroup<ThemeGroupIds>
+>;
+export type ClassGroup<ThemeGroupIds extends string> = readonly ClassDefinition<ThemeGroupIds>[];
+type ClassDefinition<ThemeGroupIds extends string> =
+  | string
+  | ClassValidator
+  | ThemeGetter
+  | ClassObject<ThemeGroupIds>;
+export type ClassValidator = (classPart: string) => boolean;
+export interface ThemeGetter {
+  (theme: ThemeObject<AnyThemeGroupIds>): ClassGroup<AnyClassGroupIds>;
+  isThemeGetter: true;
+}
+type ClassObject<ThemeGroupIds extends string> = Record<
+  string,
+  readonly ClassDefinition<ThemeGroupIds>[]
+>;
+
+/**
+ * Hack from https://stackoverflow.com/questions/56687668/a-way-to-disable-type-argument-inference-in-generics/56688073#56688073
+ *
+ * Could be replaced with NoInfer utility type from TypeScript (https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype), but that is only supported in TypeScript 5.4 or higher, so I should wait some time before using it.
+ */
+export type NoInfer<T> = [T][T extends unknown ? 0 : never];
+
+/**
+ * Special-purpose NoInfer variant for string unions used in array item positions.
+ *
+ * The NoInfer helper above doesn't prevent inference from array items in all cases, so this keeps config arrays like `postfixLookupClassGroups` from defining or narrowing class group IDs. Once tailwind-merge only supports TypeScript 5.4 and newer, this can be replaced with TypeScript's built-in NoInfer utility type.
+ */
+type NoInferString<T extends string> = T extends infer S ? S & string : never;
+
+/**
+ * Theme group IDs included in the default configuration of tailwind-merge.
+ *
+ * If you want to use a scale that is not supported in the `ThemeObject` type,
+ * consider using `classGroups` instead of `theme`.
+ *
+ * @see https://github.com/dcastil/tailwind-merge/blob/main/docs/configuration.md#theme
+ *      (the list of supported keys may vary between `tailwind-merge` versions)
+ */
+export type DefaultThemeGroupIds =
+  | "animate"
+  | "aspect"
+  | "blur"
+  | "breakpoint"
+  | "color"
+  | "container"
+  | "drop-shadow"
+  | "ease"
+  | "font-weight"
+  | "font"
+  | "inset-shadow"
+  | "leading"
+  | "perspective"
+  | "radius"
+  | "shadow"
+  | "spacing"
+  | "text"
+  | "text-shadow"
+  | "tracking";
+
+/**
+ * Class group IDs included in the default configuration of tailwind-merge.
+ */
+export type DefaultClassGroupIds =
+  | "accent"
+  | "align-content"
+  | "align-items"
+  | "align-self"
+  | "animate"
+  | "appearance"
+  | "aspect"
+  | "auto-cols"
+  | "auto-rows"
+  | "backdrop-blur"
+  | "backdrop-brightness"
+  | "backdrop-contrast"
+  | "backdrop-filter"
+  | "backdrop-grayscale"
+  | "backdrop-hue-rotate"
+  | "backdrop-invert"
+  | "backdrop-opacity"
+  | "backdrop-saturate"
+  | "backdrop-sepia"
+  | "backface"
+  | "basis"
+  | "bg-attachment"
+  | "bg-blend"
+  | "bg-clip"
+  | "bg-color"
+  | "bg-image"
+  | "bg-origin"
+  | "bg-position"
+  | "bg-repeat"
+  | "bg-size"
+  | "block-size"
+  | "blur"
+  | "border-collapse"
+  | "border-color-b"
+  | "border-color-be"
+  | "border-color-bs"
+  | "border-color-e"
+  | "border-color-l"
+  | "border-color-r"
+  | "border-color-s"
+  | "border-color-t"
+  | "border-color-x"
+  | "border-color-y"
+  | "border-color"
+  | "border-spacing-x"
+  | "border-spacing-y"
+  | "border-spacing"
+  | "border-style"
+  | "border-w-b"
+  | "border-w-be"
+  | "border-w-bs"
+  | "border-w-e"
+  | "border-w-l"
+  | "border-w-r"
+  | "border-w-s"
+  | "border-w-t"
+  | "border-w-x"
+  | "border-w-y"
+  | "border-w"
+  | "bottom"
+  | "box-decoration"
+  | "box"
+  | "break-after"
+  | "break-before"
+  | "break-inside"
+  | "break"
+  | "brightness"
+  | "caption"
+  | "caret-color"
+  | "clear"
+  | "col-end"
+  | "col-start-end"
+  | "col-start"
+  | "color-scheme"
+  | "columns"
+  | "container"
+  | "container-named"
+  | "container-type"
+  | "content"
+  | "contrast"
+  | "cursor"
+  | "delay"
+  | "display"
+  | "divide-color"
+  | "divide-style"
+  | "divide-x-reverse"
+  | "divide-x"
+  | "divide-y-reverse"
+  | "divide-y"
+  | "drop-shadow"
+  | "drop-shadow-color"
+  | "duration"
+  | "ease"
+  | "end"
+  | "field-sizing"
+  | "fill"
+  | "filter"
+  | "flex-direction"
+  | "flex-wrap"
+  | "flex"
+  | "float"
+  | "font-family"
+  | "font-features"
+  | "font-size"
+  | "font-smoothing"
+  | "font-stretch"
+  | "font-style"
+  | "font-weight"
+  | "forced-color-adjust"
+  | "fvn-figure"
+  | "fvn-fraction"
+  | "fvn-normal"
+  | "fvn-ordinal"
+  | "fvn-slashed-zero"
+  | "fvn-spacing"
+  | "gap-x"
+  | "gap-y"
+  | "gap"
+  | "gradient-from-pos"
+  | "gradient-from"
+  | "gradient-to-pos"
+  | "gradient-to"
+  | "gradient-via-pos"
+  | "gradient-via"
+  | "grayscale"
+  | "grid-cols"
+  | "grid-flow"
+  | "grid-rows"
+  | "grow"
+  | "h"
+  | "hue-rotate"
+  | "hyphens"
+  | "indent"
+  | "inline-size"
+  | "inset-ring-color"
+  | "inset-ring-w"
+  | "inset-shadow-color"
+  | "inset-shadow"
+  | "inset-be"
+  | "inset-bs"
+  | "inset-x"
+  | "inset-y"
+  | "inset"
+  | "invert"
+  | "isolation"
+  | "justify-content"
+  | "justify-items"
+  | "justify-self"
+  | "leading"
+  | "left"
+  | "line-clamp"
+  | "list-image"
+  | "list-style-position"
+  | "list-style-type"
+  | "m"
+  | "mask-clip"
+  | "mask-composite"
+  | "mask-image-b-from-color"
+  | "mask-image-b-from-pos"
+  | "mask-image-b-to-color"
+  | "mask-image-b-to-pos"
+  | "mask-image-conic-from-color"
+  | "mask-image-conic-from-pos"
+  | "mask-image-conic-pos"
+  | "mask-image-conic-to-color"
+  | "mask-image-conic-to-pos"
+  | "mask-image-l-from-color"
+  | "mask-image-l-from-pos"
+  | "mask-image-l-to-color"
+  | "mask-image-l-to-pos"
+  | "mask-image-linear-from-color"
+  | "mask-image-linear-from-pos"
+  | "mask-image-linear-pos"
+  | "mask-image-linear-to-color"
+  | "mask-image-linear-to-pos"
+  | "mask-image-r-from-color"
+  | "mask-image-r-from-pos"
+  | "mask-image-r-to-color"
+  | "mask-image-r-to-pos"
+  | "mask-image-radial-from-color"
+  | "mask-image-radial-from-pos"
+  | "mask-image-radial-pos"
+  | "mask-image-radial-shape"
+  | "mask-image-radial-size"
+  | "mask-image-radial-to-color"
+  | "mask-image-radial-to-pos"
+  | "mask-image-radial"
+  | "mask-image-t-from-color"
+  | "mask-image-t-from-pos"
+  | "mask-image-t-to-color"
+  | "mask-image-t-to-pos"
+  | "mask-image-x-from-color"
+  | "mask-image-x-from-pos"
+  | "mask-image-x-to-color"
+  | "mask-image-x-to-pos"
+  | "mask-image-y-from-color"
+  | "mask-image-y-from-pos"
+  | "mask-image-y-to-color"
+  | "mask-image-y-to-pos"
+  | "mask-image"
+  | "mask-mode"
+  | "mask-origin"
+  | "mask-position"
+  | "mask-repeat"
+  | "mask-size"
+  | "mask-type"
+  | "max-block-size"
+  | "max-h"
+  | "max-inline-size"
+  | "max-w"
+  | "mb"
+  | "mbe"
+  | "mbs"
+  | "me"
+  | "min-block-size"
+  | "min-h"
+  | "min-inline-size"
+  | "min-w"
+  | "mix-blend"
+  | "ml"
+  | "mr"
+  | "ms"
+  | "mt"
+  | "mx"
+  | "my"
+  | "object-fit"
+  | "object-position"
+  | "opacity"
+  | "order"
+  | "outline-color"
+  | "outline-offset"
+  | "outline-style"
+  | "outline-w"
+  | "overflow-x"
+  | "overflow-y"
+  | "overflow"
+  | "overscroll-x"
+  | "overscroll-y"
+  | "overscroll"
+  | "p"
+  | "pb"
+  | "pbe"
+  | "pe"
+  | "perspective-origin"
+  | "perspective"
+  | "pl"
+  | "place-content"
+  | "place-items"
+  | "place-self"
+  | "placeholder-color"
+  | "pointer-events"
+  | "position"
+  | "pr"
+  | "ps"
+  | "pbs"
+  | "pt"
+  | "px"
+  | "py"
+  | "resize"
+  | "right"
+  | "ring-color"
+  | "ring-offset-color"
+  | "ring-offset-w"
+  | "ring-w-inset"
+  | "ring-w"
+  | "rotate-x"
+  | "rotate-y"
+  | "rotate-z"
+  | "rotate"
+  | "rounded-b"
+  | "rounded-bl"
+  | "rounded-br"
+  | "rounded-e"
+  | "rounded-ee"
+  | "rounded-es"
+  | "rounded-l"
+  | "rounded-r"
+  | "rounded-s"
+  | "rounded-se"
+  | "rounded-ss"
+  | "rounded-t"
+  | "rounded-tl"
+  | "rounded-tr"
+  | "rounded"
+  | "row-end"
+  | "row-start-end"
+  | "row-start"
+  | "saturate"
+  | "scale-3d"
+  | "scale-x"
+  | "scale-y"
+  | "scale-z"
+  | "scale"
+  | "scrollbar-gutter"
+  | "scrollbar-thumb-color"
+  | "scrollbar-track-color"
+  | "scrollbar-w"
+  | "scroll-behavior"
+  | "scroll-m"
+  | "scroll-mb"
+  | "scroll-mbe"
+  | "scroll-me"
+  | "scroll-ml"
+  | "scroll-mr"
+  | "scroll-mbs"
+  | "scroll-ms"
+  | "scroll-mt"
+  | "scroll-mx"
+  | "scroll-my"
+  | "scroll-p"
+  | "scroll-pb"
+  | "scroll-pbe"
+  | "scroll-pe"
+  | "scroll-pl"
+  | "scroll-pr"
+  | "scroll-pbs"
+  | "scroll-ps"
+  | "scroll-pt"
+  | "scroll-px"
+  | "scroll-py"
+  | "select"
+  | "sepia"
+  | "shadow-color"
+  | "shadow"
+  | "shrink"
+  | "size"
+  | "skew-x"
+  | "skew-y"
+  | "skew"
+  | "snap-align"
+  | "snap-stop"
+  | "snap-strictness"
+  | "snap-type"
+  | "space-x-reverse"
+  | "space-x"
+  | "space-y-reverse"
+  | "space-y"
+  | "sr"
+  | "start"
+  | "stroke-w"
+  | "stroke"
+  | "table-layout"
+  | "tab-size"
+  | "text-alignment"
+  | "text-color"
+  | "text-decoration-color"
+  | "text-decoration-style"
+  | "text-decoration-thickness"
+  | "text-decoration"
+  | "text-overflow"
+  | "text-shadow"
+  | "text-shadow-color"
+  | "text-transform"
+  | "text-wrap"
+  | "top"
+  | "touch-pz"
+  | "touch-x"
+  | "touch-y"
+  | "touch"
+  | "tracking"
+  | "transform-origin"
+  | "transform-style"
+  | "transform"
+  | "transition-behavior"
+  | "transition"
+  | "translate-none"
+  | "translate-x"
+  | "translate-y"
+  | "translate-z"
+  | "translate"
+  | "underline-offset"
+  | "vertical-align"
+  | "visibility"
+  | "w"
+  | "whitespace"
+  | "will-change"
+  | "wrap"
+  | "zoom"
+  | "z";
+
+export type AnyClassGroupIds = string;
+export type AnyThemeGroupIds = string;
+
+/**
+ * type of the tailwind-merge configuration that allows for any possible configuration.
+ */
+export type AnyConfig = Config<AnyClassGroupIds, AnyThemeGroupIds>;

--- a/packages/mantle/src/utils/cx/vendor/lib/utils.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/utils.ts
@@ -1,0 +1,23 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+/**
+ * Concatenates two arrays faster than the array spread operator.
+ */
+export const concatArrays = <T, U>(
+  array1: readonly T[],
+  array2: readonly U[],
+): readonly (T | U)[] => {
+  // Pre-allocate for better V8 optimization
+  const length1 = array1.length;
+  const length2 = array2.length;
+  const combinedArray: (T | U)[] = new Array(length1 + length2);
+  for (let i = 0; i < length1; i++) {
+    combinedArray[i] = array1[i]!;
+  }
+  for (let i = 0; i < length2; i++) {
+    combinedArray[length1 + i] = array2[i]!;
+  }
+  return combinedArray;
+};

--- a/packages/mantle/src/utils/cx/vendor/lib/validators.ts
+++ b/packages/mantle/src/utils/cx/vendor/lib/validators.ts
@@ -1,0 +1,154 @@
+// Vendored from cnfast@0.0.8 (https://github.com/aidenybai/cnfast), MIT-licensed.
+// Adapts clsx (Luke Edwards) + tailwind-merge (Dany Castillo). Do NOT hand-edit except
+// the marked "mantle override" sections; excluded from oxlint/oxfmt. See ../README.md for sync steps.
+
+const arbitraryValueRegex = /^\[(?:(\w[\w-]*):)?(.+)\]$/i;
+const arbitraryVariableRegex = /^\((?:(\w[\w-]*):)?(.+)\)$/i;
+const fractionRegex = /^\d+(?:\.\d+)?\/\d+(?:\.\d+)?$/;
+const tshirtUnitRegex = /^(\d+(\.\d+)?)?(xs|sm|md|lg|xl)$/;
+const lengthUnitRegex =
+  /\d+(%|px|r?em|[sdl]?v([hwib]|min|max)|pt|pc|in|cm|mm|cap|ch|ex|r?lh|cq(w|h|i|b|min|max))|\b(calc|min|max|clamp)\(.+\)|^0$/;
+const colorFunctionRegex = /^(rgba?|hsla?|hwb|(ok)?(lab|lch)|color-mix)\(.+\)$/;
+// Shadow always begins with x and y offset separated by underscore optionally prepended by inset
+const shadowRegex = /^(inset_)?-?((\d+)?\.?(\d+)[a-z]+|0)_-?((\d+)?\.?(\d+)[a-z]+|0)/;
+const imageRegex =
+  /^(url|image|image-set|cross-fade|element|(repeating-)?(linear|radial|conic)-gradient)\(.+\)$/;
+
+// Hoist global builtins to module-scope bindings (oveo "hoist globals"): plain variable
+// loads instead of repeated global-object property lookups on the per-token validator path.
+const toNumber = Number;
+const numberIsNaN = Number.isNaN;
+const numberIsInteger = Number.isInteger;
+
+export const isFraction = (value: string) => fractionRegex.test(value);
+
+export const isNumber = (value: string) => Boolean(value) && !numberIsNaN(toNumber(value));
+
+export const isInteger = (value: string) => Boolean(value) && numberIsInteger(toNumber(value));
+
+export const isPercent = (value: string) => value.endsWith("%") && isNumber(value.slice(0, -1));
+
+export const isTshirtSize = (value: string) => tshirtUnitRegex.test(value);
+
+export const isAny = () => true;
+
+const isLengthOnly = (value: string) =>
+  // `colorFunctionRegex` check is necessary because color functions can have percentages in them which which would be incorrectly classified as lengths.
+  // For example, `hsl(0 0% 0%)` would be classified as a length without this check.
+  // I could also use lookbehind assertion in `lengthUnitRegex` but that isn't supported widely enough.
+  lengthUnitRegex.test(value) && !colorFunctionRegex.test(value);
+
+const isNever = () => false;
+
+const isShadow = (value: string) => shadowRegex.test(value);
+
+const isImage = (value: string) => imageRegex.test(value);
+
+export const isAnyNonArbitrary = (value: string) =>
+  !isArbitraryValue(value) && !isArbitraryVariable(value);
+
+export const isNamedContainerQuery = (value: string) =>
+  value.startsWith("@container") &&
+  ((value[10] === "/" && value[11] !== undefined) ||
+    (value[11] === "s" && value[16] !== undefined && value.startsWith("-size/", 10)) ||
+    (value[11] === "n" && value[18] !== undefined && value.startsWith("-normal/", 10)));
+
+export const isArbitrarySize = (value: string) => getIsArbitraryValue(value, isLabelSize, isNever);
+
+export const isArbitraryValue = (value: string) => arbitraryValueRegex.test(value);
+
+export const isArbitraryLength = (value: string) =>
+  getIsArbitraryValue(value, isLabelLength, isLengthOnly);
+
+export const isArbitraryNumber = (value: string) =>
+  getIsArbitraryValue(value, isLabelNumber, isNumber);
+
+export const isArbitraryWeight = (value: string) =>
+  getIsArbitraryValue(value, isLabelWeight, isAny);
+
+export const isArbitraryFamilyName = (value: string) =>
+  getIsArbitraryValue(value, isLabelFamilyName, isNever);
+
+export const isArbitraryPosition = (value: string) =>
+  getIsArbitraryValue(value, isLabelPosition, isNever);
+
+export const isArbitraryImage = (value: string) =>
+  getIsArbitraryValue(value, isLabelImage, isImage);
+
+export const isArbitraryShadow = (value: string) =>
+  getIsArbitraryValue(value, isLabelShadow, isShadow);
+
+export const isArbitraryVariable = (value: string) => arbitraryVariableRegex.test(value);
+
+export const isArbitraryVariableLength = (value: string) =>
+  getIsArbitraryVariable(value, isLabelLength);
+
+export const isArbitraryVariableFamilyName = (value: string) =>
+  getIsArbitraryVariable(value, isLabelFamilyName);
+
+export const isArbitraryVariablePosition = (value: string) =>
+  getIsArbitraryVariable(value, isLabelPosition);
+
+export const isArbitraryVariableSize = (value: string) =>
+  getIsArbitraryVariable(value, isLabelSize);
+
+export const isArbitraryVariableImage = (value: string) =>
+  getIsArbitraryVariable(value, isLabelImage);
+
+export const isArbitraryVariableShadow = (value: string) =>
+  getIsArbitraryVariable(value, isLabelShadow, true);
+
+export const isArbitraryVariableWeight = (value: string) =>
+  getIsArbitraryVariable(value, isLabelWeight, true);
+
+const getIsArbitraryValue = (
+  value: string,
+  testLabel: (label: string) => boolean,
+  testValue: (value: string) => boolean,
+) => {
+  const result = arbitraryValueRegex.exec(value);
+
+  if (result) {
+    if (result[1]) {
+      return testLabel(result[1]);
+    }
+
+    return testValue(result[2]!);
+  }
+
+  return false;
+};
+
+const getIsArbitraryVariable = (
+  value: string,
+  testLabel: (label: string) => boolean,
+  shouldMatchNoLabel = false,
+) => {
+  const result = arbitraryVariableRegex.exec(value);
+
+  if (result) {
+    if (result[1]) {
+      return testLabel(result[1]);
+    }
+    return shouldMatchNoLabel;
+  }
+
+  return false;
+};
+
+const isLabelPosition = (label: string) => label === "position" || label === "percentage";
+
+const isLabelImage = (label: string) => label === "image" || label === "url";
+
+const isLabelSize = (label: string) =>
+  label === "length" || label === "size" || label === "bg-size";
+
+const isLabelLength = (label: string) => label === "length";
+
+const isLabelNumber = (label: string) => label === "number";
+
+const isLabelFamilyName = (label: string) => label === "family-name";
+
+const isLabelWeight = (label: string) => label === "number" || label === "weight";
+
+const isLabelShadow = (label: string) => label === "shadow";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,6 @@ importers:
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
       cmdk:
         specifier: 1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -307,9 +304,6 @@ importers:
       sonner:
         specifier: 2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      tailwind-merge:
-        specifier: 3.6.0
-        version: 3.6.0
       tiny-invariant:
         specifier: 1.3.3
         version: 1.3.3
@@ -4457,9 +4451,6 @@ packages:
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
-
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
@@ -9071,8 +9062,6 @@ snapshots:
       inline-style-parser: 0.2.7
 
   tabbable@6.4.0: {}
-
-  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.1: {}
 


### PR DESCRIPTION
Vendor the cx class-merge engine so Mantle no longer depends on clsx or tailwind-merge at runtime. The vendored implementation bakes in Mantle's existing merge overrides, preserves byte-identical output with parity coverage, and adds caching for hot re-render paths.

Add tagged-template support for cx and export the plain clsx helper from the @ngrok/mantle/cx subpath for callers that need class joining without Tailwind conflict resolution.