### PR TITLE
fix(alert-dialog): use neutral action for info dialogs

### DIFF
--- a/.changeset/neutral-alert-dialog-action.md
+++ b/.changeset/neutral-alert-dialog-action.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Use a neutral action button for informational alert dialogs.

--- a/apps/www/app/docs/components/overlays/alert-dialog.mdx
+++ b/apps/www/app/docs/components/overlays/alert-dialog.mdx
@@ -301,7 +301,7 @@ Radix [Dialog.Description](https://www.radix-ui.com/primitives/docs/components/d
 
 ### AlertDialog.Action
 
-A button that confirms the Alert Dialog action. Defaults to `appearance="filled"`, with a tone derived from `AlertDialog.Root`'s `intent`: `"danger"` dialogs get a danger button, `"info"` dialogs get an accent one — the Action carries the dialog's tone the same way its icon does. Does not close the alert dialog by default.
+A button that confirms the Alert Dialog action. Defaults to `appearance="filled"`, with a tone derived from `AlertDialog.Root`'s `intent`: `"danger"` dialogs get a danger button, `"info"` dialogs get a neutral one. Does not close the alert dialog by default.
 
 These buttons should be distinguished visually from `AlertDialog.Cancel`.
 

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.test.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.test.tsx
@@ -67,10 +67,10 @@ describe("AlertDialog", () => {
 			expect(action).toHaveAttribute("data-intent", "danger");
 		});
 
-		test(`Action derives an accent button from intent="info" — it carries the dialog's tone`, () => {
+		test(`Action derives a neutral button from intent="info"`, () => {
 			const { action } = renderAlertDialog({ intent: "info" });
 			expect(action).toHaveAttribute("data-appearance", "filled");
-			expect(action).toHaveAttribute("data-intent", "accent");
+			expect(action).toHaveAttribute("data-intent", "neutral");
 		});
 
 		test("a consumer-passed Action intent wins over the derived one", () => {

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -519,9 +519,8 @@ type AlertDialogActionProps = Omit<ButtonProps, "appearance" | "intent"> & {
 	/**
 	 * The tone of the action button. Optional here — when omitted,
 	 * `AlertDialog.Action` derives the tone from the parent `AlertDialog.Root`'s
-	 * `intent` (`"danger"` → `"danger"`, `"info"` → `"accent"`), so the Action
-	 * carries the dialog's tone the same way its icon does. A passed value
-	 * always wins over the context-derived tone.
+	 * `intent` (`"danger"` → `"danger"`, `"info"` → `"neutral"`). A passed
+	 * value always wins over the context-derived tone.
 	 */
 	intent?: ButtonIntent;
 };
@@ -531,14 +530,13 @@ type AlertDialogActionProps = Omit<ButtonProps, "appearance" | "intent"> & {
  */
 const actionIntentByDialogIntent = {
 	danger: "danger",
-	info: "accent",
+	info: "neutral",
 } as const satisfies Record<AlertDialogIntent, ButtonIntent>;
 
 /**
  * A button that confirms the Alert Dialog action.
  * Will default to appearance="filled", with a tone derived from the `AlertDialog`'s
- * intent: danger dialogs get a danger button, info dialogs get an accent one —
- * the Action carries the dialog's tone the same way its icon does.
+ * intent: danger dialogs get a danger button, info dialogs get a neutral one.
  * Does not close the alert dialog by default.
  *
  * These buttons should be distinguished visually from the AlertDialogCancel button.
@@ -926,9 +924,8 @@ const AlertDialog = {
 	 * A button that confirms the Alert Dialog action. Defaults to
 	 * `appearance="filled"`, with a tone derived from the parent
 	 * `AlertDialog.Root`'s intent: danger dialogs get a danger button, info
-	 * dialogs get an accent one — the Action carries the dialog's tone the
-	 * same way its icon does. Does not close the dialog by default — wrap
-	 * with `AlertDialog.Close asChild` if the action should also dismiss.
+	 * dialogs get a neutral one. Does not close the dialog by default — wrap with
+	 * `AlertDialog.Close asChild` if the action should also dismiss.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/alert-dialog#alertdialogaction
 	 *


### PR DESCRIPTION
## Summary
- Change informational `AlertDialog.Action` buttons to derive `intent=\"neutral\"` instead of `intent=\"accent\"`.
- Update Alert Dialog docs and regression coverage for the new derived action intent.
- Add a patch changeset for `@ngrok/mantle`.

## Test plan
- `pnpm -w run lint`
- `pnpm -w run fmt:check`
- `pnpm -w run typecheck`
- `pnpm -w run test -F @ngrok/mantle`


Made with [Cursor](https://cursor.com)