### PR TITLE
feat(www): iframed example previews with a viewport switcher

### DIFF
--- a/apps/www/app/components/code-example.tsx
+++ b/apps/www/app/components/code-example.tsx
@@ -1,6 +1,7 @@
 import { cx } from "@ngrok/mantle/cx";
 import { Tabs } from "@ngrok/mantle/tabs";
 import type { ComponentProps } from "react";
+import { PreviewFrame as PreviewFrameImpl } from "./preview-frame";
 
 type CodeExampleRootProps = Omit<
 	ComponentProps<typeof Tabs.Root>,
@@ -75,6 +76,43 @@ function Preview({ className, children, ...props }: CodeExamplePanelProps) {
 	);
 }
 
+type CodeExamplePreviewFrameProps = Omit<
+	ComponentProps<typeof Tabs.Content>,
+	"value" | "forceMount" | "children"
+> &
+	ComponentProps<typeof PreviewFrameImpl>;
+
+/**
+ * The framed alternative to `CodeExample.Preview`: hosts a {@link PreviewFrameImpl PreviewFrame}
+ * — an iframe pointed at the chrome-less `/preview/:exampleName` route with a
+ * desktop/tablet/mobile viewport switcher. Reach for it when the demo is a
+ * full-page layout that wants its own document (real `Main` landmark, isolated
+ * keyboard shortcuts, frame-driven breakpoints). The panel is force-mounted
+ * so flipping to the Code tab and back never reloads the iframe.
+ *
+ * @example
+ * ```mdx
+ * <CodeExample.Root>
+ * 	<CodeExample.PreviewFrame example="centered-layout" title="Centered layout demo" />
+ * 	<CodeExample.Code>{tsx fence}</CodeExample.Code>
+ * </CodeExample.Root>
+ * ```
+ */
+function PreviewFrame({ className, example, title, ...props }: CodeExamplePreviewFrameProps) {
+	return (
+		<Tabs.Content
+			value="preview"
+			// keep the iframe mounted while the Code tab is active — Radix leaves
+			// force-mounted inactive panels visible, so hide it ourselves
+			forceMount
+			className="data-[state=inactive]:hidden"
+			{...props}
+		>
+			<PreviewFrameImpl example={example} title={title} className={className} />
+		</Tabs.Content>
+	);
+}
+
 /**
  * The source panel of a `CodeExample`. Wrap a regular MDX code fence — it
  * still renders through the MDX provider's pre mapping (pre-rendered shiki,
@@ -110,13 +148,14 @@ function Code({ className, children, ...props }: CodeExamplePanelProps) {
  * Composition:
  * ```
  * CodeExample.Root
- * ├── CodeExample.Preview
+ * ├── CodeExample.Preview (inline demo) or CodeExample.PreviewFrame (iframed demo)
  * └── CodeExample.Code
  * ```
  */
 const CodeExample = {
 	Root,
 	Preview,
+	PreviewFrame,
 	Code,
 } as const;
 

--- a/apps/www/app/components/preview-frame.test.tsx
+++ b/apps/www/app/components/preview-frame.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+// @vitest-environment-options {"settings": {"disableIframePageLoading": true}}
+// (happy-dom otherwise fetches iframe src documents for real — these tests
+// only assert attributes and remounting, never framed content)
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PreviewFrame } from "./preview-frame";
+
+afterEach(() => {
+	cleanup();
+});
+
+function getIframe(): HTMLIFrameElement {
+	const iframe = document.querySelector("iframe");
+	if (iframe == null) {
+		throw new Error("expected the preview frame to render an iframe");
+	}
+	return iframe;
+}
+
+describe("PreviewFrame", () => {
+	it("renders an iframe pointed at the example's chrome-less preview route", () => {
+		render(<PreviewFrame example="centered-layout" title="Centered layout demo" />);
+
+		const iframe = getIframe();
+		expect(iframe.getAttribute("src")).toBe("/preview/centered-layout");
+		expect(iframe.getAttribute("title")).toBe("Preview of the Centered layout demo");
+	});
+
+	it("defaults to the desktop viewport", () => {
+		render(<PreviewFrame example="centered-layout" title="Centered layout demo" />);
+
+		expect(
+			screen.getByRole("radio", { name: "Desktop viewport" }).getAttribute("aria-checked"),
+		).toBe("true");
+		expect(getIframe().parentElement?.className).toContain("w-full");
+	});
+
+	it("resizes the frame when a viewport preset is picked", () => {
+		render(<PreviewFrame example="centered-layout" title="Centered layout demo" />);
+
+		fireEvent.click(screen.getByRole("radio", { name: "Tablet viewport" }));
+		expect(getIframe().parentElement?.className).toContain("w-192");
+
+		fireEvent.click(screen.getByRole("radio", { name: "Mobile viewport" }));
+		expect(getIframe().parentElement?.className).toContain("w-[375px]");
+	});
+
+	it("reloads the preview by remounting the iframe", () => {
+		render(<PreviewFrame example="centered-layout" title="Centered layout demo" />);
+
+		const before = getIframe();
+		fireEvent.click(
+			screen.getByRole("button", { name: "Reload the Centered layout demo preview" }),
+		);
+		const after = getIframe();
+
+		expect(after).not.toBe(before);
+		expect(after.getAttribute("src")).toBe("/preview/centered-layout");
+	});
+
+	it("links to the preview route in a new tab", () => {
+		render(<PreviewFrame example="centered-layout" title="Centered layout demo" />);
+
+		const link = screen.getByRole("link", {
+			name: "Open the Centered layout demo preview in a new tab",
+		});
+		expect(link.getAttribute("href")).toBe("/preview/centered-layout");
+		expect(link.getAttribute("target")).toBe("_blank");
+	});
+});

--- a/apps/www/app/components/preview-frame.tsx
+++ b/apps/www/app/components/preview-frame.tsx
@@ -1,0 +1,143 @@
+import { IconButton } from "@ngrok/mantle/button";
+import { cx } from "@ngrok/mantle/cx";
+import { RadioGroup } from "@ngrok/mantle/radio-group";
+import { ArrowClockwiseIcon } from "@phosphor-icons/react/ArrowClockwise";
+import { ArrowSquareOutIcon } from "@phosphor-icons/react/ArrowSquareOut";
+import { DesktopIcon } from "@phosphor-icons/react/Desktop";
+import { DeviceMobileIcon } from "@phosphor-icons/react/DeviceMobile";
+import { DeviceTabletIcon } from "@phosphor-icons/react/DeviceTablet";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { href } from "react-router";
+import type { PreviewExampleName } from "~/features/preview-registry";
+
+const viewportValues = ["desktop", "tablet", "mobile"] as const;
+
+type Viewport = (typeof viewportValues)[number];
+
+function isViewport(value: string): value is Viewport {
+	return viewportValues.some((viewport) => viewport === value);
+}
+
+const viewportOptions = [
+	{ value: "desktop", label: "Desktop viewport", icon: <DesktopIcon className="size-4" /> },
+	{ value: "tablet", label: "Tablet viewport", icon: <DeviceTabletIcon className="size-4" /> },
+	{ value: "mobile", label: "Mobile viewport", icon: <DeviceMobileIcon className="size-4" /> },
+] as const satisfies ReadonlyArray<{ value: Viewport; label: string; icon: ReactNode }>;
+
+/**
+ * Fixed preset widths, not percentages: the presets exist to exercise real
+ * media-query breakpoints inside the frame, so tablet is Tailwind's `md`
+ * boundary (48rem) and mobile is a common phone width. Desktop fills the docs
+ * column. Static class Record so Tailwind sees every class.
+ */
+const viewportWidthClasses = {
+	desktop: "w-full",
+	tablet: "w-192 max-w-full",
+	mobile: "w-[375px] max-w-full",
+} as const satisfies Record<Viewport, string>;
+
+type PreviewFrameProps = {
+	/** Which registered preview example the frame renders (see preview-registry.ts). */
+	example: PreviewExampleName;
+	/**
+	 * Human-readable name of the example — the iframe's accessible title and
+	 * part of the toolbar buttons' labels. Usually matches the registry title.
+	 */
+	title: string;
+	/** Merged onto the outer frame — e.g. to override the default `h-160` canvas height. */
+	className?: string;
+};
+
+/**
+ * A framed, viewport-switchable live example: an iframe pointed at the
+ * chrome-less `/preview/:exampleName` route with a toolbar to preview the
+ * example at desktop, tablet (48rem), and mobile (375px) widths, reload it,
+ * or open it in a new tab. Because the example is its own document it gets a
+ * real `Main` landmark, its own `window` (document-level keyboard shortcuts
+ * stay inside the frame), and media queries driven by the frame — not the
+ * reader's browser window. Theme changes on the docs page propagate automatically:
+ * both documents share mantle's cookie + BroadcastChannel theme sync.
+ *
+ * @example
+ * ```tsx
+ * <PreviewFrame example="centered-layout" title="Centered layout demo" />
+ * ```
+ */
+export function PreviewFrame({ example, title, className }: PreviewFrameProps) {
+	const [viewport, setViewport] = useState<Viewport>("desktop");
+	// remounting the iframe with a new key is a full document reload
+	const [reloadCount, setReloadCount] = useState(0);
+	const previewHref = href("/preview/:exampleName", { exampleName: example });
+
+	return (
+		<div
+			className={cx(
+				"grid h-160 grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-lg border border-gray-300",
+				className,
+			)}
+		>
+			<div className="flex items-center gap-2 border-b border-gray-300 p-1.5">
+				<RadioGroup.ButtonGroup
+					aria-label="Preview viewport"
+					className="w-fit"
+					value={viewport}
+					onChange={(value: string) => {
+						if (isViewport(value)) {
+							setViewport(value);
+						}
+					}}
+				>
+					{viewportOptions.map((option) => (
+						<RadioGroup.Button key={option.value} value={option.value} className="px-2.5">
+							{option.icon}
+							<span className="sr-only">{option.label}</span>
+						</RadioGroup.Button>
+					))}
+				</RadioGroup.ButtonGroup>
+				<div className="ml-auto flex items-center gap-1">
+					<IconButton
+						type="button"
+						appearance="ghost"
+						intent="neutral"
+						label={`Reload the ${title} preview`}
+						icon={<ArrowClockwiseIcon />}
+						onClick={() => setReloadCount((count) => count + 1)}
+					/>
+					<IconButton
+						asChild
+						appearance="ghost"
+						intent="neutral"
+						label={`Open the ${title} preview in a new tab`}
+						icon={<ArrowSquareOutIcon />}
+					>
+						<a href={previewHref} target="_blank" rel="noreferrer" />
+					</IconButton>
+				</div>
+			</div>
+			<div className="bg-base bg-[radial-gradient(var(--color-gray-300)_1px,transparent_1px)] [background-size:16px_16px]">
+				<div
+					className={cx(
+						"mx-auto h-full transition-[width] duration-200 motion-reduce:transition-none",
+						// box-content keeps the preset width as the iframe's actual
+						// viewport width — the delineating borders sit outside it
+						viewport !== "desktop" && "box-content border-x border-gray-300",
+						viewportWidthClasses[viewport],
+					)}
+				>
+					{/* oxlint-disable-next-line react/iframe-missing-sandbox -- first-party
+					same-origin example document: it needs scripts, cookies, localStorage,
+					and BroadcastChannel for theme sync, and `allow-scripts` +
+					`allow-same-origin` together make a sandbox escapable anyway */}
+					<iframe
+						key={reloadCount}
+						src={previewHref}
+						title={`Preview of the ${title}`}
+						loading="lazy"
+						className="bg-card size-full"
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/www/app/docs/layouts/centered-layout.mdx
+++ b/apps/www/app/docs/layouts/centered-layout.mdx
@@ -3,62 +3,10 @@ title: Centered Layout
 description: A viewport-filling centered page flow — utility header and footer strips around a growing, centered content region.
 ---
 
-import { Button, IconButton } from "@ngrok/mantle/button";
 import { Card } from "@ngrok/mantle/card";
 import { CenteredLayout } from "@ngrok/mantle/centered-layout";
-import { Input } from "@ngrok/mantle/input";
-import { Label } from "@ngrok/mantle/label";
-import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
-import { CheckIcon } from "@phosphor-icons/react/Check";
-import { XIcon } from "@phosphor-icons/react/X";
 import { CodeExample } from "~/components/code-example";
 import { PageHeader } from "~/components/page-header";
-
-export function SignInCard() {
-	return (
-		<Card.Root>
-			<Card.Header>
-				<Card.Title>Sign in to acme</Card.Title>
-			</Card.Header>
-			<Card.Body className="flex flex-col gap-4">
-				<div className="flex flex-col gap-1.5">
-					<Label htmlFor="centered-layout-email">Email</Label>
-					<Input id="centered-layout-email" type="email" placeholder="you@example.com" />
-				</div>
-				<div className="flex flex-col gap-1.5">
-					<Label htmlFor="centered-layout-password">Password</Label>
-					<Input id="centered-layout-password" type="password" placeholder="Your password" />
-				</div>
-				<Button type="button" intent="neutral" appearance="filled">
-					Sign in
-				</Button>
-			</Card.Body>
-		</Card.Root>
-	);
-}
-
-export function CenteredLayoutExample() {
-	return (
-		<div className="h-full w-full overflow-auto">
-			<CenteredLayout.Root>
-				<CenteredLayout.Body>
-					<a href="https://ngrok.com" className="text-strong text-lg font-semibold">
-						acme
-					</a>
-					<div className="w-full max-w-80">
-						<SignInCard />
-					</div>
-				</CenteredLayout.Body>
-				<CenteredLayout.Footer>
-					<ThemeSwitcher.Root>
-						<ThemeSwitcher.Trigger />
-						<ThemeSwitcher.Content />
-					</ThemeSwitcher.Root>
-				</CenteredLayout.Footer>
-			</CenteredLayout.Root>
-		</div>
-	);
-}
 
 export function CenteredLayoutAsChildExample() {
 	return (
@@ -86,155 +34,12 @@ export function CenteredLayoutAsChildExample() {
 	);
 }
 
-export function PlanPicker() {
-	return (
-		<div className="space-y-8 p-4">
-			<div className="space-y-2">
-				<p className="text-strong text-3xl font-medium">Choose a plan</p>
-				<p className="text-body text-lg">
-					Scale your fake apps — none of these plans, prices, or features are real.
-				</p>
-			</div>
-			<div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-3">
-				{[
-					{
-						name: "Sandbox",
-						price: "$X",
-						tagline: "A fake free tier for a fake product",
-						features: [
-							"Up to 3 imaginary endpoints",
-							"1GB of pretend bandwidth",
-							"20k hypothetical requests",
-							"Community support (also pretend)",
-							"Interstitial page on fake endpoints",
-							"1 team member (you, hypothetically)",
-							"Fake dev domain for public endpoints",
-							"$X one-time pretend usage credit",
-						],
-						action: "Current Fake Plan",
-					},
-					{
-						name: "Pretend Pro",
-						price: "$XX",
-						tagline: "For serious imaginary workloads",
-						features: [
-							"Unlimited imaginary endpoints",
-							"Custom fake domains",
-							"100k make-believe requests",
-							"Priority pretend support",
-							"No interstitial page (it never existed)",
-							"3 team members ($0 per imaginary friend)",
-							"Bring your own fictional domain",
-							"$XX monthly pretend usage credit",
-						],
-						action: "Select Pretend Pro",
-					},
-					{
-						name: "Make Believe",
-						price: "$XXX",
-						tagline: "Everything fake, at scale",
-						features: [
-							"Unlimited everything (none of it real)",
-							"SSO for your imaginary team",
-							"99.999% uptime, hypothetically",
-							"Mutual TLS, in theory",
-							"Wildcard endpoints, wildly fictional",
-							"A dedicated (imaginary) account manager",
-							"RBAC and SCIM, strictly conceptual",
-							"Unlimited pretend usage, billed never",
-						],
-						action: "Select Make Believe",
-					},
-				].map((plan) => (
-					<div
-						key={plan.name}
-						className="flex flex-col gap-6 rounded-md border border-gray-300 p-4"
-					>
-						<div className="shrink-0">
-							<span className="text-strong text-base font-medium">{plan.name}</span>
-							<p className="text-muted text-xs">
-								<span className="text-strong text-2xl font-medium">{plan.price}</span> per month
-							</p>
-						</div>
-						<div className="text-body flex flex-1 flex-col gap-4 text-xs">
-							<p className="text-strong text-sm italic">{plan.tagline}</p>
-							<ul className="space-y-1.5">
-								{plan.features.map((feature) => (
-									<li key={feature} className="flex gap-2">
-										<CheckIcon className="text-muted size-4 shrink-0" />
-										{feature}
-									</li>
-								))}
-							</ul>
-						</div>
-						<Button type="button" appearance="outlined" intent="neutral">
-							{plan.action}
-						</Button>
-					</div>
-				))}
-			</div>
-			<Card.Root className="bg-card-hover rounded-xl shadow-inner">
-				<Card.Body className="space-y-3">
-					<p className="text-strong text-sm font-medium">Wait, is any of this real?</p>
-					<p className="text-body text-sm">
-						No — every plan, price, and feature on this page is made up to demonstrate the
-						CenteredLayout composition. Scroll this frame to see the sticky header stay put.
-					</p>
-					<ul className="text-body list-disc space-y-1.5 pl-5 text-sm">
-						<li>Can I upgrade from Sandbox to Pretend Pro? Only in your imagination.</li>
-						<li>Do fake credits roll over? Forever — they aren't real, so they never expire.</li>
-						<li>Is there a fake annual discount? Yes: save $0 with annual billing.</li>
-						<li>What payment methods are accepted? Monopoly money and firm handshakes.</li>
-						<li>Can I talk to fake sales? Absolutely — book a meeting that never happens.</li>
-					</ul>
-				</Card.Body>
-			</Card.Root>
-			<p className="text-muted text-xs">
-				* All prices shown in imaginary dollars (IMD). Fake plans are subject to change without
-				notice, because they do not exist. No warranty is expressed, implied, or imaginable.
-			</p>
-		</div>
-	);
-}
-
-export function CenteredLayoutHeaderExample() {
-	return (
-		<div className="h-full w-full overflow-auto">
-			<CenteredLayout.Root>
-				<CenteredLayout.Header className="bg-card sticky top-0 z-10 justify-between">
-					<span className="text-muted text-sm">cody@acme.com</span>
-					<IconButton
-						type="button"
-						appearance="ghost"
-						intent="neutral"
-						label="Close"
-						icon={<XIcon />}
-					/>
-				</CenteredLayout.Header>
-				<CenteredLayout.Body>
-					<div className="w-full max-w-5xl">
-						<PlanPicker />
-					</div>
-				</CenteredLayout.Body>
-				<CenteredLayout.Footer>
-					<ThemeSwitcher.Root>
-						<ThemeSwitcher.Trigger />
-						<ThemeSwitcher.Content />
-					</ThemeSwitcher.Root>
-				</CenteredLayout.Footer>
-			</CenteredLayout.Root>
-		</div>
-	);
-}
-
 <PageHeader id="centered-layout">Centered Layout</PageHeader>
 
-A viewport-filling centered page flow for sign-in, sign-up, onboarding, 404, and other focused full-page states. It is a **layout**: it owns _where things go_ — the flex/overflow skeleton and region ordering — not what they are. App state (routing, sessions, data) never enters it; the brand mark, form card, and footer links arrive as composed JSX. It consolidates the centered "auth shell" that was duplicated across ngrok's dashboard and login apps.
+A viewport-filling centered page flow for sign-in, sign-up, onboarding, 404, and other focused full-page states. It is a **layout**: it owns _where things go_ — the flex/overflow skeleton and region ordering — not what they are. App state (routing, sessions, data) never enters it; the brand mark, form card, and footer links arrive as composed JSX. It consolidates the centered "auth shell" that was duplicated across ngrok's dashboard and login apps. The demo runs in its own framed document, exactly like a real sign-in page — the layout owns the document, so it composes a real [Main](/components/primitives/main) landmark and a skip link (see [Landmarks](#landmarks)).
 
 <CodeExample.Root>
-	<CodeExample.Preview className="p-0 md:p-0">
-		<CenteredLayoutExample />
-	</CodeExample.Preview>
+	<CodeExample.PreviewFrame example="centered-layout" title="Centered layout demo" />
 	<CodeExample.Code>
 
 ```tsx
@@ -243,14 +48,22 @@ import { Card } from "@ngrok/mantle/card";
 import { CenteredLayout } from "@ngrok/mantle/centered-layout";
 import { Input } from "@ngrok/mantle/input";
 import { Label } from "@ngrok/mantle/label";
+import { Main } from "@ngrok/mantle/main";
+import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
 import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
 
 <CenteredLayout.Root>
+	<SkipToMainLink />
 	<CenteredLayout.Body>
-		<a href="https://ngrok.com" className="text-strong text-lg font-semibold">
+		{/* a real brand mark navigates home; the framed demo stays put */}
+		<a
+			href="https://ngrok.com"
+			onClick={(event) => event.preventDefault()}
+			className="text-strong text-lg font-semibold"
+		>
 			acme
 		</a>
-		<div className="w-full max-w-80">
+		<Main className="w-full max-w-80">
 			<Card.Root>
 				<Card.Header>
 					<Card.Title>Sign in to acme</Card.Title>
@@ -269,7 +82,7 @@ import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
 					</Button>
 				</Card.Body>
 			</Card.Root>
-		</div>
+		</Main>
 	</CenteredLayout.Body>
 	<CenteredLayout.Footer>
 		<ThemeSwitcher.Root>
@@ -300,29 +113,30 @@ CenteredLayout.Root
 
 ## Header
 
-Focused flows that the user can leave — checkout, plan pickers, onboarding steps — carry a utility strip at the top: who is signed in on the left, a close button on the right. `Header` is that strip, the mirror of `Footer`. To keep the close button reachable while the page scrolls, merge `sticky top-0 z-10` (and a background) via `className` — prefer `sticky` over `fixed`, which removes the strip from flow and underlaps the content below it. On a real page the flow owns the document scroller — give it `overscroll-none` there to suppress rubber-banding and pull-to-refresh (on the root it can't trap anything, because there is nothing behind it to chain to). Don't set it on a nested scroller like this demo: cutting scroll chaining swallows the wheel at the scroller's edge instead of handing it back to the page. Scroll the demo to see the header stay pinned.
+Focused flows that the user can leave — checkout, plan pickers, onboarding steps — carry a utility strip at the top: who is signed in on the left, a close button on the right. `Header` is that strip, the mirror of `Footer`. To keep the close button reachable while the page scrolls, merge `sticky top-0 z-10` (and a background) via `className` — prefer `sticky` over `fixed`, which removes the strip from flow and underlaps the content below it. The demo runs in its own framed document, so its page really does own the scroller — scroll it to see the header stay pinned. On a real page, give the document scroller `overscroll-none` to suppress rubber-banding and pull-to-refresh; don't set it on a nested scroller, where cutting scroll chaining swallows the wheel at the scroller's edge instead of handing it back to the page.
 
 <CodeExample.Root>
-	<CodeExample.Preview className="p-0 md:p-0">
-		<CenteredLayoutHeaderExample />
-	</CodeExample.Preview>
+	<CodeExample.PreviewFrame example="centered-layout-header" title="Centered layout header demo" />
 	<CodeExample.Code>
 
 ```tsx
 import { IconButton } from "@ngrok/mantle/button";
 import { CenteredLayout } from "@ngrok/mantle/centered-layout";
+import { Main } from "@ngrok/mantle/main";
+import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
 import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
 import { XIcon } from "@phosphor-icons/react/X";
 
 <CenteredLayout.Root>
+	<SkipToMainLink />
 	<CenteredLayout.Header className="bg-card sticky top-0 z-10 justify-between">
 		<span className="text-muted text-sm">cody@acme.com</span>
 		<IconButton type="button" appearance="ghost" intent="neutral" label="Close" icon={<XIcon />} />
 	</CenteredLayout.Header>
 	<CenteredLayout.Body>
-		<div className="w-full max-w-5xl">
+		<Main className="w-full max-w-5xl">
 			<PlanPicker />
-		</div>
+		</Main>
 	</CenteredLayout.Body>
 	<CenteredLayout.Footer>
 		<ThemeSwitcher.Root>
@@ -339,7 +153,7 @@ import { XIcon } from "@phosphor-icons/react/X";
 
 ## Landmarks
 
-Exactly one element in a document may be the Main landmark, so the layout does not render one for you — content arrives as composed JSX, and composing the layout inside a shell that already owns the landmark (an app frame, a docs page — including the live demos on this page) is safe by default. When the layout owns the document — a sign-in page, a 404 — compose mantle's [Main](/components/primitives/main) directly in `Body`, and pair a [SkipToMainLink](/components/primitives/skip-to-main-link) as the first child of `Root`: its default `targetId` matches `Main`'s `id="main"`, so keyboard users can jump past the brand mark straight to the content.
+Exactly one element in a document may be the Main landmark, so the layout does not render one for you — content arrives as composed JSX, and composing the layout inside a shell that already owns the landmark (an app frame, or this page's inline [Polymorphism](#polymorphism) example) is safe by default. When the layout owns the document — a sign-in page, a 404 — compose mantle's [Main](/components/primitives/main) directly in `Body`, and pair a [SkipToMainLink](/components/primitives/skip-to-main-link) as the first child of `Root`: its default `targetId` matches `Main`'s `id="main"`, so keyboard users can jump past the brand mark straight to the content. The framed demos on this page do exactly this — each preview is its own document, so each owns a real `Main`.
 
 ```tsx
 import { CenteredLayout } from "@ngrok/mantle/centered-layout";

--- a/apps/www/app/entry.server.tsx
+++ b/apps/www/app/entry.server.tsx
@@ -85,6 +85,16 @@ export default function handleRequest(
 	const isProdEnv = process.env.VERCEL_ENV === "production";
 	const isNgrokProxy = request.headers.get("x-ngrok-edge") != null;
 
+	/**
+	 * Framed example previews (`/preview/:exampleName`, see routes.ts) are
+	 * embedded in same-origin iframes by the docs pages' preview frames, so
+	 * they alone allow same-origin framing; every other document refuses
+	 * framing entirely (clickjacking mitigation).
+	 */
+	const requestPathname = new URL(request.url).pathname;
+	const allowSameOriginFraming =
+		requestPathname === "/preview" || requestPathname.startsWith("/preview/");
+
 	return new Promise((resolve, reject) => {
 		let shellRendered = false;
 		const userAgent = request.headers.get("user-agent");
@@ -129,7 +139,9 @@ export default function handleRequest(
 					 */
 					const shouldBlockIndexing = !(isProdEnv && isNgrokProxy);
 
-					if (shouldBlockIndexing) {
+					// preview documents are chrome-less fragments of their docs page —
+					// they should never land in a search index, even in production
+					if (shouldBlockIndexing || allowSameOriginFraming) {
 						responseHeaders.set("X-Robots-Tag", "noindex, nofollow");
 					}
 
@@ -167,9 +179,12 @@ export default function handleRequest(
 
 					/**
 					 * Prevent the page from being embedded in an iframe to mitigate
-					 * clickjacking attacks
+					 * clickjacking attacks. Framed example previews are the exception:
+					 * the docs pages iframe them from the same origin. The CSP
+					 * `frame-ancestors` directive below mirrors this for modern
+					 * browsers.
 					 */
-					responseHeaders.set("X-Frame-Options", "DENY");
+					responseHeaders.set("X-Frame-Options", allowSameOriginFraming ? "SAMEORIGIN" : "DENY");
 
 					/**
 					 * Enable basic XSS protection in older browsers by instructing them
@@ -183,7 +198,7 @@ export default function handleRequest(
 					 */
 					responseHeaders.set(
 						"Content-Security-Policy",
-						buildCSPHeader({ nonce: uniquePerRequestNonce, baseUrl }),
+						buildCSPHeader({ nonce: uniquePerRequestNonce, baseUrl, allowSameOriginFraming }),
 					);
 
 					resolve(
@@ -275,8 +290,18 @@ function buildLinkHeader(requestUrl: string) {
  * The `nonce` should be securely generated for each request and inserted into script tags.
  *
  * The script-src directive includes only trusted third-party scripts used in production.
+ * `allowSameOriginFraming` relaxes `frame-ancestors` to `'self'` for the
+ * framed example preview documents; everything else refuses framing.
  */
-function buildCSPHeader({ nonce, baseUrl }: { nonce: string; baseUrl: string }): string {
+function buildCSPHeader({
+	nonce,
+	baseUrl,
+	allowSameOriginFraming,
+}: {
+	nonce: string;
+	baseUrl: string;
+	allowSameOriginFraming: boolean;
+}): string {
 	const scriptNonce = `'nonce-${nonce}'`;
 
 	/**
@@ -297,6 +322,9 @@ function buildCSPHeader({ nonce, baseUrl }: { nonce: string; baseUrl: string }):
 	const baseUri = "base-uri 'self';";
 	const objectSrc = "object-src 'none';";
 	const workerSrc = "worker-src 'self' blob:;";
+	const frameAncestors = allowSameOriginFraming
+		? "frame-ancestors 'self';"
+		: "frame-ancestors 'none';";
 
 	return [
 		//,
@@ -304,5 +332,6 @@ function buildCSPHeader({ nonce, baseUrl }: { nonce: string; baseUrl: string }):
 		baseUri,
 		objectSrc,
 		workerSrc,
+		frameAncestors,
 	].join("; ");
 }

--- a/apps/www/app/features/centered-layout-demos.tsx
+++ b/apps/www/app/features/centered-layout-demos.tsx
@@ -1,0 +1,215 @@
+import { Button, IconButton } from "@ngrok/mantle/button";
+import { Card } from "@ngrok/mantle/card";
+import { CenteredLayout } from "@ngrok/mantle/centered-layout";
+import { Input } from "@ngrok/mantle/input";
+import { Label } from "@ngrok/mantle/label";
+import { Main } from "@ngrok/mantle/main";
+import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
+import { ThemeSwitcher } from "@ngrok/mantle/theme-switcher";
+import { CheckIcon } from "@phosphor-icons/react/Check";
+import { XIcon } from "@phosphor-icons/react/X";
+
+function SignInCard() {
+	return (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Sign in to acme</Card.Title>
+			</Card.Header>
+			<Card.Body className="flex flex-col gap-4">
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="centered-layout-email">Email</Label>
+					<Input id="centered-layout-email" type="email" placeholder="you@example.com" />
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor="centered-layout-password">Password</Label>
+					<Input id="centered-layout-password" type="password" placeholder="Your password" />
+				</div>
+				<Button type="button" intent="neutral" appearance="filled">
+					Sign in
+				</Button>
+			</Card.Body>
+		</Card.Root>
+	);
+}
+
+function PlanPicker() {
+	return (
+		<div className="space-y-8 p-4">
+			<div className="space-y-2">
+				<p className="text-strong text-3xl font-medium">Choose a plan</p>
+				<p className="text-body text-lg">
+					Scale your fake apps — none of these plans, prices, or features are real.
+				</p>
+			</div>
+			<div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-3">
+				{[
+					{
+						name: "Sandbox",
+						price: "$X",
+						tagline: "A fake free tier for a fake product",
+						features: [
+							"Up to 3 imaginary endpoints",
+							"1GB of pretend bandwidth",
+							"20k hypothetical requests",
+							"Community support (also pretend)",
+							"Interstitial page on fake endpoints",
+							"1 team member (you, hypothetically)",
+							"Fake dev domain for public endpoints",
+							"$X one-time pretend usage credit",
+						],
+						action: "Current Fake Plan",
+					},
+					{
+						name: "Pretend Pro",
+						price: "$XX",
+						tagline: "For serious imaginary workloads",
+						features: [
+							"Unlimited imaginary endpoints",
+							"Custom fake domains",
+							"100k make-believe requests",
+							"Priority pretend support",
+							"No interstitial page (it never existed)",
+							"3 team members ($0 per imaginary friend)",
+							"Bring your own fictional domain",
+							"$XX monthly pretend usage credit",
+						],
+						action: "Select Pretend Pro",
+					},
+					{
+						name: "Make Believe",
+						price: "$XXX",
+						tagline: "Everything fake, at scale",
+						features: [
+							"Unlimited everything (none of it real)",
+							"SSO for your imaginary team",
+							"99.999% uptime, hypothetically",
+							"Mutual TLS, in theory",
+							"Wildcard endpoints, wildly fictional",
+							"A dedicated (imaginary) account manager",
+							"RBAC and SCIM, strictly conceptual",
+							"Unlimited pretend usage, billed never",
+						],
+						action: "Select Make Believe",
+					},
+				].map((plan) => (
+					<div
+						key={plan.name}
+						className="flex flex-col gap-6 rounded-md border border-gray-300 p-4"
+					>
+						<div className="shrink-0">
+							<span className="text-strong text-base font-medium">{plan.name}</span>
+							<p className="text-muted text-xs">
+								<span className="text-strong text-2xl font-medium">{plan.price}</span> per month
+							</p>
+						</div>
+						<div className="text-body flex flex-1 flex-col gap-4 text-xs">
+							<p className="text-strong text-sm italic">{plan.tagline}</p>
+							<ul className="space-y-1.5">
+								{plan.features.map((feature) => (
+									<li key={feature} className="flex gap-2">
+										<CheckIcon className="text-muted size-4 shrink-0" />
+										{feature}
+									</li>
+								))}
+							</ul>
+						</div>
+						<Button type="button" appearance="outlined" intent="neutral">
+							{plan.action}
+						</Button>
+					</div>
+				))}
+			</div>
+			<Card.Root className="bg-card-hover rounded-xl shadow-inner">
+				<Card.Body className="space-y-3">
+					<p className="text-strong text-sm font-medium">Wait, is any of this real?</p>
+					<p className="text-body text-sm">
+						No — every plan, price, and feature on this page is made up to demonstrate the
+						CenteredLayout composition. Scroll this frame to see the sticky header stay put.
+					</p>
+					<ul className="text-body list-disc space-y-1.5 pl-5 text-sm">
+						<li>Can I upgrade from Sandbox to Pretend Pro? Only in your imagination.</li>
+						<li>
+							Do fake credits roll over? Forever — they aren&apos;t real, so they never expire.
+						</li>
+						<li>Is there a fake annual discount? Yes: save $0 with annual billing.</li>
+						<li>What payment methods are accepted? Monopoly money and firm handshakes.</li>
+						<li>Can I talk to fake sales? Absolutely — book a meeting that never happens.</li>
+					</ul>
+				</Card.Body>
+			</Card.Root>
+			<p className="text-muted text-xs">
+				* All prices shown in imaginary dollars (IMD). Fake plans are subject to change without
+				notice, because they do not exist. No warranty is expressed, implied, or imaginable.
+			</p>
+		</div>
+	);
+}
+
+/**
+ * The canonical sign-in composition for the centered-layout docs. Renders as
+ * an entire framed-preview document (see preview-registry.ts), so it composes
+ * exactly like a real sign-in page: the layout owns the document, with a
+ * `SkipToMainLink` first and the `Main` landmark composed directly in `Body`.
+ */
+export function CenteredLayoutDemo() {
+	return (
+		<CenteredLayout.Root>
+			<SkipToMainLink />
+			<CenteredLayout.Body>
+				{/* a real brand mark navigates home; the framed demo stays put */}
+				<a
+					href="https://ngrok.com"
+					onClick={(event) => event.preventDefault()}
+					className="text-strong text-lg font-semibold"
+				>
+					acme
+				</a>
+				<Main className="w-full max-w-80">
+					<SignInCard />
+				</Main>
+			</CenteredLayout.Body>
+			<CenteredLayout.Footer>
+				<ThemeSwitcher.Root>
+					<ThemeSwitcher.Trigger />
+					<ThemeSwitcher.Content />
+				</ThemeSwitcher.Root>
+			</CenteredLayout.Footer>
+		</CenteredLayout.Root>
+	);
+}
+
+/**
+ * The `CenteredLayout.Header` composition for the centered-layout docs: a
+ * sticky utility strip over a scrolling plan picker. Renders as an entire
+ * framed-preview document (see preview-registry.ts), so the page's own
+ * scroller does the scrolling and the sticky header pins to the document —
+ * exactly like the real checkout/plan-picker flows it demonstrates.
+ */
+export function CenteredLayoutHeaderDemo() {
+	return (
+		<CenteredLayout.Root>
+			<SkipToMainLink />
+			<CenteredLayout.Header className="bg-card sticky top-0 z-10 justify-between">
+				<span className="text-muted text-sm">cody@acme.com</span>
+				<IconButton
+					type="button"
+					appearance="ghost"
+					intent="neutral"
+					label="Close"
+					icon={<XIcon />}
+				/>
+			</CenteredLayout.Header>
+			<CenteredLayout.Body>
+				<Main className="w-full max-w-5xl">
+					<PlanPicker />
+				</Main>
+			</CenteredLayout.Body>
+			<CenteredLayout.Footer>
+				<ThemeSwitcher.Root>
+					<ThemeSwitcher.Trigger />
+					<ThemeSwitcher.Content />
+				</ThemeSwitcher.Root>
+			</CenteredLayout.Footer>
+		</CenteredLayout.Root>
+	);
+}

--- a/apps/www/app/features/preview-registry.test.ts
+++ b/apps/www/app/features/preview-registry.test.ts
@@ -19,4 +19,12 @@ describe("isPreviewExampleName", () => {
 		expect(isPreviewExampleName("nope")).toBe(false);
 		expect(isPreviewExampleName("")).toBe(false);
 	});
+
+	// Regression: `in` matched prototype-chain names, so /preview/toString
+	// passed the guard and crashed the route instead of 404ing.
+	it("rejects prototype-chain property names", () => {
+		expect(isPreviewExampleName("toString")).toBe(false);
+		expect(isPreviewExampleName("constructor")).toBe(false);
+		expect(isPreviewExampleName("hasOwnProperty")).toBe(false);
+	});
 });

--- a/apps/www/app/features/preview-registry.test.ts
+++ b/apps/www/app/features/preview-registry.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isPreviewExampleName, previewExamples } from "./preview-registry";
+
+describe("previewExamples", () => {
+	it("registers a component and a human-readable title for every example", () => {
+		for (const [name, example] of Object.entries(previewExamples)) {
+			expect(typeof example.Component, `${name} Component`).toBe("function");
+			expect(example.title.length, `${name} title`).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("isPreviewExampleName", () => {
+	it("accepts registered example names", () => {
+		expect(isPreviewExampleName("centered-layout")).toBe(true);
+	});
+
+	it("rejects unknown URL segments — the preview route 404s on these", () => {
+		expect(isPreviewExampleName("nope")).toBe(false);
+		expect(isPreviewExampleName("")).toBe(false);
+	});
+});

--- a/apps/www/app/features/preview-registry.ts
+++ b/apps/www/app/features/preview-registry.ts
@@ -61,5 +61,7 @@ export type PreviewExampleName = keyof typeof previewExamples;
  * ```
  */
 export function isPreviewExampleName(value: string): value is PreviewExampleName {
-	return value in previewExamples;
+	// own-property check: `in` also matches prototype-chain names ("toString",
+	// "constructor", …), which would pass the guard and crash the route
+	return Object.hasOwn(previewExamples, value);
 }

--- a/apps/www/app/features/preview-registry.ts
+++ b/apps/www/app/features/preview-registry.ts
@@ -1,0 +1,65 @@
+import type { ComponentType } from "react";
+import { CenteredLayoutDemo, CenteredLayoutHeaderDemo } from "./centered-layout-demos";
+
+type PreviewExample = {
+	/**
+	 * Human-readable name for the example — becomes the preview document's
+	 * title and the accessible label of the docs page's preview frame.
+	 */
+	title: string;
+	/**
+	 * The demo component. It renders as the entire preview document (no site
+	 * chrome), so it must size itself to the viewport — full-page layout demos
+	 * fill it (`min-h-full`) or pin themselves with `fixed inset-0` — and
+	 * should own the document's landmarks (a real `Main`, optionally a
+	 * `SkipToMainLink`).
+	 */
+	Component: ComponentType;
+};
+
+/**
+ * Every example that can render as a framed preview. The key is the
+ * `:exampleName` URL segment of the chrome-less `/preview/:exampleName` route,
+ * and the docs pages point `<CodeExample.PreviewFrame example="…">` at the
+ * same key. Because the preview is its own document, examples get a real
+ * `Main` landmark, their own `window` (document-level keyboard shortcuts and
+ * listeners never leak onto the docs page), and media queries that track the
+ * frame's viewport instead of the reader's browser window.
+ *
+ * @example
+ * ```tsx
+ * const { title, Component } = previewExamples["centered-layout"];
+ * <Component />; // renders the whole preview document
+ * ```
+ */
+export const previewExamples = {
+	"centered-layout": {
+		title: "Centered layout demo",
+		Component: CenteredLayoutDemo,
+	},
+	"centered-layout-header": {
+		title: "Centered layout header demo",
+		Component: CenteredLayoutHeaderDemo,
+	},
+} as const satisfies Record<string, PreviewExample>;
+
+/**
+ * The names of all registered preview examples — the valid values for the
+ * `/preview/:exampleName` URL segment and `CodeExample.PreviewFrame`'s
+ * `example` prop.
+ */
+export type PreviewExampleName = keyof typeof previewExamples;
+
+/**
+ * Type guard narrowing an arbitrary URL segment to a registered preview
+ * example name.
+ *
+ * @example
+ * ```ts
+ * isPreviewExampleName("centered-layout"); // true
+ * isPreviewExampleName("nope"); // false
+ * ```
+ */
+export function isPreviewExampleName(value: string): value is PreviewExampleName {
+	return value in previewExamples;
+}

--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -25,6 +25,7 @@ import {
 	Scripts,
 	ScrollRestoration,
 	type ShouldRevalidateFunctionArgs,
+	useMatches,
 	useRouteLoaderData,
 } from "react-router";
 import type { Route } from "./+types/root";
@@ -126,6 +127,18 @@ export function shouldRevalidate(_: ShouldRevalidateFunctionArgs) {
 	return false;
 }
 
+/**
+ * Whether the matched route is a chrome-less framed example preview
+ * (`/preview/:exampleName`). Matched on route identity, not pathname —
+ * mirroring the `layouts-index` pattern in layouts-layout.tsx. Preview
+ * documents render inside the docs pages' iframes, so they skip the site
+ * chrome and the forced scrollbar gutter.
+ */
+function useIsFramedPreview() {
+	const matches = useMatches();
+	return matches.some((match) => match.id === "preview-example");
+}
+
 const ReactQueryDevtoolsLazy = lazy(() =>
 	import("@tanstack/react-query-devtools/production").then((module) => ({
 		default: module.ReactQueryDevtools,
@@ -144,6 +157,7 @@ export function Layout({ children }: PropsWithChildren) {
 		className: "h-full",
 	});
 	const scrollBehavior = useScrollBehavior();
+	const isFramedPreview = useIsFramedPreview();
 	const nonce = useNonce();
 	const [showReactQueryDevtools, setShowReactQueryDevtools] = useState(
 		Boolean(loaderData?.renderReactQueryDevtools),
@@ -180,7 +194,11 @@ export function Layout({ children }: PropsWithChildren) {
 			</head>
 			<body
 				className={cx(
-					"bg-card h-full min-h-full overflow-y-scroll scrollbar isolate relative",
+					"bg-card h-full min-h-full scrollbar isolate relative",
+					// the docs site forces a permanent scrollbar gutter so page length
+					// never shifts the layout; inside a preview iframe that gutter reads
+					// as a broken demo, so preview documents scroll only when needed
+					isFramedPreview ? "overflow-y-auto" : "overflow-y-scroll",
 					scrollBehavior === "smooth" && "scroll-smooth",
 				)}
 			>
@@ -209,9 +227,19 @@ export function Layout({ children }: PropsWithChildren) {
 /**
  * The outermost route component. Renders only the truly page-agnostic chrome —
  * skip link, header, and the outer page wrapper. Each layout route owns its
- * own sidebar / main / TOC grid inside the `<Outlet />`.
+ * own sidebar / main / TOC grid inside the `<Outlet />`. Framed example
+ * previews are the exception: they render the bare outlet so the example owns
+ * the entire document.
  */
 export default function App() {
+	const isFramedPreview = useIsFramedPreview();
+
+	// framed example previews own their whole document: no site header or skip
+	// link — the example brings its own landmarks (see routes/preview.tsx)
+	if (isFramedPreview) {
+		return <Outlet />;
+	}
+
 	return (
 		<div className="flex min-h-full flex-col">
 			<SkipToMainLink />

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -181,6 +181,13 @@ export default [
 		...migrationRoute("priority-to-intent-migration"),
 	]),
 
+	// chrome-less framed example previews — the document the docs pages' iframe
+	// preview frames point at. The explicit id is load-bearing: root.tsx matches
+	// on it to skip the site chrome, and entry.server.tsx path-matches /preview/
+	// to allow same-origin framing. Dynamic-param routes are excluded from
+	// prerendering and served by the runtime SSR function.
+	route("preview/:exampleName", "./routes/preview.tsx", { id: "preview-example" }),
+
 	// 404 + legacy redirects — splat catch-all for any unmatched URL. Matches
 	// (so ancestor loaders run) and 301s known pre-IA-reorg paths (e.g.
 	// /components/button, /blocks/*) to their new homes, returning a 404

--- a/apps/www/app/routes/preview.tsx
+++ b/apps/www/app/routes/preview.tsx
@@ -1,0 +1,46 @@
+import { data } from "react-router";
+import { isPreviewExampleName, previewExamples } from "~/features/preview-registry";
+import type { Route } from "./+types/preview";
+
+/**
+ * Validates the `:exampleName` segment against the preview registry. Unknown
+ * names 404 — this route is only ever iframed (or opened in a new tab) by the
+ * docs pages' preview frames, which type the name at the call site.
+ */
+export const loader = ({ params }: Route.LoaderArgs) => {
+	if (!isPreviewExampleName(params.exampleName)) {
+		throw data(null, { status: 404 });
+	}
+
+	return { exampleName: params.exampleName };
+};
+
+/**
+ * Titles the preview document after its example and marks it noindex —
+ * preview documents are chrome-less fragments of their docs page. Falls back
+ * to the bare site title when the loader 404s (no loader data).
+ */
+export function meta({ loaderData }: Route.MetaArgs) {
+	return [
+		{
+			title: loaderData
+				? `${previewExamples[loaderData.exampleName].title} — @ngrok/mantle`
+				: "@ngrok/mantle",
+		},
+		// belt-and-suspenders with the X-Robots-Tag entry.server sets for /preview
+		// documents: preview fragments should never land in a search index
+		{ name: "robots", content: "noindex, nofollow" },
+	];
+}
+
+/**
+ * The chrome-less document a docs `PreviewFrame` iframes. Renders nothing but
+ * the registered example: the root `App` skips the site header and skip link
+ * for this route (matched by route id), so the example owns the whole
+ * document — its own `Main` landmark, its own `window` for document-level
+ * keyboard shortcuts, and media queries that track the frame's viewport.
+ */
+export default function PreviewExamplePage({ loaderData }: Route.ComponentProps) {
+	const { Component } = previewExamples[loaderData.exampleName];
+	return <Component />;
+}

--- a/apps/www/app/utilities/render-mdx-to-markdown.server.test.ts
+++ b/apps/www/app/utilities/render-mdx-to-markdown.server.test.ts
@@ -29,6 +29,28 @@ describe("renderMdxToMarkdown", () => {
 		expect(result).not.toContain("omitted in markdown output");
 	});
 
+	test("drops the self-closing CodeExample.PreviewFrame and keeps the fence", () => {
+		const result = renderMdxToMarkdown(
+			[
+				"<CodeExample.Root>",
+				'\t<CodeExample.PreviewFrame example="centered-layout" title="Centered layout demo" />',
+				"\t<CodeExample.Code>",
+				"",
+				"```tsx",
+				"const answer = 42;",
+				"```",
+				"",
+				"\t</CodeExample.Code>",
+				"</CodeExample.Root>",
+			].join("\n"),
+		);
+
+		expect(result).toContain("const answer = 42;");
+		expect(result).not.toContain("CodeExample");
+		expect(result).not.toContain("centered-layout");
+		expect(result).not.toContain("omitted in markdown output");
+	});
+
 	test("drops Example previews without a trail comment", () => {
 		const result = renderMdxToMarkdown("<Example>\n\t<MyDemo />\n</Example>\n\nAfter.");
 

--- a/apps/www/app/utilities/render-mdx-to-markdown.server.ts
+++ b/apps/www/app/utilities/render-mdx-to-markdown.server.ts
@@ -75,12 +75,13 @@ const handlers: Record<string, Handler> = {
 	// by a fenced code block that contains the same code in textual form.
 	// Dropping it removes a wall of rendered DOM without losing information.
 	Example: () => ({ kind: "drop" }),
-	// `<CodeExample>` is the tabbed Preview/Code example. The preview panel
-	// wraps a live demo (dropped, like `<Example>`); every other part is a
-	// structural wrapper around real markdown — unwrap them so the fenced
-	// code block inside `CodeExample.Code` lands in the markdown output.
+	// `<CodeExample>` is the tabbed Preview/Code example. The preview panels
+	// wrap a live demo (dropped, like `<Example>`) — `PreviewFrame` is the
+	// iframed variant; every other part is a structural wrapper around real
+	// markdown — unwrap them so the fenced code block inside
+	// `CodeExample.Code` lands in the markdown output.
 	CodeExample: (node) => {
-		if (node.name === "CodeExample.Preview") {
+		if (node.name === "CodeExample.Preview" || node.name === "CodeExample.PreviewFrame") {
 			return { kind: "drop" };
 		}
 		return { kind: "unwrap" };


### PR DESCRIPTION
## Summary

shadcn-blocks-style framed previews for the docs site: full-page layout demos render inside a same-origin `<iframe>` pointed at a chrome-less `/preview/:exampleName` route, with a toolbar to preview the example at **desktop / tablet (768px) / mobile (375px)** widths, reload the frame, or open it in a new tab (the route doubles as the standalone full-screen page).

Because each preview is its own document:

- Examples own **real landmarks** — `Main` + `SkipToMainLink` — instead of the embeddability hacks inline demos need (the docs page already owns its `<main>`).
- **Keyboard shortcuts and window listeners stay inside the frame** (an iframe is its own `window`).
- **Media queries track the frame's viewport**, so the tablet/mobile presets exercise real breakpoint behavior instead of tracking the reader's browser window.
- **Theme stays in sync for free**: the preview document renders through the root layout, and mantle's ThemeProvider already propagates cookie + BroadcastChannel changes across same-origin browsing contexts — toggling the docs theme live-updates the frame.

## Changes

- `routes/preview.tsx` — chrome-less route; validates `:exampleName` against the registry (404 otherwise), noindex meta. `root.tsx` skips the site header/skip-link for it (matched by route id, the `layouts-index` pattern) and relaxes the forced scrollbar gutter.
- `features/preview-registry.ts` — example id → { title, Component }. Only the route imports components; the docs-side frame imports the name **type** only, so demo code stays out of docs-page bundles.
- `components/preview-frame.tsx` — the frame UI (RadioGroup.ButtonGroup switcher, reload = key remount, open-in-new-tab). Fixed preset widths, `box-content` on the bordered wrapper so the iframe viewport is exactly the preset width.
- `CodeExample.PreviewFrame` — new compound part: a force-mounted `Tabs.Content` so flipping Preview↔Code never reloads the iframe.
- `entry.server.tsx` — `/preview` documents get `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'` + forced noindex; every other document now sends `DENY` + `frame-ancestors 'none'` (previously the global DENY blocked even same-origin framing).
- `render-mdx-to-markdown` drops the new part like `CodeExample.Preview`, so `.md`/llms endpoints keep only the fences.
- **centered-layout docs adopt it**: both full-page demos move out of inline MDX into `~/features/centered-layout-demos.tsx` and render framed with real `Main` + `SkipToMainLink` (fences updated to match — they now show real-page composition instead of the sized-wrapper hack, and the sticky-header demo's page genuinely owns its scroller).

## Stacking

First of three: `feat/centered-layout-notice` (#1334) rebases on this and gains a **framed** Notice demo, then `feat/sidebar-app-layout` rebases and registers its app-shell/sidebar demos as framed previews.

## Verification

- `lint` / `fmt:check` / `typecheck` / `test` (1185 mantle + 133 www) / `build` incl. prerender — all pass
- Browser-verified against the production build: exact preset widths (375/768/fill), header responses (`SAMEORIGIN` + `frame-ancestors 'self'` on `/preview/*`, `DENY` elsewhere, unknown names 404), live theme propagation into the frame, iframe surviving Preview↔Code tab flips, sticky header pinning to the frame's own document scroll, exactly one `Main` + skip link per preview document