### PR TITLE
fix(mantle): scroll CodeBlock.TabList on overflow instead of wrapping

### DIFF
--- a/.changeset/code-block-tab-list-scroll-fade.md
+++ b/.changeset/code-block-tab-list-scroll-fade.md
@@ -1,0 +1,14 @@
+---
+"@ngrok/mantle": patch
+---
+
+fix(mantle): scroll `CodeBlock.TabList` on overflow instead of wrapping
+
+`CodeBlock.TabList` now scrolls horizontally with an edge fade
+([`scroll-fade-x`](https://mantle.ngrok.com/base/scroll-fade#horizontal--scroll-fade-x)
+plus `overflow-x-auto`) when its tabs exceed the header width, rather than
+wrapping the tab strip onto a second row. `CodeBlock.TabTrigger` gains
+`shrink-0 whitespace-nowrap` so each label keeps its intrinsic width under width
+pressure. The list reserves room (`-m-1 p-1`) for each trigger's focus ring so
+the scroll container never clips it. No API changes — consumers who hand-wired
+this on `className` can drop the workaround.

--- a/apps/www/app/docs/components/code-block.mdx
+++ b/apps/www/app/docs/components/code-block.mdx
@@ -13,6 +13,7 @@ import {
 	MantleCodeOptionsDemo,
 	OverridingIndentationDemo,
 	TabbedCodeBlockDemo,
+	ScrollingTabListDemo,
 	FoldableJsonDemo,
 	JsonCodeBlockValueDemo,
 	NestedFragmentInterpolationDemo,
@@ -346,6 +347,10 @@ const policyJson = mantleCode("json")`…`;
 	</CodeBlock.Body>
 </CodeBlock.Root>;
 ```
+
+When the tabs are too wide for the header, `CodeBlock.TabList` scrolls horizontally with a [`scroll-fade-x`](/base/scroll-fade#horizontal--scroll-fade-x) edge fade instead of wrapping onto a second row — no extra wiring required.
+
+<ScrollingTabListDemo />
 
 ### Reusing Fragments with Nested Interpolation
 

--- a/apps/www/app/features/code-block-demos.tsx
+++ b/apps/www/app/features/code-block-demos.tsx
@@ -482,6 +482,58 @@ export function TabbedCodeBlockDemo() {
 	);
 }
 
+const helloTs = mantleCode("typescript")`console.log("Hello, ngrok!");`;
+const helloPy = mantleCode("python")`print("Hello, ngrok!")`;
+const helloGo = mantleCode("go")`fmt.Println("Hello, ngrok!")`;
+const helloRs = mantleCode("rust")`println!("Hello, ngrok!");`;
+const helloJava = mantleCode("java")`System.out.println("Hello, ngrok!");`;
+const helloRb = mantleCode("ruby")`puts "Hello, ngrok!"`;
+
+/**
+ * Tabbed code block whose tab strip overflows its (deliberately narrow) container:
+ * the tabs scroll horizontally with an edge fade (`scroll-fade-x`) instead of
+ * wrapping onto a second row.
+ */
+export function ScrollingTabListDemo() {
+	return (
+		<Example>
+			<CodeBlock.Root defaultTab="ts" className="max-w-xs">
+				<CodeBlock.Header>
+					<CodeBlock.TabList>
+						<CodeBlock.TabTrigger value="ts">index.ts</CodeBlock.TabTrigger>
+						<CodeBlock.TabTrigger value="py">server.py</CodeBlock.TabTrigger>
+						<CodeBlock.TabTrigger value="go">main.go</CodeBlock.TabTrigger>
+						<CodeBlock.TabTrigger value="rs">lib.rs</CodeBlock.TabTrigger>
+						<CodeBlock.TabTrigger value="java">App.java</CodeBlock.TabTrigger>
+						<CodeBlock.TabTrigger value="rb">app.rb</CodeBlock.TabTrigger>
+					</CodeBlock.TabList>
+				</CodeBlock.Header>
+				<CodeBlock.Body>
+					<CodeBlock.CopyButton />
+					<CodeBlock.TabContent value="ts">
+						<CodeBlock.Code value={helloTs} />
+					</CodeBlock.TabContent>
+					<CodeBlock.TabContent value="py">
+						<CodeBlock.Code value={helloPy} />
+					</CodeBlock.TabContent>
+					<CodeBlock.TabContent value="go">
+						<CodeBlock.Code value={helloGo} />
+					</CodeBlock.TabContent>
+					<CodeBlock.TabContent value="rs">
+						<CodeBlock.Code value={helloRs} />
+					</CodeBlock.TabContent>
+					<CodeBlock.TabContent value="java">
+						<CodeBlock.Code value={helloJava} />
+					</CodeBlock.TabContent>
+					<CodeBlock.TabContent value="rb">
+						<CodeBlock.Code value={helloRb} />
+					</CodeBlock.TabContent>
+				</CodeBlock.Body>
+			</CodeBlock.Root>
+		</Example>
+	);
+}
+
 /**
  * Code block demonstrating all `mantleCode()` options: `showLineNumbers`, `highlightLines`,
  * `lineNumberStart`, and `indentation`.

--- a/packages/mantle/src/components/code-block/code-block.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.test.tsx
@@ -232,4 +232,31 @@ describe("CodeBlock", () => {
 			expect(onCopy).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("TabList", () => {
+		test("scrolls horizontally on overflow instead of wrapping", () => {
+			render(
+				<CodeBlock.Root defaultTab="a">
+					<CodeBlock.Header>
+						<CodeBlock.TabList>
+							<CodeBlock.TabTrigger value="a">example.ts</CodeBlock.TabTrigger>
+							<CodeBlock.TabTrigger value="b">example.json</CodeBlock.TabTrigger>
+						</CodeBlock.TabList>
+					</CodeBlock.Header>
+				</CodeBlock.Root>,
+			);
+
+			// The list is a scroll container with an edge fade rather than a wrapping row.
+			expect(screen.getByRole("tablist")).toHaveClass(
+				"scroll-fade-x",
+				"overflow-x-auto",
+				"min-w-0",
+			);
+
+			// Triggers keep their intrinsic width so labels never wrap under width pressure.
+			for (const tab of screen.getAllByRole("tab")) {
+				expect(tab).toHaveClass("shrink-0", "whitespace-nowrap");
+			}
+		});
+	});
 });

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -753,6 +753,9 @@ type CodeBlockTabListProps = Omit<ComponentProps<typeof RadixTabsList>, "asChild
  * in `CodeBlock.Body` to conditionally render code based on the active tab.
  * Tab state is managed by `CodeBlock.Root` via `defaultTab` / `activeTab` / `onActiveTabChange`.
  *
+ * When the tabs exceed the available width they scroll horizontally with an edge
+ * fade (`scroll-fade-x`) instead of wrapping to a second row.
+ *
  * @example
  * ```tsx
  * <CodeBlock.Root defaultTab="yml">
@@ -778,7 +781,15 @@ const TabList = forwardRef<ComponentRef<typeof RadixTabsList>, CodeBlockTabListP
 	({ className, ...props }, ref) => (
 		<RadixTabsList
 			data-slot="code-block-tab-list"
-			className={cx("flex items-center gap-1", className)}
+			className={cx(
+				"scroll-fade-x flex min-w-0 items-center gap-1 overflow-x-auto overscroll-x-none",
+				// Reserve room inside the scroll box for each trigger's focus ring: `overflow-x-auto`
+				// promotes `overflow-y` to `auto`, which would otherwise clip the `ring-4` box-shadow.
+				// The negative margin cancels the padding so the header layout is unchanged. `min-w-0`
+				// lets the list shrink (and thus scroll) inside the flex `CodeBlock.Header`.
+				"-m-1 p-1",
+				className,
+			)}
 			ref={ref}
 			{...props}
 		/>
@@ -805,7 +816,7 @@ const TabTrigger = forwardRef<ComponentRef<typeof RadixTabsTrigger>, CodeBlockTa
 		<RadixTabsTrigger
 			data-slot="code-block-tab-trigger"
 			className={cx(
-				"cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium",
+				"shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium whitespace-nowrap",
 				"text-gray-600 outline-hidden",
 				"hover:text-gray-900",
 				"data-[state=active]:bg-neutral-500/15 data-[state=active]:text-strong",

--- a/packages/mantle/src/components/tabs/tabs.test.tsx
+++ b/packages/mantle/src/components/tabs/tabs.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Tabs } from "./tabs.js";
+
+describe("Tabs", () => {
+	describe("List", () => {
+		// scroll-fade-x lives on the shared horizontal-orientation variant, so both
+		// appearances inherit it. This guards against a regression that would scope
+		// the overflow handling to only the classic appearance.
+		test.each(["classic", "pill"] as const)(
+			"horizontal %s appearance scrolls on overflow with scroll-fade-x",
+			(appearance) => {
+				render(
+					<Tabs.Root appearance={appearance} orientation="horizontal" defaultValue="a">
+						<Tabs.List>
+							<Tabs.Trigger value="a">Tab A</Tabs.Trigger>
+							<Tabs.Trigger value="b">Tab B</Tabs.Trigger>
+						</Tabs.List>
+					</Tabs.Root>,
+				);
+
+				expect(screen.getByRole("tablist")).toHaveClass(
+					"scroll-fade-x",
+					"overflow-x-auto",
+					"min-w-0",
+				);
+			},
+		);
+	});
+});


### PR DESCRIPTION
CodeBlock.TabList now scrolls horizontally with a scroll-fade-x edge fade (plus overflow-x-auto) when its tabs exceed the header width, rather than wrapping the tab strip onto a second row. CodeBlock.TabTrigger gains shrink-0 whitespace-nowrap so labels keep their intrinsic width, and the list reserves room (-m-1 p-1) so the scroll container never clips a trigger's focus ring. No API changes.

Also adds a regression test confirming both the classic and pill Tabs.List appearances carry scroll-fade-x (already shared via the horizontal variant).

Closes #1302