### PR TITLE
fix(mantle): ease Accordion trigger padding in step with the open/close slide

### DIFF
--- a/.changeset/accordion-trigger-transition.md
+++ b/.changeset/accordion-trigger-transition.md
@@ -1,0 +1,12 @@
+---
+"@ngrok/mantle": patch
+---
+
+fix(mantle): ease the Accordion trigger's padding in step with the open/close slide
+
+The open-state `pb-2` padding swap (which gives the focus ring its vertical
+clearance) was applied instantly, so the trigger's bottom padding — and the
+ring's bottom edge — snapped 16px→8px at the start of opening and back on close,
+jittering against the content's height animation. The padding now transitions on
+the same 200ms/ease-out curve as `Accordion.Content`'s height, so it eases in
+lockstep with the slide. `motion-reduce` disables the transition.

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -357,9 +357,10 @@ const Trigger = forwardRef<
 				// vertical clearance it needs so it stops painting over the body's first line. The
 				// split is invisible without a ring, and only applies when open — the collapsed
 				// trigger keeps its symmetric `py-4`, so the trigger-to-divider rhythm is untouched.
-				// The swap is intentionally not transitioned: the trigger stays instant while only
-				// the content height animates, keeping behavior consistent across engines.
-				"data-state-open:pb-2",
+				// Transition the padding on the same 200ms/ease-out curve as `Accordion.Content`'s
+				// height so the bottom padding (and the ring's bottom edge) eases in step with the
+				// open/close slide instead of snapping.
+				"transition-[padding] duration-200 ease-out data-state-open:pb-2 motion-reduce:transition-none",
 				"focus:outline-hidden focus-visible:ring-4 focus-visible:ring-focus-accent",
 				className,
 			)}


### PR DESCRIPTION
## What

When an Accordion section opens, the trigger hands 8px of its bottom padding to `Accordion.Body`'s `pt-2` (`data-state-open:pb-2`) to give the `ring-4` focus ring vertical clearance. That swap was applied **instantly**, so the trigger's bottom padding — and the ring's bottom edge — snapped 16px→8px at the start of opening (and back on close), jittering against the content's height animation.

This transitions the padding on the **same 200ms/ease-out curve** as `Accordion.Content`'s height, so the bottom padding eases in lockstep with the open/close slide instead of snapping. `motion-reduce` disables the transition.

## Why this approach

Keeping the open/close gaps a uniform 16px in both states requires the trigger box to change size between states (the `pb-2` swap). Given that constraint, the choice was between a stable-but-looser layout vs. a smooth transition; we chose to preserve the uniform rhythm and smooth the motion.

## Context

Follow-up to #1279. That PR's trigger change merged with the swap applied instantly; this refines it to ease. (An earlier iteration of this change was accidentally pushed straight to `main` and has been reverted in `4bd491c1`; this PR reintroduces it properly with a changeset.)

## Verification

- `pnpm -w run lint` — 0 errors
- `pnpm -w run fmt:check` — clean
- `pnpm -w run typecheck` — 7/7
- Changeset: `@ngrok/mantle` patch