### PR TITLE
docs: TanStack Form + Field examples for AlertDialog, Dialog, and Sheet

### DIFF
--- a/apps/www/app/docs/components/overlays/alert-dialog.mdx
+++ b/apps/www/app/docs/components/overlays/alert-dialog.mdx
@@ -6,6 +6,7 @@ description: A modal dialog that interrupts the user with important content and 
 import { AlertDialog } from "@ngrok/mantle/alert-dialog";
 import { Button } from "@ngrok/mantle/button";
 import { Example } from "~/components/example";
+import { TanStackFormDemo } from "~/examples/alert-dialog/alert-dialog-tanstack-form-demo";
 
 # Alert Dialog
 
@@ -112,6 +113,112 @@ AlertDialog.Root
         └── AlertDialog.Footer
             ├── AlertDialog.Cancel
             └── AlertDialog.Action
+```
+
+## With TanStack Form
+
+Compose an `AlertDialog` with [TanStack Form](https://tanstack.com/form) and [`Field`](/components/forms/field) when the destructive action requires explicit acknowledgment. Render `AlertDialog.Body` as the `<form>` element with `asChild` so the header, field, and footer keep the alert dialog layout. `AlertDialog.Action` does not close the dialog by default — make it the submit button (`type="submit"`) and close the dialog from the form's `onSubmit`, which only runs once validation passes. Control `AlertDialog.Root` with `open` / `onOpenChange` and reset the form on close so the acknowledgment is required every time the dialog opens.
+
+The acknowledgment row composes [`Choice`](/components/forms/choice) inside `Field.Control`, so the checkbox aligns to the first line of its label and the field's `name` and ARIA wiring flow onto the checkbox automatically.
+
+<Example className="w-full">
+	<TanStackFormDemo />
+</Example>
+
+```tsx
+import { AlertDialog } from "@ngrok/mantle/alert-dialog";
+import { Button } from "@ngrok/mantle/button";
+import { Checkbox } from "@ngrok/mantle/checkbox";
+import { Choice } from "@ngrok/mantle/choice";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { z } from "zod";
+
+const formSchema = z.object({
+	acknowledged: z.boolean().refine((value) => value, "Acknowledge the consequences to continue."),
+});
+
+function Example() {
+	const [open, setOpen] = useState(false);
+	const form = useForm({
+		defaultValues: {
+			acknowledged: false,
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			// Handle the destructive action with `value`, then close the dialog
+			handleOpenChange(false);
+		},
+	});
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			form.reset();
+		}
+	};
+
+	return (
+		<AlertDialog.Root priority="danger" open={open} onOpenChange={handleOpenChange}>
+			<AlertDialog.Trigger asChild>
+				<Button type="button" appearance="outlined" priority="danger">
+					Release domain
+				</Button>
+			</AlertDialog.Trigger>
+			<AlertDialog.Content>
+				<AlertDialog.Icon />
+				<AlertDialog.Body asChild>
+					<form
+						onSubmit={(event) => {
+							event.preventDefault();
+							event.stopPropagation();
+							void form.handleSubmit();
+						}}
+					>
+						<AlertDialog.Header>
+							<AlertDialog.Title>Release this domain?</AlertDialog.Title>
+							<AlertDialog.Description>
+								Releasing example.ngrok.app immediately removes it from your account.
+							</AlertDialog.Description>
+						</AlertDialog.Header>
+						<form.Field name="acknowledged">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Control>
+										<Choice.Root>
+											<Choice.Indicator>
+												<Checkbox
+													checked={field.state.value}
+													onBlur={field.handleBlur}
+													onChange={(event) => field.handleChange(event.target.checked)}
+												/>
+											</Choice.Indicator>
+											<Choice.Content>
+												<Choice.Label>I understand the consequences</Choice.Label>
+												<Choice.Description>
+													Endpoints still using this domain will go offline, and the domain may be
+													claimed by another account.
+												</Choice.Description>
+											</Choice.Content>
+										</Choice.Root>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+						<AlertDialog.Footer>
+							<AlertDialog.Cancel type="button">Cancel</AlertDialog.Cancel>
+							<AlertDialog.Action type="submit">Release domain</AlertDialog.Action>
+						</AlertDialog.Footer>
+					</form>
+				</AlertDialog.Body>
+			</AlertDialog.Content>
+		</AlertDialog.Root>
+	);
+}
 ```
 
 ## API Reference

--- a/apps/www/app/docs/components/overlays/dialog.mdx
+++ b/apps/www/app/docs/components/overlays/dialog.mdx
@@ -335,7 +335,7 @@ import { Button } from "@ngrok/mantle/button";
 
 ## With TanStack Form
 
-Use [TanStack Form](https://tanstack.com/form) with [`Field`](/components/forms/field) to gather validated input in a dialog. `Dialog.Content` is a flex column, so wrap `Dialog.Body` and `Dialog.Footer` in a `display: contents` form — the footer's submit button participates in the form while the body keeps its scrollable layout. Close the dialog from the form's `onSubmit` (it only runs once validation passes) and reset the form when the dialog closes so a cancelled draft doesn't leak into the next open.
+Use [TanStack Form](https://tanstack.com/form) with [`Field`](/components/forms/field) to gather validated input in a dialog. `Dialog.Content` is a flex column, so wrap `Dialog.Body` and `Dialog.Footer` in a `display: contents` form — the footer's submit button participates in the form while the body keeps its scrollable layout. Close the dialog from the form's `onSubmit` (it only runs once validation passes) and reset the form when the dialog closes so a cancelled draft doesn't leak into the next open. The form sets `noValidate` so the browser's native `type="email"` validation doesn't block the submit event — the schema owns validation and errors render consistently through `Field.Errors`.
 
 If password managers or browser autofill overlays interfere with outside-click dismissal, see [Handling Autofill Overlays](#handling-autofill-overlays).
 
@@ -395,6 +395,7 @@ function Example() {
 				</Dialog.Header>
 				<form
 					className="contents"
+					noValidate
 					onSubmit={(event) => {
 						event.preventDefault();
 						event.stopPropagation();

--- a/apps/www/app/docs/components/overlays/dialog.mdx
+++ b/apps/www/app/docs/components/overlays/dialog.mdx
@@ -9,6 +9,7 @@ import { Sheet } from "@ngrok/mantle/sheet";
 import { Tooltip } from "@ngrok/mantle/tooltip";
 import { TrashSimpleIcon } from "@phosphor-icons/react/TrashSimple";
 import { Example } from "~/components/example";
+import { TanStackFormDemo } from "~/examples/dialog/dialog-tanstack-form-demo";
 
 # Dialog
 
@@ -330,6 +331,134 @@ import { Button } from "@ngrok/mantle/button";
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>;
+```
+
+## With TanStack Form
+
+Use [TanStack Form](https://tanstack.com/form) with [`Field`](/components/forms/field) to gather validated input in a dialog. `Dialog.Content` is a flex column, so wrap `Dialog.Body` and `Dialog.Footer` in a `display: contents` form — the footer's submit button participates in the form while the body keeps its scrollable layout. Close the dialog from the form's `onSubmit` (it only runs once validation passes) and reset the form when the dialog closes so a cancelled draft doesn't leak into the next open.
+
+If password managers or browser autofill overlays interfere with outside-click dismissal, see [Handling Autofill Overlays](#handling-autofill-overlays).
+
+<Example className="w-full">
+	<TanStackFormDemo />
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { Input } from "@ngrok/mantle/input";
+import { Select } from "@ngrok/mantle/select";
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { z } from "zod";
+
+const formSchema = z.object({
+	email: z.email("Enter a valid email address."),
+	role: z.string().min(1, "Choose a role."),
+});
+
+function Example() {
+	const [open, setOpen] = useState(false);
+	const form = useForm({
+		defaultValues: {
+			email: "",
+			role: "",
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			// Handle the invite with `value`, then close the dialog
+			handleOpenChange(false);
+		},
+	});
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			form.reset();
+		}
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<Dialog.Trigger asChild>
+				<Button type="button" appearance="filled" priority="neutral">
+					Invite a teammate
+				</Button>
+			</Dialog.Trigger>
+			<Dialog.Content>
+				<Dialog.Header>
+					<Dialog.Title>Invite a teammate</Dialog.Title>
+					<Dialog.CloseIconButton />
+				</Dialog.Header>
+				<form
+					className="contents"
+					onSubmit={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						void form.handleSubmit();
+					}}
+				>
+					<Dialog.Body className="space-y-4">
+						<form.Field name="email">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Email</Field.Label>
+									<Field.Control>
+										<Input
+											type="email"
+											placeholder="teammate@example.com"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(event) => field.handleChange(event.target.value)}
+										/>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+						<form.Field name="role">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Role</Field.Label>
+									<Field.Control>
+										<Select.Root
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onValueChange={field.handleChange}
+										>
+											<Select.Trigger>
+												<Select.Value placeholder="Select a role" />
+											</Select.Trigger>
+											<Select.Content width="trigger">
+												<Select.Item value="admin">Admin</Select.Item>
+												<Select.Item value="developer">Developer</Select.Item>
+												<Select.Item value="read-only">Read-only</Select.Item>
+											</Select.Content>
+										</Select.Root>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+					</Dialog.Body>
+					<Dialog.Footer>
+						<Dialog.Close asChild>
+							<Button type="button" appearance="outlined" priority="neutral">
+								Cancel
+							</Button>
+						</Dialog.Close>
+						<Button type="submit" appearance="filled" priority="neutral">
+							Send invite
+						</Button>
+					</Dialog.Footer>
+				</form>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+}
 ```
 
 ## API Reference

--- a/apps/www/app/docs/components/overlays/sheet.mdx
+++ b/apps/www/app/docs/components/overlays/sheet.mdx
@@ -11,6 +11,7 @@ import { TerminalWindowIcon } from "@phosphor-icons/react/TerminalWindow";
 import { TrashSimpleIcon } from "@phosphor-icons/react/TrashSimple";
 import { useState } from "react";
 import { Example } from "~/components/example";
+import { TanStackFormDemo } from "~/examples/sheet/sheet-tanstack-form-demo";
 
 export function WithoutTriggerExample() {
 	const [isOpen, setIsOpen] = useState(false);
@@ -349,6 +350,133 @@ import { Sheet } from "@ngrok/mantle/sheet";
 		</Sheet.Footer>
 	</Sheet.Content>
 </Sheet.Root>;
+```
+
+### With TanStack Form
+
+Sheets often host small create/edit forms. Use [TanStack Form](https://tanstack.com/form) with [`Field`](/components/forms/field) for label, description, and error wiring. `Sheet.Content` is a flex column, so wrap `Sheet.Body` and `Sheet.Footer` in a `display: contents` form — the footer's submit button participates in the form while the body keeps its scrollable layout. Close the sheet from the form's `onSubmit` (it only runs once validation passes) and reset the form when the sheet closes so a cancelled draft doesn't leak into the next open.
+
+<Example className="w-full">
+	<TanStackFormDemo />
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { Input } from "@ngrok/mantle/input";
+import { Sheet } from "@ngrok/mantle/sheet";
+import { TextArea } from "@ngrok/mantle/text-area";
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { z } from "zod";
+
+const formSchema = z.object({
+	name: z.string().min(1, "Name your API key."),
+	note: z.string().max(280, "Keep the note under 280 characters."),
+});
+
+function Example() {
+	const [open, setOpen] = useState(false);
+	const form = useForm({
+		defaultValues: {
+			name: "",
+			note: "",
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			// Handle the create with `value`, then close the sheet
+			handleOpenChange(false);
+		},
+	});
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			form.reset();
+		}
+	};
+
+	return (
+		<Sheet.Root open={open} onOpenChange={handleOpenChange}>
+			<Sheet.Trigger asChild>
+				<Button type="button" appearance="filled" priority="neutral">
+					New API key
+				</Button>
+			</Sheet.Trigger>
+			<Sheet.Content>
+				<Sheet.Header>
+					<Sheet.TitleGroup>
+						<Sheet.Title>New API key</Sheet.Title>
+						<Sheet.Actions>
+							<Sheet.CloseIconButton />
+						</Sheet.Actions>
+					</Sheet.TitleGroup>
+					<Sheet.Description>
+						Create a key for programmatic access to the ngrok API.
+					</Sheet.Description>
+				</Sheet.Header>
+				<form
+					className="contents"
+					onSubmit={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						void form.handleSubmit();
+					}}
+				>
+					<Sheet.Body className="space-y-4">
+						<form.Field name="name">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Name</Field.Label>
+									<Field.Control>
+										<Input
+											placeholder="production-deploys"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(event) => field.handleChange(event.target.value)}
+										/>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+						<form.Field name="note">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Note</Field.Label>
+									<Field.Control>
+										<TextArea
+											placeholder="What is this key used for?"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(event) => field.handleChange(event.target.value)}
+										/>
+									</Field.Control>
+									<Field.Description>
+										Optional. Help your team know where this key is used.
+									</Field.Description>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+					</Sheet.Body>
+					<Sheet.Footer>
+						<Sheet.Close asChild>
+							<Button type="button" appearance="outlined" priority="neutral">
+								Cancel
+							</Button>
+						</Sheet.Close>
+						<Button type="submit" appearance="filled" priority="neutral">
+							Create key
+						</Button>
+					</Sheet.Footer>
+				</form>
+			</Sheet.Content>
+		</Sheet.Root>
+	);
+}
 ```
 
 ## Composition

--- a/apps/www/app/examples/alert-dialog/alert-dialog-tanstack-form-demo.tsx
+++ b/apps/www/app/examples/alert-dialog/alert-dialog-tanstack-form-demo.tsx
@@ -1,0 +1,102 @@
+import { AlertDialog } from "@ngrok/mantle/alert-dialog";
+import { Button } from "@ngrok/mantle/button";
+import { Checkbox } from "@ngrok/mantle/checkbox";
+import { Choice } from "@ngrok/mantle/choice";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { z } from "zod";
+
+const formSchema = z.object({
+	acknowledged: z.boolean().refine((value) => value, "Acknowledge the consequences to continue."),
+});
+
+/**
+ * Demonstrates an `AlertDialog` composed with TanStack Form: a single
+ * acknowledgment checkbox gates the destructive action, `AlertDialog.Action`
+ * is the form's submit button, and the dialog closes (and the form resets)
+ * when the form submits successfully.
+ *
+ * @example
+ * <TanStackFormDemo />
+ */
+export function TanStackFormDemo() {
+	const [open, setOpen] = useState(false);
+	const form = useForm({
+		defaultValues: {
+			acknowledged: false,
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
+			handleOpenChange(false);
+		},
+	});
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			form.reset();
+		}
+	};
+
+	return (
+		<AlertDialog.Root priority="danger" open={open} onOpenChange={handleOpenChange}>
+			<AlertDialog.Trigger asChild>
+				<Button type="button" appearance="outlined" priority="danger">
+					Release domain
+				</Button>
+			</AlertDialog.Trigger>
+			<AlertDialog.Content>
+				<AlertDialog.Icon />
+				<AlertDialog.Body asChild>
+					<form
+						onSubmit={(event) => {
+							event.preventDefault();
+							event.stopPropagation();
+							void form.handleSubmit();
+						}}
+					>
+						<AlertDialog.Header>
+							<AlertDialog.Title>Release this domain?</AlertDialog.Title>
+							<AlertDialog.Description>
+								Releasing example.ngrok.app immediately removes it from your account.
+							</AlertDialog.Description>
+						</AlertDialog.Header>
+						<form.Field name="acknowledged">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Control>
+										<Choice.Root>
+											<Choice.Indicator>
+												<Checkbox
+													checked={field.state.value}
+													onBlur={field.handleBlur}
+													onChange={(event) => field.handleChange(event.target.checked)}
+												/>
+											</Choice.Indicator>
+											<Choice.Content>
+												<Choice.Label>I understand the consequences</Choice.Label>
+												<Choice.Description>
+													Endpoints still using this domain will go offline, and the domain may be
+													claimed by another account.
+												</Choice.Description>
+											</Choice.Content>
+										</Choice.Root>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+						<AlertDialog.Footer>
+							<AlertDialog.Cancel type="button">Cancel</AlertDialog.Cancel>
+							<AlertDialog.Action type="submit">Release domain</AlertDialog.Action>
+						</AlertDialog.Footer>
+					</form>
+				</AlertDialog.Body>
+			</AlertDialog.Content>
+		</AlertDialog.Root>
+	);
+}

--- a/apps/www/app/examples/dialog/dialog-tanstack-form-demo.tsx
+++ b/apps/www/app/examples/dialog/dialog-tanstack-form-demo.tsx
@@ -58,6 +58,7 @@ export function TanStackFormDemo() {
 				</Dialog.Header>
 				<form
 					className="contents"
+					noValidate
 					onSubmit={(event) => {
 						event.preventDefault();
 						event.stopPropagation();

--- a/apps/www/app/examples/dialog/dialog-tanstack-form-demo.tsx
+++ b/apps/www/app/examples/dialog/dialog-tanstack-form-demo.tsx
@@ -1,0 +1,124 @@
+import { Button } from "@ngrok/mantle/button";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { Input } from "@ngrok/mantle/input";
+import { Select } from "@ngrok/mantle/select";
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { z } from "zod";
+
+const formSchema = z.object({
+	email: z.email("Enter a valid email address."),
+	role: z.string().min(1, "Choose a role."),
+});
+
+/**
+ * Demonstrates a `Dialog` composed with TanStack Form: a `display: contents`
+ * form wraps `Dialog.Body` and `Dialog.Footer` so the submit button lives in
+ * the footer, fields validate on submit, and the dialog closes (and the form
+ * resets) when the form submits successfully.
+ *
+ * @example
+ * <TanStackFormDemo />
+ */
+export function TanStackFormDemo() {
+	const [open, setOpen] = useState(false);
+	const form = useForm({
+		defaultValues: {
+			email: "",
+			role: "",
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
+			handleOpenChange(false);
+		},
+	});
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			form.reset();
+		}
+	};
+
+	return (
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<Dialog.Trigger asChild>
+				<Button type="button" appearance="filled" priority="neutral">
+					Invite a teammate
+				</Button>
+			</Dialog.Trigger>
+			<Dialog.Content>
+				<Dialog.Header>
+					<Dialog.Title>Invite a teammate</Dialog.Title>
+					<Dialog.CloseIconButton />
+				</Dialog.Header>
+				<form
+					className="contents"
+					onSubmit={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						void form.handleSubmit();
+					}}
+				>
+					<Dialog.Body className="space-y-4">
+						<form.Field name="email">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Email</Field.Label>
+									<Field.Control>
+										<Input
+											type="email"
+											placeholder="teammate@example.com"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(event) => field.handleChange(event.target.value)}
+										/>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+						<form.Field name="role">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Role</Field.Label>
+									<Field.Control>
+										<Select.Root
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onValueChange={field.handleChange}
+										>
+											<Select.Trigger>
+												<Select.Value placeholder="Select a role" />
+											</Select.Trigger>
+											<Select.Content width="trigger">
+												<Select.Item value="admin">Admin</Select.Item>
+												<Select.Item value="developer">Developer</Select.Item>
+												<Select.Item value="read-only">Read-only</Select.Item>
+											</Select.Content>
+										</Select.Root>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+					</Dialog.Body>
+					<Dialog.Footer>
+						<Dialog.Close asChild>
+							<Button type="button" appearance="outlined" priority="neutral">
+								Cancel
+							</Button>
+						</Dialog.Close>
+						<Button type="submit" appearance="filled" priority="neutral">
+							Send invite
+						</Button>
+					</Dialog.Footer>
+				</form>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+}

--- a/apps/www/app/examples/sheet/sheet-tanstack-form-demo.tsx
+++ b/apps/www/app/examples/sheet/sheet-tanstack-form-demo.tsx
@@ -1,0 +1,125 @@
+import { Button } from "@ngrok/mantle/button";
+import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { Input } from "@ngrok/mantle/input";
+import { Sheet } from "@ngrok/mantle/sheet";
+import { TextArea } from "@ngrok/mantle/text-area";
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import { z } from "zod";
+
+const formSchema = z.object({
+	name: z.string().min(1, "Name your API key."),
+	note: z.string().max(280, "Keep the note under 280 characters."),
+});
+
+/**
+ * Demonstrates a `Sheet` composed with TanStack Form: a `display: contents`
+ * form wraps `Sheet.Body` and `Sheet.Footer` so the submit button lives in
+ * the footer, fields validate on submit, and the sheet closes (and the form
+ * resets) when the form submits successfully.
+ *
+ * @example
+ * <TanStackFormDemo />
+ */
+export function TanStackFormDemo() {
+	const [open, setOpen] = useState(false);
+	const form = useForm({
+		defaultValues: {
+			name: "",
+			note: "",
+		},
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
+			handleOpenChange(false);
+		},
+	});
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			form.reset();
+		}
+	};
+
+	return (
+		<Sheet.Root open={open} onOpenChange={handleOpenChange}>
+			<Sheet.Trigger asChild>
+				<Button type="button" appearance="filled" priority="neutral">
+					New API key
+				</Button>
+			</Sheet.Trigger>
+			<Sheet.Content>
+				<Sheet.Header>
+					<Sheet.TitleGroup>
+						<Sheet.Title>New API key</Sheet.Title>
+						<Sheet.Actions>
+							<Sheet.CloseIconButton />
+						</Sheet.Actions>
+					</Sheet.TitleGroup>
+					<Sheet.Description>
+						Create a key for programmatic access to the ngrok API.
+					</Sheet.Description>
+				</Sheet.Header>
+				<form
+					className="contents"
+					onSubmit={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						void form.handleSubmit();
+					}}
+				>
+					<Sheet.Body className="space-y-4">
+						<form.Field name="name">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Name</Field.Label>
+									<Field.Control>
+										<Input
+											placeholder="production-deploys"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(event) => field.handleChange(event.target.value)}
+										/>
+									</Field.Control>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+						<form.Field name="note">
+							{(field) => (
+								<Field.Item name={field.name}>
+									<Field.Label>Note</Field.Label>
+									<Field.Control>
+										<TextArea
+											placeholder="What is this key used for?"
+											value={field.state.value}
+											onBlur={field.handleBlur}
+											onChange={(event) => field.handleChange(event.target.value)}
+										/>
+									</Field.Control>
+									<Field.Description>
+										Optional. Help your team know where this key is used.
+									</Field.Description>
+									<Field.Errors messages={toErrorMessages(field.state.meta.errors)} />
+								</Field.Item>
+							)}
+						</form.Field>
+					</Sheet.Body>
+					<Sheet.Footer>
+						<Sheet.Close asChild>
+							<Button type="button" appearance="outlined" priority="neutral">
+								Cancel
+							</Button>
+						</Sheet.Close>
+						<Button type="submit" appearance="filled" priority="neutral">
+							Create key
+						</Button>
+					</Sheet.Footer>
+				</form>
+			</Sheet.Content>
+		</Sheet.Root>
+	);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "cache": true,
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!**/*.test.*"],
       "dependsOn": ["^build"],
-      "outputs": ["**/build/**", "**/.vercel/**", "**/dist/**"]
+      "outputs": ["**/build/**", "**/.vercel/**", "**/dist/**", "!**/node_modules/**"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## What

Adds a first-class **With TanStack Form** section to the AlertDialog, Dialog, and Sheet docs pages, each backed by a typechecked demo component under `apps/www/app/examples/`. These are intended as the canonical reference for composing `@tanstack/react-form` + `Field` inside mantle overlays.

- **AlertDialog** — destructive "Release this domain?" confirmation where a single acknowledgment checkbox (`Choice` inside `Field.Control`) gates the action. `AlertDialog.Body asChild` renders as the `<form>`, `AlertDialog.Action` is the `type="submit"` button, and the dialog closes + resets from the form's `onSubmit` (which only runs once validation passes).
- **Dialog** — invite-a-teammate form (`Input` + `Select`) with a `display: contents` form wrapping `Dialog.Body` and `Dialog.Footer`, so the footer submit button participates in the form while the body keeps its scrollable layout. Prose links to the existing autofill-overlay guidance.
- **Sheet** — new-API-key form (`Input` + `TextArea` with `Field.Description`) using the same contents-form pattern.

All three use controlled `open` state so cancel/Escape/backdrop close resets the form (no stale drafts on reopen), and render validator errors via `toErrorMessages` → `Field.Errors`. MDX code fences mirror the demo sources.

## Also: turbo cache poisoning fix

`turbo.json` build outputs now append `"!**/node_modules/**"`. The `**/dist/**` glob was capturing node_modules through the pnpm `@cfg/tsconfig` symlink, so cached `@ngrok/mantle#build` artifacts included node_modules paths; on cache restore turbo rewrote them as real directories, clobbering the symlink (TS2688/TS6053 on typecheck, then ~300 stray `.js` files emitted into `packages/mantle/src`, breaking lint and build). Verified: fresh cache manifests contain zero node_modules paths after the fix. Local poisoned cache entries should be purged once (`grep -l 'node_modules/' .turbo/cache/*-manifest.json` → delete the manifest/meta/tar triplet); the hash change from editing turbo.json also prevents old artifacts from restoring.

## Verification

- `pnpm -w run lint` — 0 errors
- `pnpm -w run fmt:check` — clean
- `pnpm -w run typecheck` — 7/7 tasks pass
- Tests/changeset: not applicable — `packages/mantle` source untouched
- Reviewed via a 16-agent adversarial pass (API correctness, conventions, docs drift, runtime behavior); the single candidate finding (`Select.Root onBlur` is a documented no-op) was kept for consistency with the canonical `select.mdx` TanStack example