### PR TITLE
docs: keep the card border out of the scroll-fade mask in Scroll Fade examples

### DIFF
--- a/apps/www/app/docs/base/scroll-fade.mdx
+++ b/apps/www/app/docs/base/scroll-fade.mdx
@@ -29,29 +29,31 @@ Fades the top and bottom edges of a vertically scrolling container. Scroll the
 list to see each edge fade in and out.
 
 <Example>
-	<div className="scroll-fade-y scrollbar h-56 w-64 overflow-y-auto rounded-lg border border-card bg-card px-4 py-3">
-		<ul className="flex flex-col gap-2 text-sm">
-			{[
-				"Getting Started",
-				"Universal Gateway",
-				"Endpoints",
-				"Domains",
-				"TCP Addresses",
-				"TLS Certificates",
-				"Kubernetes Operators",
-				"Vaults & Secrets",
-				"IP Policies",
-				"Traffic Inspector",
-				"Agents",
-				"Team Members",
-				"Service Users",
-				"Authtokens",
-			].map((label) => (
-				<li key={label} className="text-muted-foreground">
-					{label}
-				</li>
-			))}
-		</ul>
+	<div className="w-64 overflow-hidden rounded-lg border border-card bg-card">
+		<div className="scroll-fade-y scrollbar h-56 overflow-y-auto px-4 py-3">
+			<ul className="flex flex-col gap-2 text-sm">
+				{[
+					"Getting Started",
+					"Universal Gateway",
+					"Endpoints",
+					"Domains",
+					"TCP Addresses",
+					"TLS Certificates",
+					"Kubernetes Operators",
+					"Vaults & Secrets",
+					"IP Policies",
+					"Traffic Inspector",
+					"Agents",
+					"Team Members",
+					"Service Users",
+					"Authtokens",
+				].map((label) => (
+					<li key={label} className="text-muted-foreground">
+						{label}
+					</li>
+				))}
+			</ul>
+		</div>
 	</div>
 </Example>
 
@@ -64,25 +66,27 @@ list to see each edge fade in and out.
 Fades the left and right edges of a horizontally scrolling container.
 
 <Example>
-	<div className="scroll-fade-x scrollbar w-72 overflow-x-auto rounded-lg border border-card bg-card p-3">
-		<div className="flex w-max gap-2 text-sm">
-			{[
-				"Overview",
-				"Endpoints",
-				"Traffic Policy",
-				"Domains",
-				"TCP Addresses",
-				"TLS Certificates",
-				"Event Subscriptions",
-				"API Keys",
-			].map((label) => (
-				<span
-					key={label}
-					className="bg-accent text-muted-foreground whitespace-nowrap rounded-md px-3 py-1.5"
-				>
-					{label}
-				</span>
-			))}
+	<div className="w-72 overflow-hidden rounded-lg border border-card bg-card">
+		<div className="scroll-fade-x scrollbar overflow-x-auto p-3">
+			<div className="flex w-max gap-2 text-sm">
+				{[
+					"Overview",
+					"Endpoints",
+					"Traffic Policy",
+					"Domains",
+					"TCP Addresses",
+					"TLS Certificates",
+					"Event Subscriptions",
+					"API Keys",
+				].map((label) => (
+					<span
+						key={label}
+						className="bg-accent text-muted-foreground whitespace-nowrap rounded-md px-3 py-1.5"
+					>
+						{label}
+					</span>
+				))}
+			</div>
 		</div>
 	</div>
 </Example>
@@ -126,3 +130,14 @@ out against the flush opposite edge.
 - The utility uses `mask-image`, so it composes with the element's background and
   content but cannot be combined with a different `mask-image` on the same
   element.
+- The mask fades _everything_ the element paints — border and background
+  included. If the scroll container sits inside a visible card, keep the
+  `border`, `background`, and `rounded-*` on a wrapper element (plus
+  `overflow-hidden` to clip the corners) and apply the fade utility to an inner
+  scroll container, as the examples on this page do:
+
+```tsx
+<div className="overflow-hidden rounded-lg border border-card bg-card">
+	<div className="scroll-fade-y h-56 overflow-y-auto">{/* tall content */}</div>
+</div>
+```

--- a/apps/www/app/features/scroll-fade-edges.tsx
+++ b/apps/www/app/features/scroll-fade-edges.tsx
@@ -56,7 +56,11 @@ function HorizontalItems() {
 	);
 }
 
-const boxClassName = "scrollbar rounded-lg border border-card bg-card px-4 py-3";
+// The card chrome (border, background, rounding) lives on a wrapper so the
+// fade mask on the inner scroll container never fades the border itself.
+// `overflow-hidden` clips the inner scrollbar to the rounded corners.
+const cardClassName = "overflow-hidden rounded-lg border border-card bg-card";
+const scrollBoxClassName = "scrollbar px-4 py-3";
 
 /**
  * Live demo grid for the single-edge `scroll-fade-{t,b,l,r}` utilities. Each box
@@ -71,35 +75,49 @@ export function ScrollFadeEdges() {
 		<div className="grid w-full grid-cols-1 gap-6 sm:grid-cols-2">
 			<figure className="flex flex-col gap-2">
 				<figcaption className="text-muted-foreground font-mono text-xs">scroll-fade-t</figcaption>
-				<div
-					ref={scrollToMiddleY}
-					className={cx("scroll-fade-t h-44 overflow-y-auto", boxClassName)}
-				>
-					<VerticalItems />
+				<div className={cardClassName}>
+					<div
+						ref={scrollToMiddleY}
+						className={cx("scroll-fade-t h-44 overflow-y-auto", scrollBoxClassName)}
+					>
+						<VerticalItems />
+					</div>
 				</div>
 			</figure>
 
 			<figure className="flex flex-col gap-2">
 				<figcaption className="text-muted-foreground font-mono text-xs">scroll-fade-b</figcaption>
-				<div
-					ref={scrollToMiddleY}
-					className={cx("scroll-fade-b h-44 overflow-y-auto", boxClassName)}
-				>
-					<VerticalItems />
+				<div className={cardClassName}>
+					<div
+						ref={scrollToMiddleY}
+						className={cx("scroll-fade-b h-44 overflow-y-auto", scrollBoxClassName)}
+					>
+						<VerticalItems />
+					</div>
 				</div>
 			</figure>
 
 			<figure className="flex flex-col gap-2">
 				<figcaption className="text-muted-foreground font-mono text-xs">scroll-fade-l</figcaption>
-				<div ref={scrollToMiddleX} className={cx("scroll-fade-l overflow-x-auto", boxClassName)}>
-					<HorizontalItems />
+				<div className={cardClassName}>
+					<div
+						ref={scrollToMiddleX}
+						className={cx("scroll-fade-l overflow-x-auto", scrollBoxClassName)}
+					>
+						<HorizontalItems />
+					</div>
 				</div>
 			</figure>
 
 			<figure className="flex flex-col gap-2">
 				<figcaption className="text-muted-foreground font-mono text-xs">scroll-fade-r</figcaption>
-				<div ref={scrollToMiddleX} className={cx("scroll-fade-r overflow-x-auto", boxClassName)}>
-					<HorizontalItems />
+				<div className={cardClassName}>
+					<div
+						ref={scrollToMiddleX}
+						className={cx("scroll-fade-r overflow-x-auto", scrollBoxClassName)}
+					>
+						<HorizontalItems />
+					</div>
 				</div>
 			</figure>
 		</div>


### PR DESCRIPTION
## Problem

Every example on [/base/scroll-fade](https://mantle.ngrok.com/base/scroll-fade) applied the `scroll-fade-*` utility to the same element that carried the card chrome (`rounded-lg border border-card bg-card`). Since the utility is a `mask-image` and a mask fades everything the element paints, the card **border faded away** at the scrolling edge — the bottom border of the vertical example dissolved wherever the content faded.

## Fix

Use the same structure `Table.Root` already uses: card chrome on an outer wrapper (`overflow-hidden rounded-lg border border-card bg-card`), and the `scroll-fade-*` + `overflow-*-auto` on an inner scroll container. The mask now only ever fades the content, and the fade blends into the card background while the border stays crisp on all edges.

Applied to all three example blocks:
- Vertical (`scroll-fade-y`)
- Horizontal (`scroll-fade-x`)
- The four single-edge boxes in `ScrollFadeEdges` (`scroll-fade-{t,b,l,r}`)

Also added a Requirements bullet documenting the caveat (the mask fades border and background too) with the wrapper snippet, so consumers copying the minimal examples don't reintroduce the bug when they add a border.

## Verification

- Playwright screenshots of the live page at rest, mid-scroll (both axes), and the single-edge grid: borders stay crisp on all four edges while content fades inside the card in every state.
- `pnpm -w run lint`, `fmt:check`, `typecheck` — all pass. Docs-site-only change, so no changeset.