### PR TITLE
feat(mantle): add Accordion.Body, make Root type optional, stop forcing text-sm

### DIFF
--- a/.changeset/accordion-body-and-optional-type.md
+++ b/.changeset/accordion-body-and-optional-type.md
@@ -1,0 +1,23 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Accordion` updates — a new `Accordion.Body` part and an optional `type`.
+
+**`Accordion.Content` is split into a `Content` viewport plus a new `Accordion.Body`**, matching the `Content` + `Body` composition of `Dialog` and `Sheet`. `Accordion.Content` is now the zero-padding region that animates open and closed; the section's bottom padding moves to `Accordion.Body`. Keeping padding off the animating element is what lets a closed section collapse fully — a padded `h-0` border-box can't shrink below its own padding — and it gives you a dedicated element to restyle. The accordion no longer forces `text-sm` on its content or its trigger; both inherit the ambient text size now (set a text class on `Accordion.Body` or `Accordion.Trigger` where you need one).
+
+- `Accordion.Content` no longer applies its own `pb-4` / `text-sm`. Wrap a section's content in `Accordion.Body` to keep the default bottom padding:
+
+  ```tsx
+  // Before
+  <Accordion.Content>Two to five business days.</Accordion.Content>
+
+  // After
+  <Accordion.Content>
+    <Accordion.Body>Two to five business days.</Accordion.Body>
+  </Accordion.Content>
+  ```
+
+  Override `Accordion.Body`'s `className` (for example `pb-0` or `px-6`) to retune the padding; `cx` resolves last-wins over the defaults.
+
+**`Accordion.Root`'s `type` prop is now optional and defaults to `"multiple"`.** Omitting `type` is the same as `type="multiple"`: sections open independently and opening one never closes another (and `value` / `defaultValue` / `onValueChange` are typed as string arrays). Set `type="single"` to opt into the accordion where opening a section auto-closes the previously open one. This is additive — existing call sites that pass `type` are unchanged — and mirrors the recent `Button` change where `type` became optional with a safe default.

--- a/apps/www/app/docs/components/accordion.mdx
+++ b/apps/www/app/docs/components/accordion.mdx
@@ -24,14 +24,18 @@ export const ControlledAccordionExample = () => {
 						Payments
 						<Accordion.TriggerIcon />
 					</Accordion.Trigger>
-					<Accordion.Content>Connect a processor and manage payouts.</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Connect a processor and manage payouts.</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 				<Accordion.Item value="members">
 					<Accordion.Trigger>
 						Members
 						<Accordion.TriggerIcon />
 					</Accordion.Trigger>
-					<Accordion.Content>Invite teammates and assign roles.</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Invite teammates and assign roles.</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>
 			<p className="text-muted text-sm">
@@ -73,8 +77,10 @@ the item is a `role="group"` and the trigger a `<button aria-expanded>`), so a s
 				<Accordion.TriggerIcon />
 			</Accordion.Trigger>
 			<Accordion.Content>
-				Add a CNAME record at your DNS provider that targets the CNAME value shown on your reserved
-				domain, then start your tunnel with the matching <code>--domain</code> flag.
+				<Accordion.Body>
+					Add a CNAME record at your DNS provider that targets the CNAME value shown on your
+					reserved domain, then start your tunnel with the matching <code>--domain</code> flag.
+				</Accordion.Body>
 			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="webhooks">
@@ -83,8 +89,10 @@ the item is a `role="group"` and the trigger a `<button aria-expanded>`), so a s
 				<Accordion.TriggerIcon />
 			</Accordion.Trigger>
 			<Accordion.Content>
-				Yes. ngrok can validate webhook signatures from providers like Stripe, GitHub, and Slack at
-				the edge before the request ever reaches your service.
+				<Accordion.Body>
+					Yes. ngrok can validate webhook signatures from providers like Stripe, GitHub, and Slack
+					at the edge before the request ever reaches your service.
+				</Accordion.Body>
 			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="pricing">
@@ -93,8 +101,10 @@ the item is a `role="group"` and the trigger a `<button aria-expanded>`), so a s
 				<Accordion.TriggerIcon />
 			</Accordion.Trigger>
 			<Accordion.Content>
-				The free plan includes ephemeral endpoints and one reserved domain — enough to demo a
-				deployment or prototype an integration.
+				<Accordion.Body>
+					The free plan includes ephemeral endpoints and one reserved domain — enough to demo a
+					deployment or prototype an integration.
+				</Accordion.Body>
 			</Accordion.Content>
 		</Accordion.Item>
 	</Accordion.Root>
@@ -109,7 +119,9 @@ import { Accordion } from "@ngrok/mantle/accordion";
 			How do I point my custom domain at an ngrok endpoint?
 			<Accordion.TriggerIcon />
 		</Accordion.Trigger>
-		<Accordion.Content>Add a CNAME record at your DNS provider…</Accordion.Content>
+		<Accordion.Content>
+			<Accordion.Body>Add a CNAME record at your DNS provider…</Accordion.Body>
+		</Accordion.Content>
 	</Accordion.Item>
 </Accordion.Root>;
 ```
@@ -135,8 +147,8 @@ import { Accordion } from "@ngrok/mantle/accordion";
 
 ### Multiple sections open at once
 
-Use `type="multiple"` to let any number of sections be open at once. Pass `defaultValue` (uncontrolled) or `value` +
-`onValueChange` (controlled) as a `string[]`.
+`type="multiple"` lets any number of sections be open at once — and it's the **default**, so you can omit `type`
+entirely. Pass `defaultValue` (uncontrolled) or `value` + `onValueChange` (controlled) as a `string[]`.
 
 <Example className="flex-col gap-6">
 	<Accordion.Root type="multiple" defaultValue={["one"]} className="max-w-xl">
@@ -145,14 +157,18 @@ Use `type="multiple"` to let any number of sections be open at once. Pass `defau
 				First section
 				<Accordion.TriggerIcon />
 			</Accordion.Trigger>
-			<Accordion.Content>This section starts expanded.</Accordion.Content>
+			<Accordion.Content>
+				<Accordion.Body>This section starts expanded.</Accordion.Body>
+			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="two">
 			<Accordion.Trigger>
 				Second section
 				<Accordion.TriggerIcon />
 			</Accordion.Trigger>
-			<Accordion.Content>Open me without closing the first one.</Accordion.Content>
+			<Accordion.Content>
+				<Accordion.Body>Open me without closing the first one.</Accordion.Body>
+			</Accordion.Content>
 		</Accordion.Item>
 	</Accordion.Root>
 </Example>
@@ -186,7 +202,9 @@ function Settings() {
 					Payments
 					<Accordion.TriggerIcon />
 				</Accordion.Trigger>
-				<Accordion.Content>Connect a processor and manage payouts.</Accordion.Content>
+				<Accordion.Content>
+					<Accordion.Body>Connect a processor and manage payouts.</Accordion.Body>
+				</Accordion.Content>
 			</Accordion.Item>
 			{/* …items… */}
 		</Accordion.Root>
@@ -224,9 +242,11 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 				</Button>
 			</div>
 			<Accordion.Content>
-				<Card.Root>
-					<Card.Body>Proident irure consequat Lorem incididunt ullamco.</Card.Body>
-				</Card.Root>
+				<Accordion.Body>
+					<Card.Root>
+						<Card.Body>Proident irure consequat Lorem incididunt ullamco.</Card.Body>
+					</Card.Root>
+				</Accordion.Body>
 			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="on_http_request" className="border-b-0">
@@ -244,9 +264,11 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 				</Button>
 			</div>
 			<Accordion.Content>
-				<Card.Root>
-					<Card.Body>Excepteur amet laboris occaecat anim minim reprehenderit.</Card.Body>
-				</Card.Root>
+				<Accordion.Body>
+					<Card.Root>
+						<Card.Body>Excepteur amet laboris occaecat anim minim reprehenderit.</Card.Body>
+					</Card.Root>
+				</Accordion.Body>
 			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="on_http_response" className="border-b-0">
@@ -264,7 +286,9 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 				</Button>
 			</div>
 			<Accordion.Content>
-				<p className="text-center">This phase does not have any rules defined</p>
+				<Accordion.Body>
+					<p className="text-center">This phase does not have any rules defined</p>
+				</Accordion.Body>
 			</Accordion.Content>
 		</Accordion.Item>
 	</Accordion.Root>
@@ -290,9 +314,11 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 			</Button>
 		</div>
 		<Accordion.Content>
-			<Card.Root>
-				<Card.Body>Proident irure consequat Lorem incididunt ullamco.</Card.Body>
-			</Card.Root>
+			<Accordion.Body>
+				<Card.Root>
+					<Card.Body>Proident irure consequat Lorem incididunt ullamco.</Card.Body>
+				</Card.Root>
+			</Accordion.Body>
 		</Accordion.Content>
 	</Accordion.Item>
 </Accordion.Root>
@@ -313,7 +339,9 @@ its `className` to change that — here a right caret rotates 90° into a downwa
 					className="group-data-[state=open]:rotate-90"
 				/>
 			</Accordion.Trigger>
-			<Accordion.Content>Inspect recent requests, status codes, and latency.</Accordion.Content>
+			<Accordion.Content>
+				<Accordion.Body>Inspect recent requests, status codes, and latency.</Accordion.Body>
+			</Accordion.Content>
 		</Accordion.Item>
 		<Accordion.Item value="metrics">
 			<Accordion.Trigger>
@@ -323,7 +351,9 @@ its `className` to change that — here a right caret rotates 90° into a downwa
 					className="group-data-[state=open]:rotate-90"
 				/>
 			</Accordion.Trigger>
-			<Accordion.Content>Track throughput and error rates over time.</Accordion.Content>
+			<Accordion.Content>
+				<Accordion.Body>Track throughput and error rates over time.</Accordion.Body>
+			</Accordion.Content>
 		</Accordion.Item>
 	</Accordion.Root>
 </Example>
@@ -364,6 +394,7 @@ Accordion.Root
     ├── Accordion.Trigger
     │   └── Accordion.TriggerIcon
     └── Accordion.Content
+        └── Accordion.Body
 ```
 
 ## API Reference
@@ -376,21 +407,26 @@ the browser's find-in-page.
 Owns the accordion state and renders a wrapping `<div>` (or your own element via `asChild`). The `type` prop is a
 discriminated union that shapes the open value:
 
-- `type="single"` — at most one section open at a time. `value` / `defaultValue` are a `string` (use `""` for none),
-  and `onValueChange` receives the newly open value.
-- `type="multiple"` — any number open. `value` / `defaultValue` are a `string[]`, and `onValueChange` receives the new
-  list.
+- `type="multiple"` — **the default.** Any number of sections may be open at once, and opening one never closes
+  another. `value` / `defaultValue` are a `string[]`, and `onValueChange` receives the new list. Omitting `type`
+  entirely is the same as `type="multiple"`.
+- `type="single"` — at most one section open at a time: opening a section auto-closes the previously open one.
+  `value` / `defaultValue` are a `string` (use `""` for none), and `onValueChange` receives the newly open value.
+
+> [!IMPORTANT]
+> `type` defaults to `"multiple"`, so sections open independently. **If you want opening one section to auto-close
+> the others, you must set `type="single"` explicitly.**
 
 Provide `value` + `onValueChange` for controlled usage, or `defaultValue` for uncontrolled usage. Accepts all `<div>`
 props, plus:
 
-| Prop             | Type                                                   | Default | Description                                                                                             |
-| :--------------- | :----------------------------------------------------- | :------ | :------------------------------------------------------------------------------------------------------ |
-| `type`           | `"single" \| "multiple"`                               |         | **Required.** Whether at most one section may be open (`"single"`) or any number (`"multiple"`).        |
-| `value?`         | `string \| string[]`                                   |         | The controlled open value(s). A `string` in `single` mode, a `string[]` in `multiple` mode.             |
-| `defaultValue?`  | `string \| string[]`                                   |         | The initial open value(s) when uncontrolled. Typed per `type`, like `value`.                            |
-| `onValueChange?` | `(value: string) => void \| (value: string[]) => void` |         | Called when the open value(s) change. Receives a `string` in `single` mode, a `string[]` in `multiple`. |
-| `asChild?`       | `boolean`                                              | `false` | Render the single child element as the container instead of a `<div>`, merging container props onto it. |
+| Prop             | Type                                                   | Default      | Description                                                                                                             |
+| :--------------- | :----------------------------------------------------- | :----------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `type?`          | `"single" \| "multiple"`                               | `"multiple"` | Whether at most one section may be open (`"single"`, auto-closes the others) or any number (`"multiple"`, the default). |
+| `value?`         | `string \| string[]`                                   |              | The controlled open value(s). A `string` in `single` mode, a `string[]` in `multiple` mode.                             |
+| `defaultValue?`  | `string \| string[]`                                   |              | The initial open value(s) when uncontrolled. Typed per `type`, like `value`.                                            |
+| `onValueChange?` | `(value: string) => void \| (value: string[]) => void` |              | Called when the open value(s) change. Receives a `string` in `single` mode, a `string[]` in `multiple`.                 |
+| `asChild?`       | `boolean`                                              | `false`      | Render the single child element as the container instead of a `<div>`, merging container props onto it.                 |
 
 ### Accordion.Item
 
@@ -421,7 +457,17 @@ The indicator icon. Defaults to a downward caret that rotates 180° when its sec
 
 ### Accordion.Content
 
-The collapsible body, rendered as a `<div>` that is always present in the DOM. When collapsed (in supporting browsers)
-it carries `hidden="until-found"` so its text stays discoverable by find-in-page, and a `beforematch` listener opens
-the section when the browser reveals a match. It is flow content, so it may contain **anything** — including
-interactive elements (buttons, links, inputs) or a nested `Accordion`. Accepts all `<div>` props.
+The collapsible region, rendered as a `<div>` that is always present in the DOM — the zero-padding viewport that slides
+open and closed. When collapsed (in supporting browsers) it carries `hidden="until-found"` so its text stays
+discoverable by find-in-page, and a `beforematch` listener opens the section when the browser reveals a match. It holds
+no padding of its own so its `h-0 ↔ h-auto` slide can collapse to zero height — put the section's content inside an
+`Accordion.Body`. It is flow content, so it may contain **anything** — including interactive elements (buttons, links,
+inputs) or a nested `Accordion`. Accepts all `<div>` props.
+
+### Accordion.Body
+
+The padded inner region of a `Content`, where the section's body content lives. It owns the bottom padding so `Content`
+can stay an unpadded animation viewport (a padded `h-0` border-box can't collapse below its padding, so the closed
+slide would never reach zero height). Text inherits the ambient size rather than being forced to a fixed size — set a
+text class where you need one. Override `className` to retune the spacing — e.g. `pb-0` to remove the bottom padding,
+`px-6` for horizontal padding — and `cx` resolves last-wins over the defaults. Accepts all `<div>` props.

--- a/apps/www/app/docs/components/accordion.mdx
+++ b/apps/www/app/docs/components/accordion.mdx
@@ -69,8 +69,11 @@ The `beforematch` event — fired right before the browser reveals a match — s
 state. It's built on plain `<div>` and `<button>` elements (matching native `<details>`/`<summary>` accessibility:
 the item is a `role="group"` and the trigger a `<button aria-expanded>`), so a section header can be any layout.
 
+`type` is optional and **defaults to `"multiple"`** — sections open independently, so any number can be open at once
+(open one without collapsing another below).
+
 <Example className="flex-col gap-6">
-	<Accordion.Root type="single" defaultValue="dns" className="max-w-xl">
+	<Accordion.Root defaultValue={["dns"]} className="max-w-xl">
 		<Accordion.Item value="dns">
 			<Accordion.Trigger>
 				How do I point my custom domain at an ngrok endpoint?
@@ -113,7 +116,8 @@ the item is a `role="group"` and the trigger a `<button aria-expanded>`), so a s
 ```tsx
 import { Accordion } from "@ngrok/mantle/accordion";
 
-<Accordion.Root type="single" defaultValue="dns">
+// `type` is optional and defaults to "multiple" — any number of sections can be open at once.
+<Accordion.Root defaultValue={["dns"]}>
 	<Accordion.Item value="dns">
 		<Accordion.Trigger>
 			How do I point my custom domain at an ngrok endpoint?
@@ -124,6 +128,64 @@ import { Accordion } from "@ngrok/mantle/accordion";
 		</Accordion.Content>
 	</Accordion.Item>
 </Accordion.Root>;
+```
+
+Set `type="single"` to make opening one section auto-close the previously open one — the classic accordion where at
+most one section is open at a time:
+
+<Example className="flex-col gap-6">
+	<Accordion.Root type="single" defaultValue="dns" className="max-w-xl">
+		<Accordion.Item value="dns">
+			<Accordion.Trigger>
+				How do I point my custom domain at an ngrok endpoint?
+				<Accordion.TriggerIcon />
+			</Accordion.Trigger>
+			<Accordion.Content>
+				<Accordion.Body>
+					Add a CNAME record at your DNS provider that targets the CNAME value shown on your
+					reserved domain, then start your tunnel with the matching <code>--domain</code> flag.
+				</Accordion.Body>
+			</Accordion.Content>
+		</Accordion.Item>
+		<Accordion.Item value="webhooks">
+			<Accordion.Trigger>
+				Can I verify inbound webhook signatures?
+				<Accordion.TriggerIcon />
+			</Accordion.Trigger>
+			<Accordion.Content>
+				<Accordion.Body>
+					Yes. ngrok can validate webhook signatures from providers like Stripe, GitHub, and Slack
+					at the edge before the request ever reaches your service.
+				</Accordion.Body>
+			</Accordion.Content>
+		</Accordion.Item>
+		<Accordion.Item value="pricing">
+			<Accordion.Trigger>
+				Is there a free tier for development?
+				<Accordion.TriggerIcon />
+			</Accordion.Trigger>
+			<Accordion.Content>
+				<Accordion.Body>
+					The free plan includes ephemeral endpoints and one reserved domain — enough to demo a
+					deployment or prototype an integration.
+				</Accordion.Body>
+			</Accordion.Content>
+		</Accordion.Item>
+	</Accordion.Root>
+</Example>
+
+```tsx
+<Accordion.Root type="single" defaultValue="dns">
+	<Accordion.Item value="dns">
+		<Accordion.Trigger>
+			How do I point my custom domain at an ngrok endpoint?
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>Add a CNAME record at your DNS provider…</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+</Accordion.Root>
 ```
 
 > [!NOTE]

--- a/apps/www/app/docs/components/accordion.mdx
+++ b/apps/www/app/docs/components/accordion.mdx
@@ -117,14 +117,41 @@ the item is a `role="group"` and the trigger a `<button aria-expanded>`), so a s
 import { Accordion } from "@ngrok/mantle/accordion";
 
 // `type` is optional and defaults to "multiple" — any number of sections can be open at once.
-<Accordion.Root defaultValue={["dns"]}>
+<Accordion.Root defaultValue={["dns"]} className="max-w-xl">
 	<Accordion.Item value="dns">
 		<Accordion.Trigger>
 			How do I point my custom domain at an ngrok endpoint?
 			<Accordion.TriggerIcon />
 		</Accordion.Trigger>
 		<Accordion.Content>
-			<Accordion.Body>Add a CNAME record at your DNS provider…</Accordion.Body>
+			<Accordion.Body>
+				Add a CNAME record at your DNS provider that targets the CNAME value shown on your reserved
+				domain, then start your tunnel with the matching <code>--domain</code> flag.
+			</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="webhooks">
+		<Accordion.Trigger>
+			Can I verify inbound webhook signatures?
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>
+				Yes. ngrok can validate webhook signatures from providers like Stripe, GitHub, and Slack at
+				the edge before the request ever reaches your service.
+			</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="pricing">
+		<Accordion.Trigger>
+			Is there a free tier for development?
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>
+				The free plan includes ephemeral endpoints and one reserved domain — enough to demo a
+				deployment or prototype an integration.
+			</Accordion.Body>
 		</Accordion.Content>
 	</Accordion.Item>
 </Accordion.Root>;
@@ -175,14 +202,41 @@ most one section is open at a time:
 </Example>
 
 ```tsx
-<Accordion.Root type="single" defaultValue="dns">
+<Accordion.Root type="single" defaultValue="dns" className="max-w-xl">
 	<Accordion.Item value="dns">
 		<Accordion.Trigger>
 			How do I point my custom domain at an ngrok endpoint?
 			<Accordion.TriggerIcon />
 		</Accordion.Trigger>
 		<Accordion.Content>
-			<Accordion.Body>Add a CNAME record at your DNS provider…</Accordion.Body>
+			<Accordion.Body>
+				Add a CNAME record at your DNS provider that targets the CNAME value shown on your reserved
+				domain, then start your tunnel with the matching <code>--domain</code> flag.
+			</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="webhooks">
+		<Accordion.Trigger>
+			Can I verify inbound webhook signatures?
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>
+				Yes. ngrok can validate webhook signatures from providers like Stripe, GitHub, and Slack at
+				the edge before the request ever reaches your service.
+			</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="pricing">
+		<Accordion.Trigger>
+			Is there a free tier for development?
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>
+				The free plan includes ephemeral endpoints and one reserved domain — enough to demo a
+				deployment or prototype an integration.
+			</Accordion.Body>
 		</Accordion.Content>
 	</Accordion.Item>
 </Accordion.Root>
@@ -236,8 +290,25 @@ entirely. Pass `defaultValue` (uncontrolled) or `value` + `onValueChange` (contr
 </Example>
 
 ```tsx
-<Accordion.Root type="multiple" defaultValue={["one"]}>
-	{/* …items… */}
+<Accordion.Root type="multiple" defaultValue={["one"]} className="max-w-xl">
+	<Accordion.Item value="one">
+		<Accordion.Trigger>
+			First section
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>This section starts expanded.</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="two">
+		<Accordion.Trigger>
+			Second section
+			<Accordion.TriggerIcon />
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>Open me without closing the first one.</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
 </Accordion.Root>
 ```
 
@@ -252,24 +323,51 @@ In `type="single"` the value is a `string` (use `""` for "nothing open"); in `ty
 
 ```tsx
 import { Accordion } from "@ngrok/mantle/accordion";
+import { Button } from "@ngrok/mantle/button";
 import { useState } from "react";
 
-function Settings() {
+function ControlledAccordionExample() {
 	const [value, setValue] = useState("payments");
 
 	return (
-		<Accordion.Root type="single" value={value} onValueChange={setValue}>
-			<Accordion.Item value="payments">
-				<Accordion.Trigger>
-					Payments
-					<Accordion.TriggerIcon />
-				</Accordion.Trigger>
-				<Accordion.Content>
-					<Accordion.Body>Connect a processor and manage payouts.</Accordion.Body>
-				</Accordion.Content>
-			</Accordion.Item>
-			{/* …items… */}
-		</Accordion.Root>
+		<div className="flex w-full flex-col gap-3">
+			<Accordion.Root type="single" value={value} onValueChange={setValue} className="max-w-xl">
+				<Accordion.Item value="payments">
+					<Accordion.Trigger>
+						Payments
+						<Accordion.TriggerIcon />
+					</Accordion.Trigger>
+					<Accordion.Content>
+						<Accordion.Body>Connect a processor and manage payouts.</Accordion.Body>
+					</Accordion.Content>
+				</Accordion.Item>
+				<Accordion.Item value="members">
+					<Accordion.Trigger>
+						Members
+						<Accordion.TriggerIcon />
+					</Accordion.Trigger>
+					<Accordion.Content>
+						<Accordion.Body>Invite teammates and assign roles.</Accordion.Body>
+					</Accordion.Content>
+				</Accordion.Item>
+			</Accordion.Root>
+			<p className="text-muted text-sm">
+				Open section: <code>{value || "none"}</code>
+			</p>
+			<div className="flex gap-2">
+				<Button
+					type="button"
+					appearance="outlined"
+					priority="neutral"
+					onClick={() => setValue("members")}
+				>
+					Open “Members”
+				</Button>
+				<Button type="button" appearance="outlined" priority="neutral" onClick={() => setValue("")}>
+					Collapse all
+				</Button>
+			</div>
+		</div>
 	);
 }
 ```
@@ -360,7 +458,18 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 // The header is a plain flex row: the Trigger button, a divider, and the action
 // button are siblings — no overlay, no absolute positioning. The Add Rule button
 // is outside the Trigger, so it never toggles the section; Content is full-width.
-<Accordion.Root type="multiple" className="space-y-2.5">
+import { Accordion } from "@ngrok/mantle/accordion";
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { Card } from "@ngrok/mantle/card";
+import { Separator } from "@ngrok/mantle/separator";
+import { PlusIcon } from "@phosphor-icons/react/Plus";
+
+<Accordion.Root
+	type="multiple"
+	defaultValue={["on_tcp_connect", "on_http_response"]}
+	className="space-y-2.5"
+>
 	<Accordion.Item value="on_tcp_connect" className="border-b-0">
 		<div className="mx-4 flex items-center gap-2">
 			<Accordion.Trigger className="w-auto gap-1.5">
@@ -372,7 +481,7 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 			</Accordion.Trigger>
 			<Separator orientation="horizontal" className="flex-1" />
 			<Button type="button" appearance="link" icon={<PlusIcon />}>
-				Add Rule
+				<span className="xs:inline hidden">Add Rule</span>
 			</Button>
 		</div>
 		<Accordion.Content>
@@ -383,7 +492,49 @@ on `Item`, `w-auto` on `Trigger` so it sizes to its label) for the spaced-card l
 			</Accordion.Body>
 		</Accordion.Content>
 	</Accordion.Item>
-</Accordion.Root>
+	<Accordion.Item value="on_http_request" className="border-b-0">
+		<div className="mx-4 flex items-center gap-2">
+			<Accordion.Trigger className="w-auto gap-1.5">
+				<span className="font-mono text-sm font-medium">on_http_request</span>
+				<Badge appearance="muted" color="neutral" className="rounded-full">
+					2
+				</Badge>
+				<Accordion.TriggerIcon />
+			</Accordion.Trigger>
+			<Separator orientation="horizontal" className="flex-1" />
+			<Button type="button" appearance="link" icon={<PlusIcon />}>
+				<span className="xs:inline hidden">Add Rule</span>
+			</Button>
+		</div>
+		<Accordion.Content>
+			<Accordion.Body>
+				<Card.Root>
+					<Card.Body>Excepteur amet laboris occaecat anim minim reprehenderit.</Card.Body>
+				</Card.Root>
+			</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="on_http_response" className="border-b-0">
+		<div className="mx-4 flex items-center gap-2">
+			<Accordion.Trigger className="w-auto gap-1.5">
+				<span className="font-mono text-sm font-medium">on_http_response</span>
+				<Badge appearance="muted" color="neutral" className="rounded-full">
+					0
+				</Badge>
+				<Accordion.TriggerIcon />
+			</Accordion.Trigger>
+			<Separator orientation="horizontal" className="flex-1" />
+			<Button type="button" appearance="link" icon={<PlusIcon />}>
+				<span className="xs:inline hidden">Add Rule</span>
+			</Button>
+		</div>
+		<Accordion.Content>
+			<Accordion.Body>
+				<p className="text-center">This phase does not have any rules defined</p>
+			</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+</Accordion.Root>;
 ```
 
 ### Custom indicator icon
@@ -421,15 +572,35 @@ its `className` to change that — here a right caret rotates 90° into a downwa
 </Example>
 
 ```tsx
+import { Accordion } from "@ngrok/mantle/accordion";
 import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
 
-<Accordion.Trigger>
-	Request logs
-	<Accordion.TriggerIcon
-		svg={<CaretRightIcon weight="bold" />}
-		className="group-data-[state=open]:rotate-90"
-	/>
-</Accordion.Trigger>;
+<Accordion.Root type="single" defaultValue="logs" className="max-w-xl">
+	<Accordion.Item value="logs">
+		<Accordion.Trigger>
+			Request logs
+			<Accordion.TriggerIcon
+				svg={<CaretRightIcon weight="bold" />}
+				className="group-data-[state=open]:rotate-90"
+			/>
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>Inspect recent requests, status codes, and latency.</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+	<Accordion.Item value="metrics">
+		<Accordion.Trigger>
+			Metrics
+			<Accordion.TriggerIcon
+				svg={<CaretRightIcon weight="bold" />}
+				className="group-data-[state=open]:rotate-90"
+			/>
+		</Accordion.Trigger>
+		<Accordion.Content>
+			<Accordion.Body>Track throughput and error rates over time.</Accordion.Body>
+		</Accordion.Content>
+	</Accordion.Item>
+</Accordion.Root>;
 ```
 
 ## Accessibility

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -7,8 +7,8 @@
     "summary": "A vertically stacked set of disclosure sections whose collapsed content stays in the DOM, so browser find-in-page (⌘F) can reveal it.",
     "jsdoc": "A vertically stacked set of disclosure sections styled after the shadcn / ngrok.com accordion.",
     "examples": [
-      "Composition:\n```\nAccordion.Root\n└── Accordion.Item\n    ├── Accordion.Trigger\n    │   └── Accordion.TriggerIcon\n    └── Accordion.Content\n```",
-      "<Accordion.Root type=\"single\" defaultValue=\"item-1\">\n  <Accordion.Item value=\"item-1\">\n    <Accordion.Trigger>\n      Is it accessible?\n      <Accordion.TriggerIcon />\n    </Accordion.Trigger>\n    <Accordion.Content>\n      Yes. It adheres to the WAI-ARIA disclosure pattern.\n    </Accordion.Content>\n  </Accordion.Item>\n</Accordion.Root>"
+      "Composition:\n```\nAccordion.Root\n└── Accordion.Item\n    ├── Accordion.Trigger\n    │   └── Accordion.TriggerIcon\n    └── Accordion.Content\n        └── Accordion.Body\n```",
+      "<Accordion.Root type=\"single\" defaultValue=\"item-1\">\n  <Accordion.Item value=\"item-1\">\n    <Accordion.Trigger>\n      Is it accessible?\n      <Accordion.TriggerIcon />\n    </Accordion.Trigger>\n    <Accordion.Content>\n      <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>\n    </Accordion.Content>\n  </Accordion.Item>\n</Accordion.Root>"
     ]
   },
   {

--- a/packages/mantle/src/components/accordion/accordion.browser.test.tsx
+++ b/packages/mantle/src/components/accordion/accordion.browser.test.tsx
@@ -19,14 +19,18 @@ describe("Accordion (browser)", () => {
 					Trigger A
 					<Accordion.TriggerIcon />
 				</Accordion.Trigger>
-				<Accordion.Content>Body of section A</Accordion.Content>
+				<Accordion.Content>
+					<Accordion.Body>Body of section A</Accordion.Body>
+				</Accordion.Content>
 			</Accordion.Item>
 			<Accordion.Item value="b">
 				<Accordion.Trigger>
 					Trigger B
 					<Accordion.TriggerIcon />
 				</Accordion.Trigger>
-				<Accordion.Content>Body of section B</Accordion.Content>
+				<Accordion.Content>
+					<Accordion.Body>Body of section B</Accordion.Body>
+				</Accordion.Content>
 			</Accordion.Item>
 		</>
 	);
@@ -158,7 +162,9 @@ describe("Accordion (browser)", () => {
 			<Accordion.Root type="single" defaultValue="">
 				<Accordion.Item value="a">
 					<Accordion.Trigger onClick={onClick}>Trigger A</Accordion.Trigger>
-					<Accordion.Content>Body of section A</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Body of section A</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>,
 		);
@@ -180,7 +186,9 @@ describe("Accordion (browser)", () => {
 							Add Rule
 						</button>
 					</div>
-					<Accordion.Content>Body of section A</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Body of section A</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>,
 		);

--- a/packages/mantle/src/components/accordion/accordion.test.tsx
+++ b/packages/mantle/src/components/accordion/accordion.test.tsx
@@ -86,14 +86,18 @@ describe("Accordion", () => {
 						Trigger A
 						<Accordion.TriggerIcon />
 					</Accordion.Trigger>
-					<Accordion.Content>Body of section A</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Body of section A</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 				<Accordion.Item value="b">
 					<Accordion.Trigger>
 						Trigger B
 						<Accordion.TriggerIcon />
 					</Accordion.Trigger>
-					<Accordion.Content>Body of section B</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Body of section B</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>,
 		);
@@ -142,7 +146,9 @@ describe("Accordion", () => {
 				<section data-testid="root-section">
 					<Accordion.Item value="a">
 						<Accordion.Trigger>Trigger A</Accordion.Trigger>
-						<Accordion.Content>Body</Accordion.Content>
+						<Accordion.Content>
+							<Accordion.Body>Body</Accordion.Body>
+						</Accordion.Content>
 					</Accordion.Item>
 				</section>
 			</Accordion.Root>,
@@ -160,7 +166,9 @@ describe("Accordion", () => {
 						Custom icon
 						<Accordion.TriggerIcon svg={<svg data-testid="custom-trigger-icon" />} />
 					</Accordion.Trigger>
-					<Accordion.Content>Body of section A</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Body of section A</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>,
 		);
@@ -181,7 +189,9 @@ describe("Accordion", () => {
 			>
 				<Accordion.Item value="a">
 					<Accordion.Trigger>Trigger A</Accordion.Trigger>
-					<Accordion.Content>Body of section A</Accordion.Content>
+					<Accordion.Content>
+						<Accordion.Body>Body of section A</Accordion.Body>
+					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>,
 		);
@@ -193,5 +203,53 @@ describe("Accordion", () => {
 		// Accordion-specific props must not leak onto the DOM element.
 		expect(root).not.toHaveAttribute("type");
 		expect(root).not.toHaveAttribute("defaultValue");
+	});
+
+	test("Body marks the content region with data-slot and forwards a consumer className", () => {
+		render(
+			<Accordion.Root type="single" defaultValue="a">
+				<Accordion.Item value="a">
+					<Accordion.Trigger>Trigger A</Accordion.Trigger>
+					<Accordion.Content>
+						<Accordion.Body className="custom-body-class" data-testid="body-a">
+							Body of section A
+						</Accordion.Body>
+					</Accordion.Content>
+				</Accordion.Item>
+			</Accordion.Root>,
+		);
+		const body = screen.getByTestId("body-a");
+		// Assert the stable contract: Body is the styleable content slot and forwards
+		// a consumer className. We deliberately avoid asserting specific Tailwind
+		// utilities (e.g. `pb-4`) — those are implementation details that can change,
+		// and `cx`'s last-wins merge has its own dedicated tests.
+		expect(body).toHaveAttribute("data-slot", "accordion-body");
+		expect(body).toHaveClass("custom-body-class");
+	});
+
+	test("defaults to multiple mode when `type` is omitted (sections open independently)", () => {
+		render(
+			<Accordion.Root defaultValue={["a", "b"]}>
+				<Accordion.Item value="a">
+					<Accordion.Trigger>Trigger A</Accordion.Trigger>
+					<Accordion.Content>
+						<Accordion.Body>Body of section A</Accordion.Body>
+					</Accordion.Content>
+				</Accordion.Item>
+				<Accordion.Item value="b">
+					<Accordion.Trigger>Trigger B</Accordion.Trigger>
+					<Accordion.Content>
+						<Accordion.Body>Body of section B</Accordion.Body>
+					</Accordion.Content>
+				</Accordion.Item>
+			</Accordion.Root>,
+		);
+		// Both sections open at once is only possible in multiple mode, so this proves
+		// the omitted `type` defaults to "multiple" (and that `defaultValue` accepts a
+		// `string[]` without `type` being set).
+		const itemA = screen.getByText("Body of section A").closest('[data-slot="accordion-item"]');
+		const itemB = screen.getByText("Body of section B").closest('[data-slot="accordion-item"]');
+		expect(itemA).toHaveAttribute("data-state", "open");
+		expect(itemB).toHaveAttribute("data-state", "open");
 	});
 });

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -16,6 +16,7 @@ import {
 import invariant from "tiny-invariant";
 import { useIsomorphicLayoutEffect } from "../../hooks/use-isomorphic-layout-effect.js";
 import type { WithAsChild } from "../../types/as-child.js";
+import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Icon, type IconProps } from "../icon/icon.js";
 import { Slot } from "../slot/index.js";
@@ -89,10 +90,18 @@ function useAccordionItemContext(component: string): AccordionItemContextValue {
 }
 
 /**
- * `"single"` mode props: at most one item open at a time. `value`/`defaultValue`
- * are the open item's value (`""` for none).
+ * `"single"` mode props: at most one item open at a time — opening a section
+ * auto-closes the previously open one. This is the **opt-in** behavior; `type`
+ * defaults to `"multiple"`, so you must set `type="single"` explicitly to get
+ * the auto-close accordion. `value`/`defaultValue` are the open item's value
+ * (`""` for none).
  */
 type AccordionSingleProps = {
+	/**
+	 * Keep at most one section open at a time: opening a section auto-closes the
+	 * previously open one. Must be set explicitly — the default is `"multiple"`,
+	 * where sections open independently.
+	 */
 	type: "single";
 	/** The controlled open item value (`""` for none). */
 	value?: string;
@@ -103,11 +112,21 @@ type AccordionSingleProps = {
 };
 
 /**
- * `"multiple"` mode props: any number of items may be open. `value`/`defaultValue`
- * are the list of open item values.
+ * `"multiple"` mode props — the **default** when `type` is omitted: any number
+ * of items may be open at once, and opening one never closes another.
+ * `value`/`defaultValue` are the list of open item values. Use `type="single"`
+ * instead if you want opening a section to auto-close the others.
  */
 type AccordionMultipleProps = {
-	type: "multiple";
+	/**
+	 * Allow any number of sections open at once — the **default** when `type` is
+	 * omitted. Opening one section never collapses the others. Switch to
+	 * `type="single"` for the accordion that auto-closes the previously open
+	 * section.
+	 *
+	 * @default "multiple"
+	 */
+	type?: "multiple";
 	/** The controlled list of open item values. */
 	value?: string[];
 	/** The initial list of open item values when uncontrolled. */
@@ -119,7 +138,11 @@ type AccordionMultipleProps = {
 /**
  * Props for {@link Root}. A discriminated union on `type` so `value`,
  * `defaultValue`, and `onValueChange` are typed as a single string in
- * `"single"` mode and a string array in `"multiple"` mode. Also accepts all
+ * `"single"` mode and a string array in `"multiple"` mode. `type` is optional
+ * and **defaults to `"multiple"`** — omitting it is the same as
+ * `type="multiple"` (sections open independently), so `value` / `defaultValue` /
+ * `onValueChange` are typed as string arrays. Set `type="single"` for the
+ * accordion that keeps at most one section open at a time. Also accepts all
  * standard `<div>` props (forwarded to the container) plus `asChild`.
  */
 type AccordionRootProps = (AccordionSingleProps | AccordionMultipleProps) &
@@ -139,6 +162,11 @@ type AccordionRootProps = (AccordionSingleProps | AccordionMultipleProps) &
  * with controlled (`value` + `onValueChange`) and uncontrolled (`defaultValue`)
  * usage in both `"single"` and `"multiple"` modes.
  *
+ * `type` is optional and **defaults to `"multiple"`** — sections open
+ * independently and opening one never closes another. Pass `type="single"` for
+ * the classic accordion where opening a section auto-closes the previously open
+ * one.
+ *
  * @see https://mantle.ngrok.com/components/accordion#api-accordion
  *
  * @example
@@ -148,7 +176,9 @@ type AccordionRootProps = (AccordionSingleProps | AccordionMultipleProps) &
  *       How long does shipping take?
  *       <Accordion.TriggerIcon />
  *     </Accordion.Trigger>
- *     <Accordion.Content>Two to five business days.</Accordion.Content>
+ *     <Accordion.Content>
+ *       <Accordion.Body>Two to five business days.</Accordion.Body>
+ *     </Accordion.Content>
  *   </Accordion.Item>
  * </Accordion.Root>
  */
@@ -159,7 +189,9 @@ const Root = forwardRef<ComponentRef<"div">, AccordionRootProps>((props, ref) =>
 	// the discriminated-union narrowing on `props.type` — so `onValueChange` is only
 	// destructured to exclude it from `domProps` (hence the `_` name).
 	const {
-		type,
+		// `type` defaults to "multiple": omitting it opens sections independently.
+		// `type="single"` is the opt-in for the auto-closing accordion.
+		type = "multiple",
 		value,
 		defaultValue,
 		onValueChange: _onValueChange,
@@ -233,7 +265,7 @@ Root.displayName = "Accordion";
  *       <Accordion.TriggerIcon />
  *     </Accordion.Trigger>
  *     <Accordion.Content>
- *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+ *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
  *     </Accordion.Content>
  *   </Accordion.Item>
  * </Accordion.Root>
@@ -294,7 +326,7 @@ Item.displayName = "AccordionItem";
  *       <Accordion.TriggerIcon />
  *     </Accordion.Trigger>
  *     <Accordion.Content>
- *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+ *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
  *     </Accordion.Content>
  *   </Accordion.Item>
  * </Accordion.Root>
@@ -314,7 +346,7 @@ const Trigger = forwardRef<
 			data-state={open ? "open" : "closed"}
 			aria-expanded={open}
 			className={cx(
-				"group flex w-full cursor-pointer items-center justify-between gap-4 py-4 text-left text-sm font-medium outline-none",
+				"group flex w-full cursor-pointer items-center justify-between gap-4 py-4 text-left font-medium outline-none",
 				// `-mx-2 px-2` gives the focus ring (and tap target) horizontal breathing room
 				// without shifting the trigger's content — the negative margin cancels the padding,
 				// the same trick the tabs trigger uses. `rounded-md` matches Button/IconButton.
@@ -354,7 +386,7 @@ const defaultTriggerIcon = <CaretDownIcon weight="bold" />;
  *       <Accordion.TriggerIcon />
  *     </Accordion.Trigger>
  *     <Accordion.Content>
- *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+ *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
  *     </Accordion.Content>
  *   </Accordion.Item>
  * </Accordion.Root>
@@ -386,11 +418,14 @@ const TriggerIcon = ({
 TriggerIcon.displayName = "AccordionTriggerIcon";
 
 /**
- * The collapsible body of an {@link Item}. Always rendered into the DOM; when
- * collapsed (in supporting browsers) it carries `hidden="until-found"` so its
- * text stays discoverable by the browser's find-in-page, and a `beforematch`
- * listener opens the section when the browser reveals a match. It is flow
- * content, so it may contain anything — including interactive elements.
+ * The collapsible region of an {@link Item} — the zero-padding viewport that
+ * slides open and closed. Wrap its children in {@link Body} for the standard
+ * padding and text size; `Content` itself stays unpadded so its `h-0` collapse
+ * can reach zero height. Always rendered into the DOM; when collapsed (in
+ * supporting browsers) it carries `hidden="until-found"` so its text stays
+ * discoverable by the browser's find-in-page, and a `beforematch` listener opens
+ * the section when the browser reveals a match. It is flow content, so it may
+ * contain anything — including interactive elements.
  *
  * @see https://mantle.ngrok.com/components/accordion#api-accordion-content
  *
@@ -402,7 +437,7 @@ TriggerIcon.displayName = "AccordionTriggerIcon";
  *       <Accordion.TriggerIcon />
  *     </Accordion.Trigger>
  *     <Accordion.Content>
- *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+ *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
  *     </Accordion.Content>
  *   </Accordion.Item>
  * </Accordion.Root>
@@ -410,25 +445,16 @@ TriggerIcon.displayName = "AccordionTriggerIcon";
 const Content = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>(
 	({ className, children, ...props }, forwardedRef) => {
 		const { open, setOpen } = useAccordionItemContext("Accordion.Content");
-		const nodeRef = useRef<HTMLDivElement | null>(null);
-
-		const assignRef = useCallback(
-			(node: HTMLDivElement | null) => {
-				nodeRef.current = node;
-				if (typeof forwardedRef === "function") {
-					forwardedRef(node);
-				} else if (forwardedRef != null) {
-					forwardedRef.current = node;
-				}
-			},
-			[forwardedRef],
-		);
+		// Track the node ourselves (for the find-in-page reveal effects below) while
+		// still forwarding it to any ref the consumer passes.
+		const nodeRef = useRef<ComponentRef<"div">>(null);
+		const composedRef = useComposedRefs(nodeRef, forwardedRef);
 
 		// When the browser is about to reveal a find-in-page match inside this
 		// (collapsed) region, open the item so our state agrees and it stays open.
 		useEffect(() => {
 			const node = nodeRef.current;
-			if (node == null || !supportsBeforeMatch()) {
+			if (!node || !supportsBeforeMatch()) {
 				return;
 			}
 			const handleBeforeMatch = () => {
@@ -444,7 +470,9 @@ const Content = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>
 				node.style.height = "auto";
 				setOpen(true);
 			};
+
 			node.addEventListener("beforematch", handleBeforeMatch);
+
 			return () => {
 				node.removeEventListener("beforematch", handleBeforeMatch);
 			};
@@ -456,9 +484,10 @@ const Content = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>
 		// Layout effect so the collapsed item is hidden before first paint (no flash).
 		useIsomorphicLayoutEffect(() => {
 			const node = nodeRef.current;
-			if (node == null) {
+			if (!node) {
 				return;
 			}
+
 			if (open || !supportsBeforeMatch()) {
 				node.removeAttribute("hidden");
 			} else {
@@ -471,7 +500,7 @@ const Content = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>
 
 		return (
 			<div
-				ref={assignRef}
+				ref={composedRef}
 				{...props}
 				data-slot="accordion-content"
 				data-state={open ? "open" : "closed"}
@@ -480,17 +509,45 @@ const Content = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>
 					// engines snap, which is fine — the slide is a progressive enhancement and
 					// find-in-page works regardless). `content-visibility` transitions with
 					// `allow-discrete` so the content stays rendered through the close slide
-					// before `hidden="until-found"` skips it; `overflow-hidden` clips.
-					"h-0 overflow-hidden text-sm transition-[height,content-visibility] duration-200 ease-out [interpolate-size:allow-keywords] transition-discrete data-[state=open]:h-auto motion-reduce:transition-none",
+					// before `hidden="until-found"` skips it; `overflow-hidden` clips. Padding
+					// lives on `Accordion.Body`, never here: a padded `h-0` border-box can't
+					// collapse below its padding, so the closed section would stop short of
+					// zero height instead of fully collapsing.
+					"h-0 overflow-hidden transition-[height,content-visibility] duration-200 ease-out [interpolate-size:allow-keywords] transition-discrete data-[state=open]:h-auto motion-reduce:transition-none",
 					className,
 				)}
 			>
-				<div className="pb-4">{children}</div>
+				{children}
 			</div>
 		);
 	},
 );
 Content.displayName = "AccordionContent";
+
+/**
+ * The padded inner region of an {@link Item}'s {@link Content} — where the
+ * section's body content lives. Owns the bottom padding so {@link Content} can
+ * stay a zero-padding animation viewport: a padded `h-0` border-box can't
+ * collapse below its padding, so keeping the padding here lets the closed slide
+ * reach zero height. Text inherits the ambient size — it isn't forced — so set a
+ * size on the content where you need one. Override `className` to retune the
+ * padding (e.g. `pb-0`, `px-6`); `cx` resolves last-wins.
+ *
+ * @see https://mantle.ngrok.com/components/accordion#api-accordion-body
+ *
+ * @example
+ * <Accordion.Content>
+ *   <Accordion.Body className="pb-6">
+ *     Yes. It adheres to the WAI-ARIA disclosure pattern.
+ *   </Accordion.Body>
+ * </Accordion.Content>
+ */
+const Body = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>(
+	({ className, ...props }, ref) => (
+		<div ref={ref} {...props} data-slot="accordion-body" className={cx("pb-4", className)} />
+	),
+);
+Body.displayName = "AccordionBody";
 
 /**
  * A vertically stacked set of disclosure sections styled after the shadcn /
@@ -503,6 +560,9 @@ Content.displayName = "AccordionContent";
  * section header can be any layout, including a non-toggling action button
  * beside the trigger.
  *
+ * `Accordion.Root` defaults to `type="multiple"` (sections open independently);
+ * pass `type="single"` when opening one section should auto-close the others.
+ *
  * @see https://mantle.ngrok.com/components/accordion
  *
  * @example
@@ -513,6 +573,7 @@ Content.displayName = "AccordionContent";
  *     ├── Accordion.Trigger
  *     │   └── Accordion.TriggerIcon
  *     └── Accordion.Content
+ *         └── Accordion.Body
  * ```
  *
  * @example
@@ -523,7 +584,7 @@ Content.displayName = "AccordionContent";
  *       <Accordion.TriggerIcon />
  *     </Accordion.Trigger>
  *     <Accordion.Content>
- *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+ *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
  *     </Accordion.Content>
  *   </Accordion.Item>
  * </Accordion.Root>
@@ -540,7 +601,7 @@ const Accordion = {
 	 *       <Accordion.TriggerIcon />
 	 *     </Accordion.Trigger>
 	 *     <Accordion.Content>
-	 *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+	 *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
 	 *     </Accordion.Content>
 	 *   </Accordion.Item>
 	 * </Accordion.Root>
@@ -557,7 +618,7 @@ const Accordion = {
 	 *       <Accordion.TriggerIcon />
 	 *     </Accordion.Trigger>
 	 *     <Accordion.Content>
-	 *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+	 *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
 	 *     </Accordion.Content>
 	 *   </Accordion.Item>
 	 * </Accordion.Root>
@@ -574,7 +635,7 @@ const Accordion = {
 	 *       <Accordion.TriggerIcon />
 	 *     </Accordion.Trigger>
 	 *     <Accordion.Content>
-	 *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+	 *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
 	 *     </Accordion.Content>
 	 *   </Accordion.Item>
 	 * </Accordion.Root>
@@ -591,7 +652,7 @@ const Accordion = {
 	 *       <Accordion.TriggerIcon />
 	 *     </Accordion.Trigger>
 	 *     <Accordion.Content>
-	 *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+	 *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
 	 *     </Accordion.Content>
 	 *   </Accordion.Item>
 	 * </Accordion.Root>
@@ -608,12 +669,23 @@ const Accordion = {
 	 *       <Accordion.TriggerIcon />
 	 *     </Accordion.Trigger>
 	 *     <Accordion.Content>
-	 *       Yes. It adheres to the WAI-ARIA disclosure pattern.
+	 *       <Accordion.Body>Yes. It adheres to the WAI-ARIA disclosure pattern.</Accordion.Body>
 	 *     </Accordion.Content>
 	 *   </Accordion.Item>
 	 * </Accordion.Root>
 	 */
 	Content,
+	/**
+	 * The padded inner region of a {@link Content}. See {@link Body}.
+	 *
+	 * @example
+	 * <Accordion.Content>
+	 *   <Accordion.Body className="pb-6">
+	 *     Yes. It adheres to the WAI-ARIA disclosure pattern.
+	 *   </Accordion.Body>
+	 * </Accordion.Content>
+	 */
+	Body,
 } as const;
 
 export {

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -420,8 +420,9 @@ TriggerIcon.displayName = "AccordionTriggerIcon";
 /**
  * The collapsible region of an {@link Item} — the zero-padding viewport that
  * slides open and closed. Wrap its children in {@link Body} for the standard
- * padding and text size; `Content` itself stays unpadded so its `h-0` collapse
- * can reach zero height. Always rendered into the DOM; when collapsed (in
+ * padding (text inherits the ambient size); `Content` itself stays unpadded so
+ * its `h-0` collapse can reach zero height. Always rendered into the DOM; when
+ * collapsed (in
  * supporting browsers) it carries `hidden="until-found"` so its text stays
  * discoverable by the browser's find-in-page, and a `beforematch` listener opens
  * the section when the browser reveals a match. It is flow content, so it may


### PR DESCRIPTION
Split `Accordion.Content` into a `Content` viewport plus a new `Accordion.Body` part, mirroring the `Content` + `Body` composition of `Dialog` and `Sheet`. `Content` is the zero-padding element that animates open/closed; `Body` owns the bottom padding. Keeping padding off the animating element is what lets a closed section fully collapse — a padded `h-0` border-box can't shrink below its own padding — and it gives consumers a dedicated element to restyle.

Make `Accordion.Root`'s `type` optional, defaulting to `"multiple"` (sections open independently); pass `type="single"` for the accordion that auto-closes the previously open section. Additive — existing `type=` call sites are unchanged — mirroring the recent `Button` change where `type` became optional with a safe default. Heavily documented so the auto-close behavior is an explicit opt-in.

Stop forcing `text-sm` on the content and the trigger; both inherit the ambient text size now, matching the pre-rewrite accordion. Real consumers confirm this: the www FAQ overrides to `text-base` and the dashboard's Traffic Policy GUI inherits `text-sm` from an ancestor, so the imposed size only got in the way.

Internal: replace the hand-rolled ref merge in `Content` with the shared `useComposedRefs` hook, and type the content node ref via `ComponentRef<"div">`.

Tests assert the stable contract (data-slot + className forwarding) rather than specific Tailwind utilities, and cover the new `Body` and the `"multiple"` default.