### PR TITLE
feat(www): containerize the docs app with a Dockerfile

### DIFF
--- a/apps/www/Dockerfile
+++ b/apps/www/Dockerfile
@@ -1,0 +1,107 @@
+# Use Node.js 24 LTS (Debian Slim)
+FROM node:24-slim AS base
+
+# Base dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libc6 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user early
+RUN groupadd nodejs && useradd --gid nodejs --uid 1001 --create-home ngrok
+
+# Set working directory
+WORKDIR /app
+
+ENV CI=true
+ENV COREPACK_HOME=/tmp/corepack-cache
+ENV XDG_CACHE_HOME=$COREPACK_HOME
+ENV PNPM_HOME=/root/.pnpm-store
+
+RUN mkdir -p $COREPACK_HOME \
+    && chmod -R 777 $COREPACK_HOME
+
+# Enable corepack for pnpm
+RUN npm install --global corepack@latest && corepack enable pnpm
+
+# Pruner stage — generates a minimal workspace containing only @app/www and
+# the workspace packages it depends on (@ngrok/mantle, mantle-vite-plugins,
+# mantle-server-syntax-highlighter, @cfg/tsconfig). turbo prune rewrites the
+# lockfile and workspace manifest down to that subset, so anything @app/www
+# does not depend on is dropped from this point forward.
+FROM base AS pruner
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps apps
+COPY packages packages
+COPY config config
+
+# Install turbo at the version declared in package.json (avoids installing all root devDeps)
+RUN TURBO_VERSION=$(node -e "process.stdout.write(require('./package.json').devDependencies.turbo)") && \
+    npm install -g turbo@$TURBO_VERSION
+
+RUN --mount=type=secret,id=TURBO_TOKEN \
+    --mount=type=secret,id=TURBO_TEAM \
+    export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN || echo "") && \
+    export TURBO_TEAM=$(cat /run/secrets/TURBO_TEAM || echo "") && \
+    export DO_NOT_TRACK=1 && \
+    export TURBO_TELEMETRY_DISABLED=1 && \
+    turbo prune @app/www --docker
+
+# Builder stage — works entirely within the pruned workspace
+FROM base AS builder
+WORKDIR /app
+
+# Copy pruned package.json files first for better layer caching
+COPY --from=pruner /app/out/json/ ./
+
+# Enable and install pnpm via corepack (uses the root package.json#packageManager field)
+RUN yes | corepack enable pnpm \
+    && yes | corepack install
+
+# Install ALL dependencies (devDeps needed for build)
+# Note: turbo prune generates a subset lockfile — skip frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/root/.pnpm-store \
+    pnpm store verify || true && \
+    pnpm install --no-frozen-lockfile
+
+# Copy full pruned source
+COPY --from=pruner /app/out/full/ ./
+
+# Build
+RUN --mount=type=secret,id=TURBO_TOKEN \
+    --mount=type=secret,id=TURBO_TEAM \
+    export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN || echo "") && \
+    export TURBO_TEAM=$(cat /run/secrets/TURBO_TEAM || echo "") && \
+    export NODE_ENV=production && \
+    export DO_NOT_TRACK=1 && \
+    export TURBO_TELEMETRY_DISABLED=1 && \
+    pnpm turbo run build --filter=@app/www...
+
+# Install only @react-router/serve + its runtime deps into a clean directory
+# so we can copy a minimal node_modules into the distroless runner.
+RUN RR_SERVE_VERSION=$(node -e "process.stdout.write(require('./apps/www/node_modules/@react-router/serve/package.json').version)") \
+    && mkdir /app/runner-deps && cd /app/runner-deps \
+    && npm init -y \
+    && npm install --omit=dev --no-fund --no-audit "@react-router/serve@${RR_SERVE_VERSION}" \
+    && rm -rf package.json package-lock.json
+
+# ---------------------------------------------------------------------------
+# Runner stage — Distroless, no shell/npm/package manager.
+# App deps are bundled into the server build (ssr.noExternal: true).
+# Only @react-router/serve + its runtime deps (express, etc.) are copied in.
+# ---------------------------------------------------------------------------
+FROM gcr.io/distroless/nodejs24-debian12 AS runner
+
+WORKDIR /app
+
+COPY --from=builder --chown=1001:1001 /app/apps/www/build build
+COPY --from=builder --chown=1001:1001 /app/runner-deps/node_modules node_modules
+
+USER 1001
+
+EXPOSE 3000
+
+ENV NODE_ENV=production
+
+CMD ["node_modules/.bin/react-router-serve", "build/server/index.js"]

--- a/apps/www/Dockerfile.dockerignore
+++ b/apps/www/Dockerfile.dockerignore
@@ -33,14 +33,15 @@ apps/*/vite-plugins
 !apps/www/public
 !apps/www/vite-plugins
 
-# Env files — production build uses .env.production (if present) and platform env vars
+# Env files — never ship local env into the build context. The www build reads
+# no build-time secrets; runtime env is supplied to the container by the
+# platform. Ignoring every `.env*` (including `.env.production`) keeps local
+# secrets out of build layers and the build cache.
 **/.env
-**/.env.local
-**/.env.*.local
-**/.env.dev
-**/.env.lan
-**/.env.stage
-!**/.env.production
+**/.env.*
+
+# Version control — large and unused by the build; keep it out of the context
+.git
 
 # Dev tool config — not needed inside the build container
 .claude

--- a/apps/www/Dockerfile.dockerignore
+++ b/apps/www/Dockerfile.dockerignore
@@ -1,0 +1,97 @@
+# ============================================================
+# Dockerfile.dockerignore — scoped to apps/www/Dockerfile
+# Paths are relative to the repo root (the build context).
+# This file takes precedence over the root .dockerignore when
+# building with: docker build -f apps/www/Dockerfile .
+# ============================================================
+
+# Dependency directories
+**/node_modules
+
+# Build output (regenerated inside Docker)
+**/build
+**/.turbo
+**/.react-router
+**/.vercel
+**/.cache
+
+# TypeScript incremental build info
+**/*.tsbuildinfo
+
+# Exclude source dirs from all apps — pnpm only needs their package.json
+# for workspace resolution, not source or static assets.
+# Glob patterns mean new apps are covered automatically without editing this file.
+apps/*/app
+apps/*/src
+apps/*/public
+apps/*/scripts
+apps/*/vite-plugins
+
+# Re-include www source — it's the app this Dockerfile builds. Its local
+# vite-plugins are imported by apps/www/vite.config.ts, so the build needs them.
+!apps/www/app
+!apps/www/public
+!apps/www/vite-plugins
+
+# Env files — production build uses .env.production (if present) and platform env vars
+**/.env
+**/.env.local
+**/.env.*.local
+**/.env.dev
+**/.env.lan
+**/.env.stage
+!**/.env.production
+
+# Dev tool config — not needed inside the build container
+.claude
+.editorconfig
+.gitattributes
+.gitignore
+.grunt
+.husky
+.idea
+.lintstagedrc.json
+.lock-wscript
+mise.lock
+mise.local.toml
+mise.toml
+.node_repl_history
+.npm
+.nvmrc
+.nyc_output
+.oxcfmtrc.json
+.oxlintrc.json
+.playwright-mcp
+.prettierignore
+.vscode
+
+# Docs and meta
+decisions
+scripts
+LICENSE
+**/*.md
+# www bundles packages/mantle/CHANGELOG.md as build input (mantleChangelogMdx
+# vite plugin + `?raw` import), so re-include package changelogs.
+!packages/*/CHANGELOG.md
+
+# Test artifacts
+**/coverage
+**/playwright-report
+**/test-results
+**/bundle-stats.html
+
+# CI
+.github
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker files (no need to ship them into the build context)
+**/Dockerfile
+**/.dockerignore

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -19,7 +19,7 @@ import { rehypeMdxToc } from "./vite-plugins/rehype-mdx-toc";
 
 const codeBlockPlugins = mantleCodeBlockPlugins();
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
 	optimizeDeps: {
 		exclude: ["@ngrok/mantle"],
 	},
@@ -84,11 +84,28 @@ export default defineConfig({
 			ignored: ["!**/node_modules/@ngrok/mantle/src/**"],
 		},
 	},
+	preview: {
+		// React Router prerenders by booting a Vite *preview* server and issuing
+		// HTTP requests to `resolvedUrls.local[0]` (always IPv4 `127.0.0.1`).
+		// Without pinning the host, Vite binds loopback as `localhost`, which
+		// inside Linux build containers (e.g. the Docker image) resolves to IPv6
+		// `::1` only — so the prerender request to 127.0.0.1 is refused and the
+		// build dies with `ECONNREFUSED` on the first route. macOS aligns both
+		// stacks, which is why it only fails in containers. Pinning IPv4 makes
+		// the bind interface match the request target.
+		host: "127.0.0.1",
+	},
 	ssr: {
-		noExternal: [
-			// https://github.com/phosphor-icons/react/issues/45#issuecomment-2721119452
-			"@phosphor-icons/react",
-		],
+		noExternal:
+			command === "build"
+				? // Bundle every dependency into the server build so the production
+					// image can run without an app `node_modules` (the Docker runner
+					// stage ships only `@react-router/serve` and its runtime deps).
+					true
+				: [
+						// https://github.com/phosphor-icons/react/issues/45#issuecomment-2721119452
+						"@phosphor-icons/react",
+					],
 		resolve: {
 			// Same as above, but for the SSR renderer.
 			// Without this, the server falls back to dist and causes hydration mismatches
@@ -96,4 +113,4 @@ export default defineConfig({
 			conditions: ["@ngrok/src-live-types"],
 		},
 	},
-});
+}));


### PR DESCRIPTION
## What

Adds a production container build for the `@app/www` docs site, replicating the multi-stage Dockerfile we use for `apps/www` in the `ngrok-private/frontend` repo.

- **`apps/www/Dockerfile`** — multi-stage build:
  - `base` (`node:24-slim`) with corepack/pnpm
  - `pruner` runs `turbo prune @app/www --docker` to a minimal workspace
  - `builder` installs deps + `turbo run build --filter=@app/www...`, then carves out just `@react-router/serve` + its runtime deps
  - `runner` (`gcr.io/distroless/nodejs24-debian12`) serves the build via `react-router-serve` on port 3000 as a non-root user
- **`apps/www/Dockerfile.dockerignore`** — ignore file scoped to the `apps/www/Dockerfile` build context. Adapted to mantle's layout, with re-includes for `apps/www/vite-plugins` and `packages/*/CHANGELOG.md` since both are build inputs (the vite config imports the plugins, and the changelog is bundled via `?raw` / the `mantleChangelogMdx` plugin).

## Why the `vite.config.ts` changes

Two config changes are required for the container to build and run, matching what the frontend repo does:

1. **`preview.host: "127.0.0.1"`** — React Router 8 prerenders by booting an in-process Vite *preview* server and fetching `resolvedUrls.local[0]` (IPv4 `127.0.0.1`). In Linux build containers, an unpinned host binds loopback as IPv6 `::1` only, so the prerender fetch is refused with `ECONNREFUSED` on the first route. macOS aligns both stacks, which is why local builds passed but the container build didn't. Pinning IPv4 makes the bind interface match the request target.
2. **`ssr.noExternal: command === "build" ? true : [...]`** — bundles all server deps into the build so the distroless runner needs no app `node_modules`.

## Heads-up for review

The `ssr.noExternal: true` branch applies to **any** production build, including the **Vercel** build (not just Docker). This is the same pattern the frontend repo uses and is generally safe, but it does change how the Vercel server bundle is produced — **please watch this PR's Vercel preview deploy.** If it regresses, we'll gate the bundling behind a Docker-only env flag (e.g. `process.env.DOCKER_BUILD === "1"`) so Vercel keeps its current behavior.

## Verification

- `pnpm -w run lint`, `fmt:check`, `typecheck` — all pass.
- `docker build -f apps/www/Dockerfile .` succeeds (prerender included).
- Ran the image locally: `/` → 200 with the real docs, doc routes → 200 (after trailing-slash canonicalization), and `Accept: text/markdown` content negotiation works. Distroless image ≈ 289 MB.

Build/run from the repo root:
```
docker build -f apps/www/Dockerfile -t mantle-www .
docker run --rm -p 3000:3000 mantle-www
```