### PR TITLE
feat(centered-layout): add the CenteredLayout.Notice window banner slot

### DIFF
--- a/.changeset/add-centered-layout-notice.md
+++ b/.changeset/add-centered-layout-notice.md
@@ -5,5 +5,6 @@
 Add `CenteredLayout.Notice`: a full-window-width strip pinned above everything else in the layout —
 including `CenteredLayout.Header` — for impersonation notices, environment warnings, and similar app-wide
 messaging. It renders an unstyled `<div>` (`w-full shrink-0`) that collapses to nothing when empty, the same
-slot contract as `AppLayout.Notice`, so an app-wide banner composes identically across both layouts. On
+slot contract as the app-layout shell's notice strip, so an app-wide banner composes identically
+across mantle's layouts. On
 flows that scroll, merge `sticky top-0 z-20` via `className` to keep it pinned to the window.

--- a/.changeset/add-centered-layout-notice.md
+++ b/.changeset/add-centered-layout-notice.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add `CenteredLayout.Notice`: a full-window-width strip pinned above everything else in the layout —
+including `CenteredLayout.Header` — for impersonation notices, environment warnings, and similar app-wide
+messaging. It renders an unstyled `<div>` (`w-full shrink-0`) that collapses to nothing when empty, the same
+slot contract as `AppLayout.Notice`, so an app-wide banner composes identically across both layouts. On
+flows that scroll, merge `sticky top-0 z-20` via `className` to keep it pinned to the window.

--- a/apps/www/app/docs/layouts/centered-layout.mdx
+++ b/apps/www/app/docs/layouts/centered-layout.mdx
@@ -101,12 +101,14 @@ import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
 
 ```text showLineNumbers=false
 CenteredLayout.Root
+├── CenteredLayout.Notice
 ├── CenteredLayout.Header
 ├── CenteredLayout.Body
 └── CenteredLayout.Footer
 ```
 
-- **`Root`** is the outer frame. It fills its nearest sized ancestor (`min-h-full`) and stacks `Header` (pinned top), `Body` (which grows), and `Footer` (pinned bottom). Merge `h-full` via `className` when the host requires an exact height — `cx` is tailwind-merge-backed, so the override is deterministic.
+- **`Root`** is the outer frame. It fills its nearest sized ancestor (`min-h-full`) and stacks `Notice` and `Header` (pinned top), `Body` (which grows), and `Footer` (pinned bottom). Merge `h-full` via `className` when the host requires an exact height — `cx` is tailwind-merge-backed, so the override is deterministic.
+- **`Notice`** is a full-window-width strip pinned above everything else — including `Header` — for impersonation notices, environment warnings, and similar app-wide messaging. It is unstyled (`w-full shrink-0`): the notice content brings its own colors, and the part collapses to nothing when empty. The same slot as [`AppLayout.Notice`](/layouts/app-layout#applayoutnotice), so an app-wide banner composes identically across both layouts. Optional.
 - **`Header`** is a utility strip at the top — an account chip, a close button — rendered **outside** the centered region as a semantic `<header>`, the mirror of `Footer`. Optional; see [Header](#header) for the window-pinned variant.
 - **`Body`** is the growing, centered region (`flex-1`, centered, `gap-6`). By convention the brand mark — a fully-styled logo/wordmark anchor — is its **first child**, and the primary content follows as composed JSX (a `div`, or the [Main](/components/primitives/main) landmark when the layout owns the document — see [Landmarks](#landmarks)). There is deliberately no `Logo` or `Content` part because they would own nothing: vertical spacing comes from `Body`'s `gap-6`, and both arrive as already-styled JSX. Content taller than the viewport top-flows and the page scrolls, because `Root` grows instead of clipping.
 - **`Footer`** is a pinned utility strip (theme switcher, legal links) rendered **outside** the centered `flex-1` region — which is exactly why `Body` exists as a separate part: `Root` cannot own the centering because `Header` and `Footer` must sit outside it. `Footer` is optional; omitting it is fine.
@@ -229,6 +231,16 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 | Prop       | Type      | Default | Description                                                                                                                 |
 | ---------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `CenteredLayout` styling onto alternative element types or your own React components. |
+
+### CenteredLayout.Notice
+
+A full-window-width strip pinned above everything else in the layout — including `CenteredLayout.Header` — for impersonation notices, environment warnings, and similar app-wide messaging. Renders an unstyled `<div>` (`w-full shrink-0`): the notice content brings its own colors and layout, and the part collapses to nothing when empty, so it can stay mounted and conditionally render its contents. Deliberately not named Banner — `CenteredLayout.Header` renders the page's `<header>` (the ARIA `banner` landmark), and this part is not that. On flows that scroll, it scrolls away with the page by default; merge `sticky top-0 z-20` via `className` to pin it to the window. Optional.
+
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                                        |
+| ---------- | --------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `CenteredLayout.Notice` styling onto alternative element types or your own React components. |
 
 ### CenteredLayout.Header
 

--- a/apps/www/app/docs/layouts/centered-layout.mdx
+++ b/apps/www/app/docs/layouts/centered-layout.mdx
@@ -108,7 +108,7 @@ CenteredLayout.Root
 ```
 
 - **`Root`** is the outer frame. It fills its nearest sized ancestor (`min-h-full`) and stacks `Notice` and `Header` (pinned top), `Body` (which grows), and `Footer` (pinned bottom). Merge `h-full` via `className` when the host requires an exact height — `cx` is tailwind-merge-backed, so the override is deterministic.
-- **`Notice`** is a full-window-width strip pinned above everything else — including `Header` — for impersonation notices, environment warnings, and similar app-wide messaging. It is unstyled (`w-full shrink-0`): the notice content brings its own colors, and the part collapses to nothing when empty. The same slot as [`AppLayout.Notice`](/layouts/app-layout#applayoutnotice), so an app-wide banner composes identically across both layouts. Optional.
+- **`Notice`** is a full-window-width strip pinned above everything else — including `Header` — for impersonation notices, environment warnings, and similar app-wide messaging. It is unstyled (`w-full shrink-0`): the notice content brings its own colors, and the part collapses to nothing when empty. The same slot as [`AppLayout.Notice`](/layouts/app-layout#applayoutnotice), so an app-wide banner composes identically across both layouts — see [Notice](#notice). Optional.
 - **`Header`** is a utility strip at the top — an account chip, a close button — rendered **outside** the centered region as a semantic `<header>`, the mirror of `Footer`. Optional; see [Header](#header) for the window-pinned variant.
 - **`Body`** is the growing, centered region (`flex-1`, centered, `gap-6`). By convention the brand mark — a fully-styled logo/wordmark anchor — is its **first child**, and the primary content follows as composed JSX (a `div`, or the [Main](/components/primitives/main) landmark when the layout owns the document — see [Landmarks](#landmarks)). There is deliberately no `Logo` or `Content` part because they would own nothing: vertical spacing comes from `Body`'s `gap-6`, and both arrive as already-styled JSX. Content taller than the viewport top-flows and the page scrolls, because `Root` grows instead of clipping.
 - **`Footer`** is a pinned utility strip (theme switcher, legal links) rendered **outside** the centered `flex-1` region — which is exactly why `Body` exists as a separate part: `Root` cannot own the centering because `Header` and `Footer` must sit outside it. `Footer` is optional; omitting it is fine.
@@ -147,6 +147,67 @@ import { XIcon } from "@phosphor-icons/react/X";
 		</ThemeSwitcher.Root>
 	</CenteredLayout.Footer>
 </CenteredLayout.Root>;
+```
+
+    </CodeExample.Code>
+
+</CodeExample.Root>
+
+## Notice
+
+App-wide messaging — an impersonation notice, an environment warning — belongs in a strip pinned above
+everything else on the page, **including the header**. `Notice` is that strip: the same slot as
+[`AppLayout.Notice`](/layouts/app-layout#applayoutnotice), so a banner composes identically across both
+layouts. It is unstyled (`w-full shrink-0`) — the notice content brings its own colors — and it collapses to
+nothing when empty, so it can stay mounted and conditionally render its contents. Toggle the notice in the
+demo to see it push the whole page (header included) down. On flows that scroll, it scrolls away with the
+page by default; merge `sticky top-0 z-20` via `className` to pin it to the window.
+
+<CodeExample.Root>
+	<CodeExample.PreviewFrame example="centered-layout-notice" title="Centered layout notice demo" />
+	<CodeExample.Code>
+
+```tsx
+import { Button, IconButton } from "@ngrok/mantle/button";
+import { Card } from "@ngrok/mantle/card";
+import { CenteredLayout } from "@ngrok/mantle/centered-layout";
+import { Main } from "@ngrok/mantle/main";
+import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
+import { WarningCircleIcon } from "@phosphor-icons/react/WarningCircle";
+import { XIcon } from "@phosphor-icons/react/X";
+import { useState } from "react";
+
+export function CheckoutPage() {
+	const [isImpersonating, setIsImpersonating] = useState(true);
+
+	return (
+		<CenteredLayout.Root>
+			<SkipToMainLink />
+			<CenteredLayout.Notice>
+				{isImpersonating && (
+					<div className="text-on-filled flex items-center gap-2 bg-red-600 px-4 py-1 text-xs">
+						<WarningCircleIcon weight="fill" className="shrink-0" />
+						You are impersonating jane@example.com in read-only mode.
+					</div>
+				)}
+			</CenteredLayout.Notice>
+			<CenteredLayout.Header className="justify-between">
+				<span className="text-muted text-sm">cody@acme.com</span>
+				<IconButton
+					type="button"
+					appearance="ghost"
+					intent="neutral"
+					label="Close"
+					icon={<XIcon />}
+				/>
+			</CenteredLayout.Header>
+			<CenteredLayout.Body>
+				<span className="text-strong text-lg font-semibold">acme</span>
+				<Main className="w-full max-w-80">{/* your page content */}</Main>
+			</CenteredLayout.Body>
+		</CenteredLayout.Root>
+	);
+}
 ```
 
     </CodeExample.Code>

--- a/apps/www/app/docs/layouts/centered-layout.mdx
+++ b/apps/www/app/docs/layouts/centered-layout.mdx
@@ -160,7 +160,9 @@ everything else on the page, **including the header**. `Notice` is that strip: t
 as the app-layout shell's notice strip, so a banner composes identically across mantle's layouts. It is unstyled (`w-full shrink-0`) — the notice content brings its own colors — and it collapses to
 nothing when empty, so it can stay mounted and conditionally render its contents. Toggle the notice in the
 demo to see it push the whole page (header included) down. On flows that scroll, it scrolls away with the
-page by default; merge `sticky top-0 z-20` via `className` to pin it to the window.
+page by default; merge `sticky top-0 z-20` via `className` to pin it to the window. To keep a sticky
+[`Header`](#header) pinned as well, wrap the two strips in a single `sticky top-0` container — two
+elements pinned at `top-0` overlap each other once the page scrolls.
 
 <CodeExample.Root>
 	<CodeExample.PreviewFrame example="centered-layout-notice" title="Centered layout notice demo" />
@@ -294,7 +296,9 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 
 ### CenteredLayout.Notice
 
-A full-window-width strip pinned above everything else in the layout — including `CenteredLayout.Header` — for impersonation notices, environment warnings, and similar app-wide messaging. Renders an unstyled `<div>` (`w-full shrink-0`): the notice content brings its own colors and layout, and the part collapses to nothing when empty, so it can stay mounted and conditionally render its contents. Deliberately not named Banner — `CenteredLayout.Header` renders the page's `<header>` (the ARIA `banner` landmark), and this part is not that. On flows that scroll, it scrolls away with the page by default; merge `sticky top-0 z-20` via `className` to pin it to the window. Optional.
+A full-window-width strip pinned above everything else in the layout — including `CenteredLayout.Header` — for impersonation notices, environment warnings, and similar app-wide messaging. Renders an unstyled `<div>` (`w-full shrink-0`): the notice content brings its own colors and layout, and the part collapses to nothing when empty, so it can stay mounted and conditionally render its contents. Deliberately not named Banner — `CenteredLayout.Header` renders the page's `<header>` (the ARIA `banner` landmark), and this part is not that. On flows that scroll, it scrolls away with the page by default; merge `sticky top-0 z-20` via `className` to pin it to the window. To keep a sticky
+[`Header`](#header) pinned as well, wrap the two strips in a single `sticky top-0` container — two
+elements pinned at `top-0` overlap each other once the page scrolls. Optional.
 
 All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
 

--- a/apps/www/app/docs/layouts/centered-layout.mdx
+++ b/apps/www/app/docs/layouts/centered-layout.mdx
@@ -108,7 +108,7 @@ CenteredLayout.Root
 ```
 
 - **`Root`** is the outer frame. It fills its nearest sized ancestor (`min-h-full`) and stacks `Notice` and `Header` (pinned top), `Body` (which grows), and `Footer` (pinned bottom). Merge `h-full` via `className` when the host requires an exact height — `cx` is tailwind-merge-backed, so the override is deterministic.
-- **`Notice`** is a full-window-width strip pinned above everything else — including `Header` — for impersonation notices, environment warnings, and similar app-wide messaging. It is unstyled (`w-full shrink-0`): the notice content brings its own colors, and the part collapses to nothing when empty. The same slot as [`AppLayout.Notice`](/layouts/app-layout#applayoutnotice), so an app-wide banner composes identically across both layouts — see [Notice](#notice). Optional.
+- **`Notice`** is a full-window-width strip pinned above everything else — including `Header` — for impersonation notices, environment warnings, and similar app-wide messaging. It is unstyled (`w-full shrink-0`): the notice content brings its own colors, and the part collapses to nothing when empty. The same slot contract as the app-layout shell's notice strip, so an app-wide banner composes identically across mantle's layouts — see [Notice](#notice). Optional.
 - **`Header`** is a utility strip at the top — an account chip, a close button — rendered **outside** the centered region as a semantic `<header>`, the mirror of `Footer`. Optional; see [Header](#header) for the window-pinned variant.
 - **`Body`** is the growing, centered region (`flex-1`, centered, `gap-6`). By convention the brand mark — a fully-styled logo/wordmark anchor — is its **first child**, and the primary content follows as composed JSX (a `div`, or the [Main](/components/primitives/main) landmark when the layout owns the document — see [Landmarks](#landmarks)). There is deliberately no `Logo` or `Content` part because they would own nothing: vertical spacing comes from `Body`'s `gap-6`, and both arrive as already-styled JSX. Content taller than the viewport top-flows and the page scrolls, because `Root` grows instead of clipping.
 - **`Footer`** is a pinned utility strip (theme switcher, legal links) rendered **outside** the centered `flex-1` region — which is exactly why `Body` exists as a separate part: `Root` cannot own the centering because `Header` and `Footer` must sit outside it. `Footer` is optional; omitting it is fine.
@@ -156,9 +156,8 @@ import { XIcon } from "@phosphor-icons/react/X";
 ## Notice
 
 App-wide messaging — an impersonation notice, an environment warning — belongs in a strip pinned above
-everything else on the page, **including the header**. `Notice` is that strip: the same slot as
-[`AppLayout.Notice`](/layouts/app-layout#applayoutnotice), so a banner composes identically across both
-layouts. It is unstyled (`w-full shrink-0`) — the notice content brings its own colors — and it collapses to
+everything else on the page, **including the header**. `Notice` is that strip: the same slot contract
+as the app-layout shell's notice strip, so a banner composes identically across mantle's layouts. It is unstyled (`w-full shrink-0`) — the notice content brings its own colors — and it collapses to
 nothing when empty, so it can stay mounted and conditionally render its contents. Toggle the notice in the
 demo to see it push the whole page (header included) down. On flows that scroll, it scrolls away with the
 page by default; merge `sticky top-0 z-20` via `className` to pin it to the window.

--- a/apps/www/app/features/centered-layout-demos.tsx
+++ b/apps/www/app/features/centered-layout-demos.tsx
@@ -7,7 +7,9 @@ import { Main } from "@ngrok/mantle/main";
 import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
 import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
 import { CheckIcon } from "@phosphor-icons/react/Check";
+import { WarningCircleIcon } from "@phosphor-icons/react/WarningCircle";
 import { XIcon } from "@phosphor-icons/react/X";
+import { useState } from "react";
 
 function SignInCard() {
 	return (
@@ -210,6 +212,64 @@ export function CenteredLayoutHeaderDemo() {
 					<ThemeSwitcher.Content />
 				</ThemeSwitcher.Root>
 			</CenteredLayout.Footer>
+		</CenteredLayout.Root>
+	);
+}
+
+/**
+ * The `CenteredLayout.Notice` composition for the centered-layout docs: a
+ * toggleable impersonation strip pinned above everything — the header
+ * included. Renders as an entire framed-preview document (see
+ * preview-registry.ts), so it composes exactly like a real page: the layout
+ * owns the document, with a `SkipToMainLink` first and the `Main` landmark
+ * composed directly in `Body`.
+ */
+export function CenteredLayoutNoticeDemo() {
+	const [showNotice, setShowNotice] = useState(true);
+
+	return (
+		<CenteredLayout.Root>
+			<SkipToMainLink />
+			<CenteredLayout.Notice>
+				{showNotice && (
+					<div className="text-on-filled flex items-center gap-2 bg-red-600 px-4 py-1 text-xs">
+						<WarningCircleIcon weight="fill" className="shrink-0" />
+						You are impersonating jane@example.com in read-only mode.
+					</div>
+				)}
+			</CenteredLayout.Notice>
+			<CenteredLayout.Header className="justify-between">
+				<span className="text-muted text-sm">cody@acme.com</span>
+				<IconButton
+					type="button"
+					appearance="ghost"
+					intent="neutral"
+					label="Close"
+					icon={<XIcon />}
+				/>
+			</CenteredLayout.Header>
+			<CenteredLayout.Body>
+				<span className="text-strong text-lg font-semibold">acme</span>
+				<Main className="w-full max-w-80">
+					<Card.Root>
+						<Card.Body className="space-y-3">
+							<p className="text-body text-sm">
+								The notice strip pushes everything down — the header included — and collapses to
+								nothing when empty.
+							</p>
+							<Button
+								type="button"
+								appearance="outlined"
+								intent="neutral"
+								size="sm"
+								onClick={() => setShowNotice((current) => !current)}
+							>
+								Toggle notice
+							</Button>
+						</Card.Body>
+					</Card.Root>
+				</Main>
+			</CenteredLayout.Body>
 		</CenteredLayout.Root>
 	);
 }

--- a/apps/www/app/features/preview-registry.ts
+++ b/apps/www/app/features/preview-registry.ts
@@ -1,5 +1,9 @@
 import type { ComponentType } from "react";
-import { CenteredLayoutDemo, CenteredLayoutHeaderDemo } from "./centered-layout-demos";
+import {
+	CenteredLayoutDemo,
+	CenteredLayoutHeaderDemo,
+	CenteredLayoutNoticeDemo,
+} from "./centered-layout-demos";
 
 type PreviewExample = {
 	/**
@@ -40,6 +44,10 @@ export const previewExamples = {
 	"centered-layout-header": {
 		title: "Centered layout header demo",
 		Component: CenteredLayoutHeaderDemo,
+	},
+	"centered-layout-notice": {
+		title: "Centered layout notice demo",
+		Component: CenteredLayoutNoticeDemo,
 	},
 } as const satisfies Record<string, PreviewExample>;
 

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -145,7 +145,7 @@
     "summary": "A viewport-filling centered page flow — utility header and footer strips around a growing, centered content region.",
     "jsdoc": "A viewport-filling centered page flow for sign-in, sign-up, onboarding, 404, checkout, and other focused full-page states.",
     "examples": [
-      "Composition:\n```\nCenteredLayout.Root\n├── CenteredLayout.Header\n├── CenteredLayout.Body\n└── CenteredLayout.Footer\n```",
+      "Composition:\n```\nCenteredLayout.Root\n├── CenteredLayout.Notice\n├── CenteredLayout.Header\n├── CenteredLayout.Body\n└── CenteredLayout.Footer\n```",
       "```tsx\n<CenteredLayout.Root>\n  <SkipToMainLink />\n  <CenteredLayout.Body>\n    <a href=\"https://ngrok.com\">\n      <NgrokWordmarkIcon className=\"h-auto w-24\" />\n    </a>\n    <Main>\n      <SignInCard />\n    </Main>\n  </CenteredLayout.Body>\n  <CenteredLayout.Footer>\n    <ThemeSwitcher.Root>\n      <ThemeSwitcher.Trigger />\n      <ThemeSwitcher.Content />\n    </ThemeSwitcher.Root>\n  </CenteredLayout.Footer>\n</CenteredLayout.Root>\n```"
     ]
   },

--- a/packages/mantle/src/components/centered-layout/centered-layout.test.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.test.tsx
@@ -90,6 +90,43 @@ describe("CenteredLayout", () => {
 		expect(ref.current).toBe(body);
 	});
 
+	test("Notice renders an unstyled full-width strip", () => {
+		render(<CenteredLayout.Notice data-testid="notice">impersonating</CenteredLayout.Notice>);
+		const notice = screen.getByTestId("notice");
+		expect(notice.tagName).toBe("DIV");
+		expect(notice).toHaveAttribute("data-slot", "centered-layout-notice");
+		expect(notice.className).toContain("shrink-0");
+		expect(notice).toHaveTextContent("impersonating");
+	});
+
+	test("Notice is not a header banner landmark", () => {
+		render(<CenteredLayout.Notice>impersonating</CenteredLayout.Notice>);
+		expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+	});
+
+	test("Notice renders as child element when asChild is true, keeping data-slot", () => {
+		render(
+			<CenteredLayout.Notice asChild>
+				<aside data-testid="notice">impersonating</aside>
+			</CenteredLayout.Notice>,
+		);
+		const notice = screen.getByTestId("notice");
+		expect(notice.tagName).toBe("ASIDE");
+		expect(notice).toHaveAttribute("data-slot", "centered-layout-notice");
+	});
+
+	test("Notice forwards refs and data-* attributes", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<CenteredLayout.Notice data-testid="notice" data-flavor="warning" ref={ref}>
+				impersonating
+			</CenteredLayout.Notice>,
+		);
+		const notice = screen.getByTestId("notice");
+		expect(notice).toHaveAttribute("data-flavor", "warning");
+		expect(ref.current).toBe(notice);
+	});
+
 	test("Footer renders a footer element with data-slot", () => {
 		render(<CenteredLayout.Footer data-testid="footer">legal</CenteredLayout.Footer>);
 		const footer = screen.getByTestId("footer");
@@ -203,6 +240,7 @@ describe("CenteredLayout", () => {
 		render(
 			<CenteredLayout.Root data-testid="root">
 				<a href="#main">Skip to main content</a>
+				<CenteredLayout.Notice data-testid="notice">impersonating</CenteredLayout.Notice>
 				<CenteredLayout.Header data-testid="header">
 					<button type="button">Close</button>
 				</CenteredLayout.Header>
@@ -220,6 +258,10 @@ describe("CenteredLayout", () => {
 		const root = screen.getByTestId("root");
 		expect(root).toHaveAttribute("data-slot", "centered-layout");
 		expect(screen.getByTestId("body")).toHaveAttribute("data-slot", "centered-layout-body");
+		// the notice strip sits above everything, including the header banner
+		expect(screen.getByTestId("notice").compareDocumentPosition(screen.getByTestId("header"))).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING,
+		);
 		expect(screen.getByRole("banner")).toBe(screen.getByTestId("header"));
 		expect(screen.getByRole("main")).toHaveTextContent("Sign in to your account");
 		expect(screen.getByRole("contentinfo")).toBe(screen.getByTestId("footer"));

--- a/packages/mantle/src/components/centered-layout/centered-layout.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.tsx
@@ -62,8 +62,9 @@ Root.displayName = "CenteredLayout";
  * warnings, and similar app-wide messaging. Renders an unstyled `<div>`
  * (`w-full shrink-0`): the notice content brings its own colors and layout,
  * and the part collapses to nothing when empty, so it can stay mounted and
- * conditionally render its contents. The same slot as `AppLayout.Notice`, so
- * an app-wide banner composes identically across both layouts. Deliberately
+ * conditionally render its contents. The same slot contract as the
+ * app-layout shell's notice strip, so an app-wide banner composes
+ * identically across mantle's layouts. Deliberately
  * not named Banner — `CenteredLayout.Header` renders the page's `<header>`
  * (the ARIA `banner` landmark), and this part is not that. Optional: omitting
  * it is fine.
@@ -336,8 +337,9 @@ const CenteredLayout = {
 	 * including `Header` — for impersonation notices and environment warnings.
 	 * Renders an unstyled `<div>` (`w-full shrink-0`): the notice content
 	 * brings its own colors, and the part collapses to nothing when empty. The
-	 * same slot as `AppLayout.Notice`, so an app-wide banner composes
-	 * identically across both layouts. Merge `sticky top-0 z-20` via
+	 * same slot contract as the app-layout shell's notice strip, so an
+	 * app-wide banner composes identically across mantle's layouts. Merge
+	 * `sticky top-0 z-20` via
 	 * `className` to pin it while a long flow scrolls. Optional — omitting it
 	 * is fine.
 	 *

--- a/packages/mantle/src/components/centered-layout/centered-layout.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.tsx
@@ -9,10 +9,11 @@ import { Slot } from "../slot/index.js";
 /**
  * The outer frame of a centered page flow. Renders a `<div>` with
  * `flex min-h-full flex-col` so it fills its nearest sized ancestor and stacks
- * `CenteredLayout.Header` (pinned top), `CenteredLayout.Body` (which grows),
- * and `CenteredLayout.Footer` (pinned bottom). Consumers whose host requires
- * an exact height can merge `h-full` via `className` — `cx` is
- * tailwind-merge-backed, so the override is deterministic.
+ * `CenteredLayout.Notice` and `CenteredLayout.Header` (pinned top),
+ * `CenteredLayout.Body` (which grows), and `CenteredLayout.Footer` (pinned
+ * bottom). Consumers whose host requires an exact height can merge `h-full`
+ * via `className` — `cx` is tailwind-merge-backed, so the override is
+ * deterministic.
  *
  * @see https://mantle.ngrok.com/layouts/centered-layout
  *
@@ -302,9 +303,9 @@ Footer.displayName = "CenteredLayoutFooter";
 const CenteredLayout = {
 	/**
 	 * The outer frame of a centered page flow. Fills its nearest sized ancestor
-	 * (`min-h-full`) and stacks `Header` (pinned top), `Body` (which grows),
-	 * and `Footer` (pinned bottom). Merge `h-full` via `className` when the
-	 * host requires an exact height.
+	 * (`min-h-full`) and stacks `Notice` and `Header` (pinned top), `Body`
+	 * (which grows), and `Footer` (pinned bottom). Merge `h-full` via
+	 * `className` when the host requires an exact height.
 	 *
 	 * @see https://mantle.ngrok.com/layouts/centered-layout
 	 *

--- a/packages/mantle/src/components/centered-layout/centered-layout.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.tsx
@@ -56,6 +56,56 @@ const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild
 Root.displayName = "CenteredLayout";
 
 /**
+ * A full-window-width strip pinned above everything else in the layout —
+ * including `CenteredLayout.Header` — for impersonation notices, environment
+ * warnings, and similar app-wide messaging. Renders an unstyled `<div>`
+ * (`w-full shrink-0`): the notice content brings its own colors and layout,
+ * and the part collapses to nothing when empty, so it can stay mounted and
+ * conditionally render its contents. The same slot as `AppLayout.Notice`, so
+ * an app-wide banner composes identically across both layouts. Deliberately
+ * not named Banner — `CenteredLayout.Header` renders the page's `<header>`
+ * (the ARIA `banner` landmark), and this part is not that. Optional: omitting
+ * it is fine.
+ *
+ * On flows that scroll (checkout, plan pickers), the strip scrolls away with
+ * the page by default; merge `sticky top-0 z-20` via `className` to pin it to
+ * the window.
+ *
+ * @see https://mantle.ngrok.com/layouts/centered-layout
+ *
+ * @example
+ * ```tsx
+ * <CenteredLayout.Root>
+ *   <CenteredLayout.Notice>
+ *     {isImpersonating && <ImpersonationBanner />}
+ *   </CenteredLayout.Notice>
+ *   <CenteredLayout.Body>
+ *     <Main>
+ *       <SignInCard />
+ *     </Main>
+ *   </CenteredLayout.Body>
+ * </CenteredLayout.Root>
+ * ```
+ */
+const Notice = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild & WithDataSlot>(
+	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
+		const Comp = asChild ? Slot : "div";
+
+		return (
+			<Comp
+				ref={ref}
+				data-slot={joinDataSlot(dataSlot, "centered-layout-notice")}
+				className={cx("w-full shrink-0", className)}
+				{...props}
+			>
+				{children}
+			</Comp>
+		);
+	},
+);
+Notice.displayName = "CenteredLayoutNotice";
+
+/**
  * A utility strip at the top of the layout — an account chip, a close/dismiss
  * button, and similar page furniture for focused flows (checkout, plan
  * pickers). Renders a semantic `<header>` (a page-level frame, so it is
@@ -222,6 +272,7 @@ Footer.displayName = "CenteredLayoutFooter";
  * Composition:
  * ```
  * CenteredLayout.Root
+ * ├── CenteredLayout.Notice
  * ├── CenteredLayout.Header
  * ├── CenteredLayout.Body
  * └── CenteredLayout.Footer
@@ -279,6 +330,33 @@ const CenteredLayout = {
 	 * ```
 	 */
 	Root,
+	/**
+	 * A full-window-width strip pinned above everything else in the layout —
+	 * including `Header` — for impersonation notices and environment warnings.
+	 * Renders an unstyled `<div>` (`w-full shrink-0`): the notice content
+	 * brings its own colors, and the part collapses to nothing when empty. The
+	 * same slot as `AppLayout.Notice`, so an app-wide banner composes
+	 * identically across both layouts. Merge `sticky top-0 z-20` via
+	 * `className` to pin it while a long flow scrolls. Optional — omitting it
+	 * is fine.
+	 *
+	 * @see https://mantle.ngrok.com/layouts/centered-layout
+	 *
+	 * @example
+	 * ```tsx
+	 * <CenteredLayout.Root>
+	 *   <CenteredLayout.Notice>
+	 *     {isImpersonating && <ImpersonationBanner />}
+	 *   </CenteredLayout.Notice>
+	 *   <CenteredLayout.Body>
+	 *     <Main>
+	 *       <SignInCard />
+	 *     </Main>
+	 *   </CenteredLayout.Body>
+	 * </CenteredLayout.Root>
+	 * ```
+	 */
+	Notice,
 	/**
 	 * A utility strip at the top of the layout (account chip, close button)
 	 * rendered as a semantic `<header>` (`banner` landmark) outside the

--- a/packages/mantle/src/components/centered-layout/centered-layout.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.tsx
@@ -71,7 +71,9 @@ Root.displayName = "CenteredLayout";
  *
  * On flows that scroll (checkout, plan pickers), the strip scrolls away with
  * the page by default; merge `sticky top-0 z-20` via `className` to pin it to
- * the window.
+ * the window. To pin it alongside a sticky `Header`, wrap the two strips in
+ * a single `sticky top-0` container instead — two elements pinned at `top-0`
+ * overlap each other once the page scrolls.
  *
  * @see https://mantle.ngrok.com/layouts/centered-layout
  *
@@ -339,9 +341,10 @@ const CenteredLayout = {
 	 * brings its own colors, and the part collapses to nothing when empty. The
 	 * same slot contract as the app-layout shell's notice strip, so an
 	 * app-wide banner composes identically across mantle's layouts. Merge
-	 * `sticky top-0 z-20` via
-	 * `className` to pin it while a long flow scrolls. Optional — omitting it
-	 * is fine.
+	 * `sticky top-0 z-20` via `className` to pin it while a long flow scrolls
+	 * (to pin it alongside a sticky `Header`, wrap the two strips in a single
+	 * `sticky top-0` container instead — two elements pinned at `top-0`
+	 * overlap once the page scrolls). Optional — omitting it is fine.
 	 *
 	 * @see https://mantle.ngrok.com/layouts/centered-layout
 	 *


### PR DESCRIPTION
## Summary

Adds `CenteredLayout.Notice` — the pinned window-banner slot `AppLayout` already has, now in the centered layout too:

- A full-window-width strip pinned above everything else in the layout, **including `CenteredLayout.Header`**, for impersonation notices, environment warnings, and similar app-wide messaging.
- Unstyled (`w-full shrink-0`): the notice content brings its own colors, and the part collapses to nothing when empty, so it can stay mounted and conditionally render its contents.
- Mirrors the `AppLayout.Notice` slot contract exactly, so an app-wide banner composes identically across both layouts. Deliberately not named Banner — `CenteredLayout.Header` renders the page's `<header>` (the ARIA `banner` landmark).
- On flows that scroll (checkout, plan pickers), merge `sticky top-0 z-20` via `className` to keep it pinned.

## Changes

- `CenteredLayout.Notice` part (forwardRef, `asChild`, `data-slot="centered-layout-notice"`) with JSDoc + examples on both the part and the namespace member
- Tests: strip rendering, no banner landmark, `asChild`, ref/data-\* forwarding, and DOM order above `Header` in the full composition
- Docs: a **Notice section with a live framed example** — `CenteredLayoutNoticeDemo` renders in its own iframed preview document (viewport switcher, real `Main` + `SkipToMainLink`) with a toggleable impersonation strip pushing the whole page, header included, down — plus the composition tree/bullet and an API-reference section
- Patch changeset for `@ngrok/mantle`; component-manifest snapshot regenerated (composition diagram gained the Notice line)

## Stacking

**Based on #1335** (`feat/framed-previews`), which brings the iframe preview infrastructure — merge that first, then retarget this to `main` (GitHub does this automatically on branch deletion). `feat/sidebar-app-layout` rebases on both once they land.

## Verification

- `pnpm -w run lint` / `fmt:check` / `typecheck` — 0 errors
- `pnpm -w run test` — all pass (1189 mantle incl. 5 new Notice tests + 133 www)
- Browser-verified: the framed demo's strip renders above the header; toggling collapses it to nothing and the header slides up to reclaim the space