### PR TITLE
fix(mantle): refine CodeBlock styling

### DIFF
--- a/.changeset/calm-blocks-rest.md
+++ b/.changeset/calm-blocks-rest.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Refine CodeBlock backgrounds, hover states, and header typography.

--- a/packages/mantle/src/components/code-block/code-block.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.test.tsx
@@ -15,44 +15,6 @@ function makeValue(code: string, preHtml?: string) {
 }
 
 describe("CodeBlock", () => {
-	describe("surfaces", () => {
-		test("uses the base background for the root and interactive controls", () => {
-			const { container } = render(
-				<CodeBlock.Root>
-					<CodeBlock.Header>
-						<CodeBlock.Icon preset="file" />
-						<CodeBlock.Title>example.ts</CodeBlock.Title>
-					</CodeBlock.Header>
-					<CodeBlock.Body>
-						<CodeBlock.CopyButton />
-						<CodeBlock.Code value={makeValue("code")} />
-					</CodeBlock.Body>
-					<CodeBlock.ExpanderButton />
-				</CodeBlock.Root>,
-			);
-
-			expect(container.querySelector("[data-slot='code-block']")).toHaveClass("bg-base");
-			expect(container.querySelector("[data-slot='code-block-header']")).toHaveClass("bg-base");
-			expect(container.querySelector("[data-slot='code-block-icon']")).toHaveClass("size-5");
-			expect(container.querySelector("[data-slot='code-block-title']")).toHaveClass(
-				"font-sans",
-				"text-xs",
-				"font-medium",
-			);
-			expect(container.querySelector("[data-slot='code-block-copy-button']")).toHaveClass(
-				"bg-base",
-			);
-			expect(screen.getByRole("button", { name: /copy code/i })).toHaveClass(
-				"bg-base",
-				"not-disabled:hover:bg-neutral-500/15",
-			);
-			expect(screen.getByRole("button", { name: /show more/i })).toHaveClass(
-				"bg-base",
-				"hover:bg-base-hover",
-			);
-		});
-	});
-
 	describe("Code", () => {
 		test("renders plain text fallback when preHtml is missing", () => {
 			const value = createMantleCodeBlockValue({
@@ -293,13 +255,7 @@ describe("CodeBlock", () => {
 
 			// Triggers keep their intrinsic width so labels never wrap under width pressure.
 			for (const tab of screen.getAllByRole("tab")) {
-				expect(tab).toHaveClass(
-					"shrink-0",
-					"whitespace-nowrap",
-					"font-sans",
-					"text-xs",
-					"font-medium",
-				);
+				expect(tab).toHaveClass("shrink-0", "whitespace-nowrap");
 			}
 		});
 	});

--- a/packages/mantle/src/components/code-block/code-block.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.test.tsx
@@ -15,6 +15,44 @@ function makeValue(code: string, preHtml?: string) {
 }
 
 describe("CodeBlock", () => {
+	describe("surfaces", () => {
+		test("uses the base background for the root and interactive controls", () => {
+			const { container } = render(
+				<CodeBlock.Root>
+					<CodeBlock.Header>
+						<CodeBlock.Icon preset="file" />
+						<CodeBlock.Title>example.ts</CodeBlock.Title>
+					</CodeBlock.Header>
+					<CodeBlock.Body>
+						<CodeBlock.CopyButton />
+						<CodeBlock.Code value={makeValue("code")} />
+					</CodeBlock.Body>
+					<CodeBlock.ExpanderButton />
+				</CodeBlock.Root>,
+			);
+
+			expect(container.querySelector("[data-slot='code-block']")).toHaveClass("bg-base");
+			expect(container.querySelector("[data-slot='code-block-header']")).toHaveClass("bg-base");
+			expect(container.querySelector("[data-slot='code-block-icon']")).toHaveClass("size-5");
+			expect(container.querySelector("[data-slot='code-block-title']")).toHaveClass(
+				"font-sans",
+				"text-xs",
+				"font-medium",
+			);
+			expect(container.querySelector("[data-slot='code-block-copy-button']")).toHaveClass(
+				"bg-base",
+			);
+			expect(screen.getByRole("button", { name: /copy code/i })).toHaveClass(
+				"bg-base",
+				"not-disabled:hover:bg-neutral-500/15",
+			);
+			expect(screen.getByRole("button", { name: /show more/i })).toHaveClass(
+				"bg-base",
+				"hover:bg-base-hover",
+			);
+		});
+	});
+
 	describe("Code", () => {
 		test("renders plain text fallback when preHtml is missing", () => {
 			const value = createMantleCodeBlockValue({
@@ -255,7 +293,13 @@ describe("CodeBlock", () => {
 
 			// Triggers keep their intrinsic width so labels never wrap under width pressure.
 			for (const tab of screen.getAllByRole("tab")) {
-				expect(tab).toHaveClass("shrink-0", "whitespace-nowrap");
+				expect(tab).toHaveClass(
+					"shrink-0",
+					"whitespace-nowrap",
+					"font-sans",
+					"text-xs",
+					"font-medium",
+				);
 			}
 		});
 	});

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -151,7 +151,7 @@ const Root = forwardRef<ComponentRef<"div">, CodeBlockRootProps>(
 			<Component
 				data-slot="code-block"
 				className={cx(
-					"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-card font-mono",
+					"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-base font-mono",
 					"[&_svg]:shrink-0",
 					className,
 				)}
@@ -504,7 +504,7 @@ const Title = forwardRef<
 		<Component
 			data-slot="code-block-title"
 			ref={ref}
-			className={cx("text-mono m-0 font-mono font-normal", className)}
+			className={cx("m-0 font-sans text-xs font-medium", className)}
 			{...props}
 		/>
 	);
@@ -566,7 +566,7 @@ const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
 		return (
 			<span
 				data-slot="code-block-copy-button"
-				className="absolute right-3 top-3 z-10 inline-flex size-7 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] bg-card"
+				className="absolute right-3 top-3 z-10 inline-flex size-7 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] bg-base"
 			>
 				<IconButton
 					type="button"
@@ -575,7 +575,7 @@ const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
 					size="sm"
 					label={label}
 					icon={wasCopied ? <CheckIcon /> : <CopyIcon />}
-					className={className}
+					className={cx("bg-base not-disabled:hover:bg-neutral-500/15", className)}
 					ref={ref}
 					onClick={async (event) => {
 						try {
@@ -653,7 +653,7 @@ const ExpanderButton = forwardRef<ComponentRef<"button">, CodeBlockExpanderButto
 				aria-controls={codeId}
 				aria-expanded={isCodeExpanded}
 				className={cx(
-					"flex w-full items-center justify-center gap-0.5 border-t border-gray-300 bg-card px-4 py-2 font-sans text-gray-700 hover:bg-gray-100",
+					"flex w-full items-center justify-center gap-0.5 border-t border-gray-300 bg-base px-4 py-2 font-sans text-gray-700 hover:bg-base-hover",
 					className,
 				)}
 				ref={ref}
@@ -743,7 +743,14 @@ function CodeBlockIconComponent({
 				break;
 		}
 	}
-	return <MantleIcon data-slot="code-block-icon" className={className} svg={svg} {...props} />;
+	return (
+		<MantleIcon
+			data-slot="code-block-icon"
+			className={cx("size-5", className)}
+			svg={svg}
+			{...props}
+		/>
+	);
 }
 CodeBlockIconComponent.displayName = "CodeBlockIcon";
 
@@ -820,7 +827,7 @@ const TabTrigger = forwardRef<ComponentRef<typeof RadixTabsTrigger>, CodeBlockTa
 		<RadixTabsTrigger
 			data-slot="code-block-tab-trigger"
 			className={cx(
-				"shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium whitespace-nowrap",
+				"shrink-0 cursor-pointer rounded px-1.5 py-0.5 font-sans text-xs font-medium whitespace-nowrap",
 				"text-gray-600 outline-hidden",
 				"hover:text-gray-900",
 				"data-[state=active]:bg-neutral-500/15 data-[state=active]:text-strong",


### PR DESCRIPTION
## Summary
- align CodeBlock body, copy control, and expander surfaces with the header background
- use compact sans-serif typography for titles and tabs, with consistent icon sizing
- match the copy-button hover treatment to selected tabs and add regression coverage

## Test plan
- [x] `pnpm -w run lint`
- [x] `pnpm -w run fmt:check`
- [x] `pnpm -w run typecheck`
- [x] `pnpm -w run test -F @ngrok/mantle`


Made with [Cursor](https://cursor.com)