### PR TITLE
docs: rewrite philosophy page around shipped evidence, wire it into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This file and [CONVENTIONS.md](./CONVENTIONS.md) are active instructions, not ba
 Before editing:
 
 - Read the relevant [CONVENTIONS.md](./CONVENTIONS.md) sections for the files being changed.
+- When designing new components, hooks, or public API, also read the [Philosophy page](./apps/www/app/docs/philosophy.mdx) (published at [mantle.ngrok.com/philosophy](https://mantle.ngrok.com/philosophy)) — it explains the design rationale the conventions distill. It is context, not a rulebook: where the two differ, CONVENTIONS.md governs.
 - Search before creating helpers, hooks, components, parsers, formatters, utilities, or dependencies — prefer existing tested code and package subpath exports over reimplementation. Inspect the smallest relevant scope first (`packages/mantle/src`, then the owning app).
 - For dependency changes, check `pnpm-workspace.yaml` and follow the catalog / exact-version rules.
 

--- a/apps/www/app/docs/philosophy.mdx
+++ b/apps/www/app/docs/philosophy.mdx
@@ -1,81 +1,262 @@
 ---
 title: Philosophy
-description: The design principles and architectural philosophy behind mantle, ngrok's UI library and design system
+description: The design principles behind mantle, ngrok's UI library and design system—and the shipped code that proves them
 ---
 
 # Philosophy
 
 Every architectural decision in Mantle traces back to a simple premise: start with the
 web platform, then layer on just enough abstraction to make it great. These principles
-guide what we build, how we build it, and—just as importantly—what we choose not to build.
-
-## Composition Over Configuration
-
-Mantle composes around established, unstyled primitive libraries—[Radix UI](https://www.radix-ui.com),
-[Ariakit](https://ariakit.org), and [Headless UI](https://headlessui.com)—rather than
-reinventing interaction patterns from scratch. This gives us battle-tested accessibility
-and behavior paired with ngrok's visual design language.
-
-Components compose naturally with each other and with your own code. The `asChild`
-pattern lets you swap the rendered element entirely, so Mantle never forces you into a
-particular DOM structure. Configuration props handle the common case; composition
-handles everything else.
+guide what we build, how we build it, and—just as importantly—what we choose not to
+build. They apply to the whole library: components, hooks, utilities, theming, and the
+docs themselves.
 
 ## Semantic HTML, Then Everything Else
 
-The right HTML element is always the starting point. A [Button](/components/button) renders
-a `<button>`, not a styled `<div>` with click handlers. Form controls use `<input>`. Headings
-follow a proper hierarchy. This isn't pedantic—it's practical.
+The right HTML element is always the starting point. A [Button](/components/button)
+renders a `<button>`, not a styled `<div>` with click handlers.
+[Checkbox](/components/checkbox) is a real `<input type="checkbox">` styled entirely with
+CSS, so it participates in native forms without wrapper elements or a scripted check icon.
+[DescriptionList](/components/description-list) is real `<dl>`/`<dt>`/`<dd>`, and
+[Kbd](/components/kbd) is a real `<kbd>`. From that foundation, Mantle progressively
+enhances. A button is still a button—but with loading states, icon slots, and variant
+styling layered on top. The underlying element always does the heavy lifting.
 
-Semantic markup gives you keyboard navigation, focus management, and screen reader
-support for free. It works when CSS fails to load and when JavaScript is disabled. It
-means every Mantle component is inherently accessible, compliant with WAI-ARIA patterns,
-and meaningful to assistive technologies, search engines, and any tool that parses HTML.
+Enhancement is deliberate, and so is degradation. [Accordion](/components/accordion)
+keeps collapsed content in the DOM with `hidden="until-found"`, so find-in-page can
+reveal matches inside closed sections; its height animation rides CSS `interpolate-size`
+and simply snaps in engines without it. [SkipToMainLink](/components/skip-to-main-link)
+is a plain `href="#main"` anchor that works with JavaScript disabled, then enhances with
+`history.replaceState` and scroll-free focus. The [scroll fade](/base/scroll-fade)
+utilities are pure CSS scroll-driven animations: where a browser lacks support, the fade
+is absent and content is never clipped. Every enhancement names its fallback.
 
-From that foundation, Mantle progressively enhances. A button is still a button—but with
-loading states, icon slots, and variant styling layered on top. The underlying element
-always does the heavy lifting.
+This extends to how components are _named_. Parts take the web platform's vocabulary for
+what they actually render: a [List](/components/list) contains `Item`s because `<li>` is
+literally a list item, a [Table](/components/table) contains `Row`s because that's what
+`<tr>` is, and every compound's outermost part is `Root`. Props read as the semantics
+they emit—`List.Item`'s `current` prop sets `aria-current`—so the API tells the truth
+about the markup. And where WAI-ARIA offers competing patterns, the component makes the
+choice for you: List is a semantic `role="list"` so every item keeps its natural tab
+stop, while [SelectableList](/components/selectable-list) is an APG grid because
+selectable rows carrying real controls require it. You never pick a role; you pick an
+intent.
 
-## Tailwind as Design Language
+## The Right Foundation, Per Problem
 
-Mantle uses [Tailwind CSS](https://tailwindcss.com) as both its styling engine and its
-design language. A custom theme defines ngrok's design tokens—colors, spacing,
-typography—as semantic values that adapt automatically across themes and contexts.
+Mantle is not "built on Radix." Where the platform is enough, components are native:
+Accordion is hand-rolled precisely because a headless collapsible would lose the
+find-in-page behavior above, and [Field](/components/field) is real
+`<fieldset>`/`<legend>`/`<label>` elements with mantle-owned wiring. Where the behavior
+is genuinely hard, Mantle wraps the best engine for that specific problem:
+[Radix](https://www.radix-ui.com) for [Dialog](/components/dialog),
+[Ariakit](https://ariakit.org) for [Combobox](/components/combobox),
+[Headless UI](https://headlessui.com) for [RadioGroup](/components/radio-group), cmdk for
+[Command](/components/command), TanStack Table for [DataTable](/components/data-table),
+sonner (mounted unstyled) for [Toast](/components/toast).
 
-Because the tokens are expressed as Tailwind utilities, developers extend components
-with the same vocabulary they already know. Custom styling stays on-system by default.
-There's no separate theming API to learn and no abstraction boundary between Mantle's
-styles and yours.
+You cannot tell which is which from the outside, and that is the point. Every foundation
+is normalized behind one house API: flat compound namespaces, `asChild` polymorphism, a
+`data-slot` attribute on every rendered part, and consumer `className` merged last with
+[cx](/utils/cx). A vendor is a starting point, not a ceiling:
+[Switch](/components/switch) adds the read-only state Radix lacks, the dialog primitive
+strips Radix's dangling `aria-describedby` when no description is mounted, and
+[Slot](/components/slot) re-implements Radix's className merge so your classes beat the
+component's. If you understand how one Mantle component works, you can predict how the
+rest behave. Learn the system once; apply it everywhere.
 
-## Developer Ergonomics
+## One Component Per Intent
 
-Every component is built with TypeScript, but Mantle avoids exposing complex generics or
-internal type machinery. Type inference does the work: variant props autocomplete
-through `class-variance-authority`, contracts are enforced at compile time, and the
-API surface stays small enough to hold in your head.
+Every public component answers a distinct question. "Click an item to go somewhere or do
+something" is [List](/components/list); "check items to select them" is
+[SelectableList](/components/selectable-list). "Pick one of a few known options" is
+[Select](/components/select); "type to filter many" is [Combobox](/components/combobox);
+"pick several" is [MultiSelect](/components/multi-select)—and the JSDoc on each names
+its siblings, so the boundary ships with the component. When two designs answer the same
+question, they become one component: a variant is a prop or a sibling part
+([RadioGroup](/components/radio-group)'s card and segmented arrangements are parts, not
+new components), never a second thing to choose between.
 
-Consistency reinforces this. Prop names, variant patterns, event handling, and
-composition patterns are uniform across the library. If you understand how one Mantle
-component works, you can predict how the rest behave. Learn the system once; apply it
-everywhere.
+The same discipline keeps shared machinery private. One unexported dialog primitive backs
+[Dialog](/components/dialog), [Sheet](/components/sheet), and
+[AlertDialog](/components/alert-dialog); one unexported list primitive backs both list
+components. Publishing a primitive later is an additive, non-breaking change; un-shipping
+one is a breaking change forever. Refusing surface applies to props, too: when DataTable
+needed empty states and pagination, the answer was documented recipes built from existing
+parts ([Empty](/components/empty) drops straight into a table's empty row), not a new
+built-in API—the gap was documentation, not primitives. Mantle ships the smallest
+surface that solves the problem and grows it only when real usage demands: the API you
+learn is the API that stays.
 
-## Ship Less, Ship Better
+## Composition Over Configuration
 
-Mantle is tree-shakable and modularly exported—you pay for only what you import. Teams
-can adopt the design system incrementally, one component at a time, without pulling in
-the entire library.
+Components compose with each other and with your code. The `asChild` pattern, powered by
+[Slot](/components/slot), swaps the rendered element entirely—internal navigation is
+`<Anchor asChild><Link to="…" /></Anchor>`, not an `href` prop with router flags—so
+Mantle never forces a DOM structure on you. Configuration props handle the common case;
+composition handles everything else. Composition is also how new components get built:
+[SplitButton](/components/split-button) is nothing but Button, IconButton, and
+DropdownMenu with the seams styled.
 
-Runtime performance is a design constraint, not an afterthought. Components minimize
-re-renders, avoid unnecessary DOM nodes, and lean on the browser's native capabilities
-wherever possible. The fastest code is the code that never runs, and the most
-reliable code is the code that doesn't exist.
+Multi-part components ship as flat, single-level namespaces (`Dialog.Root`,
+`Dialog.Content`, never `Command.Dialog.Root`) so the whole API surfaces in one
+autocomplete. That was a recorded trade: we gave up per-file tree-shaking of compound
+internals for discoverability, and kept leaf components like
+[Button](/components/button) and [Icon](/components/icon) as standalone exports so they
+still shake cleanly.
 
-## Evolution, Not Revolution
+The exception is deliberate: a component takes a **data** prop instead of children only
+when its behavior must reach items that aren't rendered yet.
+[DataTable](/components/data-table) takes `data` and
+[SelectableList](/components/selectable-list) takes `options` because filtering, "select
+all", and virtualization operate over the whole collection—including rows that are
+windowed out of the DOM—which no children-based API can see. Even then, _rendering_
+stays composable: a render-prop draws each row, and the data stays a thin description (a
+value, its text, a disabled flag). Membership is data when behavior outlives mounting;
+presentation is always composition.
 
-Mantle evolves with ngrok's needs and the broader web platform. We favor incremental
-improvements over sweeping rewrites, so existing code continues to work as the system
-grows.
+## Make Invalid States Unrepresentable
 
-This applies equally to API design, framework compatibility, and adoption of new web
-standards. Stable foundations and thoughtful migration paths beat short-term convenience
-every time.
+Where a contract can live in the type system, it does.
+[Accordion](/components/accordion)'s `type` prop is a discriminated union that retypes
+`value` and `onValueChange` as `string` or `string[]` per mode.
+[SelectableList](/components/selectable-list) requires `labelText` the moment `label`
+becomes a rich ReactNode, so a filter that would silently stop matching becomes a compile
+error instead. And [Badge](/components/badge)'s palette tables are exhaustiveness-checked
+with `satisfies Record<Color, string>` against the [color](/utils/color) vocabulary, so a
+new color cannot ship half-styled.
+
+What the compiler cannot catch fails loudly at runtime. Compound parts rendered outside
+their `Root`—[Choice](/components/choice)'s, [QrCode](/components/qr-code)'s,
+SelectableList's—throw a descriptive invariant instead of rendering an inert shell.
+Utilities treat errors as control flow: `copyToClipboard` throws when both clipboard
+strategies fail rather than no-oping. A silent fallback is a bug you find in production;
+a loud failure is one you fix in development.
+
+## Pure Cores, Thin Bindings
+
+Logic you can test without a framework is logic you can trust. Mantle's utilities are
+framework-free cores with React bound on at the edge: [in-view](/utils/in-view) wraps a
+raw IntersectionObserver and [`useInView`](/hooks) is its hook,
+[compose-refs](/utils/compose-refs) ships `composeRefs` beside `useComposedRefs`, and
+[`useCopyToClipboard`](/hooks) returns the same plain async function everything else
+uses. The vocabulary utilities, [color](/utils/color) and [sorting](/utils/sorting),
+derive their union types, type guards, and helpers from single const arrays, so runtime
+values and TypeScript types cannot drift apart. Components obey the same layering:
+[SelectableList](/components/selectable-list)'s filtering and selection math are exported
+pure functions, tested apart from rendering.
+
+## Accessibility Is Engineered, Then Given Away
+
+The promise is not that semantic markup makes accessibility free. The promise is that
+Mantle does the engineering so you get it free. [Field](/components/field) generates
+control, description, and error ids and flows them through context, so `htmlFor`,
+`aria-describedby`, and `aria-errormessage` always resolve without hand-threading—and
+its help affordance is a [Popover](/components/popover) rather than a tooltip, so touch
+users can reach it. [List](/components/list)'s disabled `asChild` items swallow clicks
+because assistive technology dispatches clicks without hit testing. Virtualized rows
+announce `aria-posinset` and `aria-setsize`, so a windowed list still reads as the whole
+collection. [IconButton](/components/icon-button) makes its screen-reader label a
+required prop. And motion defaults are conservative:
+[`usePrefersReducedMotion`](/hooks) returns `true` on the server and first paint, so
+nothing animates until the user's real preference is known.
+
+The per-component keyboard and ARIA contracts, required app setup, and testing checklists
+live on the [Accessibility](/accessibility) page. This page owns only the stance:
+accessibility here is designed and reviewed like any other behavior, never inherited on
+faith from a vendor.
+
+## The First Paint Is Part of the API
+
+Mantle assumes a server, and if it renders wrong for one frame, that's a bug. The
+[theme](/components/theme) preference persists in a cookie, not just localStorage, so SSR
+renders the correct `<html>` class; a blocking inline script—written as a plain
+TypeScript function and stringified into the `<head>`—resolves the cookie and OS
+preferences before first paint, and theme changes sync across open tabs. The three
+non-light theme stylesheets load as media-gated `<link>`s so they never block rendering,
+and font preloads can ship as HTTP `Link` headers so fetches start before the HTML
+parses.
+
+Hydration safety is a shipped primitive, not an app-side hack.
+[BrowserOnly](/components/browser-only) takes children as a render function so
+client-only code cannot even evaluate during SSR. Every browser-API hook declares its
+server answer: [`useBreakpoint`](/hooks) returns `"default"`,
+[`useMatchesMediaQuery`](/hooks) returns `false`, and [`useIsHydrated`](/hooks)—built on
+`useSyncExternalStore` precisely for consistent server and client snapshots—is the
+sanctioned escape hatch.
+
+## Tailwind Is the Design Language
+
+There is no theme object and no CSS-in-JS: the design system is a Tailwind CSS 4
+CSS-first configuration. Tokens layer from raw oklch palettes through semantic aliases to
+surface and intent tokens, so one authored class (`bg-card`, `text-muted`) is correct in
+all four resolved themes—light, dark, and two first-class high-contrast variants.
+`dark:` is an override, not a requirement, and even `white` and `black` are semantic,
+theme-swapped tokens. Because the tokens are expressed as Tailwind utilities, you extend
+components with the same vocabulary you already know—custom styling stays on-system by
+default. [Colors](/base/colors) and [Typography](/base/typography) document the
+vocabulary.
+
+Your overrides are guaranteed to win. Every component composes consumer `className` last
+through [cx](/utils/cx), whose merge engine Mantle vendors with the house spacing scale
+baked in rather than taking clsx and tailwind-merge as dependencies—className merging is
+core infrastructure, so Mantle owns it. Interactive state is styled through custom
+[Tailwind variants](/base/tailwind-variants) that match the DOM the headless layers
+actually emit (`data-state-*`, `aria-*`), and key internal defaults are wrapped in
+`:where()` so a single utility class from you outranks them.
+
+## Performance Happens Before the Browser
+
+The fastest code is the code that never runs, and the most reliable code is the code
+that doesn't exist. [CodeBlock](/components/code-block) highlights with Shiki at build
+time, so no highlighter JavaScript ships to the browser—and its React-free core is
+published as [highlight-utils](/utils/highlight-utils) so servers, workers, and build
+tools can produce the same HTML. The Tailwind source plugin scopes the utility scan to
+the mantle components an app actually imports, so unused components cost no CSS, and
+non-active theme stylesheets never block rendering.
+
+The runtime work that remains gets moved to the platform or measured down.
+[Tabs](/components/tabs)' edge fade and the [scroll fade](/base/scroll-fade) utilities
+are CSS scroll-driven animations with zero scroll listeners.
+[Table](/components/table) coalesces resize, mutation, and scroll into one
+`requestAnimationFrame` layout read to drive its overflow affordance. And
+[`useBreakpoint`](/hooks) shares a single app-wide set of `matchMedia` subscriptions
+across every caller—its subscribe functions are cached because unstable references
+measurably made window resizing sluggish.
+
+## Safe, Ecosystem-Normal Defaults
+
+A default is the library exercising judgment on your behalf, so Mantle's are safe and
+unsurprising. [Button](/components/button) defaults `type="button"`, matching the
+ecosystem and ending accidental form submits. [AlertDialog](/components/alert-dialog)'s
+`Action` deliberately does not close the dialog, so destructive handlers must opt in to
+dismissal. [Anchor](/components/anchor)'s `rel` accepts an array it merges and de-dupes,
+so `noopener` and `noreferrer` compose safely. [QrCode](/components/qr-code) renders
+static black-on-white in every theme because inverted codes fail real scanners. And
+wrapped event handlers run your callback first and bail if you called
+`event.preventDefault()`.
+
+## Docs Are Executable Contracts
+
+Every export carries JSDoc with `@example` blocks and when-to-use guidance, and those
+examples feed the published types, `llms.txt`, and the component manifest. That makes
+them normative: humans and AI agents reproduce them verbatim—one recorded migration
+copied the patterns the docs showed into ~57 call sites before the docs were fixed—so
+examples are maintained with the same care as API. Every docs page ships a
+plain-markdown twin, and agents get a canonical entry point at
+[For AI Agents](/for-ai-agents), because this library now has two audiences that write
+code with it.
+
+## Decisions, Recorded
+
+These principles are conclusions, not aspirations. Significant trade-offs land as
+decision records in the repository's
+[`decisions/`](https://github.com/ngrok/mantle/tree/main/decisions) directory, each with
+alternatives considered and honest negative consequences: the compound-namespace record
+admits the tree-shaking cost, and the button-type record names the silent non-submit
+footgun it accepts. Their conclusions are distilled into
+[conventions](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md) that gate new
+work, so the next component starts where the last argument ended. Unstable surface says
+so out loud—[Calendar](/components/preview/calendar) ships flagged `@preview` with an
+open invitation to file issues—and breaking cleanups wait for majors. A principle you
+can't cite is a slogan; every principle on this page has a paper trail.


### PR DESCRIPTION
## Summary

- Rewrite `apps/www/app/docs/philosophy.mdx` from short aspirational sections into evidence-backed principles — each claim now cites the shipped component, hook, utility, or decision record that proves it.
- New/reworked sections: semantic HTML & progressive enhancement, per-problem foundations (not "built on Radix"), one component per intent, invalid states made unrepresentable, pure cores with thin React bindings, engineered accessibility, SSR/first-paint guarantees, Tailwind as the design language, build-time performance, safe ecosystem-normal defaults, docs as executable contracts, and recorded decisions.
- Wire the page into the AGENTS.md agent contract: when designing new components, hooks, or public API, agents also read the Philosophy page for the rationale the conventions distill. It is context, not a rulebook — CONVENTIONS.md governs where they differ.

## Notes

Docs + agent-instructions only; no runtime or package source changes.