### PR TITLE
feat!: drop React 18 support, migrate to React 19 ref-as-prop

### DIFF
--- a/.changeset/drop-react-18-support.md
+++ b/.changeset/drop-react-18-support.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle": minor
+---
+
+**BREAKING**: Drop React 18 support — `@ngrok/mantle` now requires `react@^19` and `react-dom@^19` peers (previously `^18 || ^19`).
+
+- All components use React 19's native ref-as-prop instead of `forwardRef`. Call sites are unchanged (`<Button ref={ref} />` keeps working); exported components are now plain function components, and every public `*Props` type includes `ref` via `ComponentProps`.
+- `composeRefs` and `useComposedRefs` now propagate React 19 ref cleanup functions: when a composed callback ref returns a cleanup, the composed ref returns a cleanup that invokes it (refs without cleanups still receive the legacy `null` write on detach).
+- Removed redundant `displayName` assignments — component names are inferred from their declarations; intentional DevTools names on compound parts are kept.

--- a/.claude/commands/audit-component.md
+++ b/.claude/commands/audit-component.md
@@ -56,12 +56,12 @@ For compound components only:
 
 - **The namespace object is single-level.** No nested namespaces (e.g. `Foo.Bar.Root` is forbidden). If you find a nested namespace, flag it for flattening into top-level members (`Foo.BarRoot`, `Foo.BarTrigger`, …) and recommend removing any pass-through re-exports of other mantle namespaces. See `CONVENTIONS.md#compound-components`.
 - **If any namespace member's type comes from a third-party namespace** (e.g. `Radix.Root`, `Radix.Trigger`), the enclosing namespace declaration must carry an explicit type annotation (`const Foo: { Root: typeof Root; … } = { … }`). Without it, `.d.ts` emit can synthesize types that pull in non-portable `@types/react` paths and break on minor `@types/react` upgrades (`TS2883`).
-- Each sub-component `const Foo = forwardRef(...)` / `const Foo = (props) => ...` has a `displayName` set to the **original flat name** (e.g. `Root.displayName = "MyComponent"`, `Content.displayName = "MyComponentContent"`).
+- Each sub-component whose const name differs from the **original flat name** has a `displayName` set to that flat name (e.g. `Root.displayName = "MyComponent"`, `Content.displayName = "MyComponentContent"`). When the const name already matches, no `displayName` — the name is inferred. Never `forwardRef`: `ref` is a regular prop (React 19+).
 - The JSDoc **immediately above the top-level namespace declaration** (`const <ComponentName> = {`) contains two `@example` blocks, in this order:
   1. A `Composition` ASCII-tree block — `@example` on one line, `Composition:` on the next, then a plain (no-language) fenced code block containing the tree. Use real Unicode box-drawing chars (`├` U+251C, `─` U+2500, `└` U+2514, `│` U+2502) with 4-char per-level indentation.
   2. A full-tree JSX usage example showing all commonly-used parts.
 - Every property inside the namespace object has **inline JSDoc** with its own full-tree `@example` (JSX, the same tree shape the top-level block shows). Variant entry points (e.g. tab-enabled variants of the same component) may use a distinct full-tree example for that variant.
-- The JSDoc on the underlying `const Root = forwardRef(...)` / `const Title = ...` declarations mirrors the namespace-property JSDoc: full-tree `@example`, not an abbreviated snippet.
+- The JSDoc on the underlying `const Root = (...) => ...` / `const Title = ...` declarations mirrors the namespace-property JSDoc: full-tree `@example`, not an abbreviated snippet.
 - Provider components and standalone utility functions (e.g. the Toast/Toaster pattern) live **alongside** the namespace object as their own named exports — they are not folded into the namespace.
 
 ### 2.3. `asChild` rules

--- a/.claude/commands/scaffold-component.md
+++ b/.claude/commands/scaffold-component.md
@@ -192,7 +192,7 @@ If the component has sub-parts, follow the POJO namespace pattern from `decision
   } as const;
   ````
 
-  The same rule applies to the JSDoc on the underlying `const Root = forwardRef(...)` / `const Title = (...) => ...` declarations — use full-tree `@example` blocks there too. See `alert.tsx`, `code-block.tsx`, and `empty.tsx` for the canonical pattern.
+  The same rule applies to the JSDoc on the underlying `const Root = (...) => ...` / `const Title = (...) => ...` declarations — use full-tree `@example` blocks there too. See `alert.tsx`, `code-block.tsx`, and `empty.tsx` for the canonical pattern.
 
 - Provider components and standalone utility functions stay as **separate named exports** alongside the namespace object (see the Toast/Toaster pattern in the decisions doc).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Run these from the workspace root once a coherent chunk of work is done and befo
 
 ## Technology Stack
 
-- **React 19** for development; `@ngrok/mantle` publishes peer support for `^18 || ^19` (components must stay compatible with React 18 consumers), TypeScript, **Tailwind CSS 4**, vitest, pnpm, **Node.js 24**, Turborepo
+- **React 19** only; `@ngrok/mantle` requires peer `react@^19` — `ref` is a regular prop, never use `forwardRef` — TypeScript, **Tailwind CSS 4**, vitest, pnpm, **Node.js 24**, Turborepo
 - Radix UI, Ariakit, Headless UI, class-variance-authority
 - **Icons**: `@phosphor-icons/react` primarily, custom ngrok icons via `@ngrok/mantle/icons`
 - **Theme**: Built-in light/dark mode with ThemeProvider and FOUC prevention

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -26,6 +26,7 @@ Single source of truth for code style, patterns, and conventions in the Mantle d
 - Prefer inline single-use event handlers when they improve locality and readability. Hoist handlers only when reused, memoized, or meaningfully simplifying the render body.
 - Avoid nested ternaries. Prefer early returns or component-based branching. A single ternary is fine; nesting harms readability.
 - Never use `React.FC` / `FC` — use inline function types.
+- Never use `forwardRef` — mantle targets React 19+, where `ref` is a regular prop. Base props on `ComponentProps<…>` (which includes `ref`) and destructure `ref` from props when the implementation needs it.
 - Prefer named options objects over positional params: any boolean param, 3+ params, or 2 params when call sites would not be self-evident (`fn({ enabled: true })`, not `fn(true)`).
 - Optimize APIs for readability at the call site. Shared abstractions should make common usage simpler and more obvious, not merely reduce implementation duplication.
 - Do not use deprecated APIs or features — pick the current replacement. Only reach for a deprecated path when it is genuinely unavoidable (no working substitute, or a framework/runtime constraint forces it) and leave a short `// Why:` comment naming the constraint.
@@ -129,7 +130,7 @@ const Command = {
 1. A compound's namespace object has exactly one level of properties.
 2. If a sub-feature relates to a different existing primitive (e.g. Command's dialog-wrapped variant), flatten the relationship into member names (`DialogRoot`, `DialogTrigger`, `DialogContent`) rather than nesting.
 3. Do not re-export another component's namespace under your namespace. If consumers need that primitive, they can import it directly.
-4. Each member of a compound namespace must be a directly-defined component or `forwardRef` result whose type has an explicit name (`forwardRef<…, …>(…)`, `ComponentType<…>`, etc.) — not an inferred literal whose shape depends on chasing types through external packages.
+4. Each member of a compound namespace must be a directly-defined component whose type has an explicit name (a plain function component with annotated props, `ComponentType<…>`, etc.) — not an inferred literal whose shape depends on chasing types through external packages.
 5. When wrapping a third-party namespace primitive (e.g. Radix), explicitly annotate the enclosing namespace object's type so `.d.ts` emit doesn't have to synthesize it: `const Foo: { Root: typeof Root; … } = { … }`.
 6. Every compound's outermost part is named `Root` — even when the compound has no separate state owner and `Root` is the whole component. Consumers should never have to learn which part is outermost per component.
 

--- a/apps/www/app/docs/hooks.mdx
+++ b/apps/www/app/docs/hooks.mdx
@@ -88,17 +88,17 @@ function Example({ onChange }: { onChange?: (value: string) => void }) {
 const ref = useComposedRefs(internalRef, forwardedRef);
 ```
 
-Composes multiple React refs (callback refs and `RefObject`s) into a single stable callback ref using `useCallback`. Useful when a component needs to forward a ref while also keeping an internal one.
+Composes multiple React refs (callback refs and `RefObject`s) into a single stable callback ref using `useCallback`. Useful when a component accepts a `ref` prop while also keeping an internal one.
 
 ```tsx
-import { forwardRef, useRef } from "react";
+import { useRef, type ComponentProps } from "react";
 import { useComposedRefs } from "@ngrok/mantle/hooks";
 
-const MyInput = forwardRef<HTMLInputElement>((props, forwardedRef) => {
+const MyInput = ({ ref: forwardedRef, ...props }: ComponentProps<"input">) => {
 	const internalRef = useRef<HTMLInputElement>(null);
 	const ref = useComposedRefs(internalRef, forwardedRef);
 	return <input ref={ref} {...props} />;
-});
+};
 ```
 
 ## useCopyToClipboard

--- a/apps/www/app/docs/index.mdx
+++ b/apps/www/app/docs/index.mdx
@@ -46,7 +46,7 @@ Mantle is available on [NPM](https://www.npmjs.com/package/@ngrok/mantle) and is
 ### Installation
 
 > [!NOTE]
-> Mantle supports `react` and `react-dom` versions 18 and 19.
+> Mantle requires `react` and `react-dom` version 19.
 
 Install `@ngrok/mantle` and all required `peerDependencies`:
 
@@ -339,8 +339,8 @@ You are now ready to use mantle components in your application! For example, you
 ### Next.js
 
 > [!CAUTION]
-> Mantle does not yet support Next.js 15, especially with react 19 and RSC. We are working on
-> adding support for it soon.
+> Mantle does not yet support Next.js 15, especially with React Server Components (RSC). We are
+> working on adding support for it soon.
 
 ### React SPA
 

--- a/apps/www/app/docs/migrations/code-block-migration.mdx
+++ b/apps/www/app/docs/migrations/code-block-migration.mdx
@@ -459,9 +459,9 @@ If you also have code blocks in React components (not MDX), use `mantleCode` tag
 
 ---
 
-## Use Case 3: React 18 + Vite + Go Server
+## Use Case 3: Vite SPA + Go Server
 
-This is for apps where the frontend is a Vite-built React 18 SPA and the backend is a Go server. The Go server cannot run Shiki (it's JavaScript/Wasm), so you have two options for dynamic code:
+This is for apps where the frontend is a Vite-built React SPA and the backend is a Go server. The Go server cannot run Shiki (it's JavaScript/Wasm), so you have two options for dynamic code:
 
 **Option A:** Use `mantleCode` tagged templates for all static code (build-time, via Vite plugin) and skip server highlighting entirely. Code not known at build time renders as plain text (no syntax highlighting).
 
@@ -636,9 +636,9 @@ function DynamicCodeBlock({ code, language }: { code: string; language: string }
 }
 ```
 
-### React 18 compatibility note
+### React 19 requirement
 
-`@ngrok/mantle` supports React 18. The CodeBlock component uses `"use client"` directives, `useId()`, and standard hooks — all available in React 18. No React 19 features are required.
+As of this release, `@ngrok/mantle` requires `react@^19` and `react-dom@^19`.
 
 ---
 

--- a/apps/www/app/docs/utils/compose-refs.mdx
+++ b/apps/www/app/docs/utils/compose-refs.mdx
@@ -15,19 +15,19 @@ import { composeRefs } from "@ngrok/mantle/utils";
 
 ## Usage
 
-### With `forwardRef`
+### Forwarding a ref while keeping an internal ref
 
-The most common use case: forward a ref to a parent while keeping an internal ref for the component itself.
+The most common use case: accept a `ref` prop from the parent while keeping an internal ref for the component itself.
 
 ```tsx
-import { forwardRef, useRef } from "react";
+import { useRef, type ComponentProps } from "react";
 import { composeRefs } from "@ngrok/mantle/utils";
 
-const MyInput = forwardRef<HTMLInputElement>((props, forwardedRef) => {
+const MyInput = ({ ref: forwardedRef, ...props }: ComponentProps<"input">) => {
 	const internalRef = useRef<HTMLInputElement>(null);
 
 	return <input ref={composeRefs(internalRef, forwardedRef)} {...props} />;
-});
+};
 ```
 
 ### With multiple refs
@@ -67,9 +67,9 @@ function Example() {
 ## API
 
 ```ts
-function composeRefs<T>(...refs: PossibleRef<T>[]): (node: T) => void;
+function composeRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T>;
 
 type PossibleRef<T> = React.Ref<T> | undefined;
 ```
 
-Accepts any number of refs (callback refs, `RefObject`s, or `undefined`). Returns a single callback ref that, when called with a node, assigns the node to all provided refs. `undefined` refs are safely skipped.
+Accepts any number of refs (callback refs, `RefObject`s, or `undefined`). Returns a single callback ref that, when called with a node, assigns the node to all provided refs. `undefined` refs are safely skipped. When a callback ref returns a React 19 ref cleanup function, the composed ref propagates it, so each cleanup runs on unmount.

--- a/config/tsconfig/package.json
+++ b/config/tsconfig/package.json
@@ -20,6 +20,6 @@
     "react": "19.2.7"
   },
   "peerDependencies": {
-    "react": "^18 || ^19"
+    "react": "^19"
   }
 }

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -433,8 +433,8 @@
 	},
 	"peerDependencies": {
 		"@phosphor-icons/react": "^2.1.10",
-		"react": "^18 || ^19",
-		"react-dom": "^18 || ^19",
+		"react": "^19",
+		"react-dom": "^19",
 		"tailwindcss": "^4.3.3"
 	},
 	"engines": {

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -2,10 +2,9 @@
 
 import { CaretDownIcon } from "@phosphor-icons/react/CaretDown";
 import {
-	type ComponentPropsWithoutRef,
+	type ComponentProps,
 	type ComponentRef,
 	createContext,
-	forwardRef,
 	useCallback,
 	useContext,
 	useEffect,
@@ -148,7 +147,7 @@ type AccordionMultipleProps = {
 type AccordionRootProps = (AccordionSingleProps | AccordionMultipleProps) &
 	// `defaultValue` is omitted because the discriminated union above types it per
 	// `type` (a `string` or `string[]`), narrower than the DOM's `defaultValue`.
-	Omit<ComponentPropsWithoutRef<"div">, "defaultValue"> &
+	Omit<ComponentProps<"div">, "defaultValue"> &
 	WithAsChild;
 
 /**
@@ -187,7 +186,7 @@ type AccordionRootProps = (AccordionSingleProps | AccordionMultipleProps) &
  *   </Accordion.Item>
  * </Accordion.Root>
  */
-const Root = forwardRef<ComponentRef<"div">, AccordionRootProps>((props, ref) => {
+const Root = (props: AccordionRootProps) => {
 	// Pull the accordion-specific props out so the rest (`aria-*`, `data-*`, `id`,
 	// `style`, event handlers, …) can be forwarded to the container without leaking
 	// non-DOM attributes. `props` stays whole for `emitValueChange`, which relies on
@@ -203,6 +202,7 @@ const Root = forwardRef<ComponentRef<"div">, AccordionRootProps>((props, ref) =>
 		asChild,
 		children,
 		className,
+		ref,
 		...domProps
 	} = props;
 	const isControlled = value != null;
@@ -252,7 +252,7 @@ const Root = forwardRef<ComponentRef<"div">, AccordionRootProps>((props, ref) =>
 			)}
 		</AccordionContext.Provider>
 	);
-});
+};
 Root.displayName = "Accordion";
 
 /**
@@ -278,13 +278,15 @@ Root.displayName = "Accordion";
  *   </Accordion.Item>
  * </Accordion.Root>
  */
-const Item = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<"div"> & {
-		/** The unique value identifying this item within its accordion. */
-		value: string;
-	}
->(({ children, value, ...props }, ref) => {
+const Item = ({
+	children,
+	value,
+	ref,
+	...props
+}: ComponentProps<"div"> & {
+	/** The unique value identifying this item within its accordion. */
+	value: string;
+}) => {
 	const { openValues, setItemOpen } = useAccordionContext("Accordion.Item");
 	const open = isItemOpen(openValues, value);
 
@@ -313,7 +315,7 @@ const Item = forwardRef<
 			</div>
 		</AccordionItemContext.Provider>
 	);
-});
+};
 Item.displayName = "AccordionItem";
 
 /**
@@ -338,10 +340,13 @@ Item.displayName = "AccordionItem";
  *   </Accordion.Item>
  * </Accordion.Root>
  */
-const Trigger = forwardRef<
-	ComponentRef<"button">,
-	Omit<ComponentPropsWithoutRef<"button">, "type">
->(({ className, children, onClick, ...props }, ref) => {
+const Trigger = ({
+	className,
+	children,
+	onClick,
+	ref,
+	...props
+}: Omit<ComponentProps<"button">, "type">) => {
 	const { open, setOpen } = useAccordionItemContext("Accordion.Trigger");
 
 	return (
@@ -379,7 +384,7 @@ const Trigger = forwardRef<
 			{children}
 		</button>
 	);
-});
+};
 Trigger.displayName = "AccordionTrigger";
 
 // Hoisted so the default `svg` is a stable element reference instead of a new
@@ -470,86 +475,84 @@ TriggerIcon.displayName = "AccordionTriggerIcon";
  *   </Accordion.Item>
  * </Accordion.Root>
  */
-const Content = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>(
-	({ className, children, ...props }, forwardedRef) => {
-		const { open, setOpen } = useAccordionItemContext("Accordion.Content");
-		// Track the node ourselves (for the find-in-page reveal effects below) while
-		// still forwarding it to any ref the consumer passes.
-		const nodeRef = useRef<ComponentRef<"div">>(null);
-		const composedRef = useComposedRefs(nodeRef, forwardedRef);
+const Content = ({ className, children, ref, ...props }: ComponentProps<"div">) => {
+	const { open, setOpen } = useAccordionItemContext("Accordion.Content");
+	// Track the node ourselves (for the find-in-page reveal effects below) while
+	// still forwarding it to any ref the consumer passes.
+	const nodeRef = useRef<ComponentRef<"div">>(null);
+	const composedRef = useComposedRefs(nodeRef, ref);
 
-		// When the browser is about to reveal a find-in-page match inside this
-		// (collapsed) region, open the item so our state agrees and it stays open.
-		useEffect(() => {
-			const node = nodeRef.current;
-			if (!node || !supportsBeforeMatch()) {
-				return;
-			}
-			const handleBeforeMatch = () => {
-				// The browser reveals and highlights the match synchronously right after
-				// this event, but our React-driven height (`data-state-open:h-auto`) only
-				// applies a tick later. Without expanding now, the box is still
-				// `h-0 overflow-hidden` when the browser paints its find highlight, so the
-				// match opens but its highlight is clipped to zero height and lost. Removing
-				// `hidden` restores `content-visibility`, so setting `height: auto` lays the
-				// text out at full height before the highlight paints. The close branch of
-				// the effect below clears this inline height so the slide animation resumes.
-				node.removeAttribute("hidden");
-				node.style.height = "auto";
-				setOpen(true);
-			};
+	// When the browser is about to reveal a find-in-page match inside this
+	// (collapsed) region, open the item so our state agrees and it stays open.
+	useEffect(() => {
+		const node = nodeRef.current;
+		if (!node || !supportsBeforeMatch()) {
+			return;
+		}
+		const handleBeforeMatch = () => {
+			// The browser reveals and highlights the match synchronously right after
+			// this event, but our React-driven height (`data-state-open:h-auto`) only
+			// applies a tick later. Without expanding now, the box is still
+			// `h-0 overflow-hidden` when the browser paints its find highlight, so the
+			// match opens but its highlight is clipped to zero height and lost. Removing
+			// `hidden` restores `content-visibility`, so setting `height: auto` lays the
+			// text out at full height before the highlight paints. The close branch of
+			// the effect below clears this inline height so the slide animation resumes.
+			node.removeAttribute("hidden");
+			node.style.height = "auto";
+			setOpen(true);
+		};
 
-			node.addEventListener("beforematch", handleBeforeMatch);
+		node.addEventListener("beforematch", handleBeforeMatch);
 
-			return () => {
-				node.removeEventListener("beforematch", handleBeforeMatch);
-			};
-		}, [setOpen]);
+		return () => {
+			node.removeEventListener("beforematch", handleBeforeMatch);
+		};
+	}, [setOpen]);
 
-		// Toggle `hidden="until-found"` with the open state, imperatively: React types
-		// `hidden` as boolean-only (no `"until-found"`) and has no `onBeforeMatch`, so
-		// going through the JSX attribute is impossible without a type assertion.
-		// Layout effect so the collapsed item is hidden before first paint (no flash).
-		useIsomorphicLayoutEffect(() => {
-			const node = nodeRef.current;
-			if (!node) {
-				return;
-			}
+	// Toggle `hidden="until-found"` with the open state, imperatively: React types
+	// `hidden` as boolean-only (no `"until-found"`) and has no `onBeforeMatch`, so
+	// going through the JSX attribute is impossible without a type assertion.
+	// Layout effect so the collapsed item is hidden before first paint (no flash).
+	useIsomorphicLayoutEffect(() => {
+		const node = nodeRef.current;
+		if (!node) {
+			return;
+		}
 
-			if (open || !supportsBeforeMatch()) {
-				node.removeAttribute("hidden");
-			} else {
-				node.setAttribute("hidden", "until-found");
-				// Drop any inline height a find-in-page reveal set so the class-driven
-				// `h-0 ↔ h-auto` open/close slide takes over again.
-				node.style.height = "";
-			}
-		}, [open]);
+		if (open || !supportsBeforeMatch()) {
+			node.removeAttribute("hidden");
+		} else {
+			node.setAttribute("hidden", "until-found");
+			// Drop any inline height a find-in-page reveal set so the class-driven
+			// `h-0 ↔ h-auto` open/close slide takes over again.
+			node.style.height = "";
+		}
+	}, [open]);
 
-		return (
-			<div
-				ref={composedRef}
-				{...props}
-				data-slot="accordion-content"
-				data-state={open ? "open" : "closed"}
-				className={cx(
-					// Animate height 0 <-> auto via `interpolate-size` (Chromium only; other
-					// engines snap, which is fine — the slide is a progressive enhancement and
-					// find-in-page works regardless). `content-visibility` transitions with
-					// `allow-discrete` so the content stays rendered through the close slide
-					// before `hidden="until-found"` skips it; `overflow-hidden` clips. Padding
-					// lives on `Accordion.Body`, never here: a padded `h-0` border-box can't
-					// collapse below its padding, so the closed section would stop short of
-					// zero height instead of fully collapsing.
-					"h-0 overflow-hidden transition-[height,content-visibility] duration-200 ease-out [interpolate-size:allow-keywords] transition-discrete data-state-open:h-auto motion-reduce:transition-none",
-					className,
-				)}
-			>
-				{children}
-			</div>
-		);
-	},
-);
+	return (
+		<div
+			ref={composedRef}
+			{...props}
+			data-slot="accordion-content"
+			data-state={open ? "open" : "closed"}
+			className={cx(
+				// Animate height 0 <-> auto via `interpolate-size` (Chromium only; other
+				// engines snap, which is fine — the slide is a progressive enhancement and
+				// find-in-page works regardless). `content-visibility` transitions with
+				// `allow-discrete` so the content stays rendered through the close slide
+				// before `hidden="until-found"` skips it; `overflow-hidden` clips. Padding
+				// lives on `Accordion.Body`, never here: a padded `h-0` border-box can't
+				// collapse below its padding, so the closed section would stop short of
+				// zero height instead of fully collapsing.
+				"h-0 overflow-hidden transition-[height,content-visibility] duration-200 ease-out [interpolate-size:allow-keywords] transition-discrete data-state-open:h-auto motion-reduce:transition-none",
+				className,
+			)}
+		>
+			{children}
+		</div>
+	);
+};
 Content.displayName = "AccordionContent";
 
 /**
@@ -582,10 +585,8 @@ Content.displayName = "AccordionContent";
  *   </Accordion.Item>
  * </Accordion.Root>
  */
-const Body = forwardRef<ComponentRef<"div">, ComponentPropsWithoutRef<"div">>(
-	({ className, ...props }, ref) => (
-		<div ref={ref} {...props} data-slot="accordion-body" className={cx("pt-2 pb-4", className)} />
-	),
+const Body = ({ className, ref, ...props }: ComponentProps<"div">) => (
+	<div ref={ref} {...props} data-slot="accordion-body" className={cx("pt-2 pb-4", className)} />
 );
 Body.displayName = "AccordionBody";
 

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -2,16 +2,7 @@
 
 import { InfoIcon } from "@phosphor-icons/react/Info";
 import { WarningIcon } from "@phosphor-icons/react/Warning";
-import {
-	type ComponentProps,
-	type ComponentPropsWithoutRef,
-	type ComponentRef,
-	type ReactNode,
-	createContext,
-	forwardRef,
-	useContext,
-	useMemo,
-} from "react";
+import { type ComponentProps, type ReactNode, createContext, useContext, useMemo } from "react";
 import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -133,12 +124,9 @@ Root.displayName = "AlertDialog";
  * </AlertDialog.Root>
  * ```
  */
-const Trigger = forwardRef<
-	ComponentRef<typeof AlertDialogPrimitive.Trigger>,
-	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Trigger>
->(({ ...props }, ref) => (
+const Trigger = ({ ref, ...props }: ComponentProps<typeof AlertDialogPrimitive.Trigger>) => (
 	<AlertDialogPrimitive.Trigger ref={ref} data-slot="alert-dialog-trigger" {...props} />
-));
+);
 Trigger.displayName = "AlertDialogTrigger";
 
 /**
@@ -154,10 +142,11 @@ AlertDialogPortal.displayName = "AlertDialogPortal";
  *
  * @private
  */
-const AlertDialogOverlay = forwardRef<
-	ComponentRef<typeof AlertDialogPrimitive.Overlay>,
-	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const AlertDialogOverlay = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof AlertDialogPrimitive.Overlay>) => (
 	<AlertDialogPrimitive.Overlay
 		data-slot="alert-dialog-overlay"
 		className={cx(
@@ -167,10 +156,9 @@ const AlertDialogOverlay = forwardRef<
 		{...props}
 		ref={ref}
 	/>
-));
-AlertDialogOverlay.displayName = "AlertDialogOverlay";
+);
 
-type AlertDialogContentProps = ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & {
+type AlertDialogContentProps = ComponentProps<typeof AlertDialogPrimitive.Content> & {
 	/**
 	 * The preferred width of the `AlertDialogContent` as a tailwind `max-w-` class.
 	 *
@@ -223,10 +211,12 @@ type AlertDialogContentProps = ComponentPropsWithoutRef<typeof AlertDialogPrimit
  * </AlertDialog.Root>
  * ```
  */
-const Content = forwardRef<
-	ComponentRef<typeof AlertDialogPrimitive.Content>,
-	AlertDialogContentProps
->(({ className, preferredWidth = "max-w-md", ...props }, ref) => (
+const Content = ({
+	className,
+	preferredWidth = "max-w-md",
+	ref,
+	...props
+}: AlertDialogContentProps) => (
 	<AlertDialogPortal>
 		<AlertDialogOverlay />
 		<div className="fixed inset-4 z-50 flex items-center justify-center">
@@ -247,7 +237,7 @@ const Content = forwardRef<
 			/>
 		</div>
 	</AlertDialogPortal>
-));
+);
 Content.displayName = "AlertDialogContent";
 
 /**
@@ -285,20 +275,23 @@ Content.displayName = "AlertDialogContent";
  * </AlertDialog.Root>
  * ```
  */
-const Body = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Body = ({
+	asChild = false,
+	className,
+	ref,
+	...props
+}: ComponentProps<"div"> & WithAsChild) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				data-slot="alert-dialog-body"
-				className={cx("flex-1 space-y-4", className)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			data-slot="alert-dialog-body"
+			className={cx("flex-1 space-y-4", className)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Body.displayName = "AlertDialogBody";
 
 /**
@@ -336,20 +329,23 @@ Body.displayName = "AlertDialogBody";
  * </AlertDialog.Root>
  * ```
  */
-const Header = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Header = ({
+	asChild = false,
+	className,
+	ref,
+	...props
+}: ComponentProps<"div"> & WithAsChild) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				data-slot="alert-dialog-header"
-				className={cx("flex flex-col space-y-2 text-center sm:text-start", className)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			data-slot="alert-dialog-header"
+			className={cx("flex flex-col space-y-2 text-center sm:text-start", className)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Header.displayName = "AlertDialogHeader";
 
 /**
@@ -387,20 +383,23 @@ Header.displayName = "AlertDialogHeader";
  * </AlertDialog.Root>
  * ```
  */
-const Footer = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Footer = ({
+	asChild = false,
+	className,
+	ref,
+	...props
+}: ComponentProps<"div"> & WithAsChild) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				data-slot="alert-dialog-footer"
-				className={cx("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			data-slot="alert-dialog-footer"
+			className={cx("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Footer.displayName = "AlertDialogFooter";
 
 /**
@@ -441,17 +440,14 @@ Footer.displayName = "AlertDialogFooter";
  * </AlertDialog.Root>
  * ```
  */
-const Title = forwardRef<
-	ComponentRef<typeof AlertDialogPrimitive.Title>,
-	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+const Title = ({ className, ref, ...props }: ComponentProps<typeof AlertDialogPrimitive.Title>) => (
 	<AlertDialogPrimitive.Title
 		ref={ref}
 		data-slot="alert-dialog-title"
 		className={cx("text-strong text-center text-lg font-medium sm:text-start", className)}
 		{...props}
 	/>
-));
+);
 Title.displayName = "AlertDialogTitle";
 
 /**
@@ -494,17 +490,18 @@ Title.displayName = "AlertDialogTitle";
  * </AlertDialog.Root>
  * ```
  */
-const Description = forwardRef<
-	ComponentRef<typeof AlertDialogPrimitive.Description>,
-	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
->(({ className, ...props }, ref) => (
+const Description = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof AlertDialogPrimitive.Description>) => (
 	<AlertDialogPrimitive.Description
 		ref={ref}
 		data-slot="alert-dialog-description"
 		className={cx("text-body text-center text-sm font-normal sm:text-start", className)}
 		{...props}
 	/>
-));
+);
 Description.displayName = "AlertDialogDescription";
 
 type AlertDialogActionProps = Omit<ButtonProps, "appearance" | "intent"> & {
@@ -575,31 +572,27 @@ const actionIntentByDialogIntent = {
  * </AlertDialog.Root>
  * ```
  */
-const Action = forwardRef<ComponentRef<"button">, AlertDialogActionProps>(
-	(
-		{
-			//,
-			appearance = "filled",
-			intent,
-			...props
-		},
-		ref,
-	) => {
-		const ctx = useAlertDialogContext();
-		const contextIntent = actionIntentByDialogIntent[ctx.intent];
+const Action = ({
+	//,
+	appearance = "filled",
+	intent,
+	ref,
+	...props
+}: AlertDialogActionProps) => {
+	const ctx = useAlertDialogContext();
+	const contextIntent = actionIntentByDialogIntent[ctx.intent];
 
-		return (
-			<Button
-				//
-				appearance={appearance}
-				data-slot="alert-dialog-action"
-				intent={intent ?? contextIntent}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Button
+			//
+			appearance={appearance}
+			data-slot="alert-dialog-action"
+			intent={intent ?? contextIntent}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Action.displayName = "AlertDialogAction";
 
 type AlertDialogCancelProps = Omit<ButtonProps, "appearance" | "intent"> & {
@@ -660,28 +653,24 @@ type AlertDialogCancelProps = Omit<ButtonProps, "appearance" | "intent"> & {
  * </AlertDialog.Root>
  * ```
  */
-const Cancel = forwardRef<ComponentRef<"button">, AlertDialogCancelProps>(
-	(
-		{
-			//,
-			appearance = "outlined",
-			className,
-			intent = "neutral",
-			...props
-		},
-		ref,
-	) => (
-		<AlertDialogPrimitive.Close asChild>
-			<Button
-				appearance={appearance}
-				data-slot="alert-dialog-cancel"
-				className={cx("mt-2 sm:mt-0", className)}
-				intent={intent}
-				ref={ref}
-				{...props}
-			/>
-		</AlertDialogPrimitive.Close>
-	),
+const Cancel = ({
+	//,
+	appearance = "outlined",
+	className,
+	intent = "neutral",
+	ref,
+	...props
+}: AlertDialogCancelProps) => (
+	<AlertDialogPrimitive.Close asChild>
+		<Button
+			appearance={appearance}
+			data-slot="alert-dialog-cancel"
+			className={cx("mt-2 sm:mt-0", className)}
+			intent={intent}
+			ref={ref}
+			{...props}
+		/>
+	</AlertDialogPrimitive.Close>
 );
 Cancel.displayName = "AlertDialogCancel";
 
@@ -745,23 +734,21 @@ const defaultIconColors = {
  * </AlertDialog.Root>
  * ```
  */
-const Icon = forwardRef<ComponentRef<"svg">, AlertDialogIconProps>(
-	({ className, svg, ...props }, ref) => {
-		const ctx = useAlertDialogContext();
-		const defaultColor = defaultIconColors[ctx.intent];
-		const defaultIcon = defaultIcons[ctx.intent];
+const Icon = ({ className, ref, svg, ...props }: AlertDialogIconProps) => {
+	const ctx = useAlertDialogContext();
+	const defaultColor = defaultIconColors[ctx.intent];
+	const defaultIcon = defaultIcons[ctx.intent];
 
-		return (
-			<SvgOnly
-				ref={ref}
-				data-slot="alert-dialog-icon"
-				className={cx("size-12 sm:size-7", defaultColor, className)}
-				svg={svg ?? defaultIcon}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<SvgOnly
+			ref={ref}
+			data-slot="alert-dialog-icon"
+			className={cx("size-12 sm:size-7", defaultColor, className)}
+			svg={svg ?? defaultIcon}
+			{...props}
+		/>
+	);
+};
 Icon.displayName = "AlertDialogIcon";
 
 /**
@@ -806,12 +793,9 @@ Icon.displayName = "AlertDialogIcon";
  * </AlertDialog.Root>
  * ```
  */
-const Close = forwardRef<
-	ComponentRef<typeof AlertDialogPrimitive.Close>,
-	ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Close>
->(({ ...props }, ref) => (
+const Close = ({ ref, ...props }: ComponentProps<typeof AlertDialogPrimitive.Close>) => (
 	<AlertDialogPrimitive.Close ref={ref} data-slot="alert-dialog-close" {...props} />
-));
+);
 Close.displayName = "AlertDialogClose";
 
 /**

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -5,8 +5,8 @@ import { WarningIcon } from "@phosphor-icons/react/Warning";
 import { WarningDiamondIcon } from "@phosphor-icons/react/WarningDiamond";
 import { XIcon } from "@phosphor-icons/react/X";
 import { cva } from "class-variance-authority";
-import type { ComponentProps, ComponentRef, HTMLAttributes, ReactNode } from "react";
-import { createContext, forwardRef, useContext, useMemo } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { createContext, useContext, useMemo } from "react";
 import invariant from "tiny-invariant";
 import { $cssProperties, type WithAsChild } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -118,22 +118,20 @@ type AlertProps = ComponentProps<"div"> & {
  * </Alert>
  *```
  */
-const Root = forwardRef<ComponentRef<"div">, AlertProps>(
-	({ appearance = "default", className, intent, ...props }, ref) => {
-		const context: AlertContextValue = useMemo(() => ({ intent }), [intent]);
+const Root = ({ appearance = "default", className, intent, ref, ...props }: AlertProps) => {
+	const context: AlertContextValue = useMemo(() => ({ intent }), [intent]);
 
-		return (
-			<AlertContext.Provider value={context}>
-				<div
-					ref={ref}
-					data-slot="alert"
-					className={cx(alertVariants({ appearance, intent }), className)}
-					{...props}
-				/>
-			</AlertContext.Provider>
-		);
-	},
-);
+	return (
+		<AlertContext.Provider value={context}>
+			<div
+				ref={ref}
+				data-slot="alert"
+				className={cx(alertVariants({ appearance, intent }), className)}
+				{...props}
+			/>
+		</AlertContext.Provider>
+	);
+};
 Root.displayName = "Alert";
 
 type AlertIconProps = Omit<SvgAttributes, "children"> & {
@@ -176,22 +174,20 @@ const defaultIcons = {
  * </Alert>
  * ```
  */
-const Icon = forwardRef<ComponentRef<"svg">, AlertIconProps>(
-	({ className, svg, ...props }, ref) => {
-		const ctx = useAlertContext();
-		const defaultIcon = defaultIcons[ctx.intent];
+const Icon = ({ className, ref, svg, ...props }: AlertIconProps) => {
+	const ctx = useAlertContext();
+	const defaultIcon = defaultIcons[ctx.intent];
 
-		return (
-			<SvgOnly
-				ref={ref}
-				data-slot="alert-icon"
-				className={cx("size-5", className)}
-				svg={svg ?? defaultIcon}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<SvgOnly
+			ref={ref}
+			data-slot="alert-icon"
+			className={cx("size-5", className)}
+			svg={svg ?? defaultIcon}
+			{...props}
+		/>
+	);
+};
 Icon.displayName = "AlertIcon";
 
 /**
@@ -213,19 +209,17 @@ Icon.displayName = "AlertIcon";
  * </Alert>
  *```
  */
-const Content = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
-	({ className, ...props }, ref) => (
-		<div
-			ref={ref}
-			data-slot="alert-content"
-			className={cx("min-w-0 flex-1 has-data-alert-dismiss:pr-6", className)}
-			{...props}
-		/>
-	),
+const Content = ({ className, ref, ...props }: ComponentProps<"div">) => (
+	<div
+		ref={ref}
+		data-slot="alert-content"
+		className={cx("min-w-0 flex-1 has-data-alert-dismiss:pr-6", className)}
+		{...props}
+	/>
 );
 Content.displayName = "AlertContent";
 
-type AlertTitleProps = HTMLAttributes<HTMLHeadingElement> & WithAsChild;
+type AlertTitleProps = ComponentProps<"h5"> & WithAsChild;
 
 /**
  * The title of an alert. Default renders as an h5 element, use asChild to render something else.
@@ -246,20 +240,18 @@ type AlertTitleProps = HTMLAttributes<HTMLHeadingElement> & WithAsChild;
  * </Alert>
  *```
  */
-const Title = forwardRef<HTMLHeadingElement, AlertTitleProps>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "h5";
+const Title = ({ asChild = false, className, ref, ...props }: AlertTitleProps) => {
+	const Component = asChild ? Slot : "h5";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="alert-title"
-				className={cx("font-medium", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="alert-title"
+			className={cx("font-medium", className)}
+			{...props}
+		/>
+	);
+};
 Title.displayName = "AlertTitle";
 
 type AlertDescriptionProps = ComponentProps<"div"> & WithAsChild;
@@ -285,20 +277,18 @@ type AlertDescriptionProps = ComponentProps<"div"> & WithAsChild;
  * </Alert>
  * ```
  */
-const Description = forwardRef<ComponentRef<"div">, AlertDescriptionProps>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Description = ({ asChild = false, className, ref, ...props }: AlertDescriptionProps) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="alert-description"
-				className={cx("text-sm", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="alert-description"
+			className={cx("text-sm", className)}
+			{...props}
+		/>
+	);
+};
 Description.displayName = "AlertDescription";
 
 const dismissTextColor = (intent: AlertIntent) => `var(--color-${intent}-700)`;

--- a/packages/mantle/src/components/anchor/anchor.tsx
+++ b/packages/mantle/src/components/anchor/anchor.tsx
@@ -1,5 +1,5 @@
-import type { ComponentProps, ComponentRef, ReactNode } from "react";
-import { Children, cloneElement, forwardRef, isValidElement } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { Children, cloneElement, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -98,57 +98,58 @@ type AnchorProps = Omit<ComponentProps<"a">, "rel"> &
  * </Anchor>
  * ```
  */
-const Anchor = forwardRef<ComponentRef<"a">, AnchorProps>(
-	(
-		{ asChild, children, className, rel: propRel, icon, iconPlacement = "start", ...props },
+const Anchor = ({
+	asChild,
+	children,
+	className,
+	rel: propRel,
+	icon,
+	iconPlacement = "start",
+	ref,
+	...props
+}: AnchorProps) => {
+	const rel = resolveRel(propRel);
+	const componentProps = {
+		"data-slot": "anchor",
+		className: anchorClassNames(className),
 		ref,
-	) => {
-		const rel = resolveRel(propRel);
-		const componentProps = {
-			"data-slot": "anchor",
-			className: anchorClassNames(className),
-			ref,
-			rel,
-			...props,
-		};
+		rel,
+		...props,
+	};
 
-		if (asChild) {
-			const singleChild = Children.only(children);
-			invariant(
-				isValidElement<AnchorProps>(singleChild),
-				"When using `asChild`, Anchor must be passed a single child as a JSX tag.",
-			);
-			const grandchildren = singleChild.props?.children;
-
-			return (
-				<Slot {...componentProps}>
-					{cloneElement(
-						singleChild,
-						{},
-						<>
-							{icon && iconPlacement === "start" && (
-								<Icon className="inline-block mr-1.5" svg={icon} />
-							)}
-							{grandchildren}
-							{icon && iconPlacement === "end" && (
-								<Icon className="inline-block ml-1.5" svg={icon} />
-							)}
-						</>,
-					)}
-				</Slot>
-			);
-		}
+	if (asChild) {
+		const singleChild = Children.only(children);
+		invariant(
+			isValidElement<AnchorProps>(singleChild),
+			"When using `asChild`, Anchor must be passed a single child as a JSX tag.",
+		);
+		const grandchildren = singleChild.props?.children;
 
 		return (
-			<a {...componentProps}>
-				{icon && iconPlacement === "start" && <Icon className="inline-block mr-1.5" svg={icon} />}
-				{children}
-				{icon && iconPlacement === "end" && <Icon className="inline-block ml-1.5" svg={icon} />}
-			</a>
+			<Slot {...componentProps}>
+				{cloneElement(
+					singleChild,
+					{},
+					<>
+						{icon && iconPlacement === "start" && (
+							<Icon className="inline-block mr-1.5" svg={icon} />
+						)}
+						{grandchildren}
+						{icon && iconPlacement === "end" && <Icon className="inline-block ml-1.5" svg={icon} />}
+					</>,
+				)}
+			</Slot>
 		);
-	},
-);
-Anchor.displayName = "Anchor";
+	}
+
+	return (
+		<a {...componentProps}>
+			{icon && iconPlacement === "start" && <Icon className="inline-block mr-1.5" svg={icon} />}
+			{children}
+			{icon && iconPlacement === "end" && <Icon className="inline-block ml-1.5" svg={icon} />}
+		</a>
+	);
+};
 
 /**
  * Resolves the `rel` attribute to a string.

--- a/packages/mantle/src/components/badge/badge.tsx
+++ b/packages/mantle/src/components/badge/badge.tsx
@@ -116,7 +116,6 @@ const Badge = ({
 		</span>
 	);
 };
-Badge.displayName = "Badge";
 
 // MARK: - Exports
 

--- a/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
-import type { ComponentProps, ComponentRef, ReactNode } from "react";
-import { cloneElement, forwardRef, isValidElement } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { cloneElement, isValidElement } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
@@ -35,22 +35,26 @@ import { Slot } from "../slot/index.js";
  * </Breadcrumb.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"nav">, ComponentProps<"nav"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "nav";
+const Root = ({
+	asChild,
+	children,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<"nav"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "nav";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "breadcrumb")}
-				aria-label="Breadcrumb"
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "breadcrumb")}
+			aria-label="Breadcrumb"
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Root.displayName = "Breadcrumb";
 
 /**
@@ -79,22 +83,27 @@ Root.displayName = "Breadcrumb";
  * </Breadcrumb.Root>
  * ```
  */
-const List = forwardRef<ComponentRef<"ol">, ComponentProps<"ol"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "ol";
+const List = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<"ol"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "ol";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "breadcrumb-list")}
-				className={cx("text-muted flex flex-wrap items-center gap-1.5 text-sm", className)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "breadcrumb-list")}
+			className={cx("text-muted flex flex-wrap items-center gap-1.5 text-sm", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 List.displayName = "BreadcrumbList";
 
 /**
@@ -122,22 +131,27 @@ List.displayName = "BreadcrumbList";
  * </Breadcrumb.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<"li">, ComponentProps<"li"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "li";
+const Item = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<"li"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "li";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "breadcrumb-item")}
-				className={cx("inline-flex items-center gap-1.5", className)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "breadcrumb-item")}
+			className={cx("inline-flex items-center gap-1.5", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Item.displayName = "BreadcrumbItem";
 
 /**
@@ -174,22 +188,27 @@ Item.displayName = "BreadcrumbItem";
  * </Breadcrumb.Link>
  * ```
  */
-const Link = forwardRef<ComponentRef<"a">, ComponentProps<"a"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "a";
+const Link = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<"a"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "a";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "breadcrumb-link")}
-				className={cx("hover:text-strong transition-colors", className)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "breadcrumb-link")}
+			className={cx("hover:text-strong transition-colors", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Link.displayName = "BreadcrumbLink";
 
 /**
@@ -219,29 +238,34 @@ Link.displayName = "BreadcrumbLink";
  * </Breadcrumb.Root>
  * ```
  */
-const Page = forwardRef<ComponentRef<"span">, ComponentProps<"span"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "span";
-		// Slot merges child props over slot props, so with asChild the enforced
-		// ARIA must be cloned onto the child element itself to stay un-overridable.
-		const content =
-			asChild && isValidElement<ComponentProps<"span">>(children)
-				? cloneElement(children, { "aria-current": "page" })
-				: children;
+const Page = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<"span"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "span";
+	// Slot merges child props over slot props, so with asChild the enforced
+	// ARIA must be cloned onto the child element itself to stay un-overridable.
+	const content =
+		asChild && isValidElement<ComponentProps<"span">>(children)
+			? cloneElement(children, { "aria-current": "page" })
+			: children;
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "breadcrumb-page")}
-				className={cx("text-strong", className)}
-				{...props}
-				aria-current="page"
-			>
-				{content}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "breadcrumb-page")}
+			className={cx("text-strong", className)}
+			{...props}
+			aria-current="page"
+		>
+			{content}
+		</Comp>
+	);
+};
 Page.displayName = "BreadcrumbPage";
 
 /**
@@ -292,30 +316,35 @@ type BreadcrumbSeparatorProps = Omit<ComponentProps<"li">, "children"> &
  * </Breadcrumb.Root>
  * ```
  */
-const Separator = forwardRef<ComponentRef<"li">, BreadcrumbSeparatorProps & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "li";
-		// Slot merges child props over slot props, so with asChild the enforced
-		// ARIA must be cloned onto the child element itself to stay un-overridable.
-		const content =
-			asChild && isValidElement<ComponentProps<"li">>(children)
-				? cloneElement(children, { role: "presentation", "aria-hidden": "true" })
-				: (children ?? <Icon svg={<CaretRightIcon />} className="size-3.5" />);
+const Separator = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: BreadcrumbSeparatorProps & WithDataSlot) => {
+	const Comp = asChild ? Slot : "li";
+	// Slot merges child props over slot props, so with asChild the enforced
+	// ARIA must be cloned onto the child element itself to stay un-overridable.
+	const content =
+		asChild && isValidElement<ComponentProps<"li">>(children)
+			? cloneElement(children, { role: "presentation", "aria-hidden": "true" })
+			: (children ?? <Icon svg={<CaretRightIcon />} className="size-3.5" />);
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "breadcrumb-separator")}
-				className={className}
-				{...props}
-				role="presentation"
-				aria-hidden="true"
-			>
-				{content}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "breadcrumb-separator")}
+			className={className}
+			{...props}
+			role="presentation"
+			aria-hidden="true"
+		>
+			{content}
+		</Comp>
+	);
+};
 Separator.displayName = "BreadcrumbSeparator";
 
 /**

--- a/packages/mantle/src/components/button/button-group.tsx
+++ b/packages/mantle/src/components/button/button-group.tsx
@@ -1,5 +1,5 @@
 import { cva } from "class-variance-authority";
-import { type ComponentProps, type ComponentRef, forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { VariantProps } from "../../types/index.js";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -40,22 +40,26 @@ type ButtonGroupProps = ComponentProps<"div"> & ButtonGroupVariants & WithAsChil
  * </ButtonGroup>
  * ```
  */
-const ButtonGroup = forwardRef<ComponentRef<"div">, ButtonGroupProps>(
-	({ appearance, asChild, className, children, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
-		return (
-			<Comp
-				data-slot="button-group"
-				className={cx(buttonGroupVariants({ appearance }), className)}
-				ref={ref}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
-ButtonGroup.displayName = "ButtonGroup";
+const ButtonGroup = ({
+	appearance,
+	asChild,
+	className,
+	children,
+	ref,
+	...props
+}: ButtonGroupProps) => {
+	const Comp = asChild ? Slot : "div";
+	return (
+		<Comp
+			data-slot="button-group"
+			className={cx(buttonGroupVariants({ appearance }), className)}
+			ref={ref}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -1,7 +1,7 @@
 import { CircleNotchIcon } from "@phosphor-icons/react/CircleNotch";
 import { cva } from "class-variance-authority";
 import type { ComponentProps, ReactNode } from "react";
-import { Children, cloneElement, forwardRef, isValidElement } from "react";
+import { Children, cloneElement, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import { parseBooleanish } from "../../types/index.js";
 import type { WithAsChild } from "../../types/index.js";
@@ -265,89 +265,82 @@ type ButtonProps = ComponentProps<"button"> &
  * <IconButton appearance="outlined" intent="neutral" icon={<CopyIcon />} label="Copy page" onClick={copyPage} />
  * ```
  */
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-	(
-		{
-			"aria-disabled": _ariaDisabled,
-			appearance,
-			asChild,
-			children,
+const Button = ({
+	"aria-disabled": _ariaDisabled,
+	appearance,
+	asChild,
+	children,
+	className,
+	disabled: _disabled,
+	icon: propIcon,
+	iconPlacement = "start",
+	intent,
+	isLoading = false,
+	ref,
+	size = "md",
+	type,
+	...props
+}: ButtonProps) => {
+	const disabled = parseBooleanish(_ariaDisabled ?? _disabled ?? isLoading);
+	const icon = isLoading ? <CircleNotchIcon className="animate-spin" /> : propIcon;
+
+	/**
+	 * If the button has an icon and is not a link, add padding-start or padding-end to the button depending on the icon placement.
+	 */
+	const hasSpecialIconPadding = icon && appearance !== "link";
+
+	const buttonProps = {
+		"aria-disabled": disabled,
+		"data-slot": "button",
+		className: cx(
+			"inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md",
+			"focus:outline-hidden focus-visible:ring-4",
+			"disabled:cursor-default disabled:opacity-50",
+			"not-disabled:active:scale-97 ease-out transition-transform duration-150",
+			buttonVariants({ appearance, intent, isLoading, size }),
+			appearance !== "link" && "font-sans", // only enforce font-sans on non-link button appearances
+			hasSpecialIconPadding && iconPlacement === "start" && iconPaddingStart[size],
+			hasSpecialIconPadding && iconPlacement === "end" && iconPaddingEnd[size],
 			className,
-			disabled: _disabled,
-			icon: propIcon,
-			iconPlacement = "start",
-			intent,
-			isLoading = false,
-			size = "md",
-			type,
-			...props
-		},
+		),
+		"data-appearance": appearance,
+		"data-disabled": disabled,
+		"data-intent": intent,
+		"data-loading": isLoading,
+		"data-size": appearance === "link" ? undefined : size,
+		disabled,
 		ref,
-	) => {
-		const disabled = parseBooleanish(_ariaDisabled ?? _disabled ?? isLoading);
-		const icon = isLoading ? <CircleNotchIcon className="animate-spin" /> : propIcon;
+		...props,
+	};
 
-		/**
-		 * If the button has an icon and is not a link, add padding-start or padding-end to the button depending on the icon placement.
-		 */
-		const hasSpecialIconPadding = icon && appearance !== "link";
-
-		const buttonProps = {
-			"aria-disabled": disabled,
-			"data-slot": "button",
-			className: cx(
-				"inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md",
-				"focus:outline-hidden focus-visible:ring-4",
-				"disabled:cursor-default disabled:opacity-50",
-				"not-disabled:active:scale-97 ease-out transition-transform duration-150",
-				buttonVariants({ appearance, intent, isLoading, size }),
-				appearance !== "link" && "font-sans", // only enforce font-sans on non-link button appearances
-				hasSpecialIconPadding && iconPlacement === "start" && iconPaddingStart[size],
-				hasSpecialIconPadding && iconPlacement === "end" && iconPaddingEnd[size],
-				className,
-			),
-			"data-appearance": appearance,
-			"data-disabled": disabled,
-			"data-intent": intent,
-			"data-loading": isLoading,
-			"data-size": appearance === "link" ? undefined : size,
-			disabled,
-			ref,
-			...props,
-		};
-
-		if (asChild) {
-			invariant(
-				isValidElement<{ children?: ReactNode }>(children) && Children.only(children),
-				"When using `asChild`, Button must be passed a single child as a JSX tag.",
-			);
-
-			return (
-				<Slot {...buttonProps}>
-					{cloneElement(
-						children,
-						{},
-						<>
-							{icon && (
-								<Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />
-							)}
-							{children.props.children}
-						</>,
-					)}
-				</Slot>
-			);
-		}
+	if (asChild) {
+		invariant(
+			isValidElement<{ children?: ReactNode }>(children) && Children.only(children),
+			"When using `asChild`, Button must be passed a single child as a JSX tag.",
+		);
 
 		return (
-			// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
-			<button {...buttonProps} type={type ?? "button"}>
-				{icon && <Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />}
-				{children}
-			</button>
+			<Slot {...buttonProps}>
+				{cloneElement(
+					children,
+					{},
+					<>
+						{icon && <Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />}
+						{children.props.children}
+					</>,
+				)}
+			</Slot>
 		);
-	},
-);
-Button.displayName = "Button";
+	}
+
+	return (
+		// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
+		<button {...buttonProps} type={type ?? "button"}>
+			{icon && <Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />}
+			{children}
+		</button>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/button/icon-button.tsx
+++ b/packages/mantle/src/components/button/icon-button.tsx
@@ -1,7 +1,7 @@
 import { CircleNotchIcon } from "@phosphor-icons/react/CircleNotch";
 import { cva } from "class-variance-authority";
-import type { ButtonHTMLAttributes, ReactNode } from "react";
-import { Children, cloneElement, forwardRef, isValidElement } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { Children, cloneElement, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import type { VariantProps, WithAsChild } from "../../types/index.js";
 import { parseBooleanish } from "../../types/index.js";
@@ -111,7 +111,7 @@ type IconButtonVariants = VariantProps<typeof iconButtonVariants>;
 /**
  * The props for the `IconButton` component.
  */
-type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+type IconButtonProps = ComponentProps<"button"> &
 	WithAsChild &
 	Omit<IconButtonVariants, "appearance" | "intent"> & {
 		/**
@@ -161,7 +161,7 @@ type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 		 *
 		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type
 		 */
-		type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
+		type?: ComponentProps<"button">["type"];
 	};
 
 /**
@@ -206,68 +206,63 @@ type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
  * />
  * ```
  */
-const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-	(
-		{
-			"aria-disabled": _ariaDisabled,
-			appearance,
-			asChild = false,
-			children,
-			className,
-			disabled: _disabled,
-			icon: propIcon,
-			intent,
-			isLoading = false,
-			label,
-			size = "md",
-			type,
-			...props
-		},
+const IconButton = ({
+	"aria-disabled": _ariaDisabled,
+	appearance,
+	asChild = false,
+	children,
+	className,
+	disabled: _disabled,
+	icon: propIcon,
+	intent,
+	isLoading = false,
+	label,
+	ref,
+	size = "md",
+	type,
+	...props
+}: IconButtonProps) => {
+	const disabled = parseBooleanish(_ariaDisabled ?? _disabled ?? isLoading);
+	const icon = isLoading ? <CircleNotchIcon className="animate-spin" /> : propIcon;
+
+	const buttonProps = {
+		"aria-disabled": disabled,
+		"data-slot": "icon-button",
+		className: cx(iconButtonVariants({ appearance, intent, isLoading, size }), className),
+		"data-appearance": appearance,
+		"data-disabled": disabled,
+		"data-icon-button": true,
+		"data-intent": intent,
+		"data-loading": isLoading,
+		"data-size": size,
+		disabled,
 		ref,
-	) => {
-		const disabled = parseBooleanish(_ariaDisabled ?? _disabled ?? isLoading);
-		const icon = isLoading ? <CircleNotchIcon className="animate-spin" /> : propIcon;
+		...props,
+	};
 
-		const buttonProps = {
-			"aria-disabled": disabled,
-			"data-slot": "icon-button",
-			className: cx(iconButtonVariants({ appearance, intent, isLoading, size }), className),
-			"data-appearance": appearance,
-			"data-disabled": disabled,
-			"data-icon-button": true,
-			"data-intent": intent,
-			"data-loading": isLoading,
-			"data-size": size,
-			disabled,
-			ref,
-			...props,
-		};
+	const innerChildren = (
+		<>
+			<span className="sr-only">{label}</span>
+			<Icon svg={icon} />
+		</>
+	);
 
-		const innerChildren = (
-			<>
-				<span className="sr-only">{label}</span>
-				<Icon svg={icon} />
-			</>
+	if (asChild) {
+		invariant(
+			isValidElement(children) && Children.only(children),
+			"When using `asChild`, IconButton must be passed a single child as a JSX tag.",
 		);
 
-		if (asChild) {
-			invariant(
-				isValidElement(children) && Children.only(children),
-				"When using `asChild`, IconButton must be passed a single child as a JSX tag.",
-			);
+		return <Slot {...buttonProps}>{cloneElement(children, {}, innerChildren)}</Slot>;
+	}
 
-			return <Slot {...buttonProps}>{cloneElement(children, {}, innerChildren)}</Slot>;
-		}
-
-		return (
-			// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
-			<button {...buttonProps} type={type ?? "button"}>
-				{innerChildren}
-			</button>
-		);
-	},
-);
-IconButton.displayName = "IconButton";
+	return (
+		// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
+		<button {...buttonProps} type={type ?? "button"}>
+			{innerChildren}
+		</button>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/calendar/calendar.tsx
+++ b/packages/mantle/src/components/calendar/calendar.tsx
@@ -96,7 +96,6 @@ function Calendar({ className, classNames, showOutsideDays = false, ...props }: 
 		/>
 	);
 }
-Calendar.displayName = "Calendar";
 
 export {
 	//,

--- a/packages/mantle/src/components/card/card.tsx
+++ b/packages/mantle/src/components/card/card.tsx
@@ -1,5 +1,4 @@
-import type { ComponentProps, ComponentRef, HTMLAttributes } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { WithAsChild } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -33,22 +32,20 @@ type CardProps = ComponentProps<"div"> & WithAsChild;
  * </Card.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, CardProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Root = ({ asChild = false, className, children, ref, ...rest }: CardProps) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="card"
-				className={cx("border-card bg-card relative rounded-md border", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="card"
+			className={cx("border-card bg-card relative rounded-md border", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Root.displayName = "Card";
 
 /**
@@ -77,22 +74,20 @@ Root.displayName = "Card";
  * </Card.Root>
  * ```
  */
-const Body = forwardRef<ComponentRef<"div">, CardProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Body = ({ asChild = false, className, children, ref, ...rest }: CardProps) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="card-body"
-				className={cx("p-6 border-t border-card-muted first:border-t-0", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="card-body"
+			className={cx("p-6 border-t border-card-muted first:border-t-0", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Body.displayName = "CardBody";
 
 /**
@@ -115,22 +110,20 @@ Body.displayName = "CardBody";
  * </Card.Root>
  * ```
  */
-const Footer = forwardRef<ComponentRef<"div">, CardProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Footer = ({ asChild = false, className, children, ref, ...rest }: CardProps) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="card-footer"
-				className={cx("px-6 py-3 border-t border-card-muted first:border-t-0", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="card-footer"
+			className={cx("px-6 py-3 border-t border-card-muted first:border-t-0", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Footer.displayName = "CardFooter";
 
 /**
@@ -153,25 +146,23 @@ Footer.displayName = "CardFooter";
  * </Card.Root>
  * ```
  */
-const Header = forwardRef<ComponentRef<"div">, CardProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Header = ({ asChild = false, className, children, ref, ...rest }: CardProps) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="card-header"
-				className={cx("px-6 py-3 border-t border-card-muted first:border-t-0", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="card-header"
+			className={cx("px-6 py-3 border-t border-card-muted first:border-t-0", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Header.displayName = "CardHeader";
 
-type CardTitleProps = HTMLAttributes<HTMLHeadingElement> & WithAsChild;
+type CardTitleProps = ComponentProps<"h3"> & WithAsChild;
 
 /**
  * The title of a card. Usually composed as a direct child of a `Card.Header`
@@ -197,19 +188,17 @@ type CardTitleProps = HTMLAttributes<HTMLHeadingElement> & WithAsChild;
  * </Card.Root>
  * ```
  */
-const Title = forwardRef<HTMLHeadingElement, CardTitleProps>(
-	({ className, asChild, ...props }, ref) => {
-		const Comp = asChild ? Slot : "h3";
-		return (
-			<Comp
-				ref={ref}
-				data-slot="card-title"
-				className={cx("text-strong text-base font-medium", className)}
-				{...props}
-			/>
-		);
-	},
-);
+const Title = ({ className, asChild, ref, ...props }: CardTitleProps) => {
+	const Comp = asChild ? Slot : "h3";
+	return (
+		<Comp
+			ref={ref}
+			data-slot="card-title"
+			className={cx("text-strong text-base font-medium", className)}
+			{...props}
+		/>
+	);
+};
 Title.displayName = "CardTitle";
 
 /**

--- a/packages/mantle/src/components/centered-layout/centered-layout.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.tsx
@@ -1,5 +1,4 @@
-import type { ComponentProps, ComponentRef } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
@@ -38,22 +37,25 @@ import { Slot } from "../slot/index.js";
  * </CenteredLayout.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Root = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"div"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "centered-layout")}
-				className={cx("flex min-h-full flex-col", className)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "centered-layout")}
+			className={cx("flex min-h-full flex-col", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Root.displayName = "CenteredLayout";
 
 /**
@@ -91,22 +93,25 @@ Root.displayName = "CenteredLayout";
  * </CenteredLayout.Root>
  * ```
  */
-const Notice = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Notice = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"div"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "centered-layout-notice")}
-				className={cx("w-full shrink-0", className)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "centered-layout-notice")}
+			className={cx("w-full shrink-0", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Notice.displayName = "CenteredLayoutNotice";
 
 /**
@@ -140,15 +145,17 @@ Notice.displayName = "CenteredLayoutNotice";
  * </CenteredLayout.Root>
  * ```
  */
-const Header = forwardRef<
-	ComponentRef<"header">,
-	ComponentProps<"header"> & WithAsChild & WithDataSlot
->(({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
+const Header = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"header"> & WithAsChild & WithDataSlot) => {
 	const Comp = asChild ? Slot : "header";
 
 	return (
 		<Comp
-			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "centered-layout-header")}
 			className={cx("flex shrink-0 items-center px-4 py-4", className)}
 			{...props}
@@ -156,7 +163,7 @@ const Header = forwardRef<
 			{children}
 		</Comp>
 	);
-});
+};
 Header.displayName = "CenteredLayoutHeader";
 
 /**
@@ -195,22 +202,25 @@ Header.displayName = "CenteredLayoutHeader";
  * </CenteredLayout.Root>
  * ```
  */
-const Body = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild & WithDataSlot>(
-	({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Body = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"div"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot={joinDataSlot(dataSlot, "centered-layout-body")}
-				className={cx("flex flex-1 flex-col items-center justify-center gap-6 py-4", className)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "centered-layout-body")}
+			className={cx("flex flex-1 flex-col items-center justify-center gap-6 py-4", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Body.displayName = "CenteredLayoutBody";
 
 /**
@@ -244,15 +254,17 @@ Body.displayName = "CenteredLayoutBody";
  * </CenteredLayout.Root>
  * ```
  */
-const Footer = forwardRef<
-	ComponentRef<"footer">,
-	ComponentProps<"footer"> & WithAsChild & WithDataSlot
->(({ asChild, children, className, "data-slot": dataSlot, ...props }, ref) => {
+const Footer = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"footer"> & WithAsChild & WithDataSlot) => {
 	const Comp = asChild ? Slot : "footer";
 
 	return (
 		<Comp
-			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "centered-layout-footer")}
 			className={cx("flex shrink-0 items-center px-4 py-4", className)}
 			{...props}
@@ -260,7 +272,7 @@ const Footer = forwardRef<
 			{children}
 		</Comp>
 	);
-});
+};
 Footer.displayName = "CenteredLayoutFooter";
 
 /**

--- a/packages/mantle/src/components/checkbox/checkbox.tsx
+++ b/packages/mantle/src/components/checkbox/checkbox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { forwardRef, useEffect, useRef, useState } from "react";
-import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { ComponentProps, ComponentRef } from "react";
 import { composeRefs } from "../../utils/compose-refs/index.js";
 import { clsx } from "../../utils/cx/clsx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
@@ -12,7 +12,7 @@ type CheckedState = boolean | "indeterminate";
 const isIndeterminate = (checked: CheckedState | undefined): checked is "indeterminate" =>
 	checked === "indeterminate";
 
-type Props = Omit<ComponentPropsWithoutRef<"input">, "type" | "checked" | "defaultChecked"> &
+type Props = Omit<ComponentProps<"input">, "type" | "checked" | "defaultChecked"> &
 	WithValidation & {
 		/**
 		 * The controlled checked state of the checkbox. Must be used in conjunction with onChange.
@@ -44,91 +44,86 @@ type Props = Omit<ComponentPropsWithoutRef<"input">, "type" | "checked" | "defau
  * </form>
  * ```
  */
-const Checkbox = forwardRef<ComponentRef<"input">, Props>(
-	(
-		{
-			"aria-invalid": _ariaInvalid,
-			className,
-			checked: _checked,
-			defaultChecked: _defaultChecked,
-			defaultValue = "on",
-			onClick,
-			readOnly,
-			validation: _validation,
-			...props
-		},
-		ref,
-	) => {
-		const innerRef = useRef<ComponentRef<"input">>(null);
-		const [defaultChecked] = useState(_defaultChecked);
-		const fieldValidation = useFieldValidation();
-		const { ariaInvalid, validation } = parseValidation({
-			"aria-invalid": _ariaInvalid,
-			validation: _validation ?? fieldValidation,
-		});
+const Checkbox = ({
+	"aria-invalid": _ariaInvalid,
+	className,
+	checked: _checked,
+	defaultChecked: _defaultChecked,
+	defaultValue = "on",
+	onClick,
+	readOnly,
+	ref,
+	validation: _validation,
+	...props
+}: Props) => {
+	const innerRef = useRef<ComponentRef<"input">>(null);
+	const [defaultChecked] = useState(_defaultChecked);
+	const fieldValidation = useFieldValidation();
+	const { ariaInvalid, validation } = parseValidation({
+		"aria-invalid": _ariaInvalid,
+		validation: _validation ?? fieldValidation,
+	});
 
-		// `indeterminate` is a DOM-only property (it has no HTML attribute), so set it
-		// imperatively from the *effective* checked state — the controlled `checked`
-		// when present, otherwise the (stable) initial `defaultChecked`. A single effect
-		// keyed on that value avoids two competing effects clobbering each other on
-		// mount, which previously dropped the indeterminate visual for a controlled
-		// `checked="indeterminate"`.
-		const effectiveChecked = _checked != null ? _checked : defaultChecked;
-		useEffect(() => {
-			if (innerRef.current) {
-				innerRef.current.indeterminate = isIndeterminate(effectiveChecked);
-			}
-		}, [effectiveChecked]);
+	// `indeterminate` is a DOM-only property (it has no HTML attribute), so set it
+	// imperatively from the *effective* checked state — the controlled `checked`
+	// when present, otherwise the (stable) initial `defaultChecked`. A single effect
+	// keyed on that value avoids two competing effects clobbering each other on
+	// mount, which previously dropped the indeterminate visual for a controlled
+	// `checked="indeterminate"`.
+	const effectiveChecked = _checked != null ? _checked : defaultChecked;
+	useEffect(() => {
+		if (innerRef.current) {
+			innerRef.current.indeterminate = isIndeterminate(effectiveChecked);
+		}
+	}, [effectiveChecked]);
 
-		// React warns (and the linter flags) when both `checked` and `defaultChecked` are
-		// passed on the same input. Pick exactly one based on whether the consumer is in
-		// controlled mode (`_checked != null`). The indeterminate *visual* is applied
-		// to the DOM node imperatively via the `useEffect`s above on both paths — so in
-		// controlled mode we still pass a boolean `checked` (treating indeterminate as
-		// unchecked) and never let it become `undefined`. Passing `checked: undefined` for
-		// the indeterminate frame flips the input controlled → uncontrolled and trips
-		// React's "changing a controlled input to be uncontrolled" warning.
-		const checkedProp =
-			_checked != null
-				? { checked: isIndeterminate(_checked) ? false : _checked }
-				: { defaultChecked: isIndeterminate(defaultChecked) ? undefined : defaultChecked };
+	// React warns (and the linter flags) when both `checked` and `defaultChecked` are
+	// passed on the same input. Pick exactly one based on whether the consumer is in
+	// controlled mode (`_checked != null`). The indeterminate *visual* is applied
+	// to the DOM node imperatively via the `useEffect`s above on both paths — so in
+	// controlled mode we still pass a boolean `checked` (treating indeterminate as
+	// unchecked) and never let it become `undefined`. Passing `checked: undefined` for
+	// the indeterminate frame flips the input controlled → uncontrolled and trips
+	// React's "changing a controlled input to be uncontrolled" warning.
+	const checkedProp =
+		_checked != null
+			? { checked: isIndeterminate(_checked) ? false : _checked }
+			: { defaultChecked: isIndeterminate(defaultChecked) ? undefined : defaultChecked };
 
-		return (
-			<input
-				aria-checked={isIndeterminate(_checked) ? "mixed" : _checked}
-				aria-invalid={ariaInvalid}
-				data-slot="checkbox"
-				className={clsx(
-					"border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50",
-					"bg-center bg-no-repeat focus:outline-hidden",
-					"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4",
-					"checked:border-accent-600 checked:bg-accent-600 checked:bg-checked-icon",
-					"indeterminate:border-accent-600 indeterminate:bg-accent-600 indeterminate:bg-indeterminate-icon",
-					"data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success",
-					"data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning",
-					"data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger",
-					"where:block where:size-4 where:p-0",
-					className,
-				)}
-				{...checkedProp}
-				data-validation={validation || undefined}
-				defaultValue={defaultValue}
-				onClick={(event) => {
-					if (readOnly) {
-						event.preventDefault();
-						return;
-					}
-					onClick?.(event);
-				}}
-				readOnly={readOnly}
-				ref={composeRefs(innerRef, ref)}
-				type="checkbox"
-				{...props}
-			/>
-		);
-	},
-);
-Checkbox.displayName = "Checkbox";
+	return (
+		<input
+			aria-checked={isIndeterminate(_checked) ? "mixed" : _checked}
+			aria-invalid={ariaInvalid}
+			data-slot="checkbox"
+			className={clsx(
+				"border-form bg-form shrink-0 cursor-pointer select-none appearance-none rounded border disabled:cursor-default disabled:opacity-50",
+				"bg-center bg-no-repeat focus:outline-hidden",
+				"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4",
+				"checked:border-accent-600 checked:bg-accent-600 checked:bg-checked-icon",
+				"indeterminate:border-accent-600 indeterminate:bg-accent-600 indeterminate:bg-indeterminate-icon",
+				"data-validation-success:border-success-600 data-validation-success:checked:bg-success-600 data-validation-success:indeterminate:bg-success-600 focus-visible:data-validation-success:border-success-600 focus-visible:data-validation-success:ring-focus-success",
+				"data-validation-warning:border-warning-600 data-validation-warning:checked:bg-warning-600 data-validation-warning:indeterminate:bg-warning-600 focus-visible:data-validation-warning:border-warning-600 focus-visible:data-validation-warning:ring-focus-warning",
+				"data-validation-error:border-danger-600 data-validation-error:checked:bg-danger-600 data-validation-error:indeterminate:bg-danger-600 focus-visible:data-validation-error:border-danger-600 focus-visible:data-validation-error:ring-focus-danger",
+				"where:block where:size-4 where:p-0",
+				className,
+			)}
+			{...checkedProp}
+			data-validation={validation || undefined}
+			defaultValue={defaultValue}
+			onClick={(event) => {
+				if (readOnly) {
+					event.preventDefault();
+					return;
+				}
+				onClick?.(event);
+			}}
+			readOnly={readOnly}
+			ref={composeRefs(innerRef, ref)}
+			type="checkbox"
+			{...props}
+		/>
+	);
+};
 
 /**
  * Resolve the tri-state `checked` value for a "select all" checkbox from the

--- a/packages/mantle/src/components/choice/choice.tsx
+++ b/packages/mantle/src/components/choice/choice.tsx
@@ -1,15 +1,7 @@
 "use client";
 
-import {
-	cloneElement,
-	createContext,
-	forwardRef,
-	isValidElement,
-	useContext,
-	useId,
-	useMemo,
-} from "react";
-import type { ComponentProps, ComponentRef, ReactNode } from "react";
+import { cloneElement, createContext, isValidElement, useContext, useId, useMemo } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -121,86 +113,81 @@ type ChoiceRootProps = Omit<ComponentProps<"div">, "id"> & {
  * </Choice.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, ChoiceRootProps>(
-	(
-		{
-			"aria-describedby": ariaDescribedBy,
-			"aria-errormessage": ariaErrorMessage,
-			"aria-invalid": ariaInvalid,
-			children,
-			className,
-			disabled = false,
-			id,
+const Root = ({
+	"aria-describedby": ariaDescribedBy,
+	"aria-errormessage": ariaErrorMessage,
+	"aria-invalid": ariaInvalid,
+	children,
+	className,
+	disabled = false,
+	id,
+	name,
+	ref,
+	...props
+}: ChoiceRootProps) => {
+	const fieldControl = useContext(FieldControlContext);
+	// Read the field values as primitives. `Field.Control` rebuilds its context
+	// object every render, so depending on the object would defeat the memo
+	// below — depend on these stable strings instead.
+	const fieldId = fieldControl?.id;
+	const fieldName = fieldControl?.name;
+	const fieldDescribedBy = fieldControl?.["aria-describedby"];
+	const fieldAriaInvalid = fieldControl?.["aria-invalid"];
+	const fieldErrorMessage = fieldControl?.["aria-errormessage"];
+	const generatedId = useId();
+	const descriptionId = useId();
+	const controlId = fieldId ?? id ?? generatedId;
+	// Reference our own description slot and append any inherited describedby
+	// (a Field.Control's description/error ids, or a caller-supplied one). Inside
+	// a Field the value can arrive via both context and a cloned prop, so prefer
+	// one (`??`, not both) to avoid listing the same id twice. Per WAI-ARIA an
+	// unresolved IDREF is ignored, so the description id is harmless when no
+	// Description is rendered.
+	const inheritedDescribedBy = fieldDescribedBy ?? ariaDescribedBy;
+	const describedBy = [inheritedDescribedBy, descriptionId].filter(Boolean).join(" ") || undefined;
+
+	const context = useMemo<ChoiceContextValue>(
+		() => ({
+			controlId,
+			descriptionId,
+			disabled,
+			controlProps: {
+				id: controlId,
+				name: fieldName ?? name,
+				disabled,
+				"aria-describedby": describedBy,
+				"aria-invalid": fieldAriaInvalid ?? ariaInvalid,
+				"aria-errormessage": fieldErrorMessage ?? ariaErrorMessage,
+			},
+		}),
+		[
+			controlId,
+			descriptionId,
+			disabled,
+			describedBy,
+			fieldName,
 			name,
-			...props
-		},
-		ref,
-	) => {
-		const fieldControl = useContext(FieldControlContext);
-		// Read the field values as primitives. `Field.Control` rebuilds its context
-		// object every render, so depending on the object would defeat the memo
-		// below — depend on these stable strings instead.
-		const fieldId = fieldControl?.id;
-		const fieldName = fieldControl?.name;
-		const fieldDescribedBy = fieldControl?.["aria-describedby"];
-		const fieldAriaInvalid = fieldControl?.["aria-invalid"];
-		const fieldErrorMessage = fieldControl?.["aria-errormessage"];
-		const generatedId = useId();
-		const descriptionId = useId();
-		const controlId = fieldId ?? id ?? generatedId;
-		// Reference our own description slot and append any inherited describedby
-		// (a Field.Control's description/error ids, or a caller-supplied one). Inside
-		// a Field the value can arrive via both context and a cloned prop, so prefer
-		// one (`??`, not both) to avoid listing the same id twice. Per WAI-ARIA an
-		// unresolved IDREF is ignored, so the description id is harmless when no
-		// Description is rendered.
-		const inheritedDescribedBy = fieldDescribedBy ?? ariaDescribedBy;
-		const describedBy =
-			[inheritedDescribedBy, descriptionId].filter(Boolean).join(" ") || undefined;
+			fieldAriaInvalid,
+			ariaInvalid,
+			fieldErrorMessage,
+			ariaErrorMessage,
+		],
+	);
 
-		const context = useMemo<ChoiceContextValue>(
-			() => ({
-				controlId,
-				descriptionId,
-				disabled,
-				controlProps: {
-					id: controlId,
-					name: fieldName ?? name,
-					disabled,
-					"aria-describedby": describedBy,
-					"aria-invalid": fieldAriaInvalid ?? ariaInvalid,
-					"aria-errormessage": fieldErrorMessage ?? ariaErrorMessage,
-				},
-			}),
-			[
-				controlId,
-				descriptionId,
-				disabled,
-				describedBy,
-				fieldName,
-				name,
-				fieldAriaInvalid,
-				ariaInvalid,
-				fieldErrorMessage,
-				ariaErrorMessage,
-			],
-		);
-
-		return (
-			<ChoiceContext.Provider value={context}>
-				{/* items-start so the indicator aligns to the first line when the title wraps. */}
-				<div
-					ref={ref}
-					data-slot="choice"
-					className={cx("flex w-full items-start gap-2", className)}
-					{...props}
-				>
-					{children}
-				</div>
-			</ChoiceContext.Provider>
-		);
-	},
-);
+	return (
+		<ChoiceContext.Provider value={context}>
+			{/* items-start so the indicator aligns to the first line when the title wraps. */}
+			<div
+				ref={ref}
+				data-slot="choice"
+				className={cx("flex w-full items-start gap-2", className)}
+				{...props}
+			>
+				{children}
+			</div>
+		</ChoiceContext.Provider>
+	);
+};
 Root.displayName = "Choice";
 
 type ChoiceIndicatorProps = ComponentProps<"span">;
@@ -231,43 +218,41 @@ type ChoiceIndicatorProps = ComponentProps<"span">;
  * </Choice.Root>
  * ```
  */
-const Indicator = forwardRef<ComponentRef<"span">, ChoiceIndicatorProps>(
-	({ children, className, ...props }, ref) => {
-		const { controlProps } = useChoiceContext("Indicator");
-		// Inject the association props onto the control. `id` and `aria-describedby`
-		// are owned by Choice and always win. `disabled` / `name` / `aria-invalid` /
-		// `aria-errormessage`, though, may have been set on the control itself — only
-		// override those when Choice (or a Field) actually provides a value, so a
-		// `<Checkbox disabled name="x" />` placed here isn't silently reset.
-		const control: ReactNode = isValidElement<Record<string, unknown>>(children)
-			? cloneElement(children, {
-					...controlProps,
-					disabled: controlProps.disabled || children.props.disabled === true,
-					name: controlProps.name ?? children.props.name,
-					"aria-invalid": controlProps["aria-invalid"] ?? children.props["aria-invalid"],
-					"aria-errormessage":
-						controlProps["aria-errormessage"] ?? children.props["aria-errormessage"],
-				})
-			: children;
+const Indicator = ({ children, className, ref, ...props }: ChoiceIndicatorProps) => {
+	const { controlProps } = useChoiceContext("Indicator");
+	// Inject the association props onto the control. `id` and `aria-describedby`
+	// are owned by Choice and always win. `disabled` / `name` / `aria-invalid` /
+	// `aria-errormessage`, though, may have been set on the control itself — only
+	// override those when Choice (or a Field) actually provides a value, so a
+	// `<Checkbox disabled name="x" />` placed here isn't silently reset.
+	const control: ReactNode = isValidElement<Record<string, unknown>>(children)
+		? cloneElement(children, {
+				...controlProps,
+				disabled: controlProps.disabled || children.props.disabled === true,
+				name: controlProps.name ?? children.props.name,
+				"aria-invalid": controlProps["aria-invalid"] ?? children.props["aria-invalid"],
+				"aria-errormessage":
+					controlProps["aria-errormessage"] ?? children.props["aria-errormessage"],
+			})
+		: children;
 
-		return (
-			<span
-				ref={ref}
-				data-slot="choice-indicator"
-				// `h-lh` resolves to this element's own line-height, so it must share the
-				// title's `text-sm` line box (14px / 20px) — otherwise the slot would size
-				// to the inherited line-height and the control could not center on the
-				// title's first line. `items-center` then centers the control in that
-				// one-line box; `items-start` on Root keeps it on the first line when the
-				// title wraps.
-				className={cx("flex h-lh shrink-0 items-center text-sm", className)}
-				{...props}
-			>
-				{control}
-			</span>
-		);
-	},
-);
+	return (
+		<span
+			ref={ref}
+			data-slot="choice-indicator"
+			// `h-lh` resolves to this element's own line-height, so it must share the
+			// title's `text-sm` line box (14px / 20px) — otherwise the slot would size
+			// to the inherited line-height and the control could not center on the
+			// title's first line. `items-center` then centers the control in that
+			// one-line box; `items-start` on Root keeps it on the first line when the
+			// title wraps.
+			className={cx("flex h-lh shrink-0 items-center text-sm", className)}
+			{...props}
+		>
+			{control}
+		</span>
+	);
+};
 Indicator.displayName = "ChoiceIndicator";
 
 type ChoiceContentProps = ComponentProps<"div"> & WithAsChild;
@@ -292,20 +277,18 @@ type ChoiceContentProps = ComponentProps<"div"> & WithAsChild;
  * </Choice.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<"div">, ChoiceContentProps>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Content = ({ asChild, className, ref, ...props }: ChoiceContentProps) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="choice-content"
-				className={cx("flex min-w-0 flex-1 flex-col gap-0.5", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="choice-content"
+			className={cx("flex min-w-0 flex-1 flex-col gap-0.5", className)}
+			{...props}
+		/>
+	);
+};
 Content.displayName = "ChoiceContent";
 
 /**
@@ -344,26 +327,23 @@ type ChoiceLabelProps = Omit<ComponentProps<typeof Label>, "htmlFor" | "disabled
  * </Choice.Root>
  * ```
  */
-const ChoiceLabel = forwardRef<ComponentRef<"label">, ChoiceLabelProps>(
-	({ className, ...props }, ref) => {
-		const { controlId, disabled } = useChoiceContext("Label");
+const ChoiceLabel = ({ className, ref, ...props }: ChoiceLabelProps) => {
+	const { controlId, disabled } = useChoiceContext("Label");
 
-		// Reuse the real `Label` rather than re-implementing it, so the title keeps
-		// all of `Label`'s styling and behavior. `htmlFor` / `disabled` come from
-		// `Choice.Root` and are applied after `{...props}` so the wiring always wins.
-		return (
-			<Label
-				ref={ref}
-				data-slot="choice-label"
-				className={cx(disabled && "opacity-50", className)}
-				{...props}
-				htmlFor={controlId}
-				disabled={disabled}
-			/>
-		);
-	},
-);
-ChoiceLabel.displayName = "ChoiceLabel";
+	// Reuse the real `Label` rather than re-implementing it, so the title keeps
+	// all of `Label`'s styling and behavior. `htmlFor` / `disabled` come from
+	// `Choice.Root` and are applied after `{...props}` so the wiring always wins.
+	return (
+		<Label
+			ref={ref}
+			data-slot="choice-label"
+			className={cx(disabled && "opacity-50", className)}
+			{...props}
+			htmlFor={controlId}
+			disabled={disabled}
+		/>
+	);
+};
 
 /**
  * The emphasized title of a `Choice`, label-styled but **not** a `<label>` —
@@ -389,25 +369,23 @@ ChoiceLabel.displayName = "ChoiceLabel";
  * </Choice.Root>
  * ```
  */
-const Title = forwardRef<ComponentRef<"p">, ComponentProps<"p"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const { disabled } = useChoiceContext("Title");
-		const Comp = asChild ? Slot : "p";
+const Title = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & WithAsChild) => {
+	const { disabled } = useChoiceContext("Title");
+	const Comp = asChild ? Slot : "p";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="choice-title"
-				className={cx(
-					"text-strong text-sm font-medium font-sans",
-					disabled && "opacity-50",
-					className,
-				)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="choice-title"
+			className={cx(
+				"text-strong text-sm font-medium font-sans",
+				disabled && "opacity-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 Title.displayName = "ChoiceTitle";
 
 /**
@@ -430,22 +408,20 @@ Title.displayName = "ChoiceTitle";
  * </Choice.Root>
  * ```
  */
-const Description = forwardRef<ComponentRef<"p">, ComponentProps<"p"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const { descriptionId, disabled } = useChoiceContext("Description");
-		const Comp = asChild ? Slot : "p";
+const Description = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & WithAsChild) => {
+	const { descriptionId, disabled } = useChoiceContext("Description");
+	const Comp = asChild ? Slot : "p";
 
-		return (
-			<Comp
-				ref={ref}
-				id={descriptionId}
-				data-slot="choice-description"
-				className={cx("text-body text-sm leading-4", disabled && "opacity-50", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			id={descriptionId}
+			data-slot="choice-description"
+			className={cx("text-body text-sm leading-4", disabled && "opacity-50", className)}
+			{...props}
+		/>
+	);
+};
 Description.displayName = "ChoiceDescription";
 
 /**

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -5,18 +5,9 @@ import { CheckIcon } from "@phosphor-icons/react/Check";
 import { CopyIcon } from "@phosphor-icons/react/Copy";
 import { FileTextIcon } from "@phosphor-icons/react/FileText";
 import { TerminalIcon } from "@phosphor-icons/react/Terminal";
-import type {
-	ComponentProps,
-	ComponentRef,
-	Dispatch,
-	HTMLAttributes,
-	MouseEvent,
-	ReactNode,
-	SetStateAction,
-} from "react";
+import type { ComponentProps, Dispatch, MouseEvent, ReactNode, SetStateAction } from "react";
 import {
 	createContext,
-	forwardRef,
 	useCallback,
 	useContext,
 	useEffect,
@@ -108,76 +99,82 @@ type CodeBlockRootProps = Omit<ComponentProps<"div">, "align"> &
  * </CodeBlock.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, CodeBlockRootProps>(
-	({ asChild = false, className, defaultTab, activeTab, onActiveTabChange, ...props }, ref) => {
-		const copyTextRef = useRef("");
-		const [hasCodeExpander, setHasCodeExpander] = useState(false);
-		const [isCodeExpanded, setIsCodeExpanded] = useState(false);
-		const [codeId, setCodeId] = useState<string | undefined>(undefined);
+const Root = ({
+	asChild = false,
+	className,
+	defaultTab,
+	activeTab,
+	onActiveTabChange,
+	ref,
+	...props
+}: CodeBlockRootProps) => {
+	const copyTextRef = useRef("");
+	const [hasCodeExpander, setHasCodeExpander] = useState(false);
+	const [isCodeExpanded, setIsCodeExpanded] = useState(false);
+	const [codeId, setCodeId] = useState<string | undefined>(undefined);
 
-		const registerCodeId = useCallback((id: string) => {
-			setCodeId((old) => {
-				assert(old == null, "You can only render a single CodeBlock.Code within a CodeBlock.");
-				return id;
-			});
-		}, []);
+	const registerCodeId = useCallback((id: string) => {
+		setCodeId((old) => {
+			assert(old == null, "You can only render a single CodeBlock.Code within a CodeBlock.");
+			return id;
+		});
+	}, []);
 
-		const unregisterCodeId = useCallback((id: string) => {
-			setCodeId((old) => {
-				assert(old === id, "You can only render a single CodeBlock.Code within a CodeBlock.");
-				return undefined;
-			});
-		}, []);
+	const unregisterCodeId = useCallback((id: string) => {
+		setCodeId((old) => {
+			assert(old === id, "You can only render a single CodeBlock.Code within a CodeBlock.");
+			return undefined;
+		});
+	}, []);
 
-		const context: CodeBlockContextType = useMemo(
-			() =>
-				({
-					codeId,
-					copyTextRef,
-					hasCodeExpander,
-					isCodeExpanded,
-					registerCodeId,
-					setHasCodeExpander,
-					setIsCodeExpanded,
-					unregisterCodeId,
-				}) as const,
-			[codeId, hasCodeExpander, isCodeExpanded, registerCodeId, unregisterCodeId],
-		);
+	const context: CodeBlockContextType = useMemo(
+		() =>
+			({
+				codeId,
+				copyTextRef,
+				hasCodeExpander,
+				isCodeExpanded,
+				registerCodeId,
+				setHasCodeExpander,
+				setIsCodeExpanded,
+				unregisterCodeId,
+			}) as const,
+		[codeId, hasCodeExpander, isCodeExpanded, registerCodeId, unregisterCodeId],
+	);
 
-		const hasTabs = defaultTab != null || activeTab != null;
-		const Component = asChild ? Slot : "div";
+	const hasTabs = defaultTab != null || activeTab != null;
+	const Component = asChild ? Slot : "div";
 
-		const tree = (
-			<Component
-				data-slot="code-block"
-				className={cx(
-					"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-base font-mono",
-					"[&_svg]:shrink-0",
-					className,
-				)}
-				ref={ref}
-				{...props}
-			/>
-		);
+	const tree = (
+		<Component
+			data-slot="code-block"
+			className={cx(
+				"text-mono w-full overflow-hidden rounded-md border border-gray-300 bg-base font-mono",
+				"[&_svg]:shrink-0",
+				className,
+			)}
+			ref={ref}
+			{...props}
+		/>
+	);
 
-		return (
-			<CodeBlockContext.Provider value={context}>
-				{hasTabs ? (
-					<RadixTabsRoot
-						asChild
-						defaultValue={defaultTab}
-						value={activeTab}
-						onValueChange={onActiveTabChange}
-					>
-						{tree}
-					</RadixTabsRoot>
-				) : (
-					tree
-				)}
-			</CodeBlockContext.Provider>
-		);
-	},
-);
+	return (
+		<CodeBlockContext.Provider value={context}>
+			{hasTabs ? (
+				<RadixTabsRoot
+					asChild
+					defaultValue={defaultTab}
+					value={activeTab}
+					onValueChange={onActiveTabChange}
+				>
+					{tree}
+				</RadixTabsRoot>
+			) : (
+				tree
+			)}
+		</CodeBlockContext.Provider>
+	);
+};
 Root.displayName = "CodeBlock";
 
 /**
@@ -199,19 +196,22 @@ Root.displayName = "CodeBlock";
  * </CodeBlock.Root>
  * ```
  */
-const Body = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
-		return (
-			<Component
-				data-slot="code-block-body"
-				className={cx("relative", className)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+const Body = ({
+	asChild = false,
+	className,
+	ref,
+	...props
+}: ComponentProps<"div"> & WithAsChild) => {
+	const Component = asChild ? Slot : "div";
+	return (
+		<Component
+			data-slot="code-block-body"
+			className={cx("relative", className)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Body.displayName = "CodeBlockBody";
 
 /**
@@ -321,122 +321,120 @@ type CodeBlockCodeProps = Omit<ComponentProps<"pre">, "children"> & {
  * </CodeBlock.Root>
  * ```
  */
-const Code = forwardRef<ComponentRef<"pre">, CodeBlockCodeProps>(
-	({ className, style, value, ...props }, ref) => {
-		const id = useId();
-		const preRef = useRef<HTMLPreElement>(null);
-		const { copyTextRef, hasCodeExpander, isCodeExpanded, registerCodeId, unregisterCodeId } =
-			useCodeBlockContext();
-		const {
-			language,
-			code,
-			"~preValToken": __preValToken,
-			"~preVals": __preVals,
-			"~highlightLines": __highlightLines,
-			"~lineNumberStart": __lineNumberStart,
-			"~preHtml": __preHtml,
-			"~showLineNumbers": __showLineNumbers,
-		} = value;
+const Code = ({ className, style, value, ref, ...props }: CodeBlockCodeProps) => {
+	const id = useId();
+	const preRef = useRef<HTMLPreElement>(null);
+	const { copyTextRef, hasCodeExpander, isCodeExpanded, registerCodeId, unregisterCodeId } =
+		useCodeBlockContext();
+	const {
+		language,
+		code,
+		"~preValToken": __preValToken,
+		"~preVals": __preVals,
+		"~highlightLines": __highlightLines,
+		"~lineNumberStart": __lineNumberStart,
+		"~preHtml": __preHtml,
+		"~showLineNumbers": __showLineNumbers,
+	} = value;
 
-		const effectiveHighlightLines = __highlightLines;
-		const effectiveLineNumberStart = __lineNumberStart ?? 1;
-		const effectiveShowLineNumbers = __showLineNumbers ?? false;
-		const copyText = useMemo(
-			() =>
-				__preVals != null && __preVals.length > 0
-					? substitutePreValsPlainText(code, __preVals, __preValToken)
-					: code,
-			[__preValToken, __preVals, code],
-		);
+	const effectiveHighlightLines = __highlightLines;
+	const effectiveLineNumberStart = __lineNumberStart ?? 1;
+	const effectiveShowLineNumbers = __showLineNumbers ?? false;
+	const copyText = useMemo(
+		() =>
+			__preVals != null && __preVals.length > 0
+				? substitutePreValsPlainText(code, __preVals, __preValToken)
+				: code,
+		[__preValToken, __preVals, code],
+	);
 
-		useLayoutEffect(() => {
-			copyTextRef.current = copyText;
-		}, [copyTextRef, copyText]);
+	useLayoutEffect(() => {
+		copyTextRef.current = copyText;
+	}, [copyTextRef, copyText]);
 
-		useEffect(() => {
-			registerCodeId(id);
+	useEffect(() => {
+		registerCodeId(id);
 
-			return () => {
-				unregisterCodeId(id);
-			};
-		}, [id, registerCodeId, unregisterCodeId]);
+		return () => {
+			unregisterCodeId(id);
+		};
+	}, [id, registerCodeId, unregisterCodeId]);
 
-		const renderedHtml = useMemo(() => {
-			if (__preHtml == null) {
-				return undefined;
+	const renderedHtml = useMemo(() => {
+		if (__preHtml == null) {
+			return undefined;
+		}
+		return __preVals != null && __preVals.length > 0
+			? substitutePreVals(__preHtml, __preVals, __preValToken)
+			: __preHtml;
+	}, [__preHtml, __preValToken, __preVals]);
+
+	// Attach a single delegated click handler per <pre> so fold toggles do
+	// not pay the cost of N React re-renders or N event handlers — see the
+	// performance rationale in `fold-runtime.ts`. Re-attaches when the
+	// rendered HTML changes since `<code>` gets a new dangerouslySetInnerHTML.
+	useEffect(() => {
+		const pre = preRef.current;
+		if (pre == null) {
+			return undefined;
+		}
+		const codeElement = pre.querySelector("code");
+		if (codeElement != null) {
+			resetFoldState(codeElement);
+		}
+		return attachFoldHandler(pre);
+	}, [renderedHtml]);
+
+	const isPreRendered = renderedHtml != null;
+	const displayHtml = renderedHtml ?? escapeHtml(copyText);
+
+	// React diffs `dangerouslySetInnerHTML` by prop reference; a fresh
+	// `{ __html }` literal each render re-applies `innerHTML`, wiping any
+	// runtime-managed DOM state on the children (e.g. fold attributes).
+	const innerHtmlProp = useMemo(() => ({ __html: displayHtml }), [displayHtml]);
+
+	return (
+		<pre
+			data-slot="code-block-code"
+			aria-expanded={hasCodeExpander ? isCodeExpanded : undefined}
+			className={cx(
+				"scrollbar overflow-x-auto overflow-y-hidden py-4",
+				!isPreRendered && "pr-14",
+				"data-[mantle-line-numbers~='false']:pl-4",
+				"text-mono m-0 font-mono outline-hidden",
+				"aria-collapsed:max-h-[13.6rem]",
+				className,
+			)}
+			data-highlighted={isPreRendered ? "true" : "false"}
+			data-lang={language}
+			data-mantle-highlight-lines={
+				isPreRendered && effectiveHighlightLines != null && effectiveHighlightLines.length > 0
+					? effectiveHighlightLines.join(",")
+					: undefined
 			}
-			return __preVals != null && __preVals.length > 0
-				? substitutePreVals(__preHtml, __preVals, __preValToken)
-				: __preHtml;
-		}, [__preHtml, __preValToken, __preVals]);
-
-		// Attach a single delegated click handler per <pre> so fold toggles do
-		// not pay the cost of N React re-renders or N event handlers — see the
-		// performance rationale in `fold-runtime.ts`. Re-attaches when the
-		// rendered HTML changes since `<code>` gets a new dangerouslySetInnerHTML.
-		useEffect(() => {
-			const pre = preRef.current;
-			if (pre == null) {
-				return undefined;
+			data-mantle-line-number-start={
+				isPreRendered && effectiveShowLineNumbers ? String(effectiveLineNumberStart) : "1"
 			}
-			const codeElement = pre.querySelector("code");
-			if (codeElement != null) {
-				resetFoldState(codeElement);
+			data-mantle-line-numbers={isPreRendered && effectiveShowLineNumbers ? "true" : "false"}
+			id={id}
+			ref={composeRefs(preRef, ref)}
+			style={
+				{
+					...style,
+					"--mantle-line-number-start": String(effectiveLineNumberStart),
+					tabSize: 2,
+					MozTabSize: 2,
+				} as ComponentProps<"pre">["style"]
 			}
-			return attachFoldHandler(pre);
-		}, [renderedHtml]);
-
-		const isPreRendered = renderedHtml != null;
-		const displayHtml = renderedHtml ?? escapeHtml(copyText);
-
-		// React diffs `dangerouslySetInnerHTML` by prop reference; a fresh
-		// `{ __html }` literal each render re-applies `innerHTML`, wiping any
-		// runtime-managed DOM state on the children (e.g. fold attributes).
-		const innerHtmlProp = useMemo(() => ({ __html: displayHtml }), [displayHtml]);
-
-		return (
-			<pre
-				data-slot="code-block-code"
-				aria-expanded={hasCodeExpander ? isCodeExpanded : undefined}
-				className={cx(
-					"scrollbar overflow-x-auto overflow-y-hidden py-4",
-					!isPreRendered && "pr-14",
-					"data-[mantle-line-numbers~='false']:pl-4",
-					"text-mono m-0 font-mono outline-hidden",
-					"aria-collapsed:max-h-[13.6rem]",
-					className,
-				)}
-				data-highlighted={isPreRendered ? "true" : "false"}
-				data-lang={language}
-				data-mantle-highlight-lines={
-					isPreRendered && effectiveHighlightLines != null && effectiveHighlightLines.length > 0
-						? effectiveHighlightLines.join(",")
-						: undefined
-				}
-				data-mantle-line-number-start={
-					isPreRendered && effectiveShowLineNumbers ? String(effectiveLineNumberStart) : "1"
-				}
-				data-mantle-line-numbers={isPreRendered && effectiveShowLineNumbers ? "true" : "false"}
-				id={id}
-				ref={composeRefs(preRef, ref)}
-				style={
-					{
-						...style,
-						"--mantle-line-number-start": String(effectiveLineNumberStart),
-						tabSize: 2,
-						MozTabSize: 2,
-					} as ComponentProps<"pre">["style"]
-				}
-				{...props}
-			>
-				<code
-					className="text-size-inherit block min-w-full w-max"
-					dangerouslySetInnerHTML={innerHtmlProp}
-				/>
-			</pre>
-		);
-	},
-);
+			{...props}
+		>
+			<code
+				className="text-size-inherit block min-w-full w-max"
+				dangerouslySetInnerHTML={innerHtmlProp}
+			/>
+		</pre>
+	);
+};
 Code.displayName = "CodeBlockCode";
 
 /**
@@ -458,22 +456,25 @@ Code.displayName = "CodeBlockCode";
  * </CodeBlock.Root>
  * ```
  */
-const Header = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
-		return (
-			<Component
-				data-slot="code-block-header"
-				className={cx(
-					"flex items-center gap-1 border-b border-gray-300 bg-base px-4 py-2 text-gray-700",
-					className,
-				)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+const Header = ({
+	asChild = false,
+	className,
+	ref,
+	...props
+}: ComponentProps<"div"> & WithAsChild) => {
+	const Component = asChild ? Slot : "div";
+	return (
+		<Component
+			data-slot="code-block-header"
+			className={cx(
+				"flex items-center gap-1 border-b border-gray-300 bg-base px-4 py-2 text-gray-700",
+				className,
+			)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Header.displayName = "CodeBlockHeader";
 
 /**
@@ -495,10 +496,12 @@ Header.displayName = "CodeBlockHeader";
  * </CodeBlock.Root>
  * ```
  */
-const Title = forwardRef<
-	HTMLHeadingElement,
-	HTMLAttributes<HTMLHeadingElement> & { asChild?: boolean }
->(({ asChild = false, className, ...props }, ref) => {
+const Title = ({
+	asChild = false,
+	className,
+	ref,
+	...props
+}: ComponentProps<"h3"> & { asChild?: boolean }) => {
 	const Component = asChild ? Slot : "h3";
 	return (
 		<Component
@@ -508,7 +511,7 @@ const Title = forwardRef<
 			{...props}
 		/>
 	);
-});
+};
 Title.displayName = "CodeBlockTitle";
 
 type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "type"> &
@@ -548,64 +551,70 @@ type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "typ
  * </CodeBlock.Root>
  * ```
  */
-const CopyButton = forwardRef<ComponentRef<"button">, CodeBlockCopyButtonProps>(
-	({ className, label = "Copy code", onCopy, onCopyError, onClick, ...props }, ref) => {
-		const { copyTextRef } = useCodeBlockContext();
-		const copyToClipboard = useCopyToClipboard();
-		const [wasCopied, setWasCopied] = useState(false);
-		const timeoutHandle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+const CopyButton = ({
+	className,
+	label = "Copy code",
+	onCopy,
+	onCopyError,
+	onClick,
+	ref,
+	...props
+}: CodeBlockCopyButtonProps) => {
+	const { copyTextRef } = useCodeBlockContext();
+	const copyToClipboard = useCopyToClipboard();
+	const [wasCopied, setWasCopied] = useState(false);
+	const timeoutHandle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-		useEffect(() => {
-			return () => {
-				if (timeoutHandle.current != null) {
-					clearTimeout(timeoutHandle.current);
-				}
-			};
-		}, []);
+	useEffect(() => {
+		return () => {
+			if (timeoutHandle.current != null) {
+				clearTimeout(timeoutHandle.current);
+			}
+		};
+	}, []);
 
-		return (
-			<span
-				data-slot="code-block-copy-button"
-				className="absolute right-3 top-3 z-10 inline-flex size-7 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] bg-base"
-			>
-				<IconButton
-					type="button"
-					appearance="ghost"
-					intent="neutral"
-					size="sm"
-					label={label}
-					icon={wasCopied ? <CheckIcon /> : <CopyIcon />}
-					className={cx("bg-base not-disabled:hover:bg-neutral-500/15", className)}
-					ref={ref}
-					onClick={async (event) => {
-						try {
-							onClick?.(event);
-							if (event.defaultPrevented) {
-								if (timeoutHandle.current != null) {
-									clearTimeout(timeoutHandle.current);
-								}
-								return;
-							}
-							const text = copyTextRef.current;
-							await copyToClipboard(text);
-							onCopy?.(text);
-							setWasCopied(true);
+	return (
+		<span
+			data-slot="code-block-copy-button"
+			className="absolute right-3 top-3 z-10 inline-flex size-7 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] bg-base"
+		>
+			<IconButton
+				type="button"
+				appearance="ghost"
+				intent="neutral"
+				size="sm"
+				label={label}
+				icon={wasCopied ? <CheckIcon /> : <CopyIcon />}
+				className={cx("bg-base not-disabled:hover:bg-neutral-500/15", className)}
+				ref={ref}
+				onClick={async (event) => {
+					try {
+						onClick?.(event);
+						if (event.defaultPrevented) {
 							if (timeoutHandle.current != null) {
 								clearTimeout(timeoutHandle.current);
 							}
-							timeoutHandle.current = setTimeout(() => {
-								setWasCopied(false);
-							}, 2000);
-						} catch (error) {
-							onCopyError?.(error);
+							return;
 						}
-					}}
-					{...props}
-				/>
-			</span>
-		);
-	},
-);
+						const text = copyTextRef.current;
+						await copyToClipboard(text);
+						onCopy?.(text);
+						setWasCopied(true);
+						if (timeoutHandle.current != null) {
+							clearTimeout(timeoutHandle.current);
+						}
+						timeoutHandle.current = setTimeout(() => {
+							setWasCopied(false);
+						}, 2000);
+					} catch (error) {
+						onCopyError?.(error);
+					}
+				}}
+				{...props}
+			/>
+		</span>
+	);
+};
 CopyButton.displayName = "CodeBlockCopyButton";
 
 type CodeBlockExpanderButtonProps = Omit<
@@ -633,47 +642,51 @@ type CodeBlockExpanderButtonProps = Omit<
  * </CodeBlock.Root>
  * ```
  */
-const ExpanderButton = forwardRef<ComponentRef<"button">, CodeBlockExpanderButtonProps>(
-	({ asChild = false, className, onClick, ...props }, ref) => {
-		const { codeId, isCodeExpanded, setIsCodeExpanded, setHasCodeExpander } = useCodeBlockContext();
+const ExpanderButton = ({
+	asChild = false,
+	className,
+	onClick,
+	ref,
+	...props
+}: CodeBlockExpanderButtonProps) => {
+	const { codeId, isCodeExpanded, setIsCodeExpanded, setHasCodeExpander } = useCodeBlockContext();
 
-		useEffect(() => {
-			setHasCodeExpander(true);
-			return () => {
-				setHasCodeExpander(false);
-			};
-		}, [setHasCodeExpander]);
+	useEffect(() => {
+		setHasCodeExpander(true);
+		return () => {
+			setHasCodeExpander(false);
+		};
+	}, [setHasCodeExpander]);
 
-		const Component = asChild ? Slot : "button";
+	const Component = asChild ? Slot : "button";
 
-		return (
-			<Component
-				{...props}
-				data-slot="code-block-expander-button"
-				aria-controls={codeId}
-				aria-expanded={isCodeExpanded}
-				className={cx(
-					"flex w-full items-center justify-center gap-0.5 border-t border-gray-300 bg-base px-4 py-2 font-sans text-gray-700 hover:bg-base-hover",
-					className,
-				)}
-				ref={ref}
-				type="button"
-				// Why: the asChild union (Slot | "button") no longer infers a single
-				// event type; React event handlers are bivariant, so pin the param.
-				onClick={(event: MouseEvent<HTMLButtonElement>) => {
-					setIsCodeExpanded((prev) => !prev);
-					onClick?.(event);
-				}}
-			>
-				{isCodeExpanded ? "Show less" : "Show more"}{" "}
-				<MantleIcon
-					svg={<CaretDownIcon weight="bold" />}
-					className={cx("size-4", isCodeExpanded && "rotate-180", "transition-all duration-150")}
-				/>
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			{...props}
+			data-slot="code-block-expander-button"
+			aria-controls={codeId}
+			aria-expanded={isCodeExpanded}
+			className={cx(
+				"flex w-full items-center justify-center gap-0.5 border-t border-gray-300 bg-base px-4 py-2 font-sans text-gray-700 hover:bg-base-hover",
+				className,
+			)}
+			ref={ref}
+			type="button"
+			// Why: the asChild union (Slot | "button") no longer infers a single
+			// event type; React event handlers are bivariant, so pin the param.
+			onClick={(event: MouseEvent<HTMLButtonElement>) => {
+				setIsCodeExpanded((prev) => !prev);
+				onClick?.(event);
+			}}
+		>
+			{isCodeExpanded ? "Show less" : "Show more"}{" "}
+			<MantleIcon
+				svg={<CaretDownIcon weight="bold" />}
+				className={cx("size-4", isCodeExpanded && "rotate-180", "transition-all duration-150")}
+			/>
+		</Component>
+	);
+};
 ExpanderButton.displayName = "CodeBlockExpanderButton";
 
 type CodeBlockIconProps = Omit<SvgAttributes, "children"> &
@@ -788,23 +801,21 @@ type CodeBlockTabListProps = Omit<ComponentProps<typeof RadixTabsList>, "asChild
  * </CodeBlock.Root>
  * ```
  */
-const TabList = forwardRef<ComponentRef<typeof RadixTabsList>, CodeBlockTabListProps>(
-	({ className, ...props }, ref) => (
-		<RadixTabsList
-			data-slot="code-block-tab-list"
-			className={cx(
-				"scroll-fade-x flex min-w-0 items-center gap-1 overflow-x-auto overscroll-x-none",
-				// Reserve room inside the scroll box for each trigger's focus ring: `overflow-x-auto`
-				// promotes `overflow-y` to `auto`, which would otherwise clip the `ring-4` box-shadow.
-				// The negative margin cancels the padding so the header layout is unchanged. `min-w-0`
-				// lets the list shrink (and thus scroll) inside the flex `CodeBlock.Header`.
-				"-m-1 p-1",
-				className,
-			)}
-			ref={ref}
-			{...props}
-		/>
-	),
+const TabList = ({ className, ref, ...props }: CodeBlockTabListProps) => (
+	<RadixTabsList
+		data-slot="code-block-tab-list"
+		className={cx(
+			"scroll-fade-x flex min-w-0 items-center gap-1 overflow-x-auto overscroll-x-none",
+			// Reserve room inside the scroll box for each trigger's focus ring: `overflow-x-auto`
+			// promotes `overflow-y` to `auto`, which would otherwise clip the `ring-4` box-shadow.
+			// The negative margin cancels the padding so the header layout is unchanged. `min-w-0`
+			// lets the list shrink (and thus scroll) inside the flex `CodeBlock.Header`.
+			"-m-1 p-1",
+			className,
+		)}
+		ref={ref}
+		{...props}
+	/>
 );
 TabList.displayName = "CodeBlockTabList";
 
@@ -822,22 +833,20 @@ type CodeBlockTabTriggerProps = Omit<ComponentProps<typeof RadixTabsTrigger>, "a
  * </CodeBlock.TabList>
  * ```
  */
-const TabTrigger = forwardRef<ComponentRef<typeof RadixTabsTrigger>, CodeBlockTabTriggerProps>(
-	({ className, ...props }, ref) => (
-		<RadixTabsTrigger
-			data-slot="code-block-tab-trigger"
-			className={cx(
-				"shrink-0 cursor-pointer rounded px-1.5 py-0.5 font-sans text-xs font-medium whitespace-nowrap",
-				"text-gray-600 outline-hidden",
-				"hover:text-gray-900",
-				"data-[state=active]:bg-neutral-500/15 data-[state=active]:text-strong",
-				"focus-visible:ring-focus-accent focus-visible:ring-4",
-				className,
-			)}
-			ref={ref}
-			{...props}
-		/>
-	),
+const TabTrigger = ({ className, ref, ...props }: CodeBlockTabTriggerProps) => (
+	<RadixTabsTrigger
+		data-slot="code-block-tab-trigger"
+		className={cx(
+			"shrink-0 cursor-pointer rounded px-1.5 py-0.5 font-sans text-xs font-medium whitespace-nowrap",
+			"text-gray-600 outline-hidden",
+			"hover:text-gray-900",
+			"data-[state=active]:bg-neutral-500/15 data-[state=active]:text-strong",
+			"focus-visible:ring-focus-accent focus-visible:ring-4",
+			className,
+		)}
+		ref={ref}
+		{...props}
+	/>
 );
 TabTrigger.displayName = "CodeBlockTabTrigger";
 
@@ -864,8 +873,8 @@ type CodeBlockTabContentProps = Omit<
  * </CodeBlock.Body>
  * ```
  */
-const TabContent = forwardRef<ComponentRef<typeof RadixTabsContent>, CodeBlockTabContentProps>(
-	(props, ref) => <RadixTabsContent data-slot="code-block-tab-content" ref={ref} {...props} />,
+const TabContent = (props: CodeBlockTabContentProps) => (
+	<RadixTabsContent data-slot="code-block-tab-content" {...props} />
 );
 TabContent.displayName = "CodeBlockTabContent";
 

--- a/packages/mantle/src/components/code/code.tsx
+++ b/packages/mantle/src/components/code/code.tsx
@@ -1,5 +1,4 @@
-import { forwardRef } from "react";
-import type { ComponentProps, ComponentRef } from "react";
+import type { ComponentProps } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -37,23 +36,20 @@ import { Slot } from "../slot/index.js";
  * </Code>
  * ```
  */
-const Code = forwardRef<ComponentRef<"code">, ComponentProps<"code"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "code";
-		return (
-			<Comp
-				ref={ref}
-				data-slot="code"
-				className={cx(
-					"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]",
-					className,
-				)}
-				{...props}
-			/>
-		);
-	},
-);
-Code.displayName = "Code";
+const Code = ({ asChild, className, ref, ...props }: ComponentProps<"code"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "code";
+	return (
+		<Comp
+			ref={ref}
+			data-slot="code"
+			className={cx(
+				"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/combobox/combobox.tsx
+++ b/packages/mantle/src/components/combobox/combobox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Primitive from "@ariakit/react";
-import { type ComponentPropsWithoutRef, type ComponentRef, createContext, forwardRef } from "react";
+import { type ComponentProps, createContext } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
@@ -62,51 +62,47 @@ type ComboboxInputProps = Omit<
  * </Combobox.Root>
  * ```
  */
-const Input = forwardRef<ComponentRef<"input">, ComboboxInputProps>(
-	(
-		{
-			"aria-invalid": _ariaInvalid,
-			autoComplete = "list",
-			autoSelect = "always",
-			className,
-			validation: _validation,
-			...props
-		},
-		ref,
-	) => {
-		const fieldValidation = useFieldValidation();
-		const { ariaInvalid, validation } = parseValidation({
-			"aria-invalid": _ariaInvalid,
-			validation: _validation ?? fieldValidation,
-		});
+const Input = ({
+	"aria-invalid": _ariaInvalid,
+	autoComplete = "list",
+	autoSelect = "always",
+	className,
+	ref,
+	validation: _validation,
+	...props
+}: ComboboxInputProps) => {
+	const fieldValidation = useFieldValidation();
+	const { ariaInvalid, validation } = parseValidation({
+		"aria-invalid": _ariaInvalid,
+		validation: _validation ?? fieldValidation,
+	});
 
-		return (
-			<Primitive.Combobox
-				aria-invalid={ariaInvalid}
-				autoComplete={autoComplete}
-				autoSelect={autoSelect}
-				data-slot="combobox-input"
-				className={cx(
-					"pointer-coarse:text-base h-9 text-sm",
-					"bg-form relative block w-full rounded-md border px-3 py-2 border-form text-strong font-sans",
-					"placeholder:text-placeholder",
-					"aria-disabled:opacity-50",
-					"hover:border-neutral-400",
-					"focus:outline-hidden focus:ring-4 aria-expanded:ring-4",
-					"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent",
-					"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success",
-					"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning",
-					"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger",
-					"autofill:shadow-(--color-blue-50) autofill:bg-blue-50 autofill:[-webkit-text-fill-color:var(--text-color-strong)]", // Autofill styling on the input itself and any children with autofill styling
-					className,
-				)}
-				data-validation={validation || undefined}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Primitive.Combobox
+			aria-invalid={ariaInvalid}
+			autoComplete={autoComplete}
+			autoSelect={autoSelect}
+			data-slot="combobox-input"
+			className={cx(
+				"pointer-coarse:text-base h-9 text-sm",
+				"bg-form relative block w-full rounded-md border px-3 py-2 border-form text-strong font-sans",
+				"placeholder:text-placeholder",
+				"aria-disabled:opacity-50",
+				"hover:border-neutral-400",
+				"focus:outline-hidden focus:ring-4 aria-expanded:ring-4",
+				"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent",
+				"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success",
+				"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning",
+				"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger",
+				"autofill:shadow-(--color-blue-50) autofill:bg-blue-50 autofill:[-webkit-text-fill-color:var(--text-color-strong)]", // Autofill styling on the input itself and any children with autofill styling
+				className,
+			)}
+			data-validation={validation || undefined}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Input.displayName = "ComboboxInput";
 
 type ComboboxContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & WithAsChild;
@@ -131,31 +127,32 @@ type ComboboxContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & Wit
  * </Combobox.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<typeof Primitive.ComboboxPopover>, ComboboxContentProps>(
-	(
-		{ asChild = false, children, className, sameWidth = true, unmountOnHide = true, ...props },
-		ref,
-	) => {
-		return (
-			<Primitive.ComboboxPopover
-				data-slot="combobox-content"
-				className={cx(
-					"border-popover bg-popover relative z-50 max-h-96 min-w-32 scrollbar overflow-y-scroll overflow-x-hidden rounded-md border shadow-md p-1 my-2 space-y-px font-sans focus:outline-hidden",
-					className,
-				)}
-				ref={ref}
-				render={
-					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
-				}
-				sameWidth={sameWidth}
-				unmountOnHide={unmountOnHide}
-				{...props}
-			>
-				{children}
-			</Primitive.ComboboxPopover>
-		);
-	},
-);
+const Content = ({
+	asChild = false,
+	children,
+	className,
+	ref,
+	sameWidth = true,
+	unmountOnHide = true,
+	...props
+}: ComboboxContentProps) => {
+	return (
+		<Primitive.ComboboxPopover
+			data-slot="combobox-content"
+			className={cx(
+				"border-popover bg-popover relative z-50 max-h-96 min-w-32 scrollbar overflow-y-scroll overflow-x-hidden rounded-md border shadow-md p-1 my-2 space-y-px font-sans focus:outline-hidden",
+				className,
+			)}
+			ref={ref}
+			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
+			sameWidth={sameWidth}
+			unmountOnHide={unmountOnHide}
+			{...props}
+		>
+			{children}
+		</Primitive.ComboboxPopover>
+	);
+};
 Content.displayName = "ComboboxContent";
 
 type ComboboxItemProps = Omit<Primitive.ComboboxItemProps, "render"> & WithAsChild;
@@ -179,32 +176,38 @@ const ComboboxItemValueContext = createContext<string | undefined>(undefined);
  * </Combobox.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<typeof Primitive.ComboboxItem>, ComboboxItemProps>(
-	({ asChild = false, children, className, focusOnHover = true, value, ...props }, ref) => {
-		return (
-			<ComboboxItemValueContext.Provider value={value}>
-				<Primitive.ComboboxItem
-					data-slot="combobox-item"
-					className={cx(
-						"cursor-pointer rounded-md px-2 py-1.5 text-strong text-sm flex min-w-0 gap-2 items-center [&>svg]:size-5 [&_svg]:shrink-0",
-						"data-active-item:bg-active-menu-item",
-						"aria-disabled:opacity-50",
-						className,
-					)}
-					focusOnHover={focusOnHover}
-					ref={ref}
-					render={
-						asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
-					}
-					value={value}
-					{...props}
-				>
-					{children}
-				</Primitive.ComboboxItem>
-			</ComboboxItemValueContext.Provider>
-		);
-	},
-);
+const Item = ({
+	asChild = false,
+	children,
+	className,
+	focusOnHover = true,
+	ref,
+	value,
+	...props
+}: ComboboxItemProps) => {
+	return (
+		<ComboboxItemValueContext.Provider value={value}>
+			<Primitive.ComboboxItem
+				data-slot="combobox-item"
+				className={cx(
+					"cursor-pointer rounded-md px-2 py-1.5 text-strong text-sm flex min-w-0 gap-2 items-center [&>svg]:size-5 [&_svg]:shrink-0",
+					"data-active-item:bg-active-menu-item",
+					"aria-disabled:opacity-50",
+					className,
+				)}
+				focusOnHover={focusOnHover}
+				ref={ref}
+				render={
+					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
+				}
+				value={value}
+				{...props}
+			>
+				{children}
+			</Primitive.ComboboxItem>
+		</ComboboxItemValueContext.Provider>
+	);
+};
 Item.displayName = "ComboboxItem";
 
 type ComboboxGroupProps = Omit<Primitive.ComboboxGroupProps, "render"> & WithAsChild;
@@ -232,23 +235,19 @@ type ComboboxGroupProps = Omit<Primitive.ComboboxGroupProps, "render"> & WithAsC
  * </Combobox.Root>
  * ```
  */
-const Group = forwardRef<ComponentRef<typeof Primitive.ComboboxGroup>, ComboboxGroupProps>(
-	({ asChild = false, children, className, ...props }, ref) => {
-		return (
-			<Primitive.ComboboxGroup
-				data-slot="combobox-group"
-				className={cx("space-y-px", className)}
-				ref={ref}
-				render={
-					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
-				}
-				{...props}
-			>
-				{children}
-			</Primitive.ComboboxGroup>
-		);
-	},
-);
+const Group = ({ asChild = false, children, className, ref, ...props }: ComboboxGroupProps) => {
+	return (
+		<Primitive.ComboboxGroup
+			data-slot="combobox-group"
+			className={cx("space-y-px", className)}
+			ref={ref}
+			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
+			{...props}
+		>
+			{children}
+		</Primitive.ComboboxGroup>
+	);
+};
 Group.displayName = "ComboboxGroup";
 
 type ComboboxGroupLabelProps = Omit<Primitive.ComboboxGroupLabelProps, "render"> & WithAsChild;
@@ -276,10 +275,13 @@ type ComboboxGroupLabelProps = Omit<Primitive.ComboboxGroupLabelProps, "render">
  * </Combobox.Root>
  * ```
  */
-const GroupLabel = forwardRef<
-	ComponentRef<typeof Primitive.ComboboxGroupLabel>,
-	ComboboxGroupLabelProps
->(({ asChild = false, children, className, ...props }, ref) => {
+const GroupLabel = ({
+	asChild = false,
+	children,
+	className,
+	ref,
+	...props
+}: ComboboxGroupLabelProps) => {
 	return (
 		<Primitive.ComboboxGroupLabel
 			data-slot="combobox-group-label"
@@ -291,7 +293,7 @@ const GroupLabel = forwardRef<
 			{children}
 		</Primitive.ComboboxGroupLabel>
 	);
-});
+};
 GroupLabel.displayName = "ComboboxGroupLabel";
 
 type ComboboxItemValueProps = Omit<Primitive.ComboboxItemValueProps<"span">, "render"> &
@@ -328,10 +330,7 @@ type ComboboxItemValueProps = Omit<Primitive.ComboboxItemValueProps<"span">, "re
  * </Combobox.Root>
  * ```
  */
-const ItemValue = forwardRef<
-	ComponentRef<typeof Primitive.ComboboxItemValue>,
-	ComboboxItemValueProps
->(({ asChild = false, className, ...props }, ref) => {
+const ItemValue = ({ asChild = false, className, ref, ...props }: ComboboxItemValueProps) => {
 	return (
 		<Primitive.ComboboxItemValue
 			data-slot="combobox-item-value"
@@ -344,7 +343,7 @@ const ItemValue = forwardRef<
 			{...props}
 		/>
 	);
-});
+};
 ItemValue.displayName = "ComboboxItemValue";
 
 /**
@@ -369,17 +368,18 @@ ItemValue.displayName = "ComboboxItemValue";
  * </Combobox.Root>
  * ```
  */
-const ComboboxSeparatorComponent = forwardRef<
-	ComponentRef<typeof Separator>,
-	ComponentPropsWithoutRef<typeof Separator>
->(({ className, ...props }, ref) => (
+const ComboboxSeparatorComponent = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof Separator>) => (
 	<Separator
 		ref={ref}
 		data-slot="combobox-separator"
 		className={cx("-mx-1.25 my-1 w-auto", className)}
 		{...props}
 	/>
-));
+);
 ComboboxSeparatorComponent.displayName = "ComboboxSeparator";
 
 /**

--- a/packages/mantle/src/components/command/command.tsx
+++ b/packages/mantle/src/components/command/command.tsx
@@ -3,17 +3,12 @@
 import { MagnifyingGlassIcon } from "@phosphor-icons/react/MagnifyingGlass";
 import { Command as CommandPrimitive, useCommandState } from "cmdk";
 
-import {
-	type ComponentPropsWithoutRef,
-	type ComponentRef,
-	type ReactNode,
-	forwardRef,
-} from "react";
+import type { ComponentProps, ComponentPropsWithoutRef, ReactNode, Ref } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import { Dialog } from "../dialog/dialog.js";
 import { Separator } from "../separator/separator.js";
 
-type CommandRootProps = ComponentPropsWithoutRef<typeof CommandPrimitive>;
+type CommandRootProps = ComponentProps<typeof CommandPrimitive>;
 
 /**
  * The root component for the Command. It provides the context for all other command sub-components.
@@ -47,15 +42,12 @@ type CommandRootProps = ComponentPropsWithoutRef<typeof CommandPrimitive>;
  * </Command.DialogRoot>
  * ```
  */
-const CommandRoot = forwardRef<ComponentRef<"div">, CommandRootProps>(
-	({ className, ...props }, ref) => (
-		<CommandPrimitive
-			ref={ref}
-			data-slot="command"
-			className={cx("bg-popover flex h-full w-full flex-col overflow-hidden rounded-md", className)}
-			{...props}
-		/>
-	),
+const CommandRoot = ({ className, ...props }: CommandRootProps) => (
+	<CommandPrimitive
+		data-slot="command"
+		className={cx("bg-popover flex h-full w-full flex-col overflow-hidden rounded-md", className)}
+		{...props}
+	/>
 );
 CommandRoot.displayName = "Command";
 
@@ -166,7 +158,6 @@ const CommandDialogContent = ({
 		)}
 	</Dialog.Content>
 );
-CommandDialogContent.displayName = "CommandDialogContent";
 
 /**
  * The input component for the Command. It provides the input for the command palette.
@@ -200,10 +191,13 @@ CommandDialogContent.displayName = "CommandDialogContent";
  * </Command.DialogRoot>
  * ```
  */
-const CommandInput = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
+const CommandInput = ({
+	className,
+	ref,
+	...props
+}: ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+	ref?: Ref<HTMLDivElement>;
+}) => (
 	<div
 		ref={ref}
 		data-slot="command-input-wrapper"
@@ -219,8 +213,7 @@ const CommandInput = forwardRef<
 			{...props}
 		/>
 	</div>
-));
-CommandInput.displayName = "CommandInput";
+);
 
 /**
  * The list component for the Command. It provides the list for the command palette.
@@ -254,18 +247,13 @@ CommandInput.displayName = "CommandInput";
  * </Command.DialogRoot>
  * ```
  */
-const CommandList = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
+const CommandList = ({ className, ...props }: ComponentProps<typeof CommandPrimitive.List>) => (
 	<CommandPrimitive.List
-		ref={ref}
 		data-slot="command-list"
 		className={cx("max-h-75 scroll-py-1 overflow-x-hidden overflow-y-auto scrollbar", className)}
 		{...props}
 	/>
-));
-CommandList.displayName = "CommandList";
+);
 
 /**
  * The empty component for the Command. It provides the empty state for the command palette.
@@ -299,18 +287,13 @@ CommandList.displayName = "CommandList";
  * </Command.DialogRoot>
  * ```
  */
-const CommandEmpty = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->(({ className, ...props }, ref) => (
+const CommandEmpty = ({ className, ...props }: ComponentProps<typeof CommandPrimitive.Empty>) => (
 	<CommandPrimitive.Empty
-		ref={ref}
 		data-slot="command-empty"
 		className={cx("py-6 text-center text-sm", className)}
 		{...props}
 	/>
-));
-CommandEmpty.displayName = "CommandEmpty";
+);
 
 /**
  * The group component for the Command. It provides the group for the command palette.
@@ -344,12 +327,8 @@ CommandEmpty.displayName = "CommandEmpty";
  * </Command.DialogRoot>
  * ```
  */
-const CommandGroup = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
+const CommandGroup = ({ className, ...props }: ComponentProps<typeof CommandPrimitive.Group>) => (
 	<CommandPrimitive.Group
-		ref={ref}
 		data-slot="command-group"
 		className={cx(
 			"[&>[cmdk-group-heading]]:text-muted overflow-hidden p-1 [&>[cmdk-group-heading]]:px-2 [&>[cmdk-group-heading]]:py-1.5 [&>[cmdk-group-heading]]:text-xs [&>[cmdk-group-heading]]:font-medium",
@@ -357,8 +336,7 @@ const CommandGroup = forwardRef<
 		)}
 		{...props}
 	/>
-));
-CommandGroup.displayName = "CommandGroup";
+);
 
 /**
  * The separator component for the Command. It provides the separator for the command palette.
@@ -392,15 +370,14 @@ CommandGroup.displayName = "CommandGroup";
  * </Command.DialogRoot>
  * ```
  */
-const CommandSeparator = forwardRef<
-	ComponentRef<typeof CommandPrimitive.Separator>,
-	ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
-	<CommandPrimitive.Separator ref={ref} data-slot="command-separator" asChild {...props}>
+const CommandSeparator = ({
+	className,
+	...props
+}: ComponentProps<typeof CommandPrimitive.Separator>) => (
+	<CommandPrimitive.Separator data-slot="command-separator" asChild {...props}>
 		<Separator className={cx("-mx-1 my-1 w-auto", className)} />
 	</CommandPrimitive.Separator>
-));
-CommandSeparator.displayName = "CommandSeparator";
+);
 
 /**
  * The item component for the Command. It provides the item for the command palette.
@@ -434,12 +411,8 @@ CommandSeparator.displayName = "CommandSeparator";
  * </Command.DialogRoot>
  * ```
  */
-const CommandItem = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+const CommandItem = ({ className, ...props }: ComponentProps<typeof CommandPrimitive.Item>) => (
 	<CommandPrimitive.Item
-		ref={ref}
 		data-slot="command-item"
 		className={cx(
 			"data-[selected=true]:bg-active-menu-item [:where(&_svg)]:text-muted relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [:where(&_svg)]:size-5",
@@ -447,8 +420,7 @@ const CommandItem = forwardRef<
 		)}
 		{...props}
 	/>
-));
-CommandItem.displayName = "CommandItem";
+);
 
 /**
  * The shortcut component for the Command. It provides the shortcut for the command palette.
@@ -482,17 +454,13 @@ CommandItem.displayName = "CommandItem";
  * </Command.DialogRoot>
  * ```
  */
-const CommandShortcut = forwardRef<ComponentRef<"span">, ComponentPropsWithoutRef<"span">>(
-	({ className, ...props }, ref) => (
-		<span
-			ref={ref}
-			data-slot="command-shortcut"
-			className={cx("text-muted ml-auto text-xs tracking-widest", className)}
-			{...props}
-		/>
-	),
+const CommandShortcut = ({ className, ...props }: ComponentProps<"span">) => (
+	<span
+		data-slot="command-shortcut"
+		className={cx("text-muted ml-auto text-xs tracking-widest", className)}
+		{...props}
+	/>
 );
-CommandShortcut.displayName = "CommandShortcut";
 
 /**
  * The command component for the Command. It provides the command for the command palette.

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -9,12 +9,9 @@ import {
 } from "@tanstack/react-table";
 import {
 	type ComponentProps,
-	type ComponentPropsWithoutRef,
-	type ComponentRef,
 	Fragment,
 	type ReactNode,
 	createContext,
-	forwardRef,
 	useContext,
 	useMemo,
 } from "react";
@@ -316,11 +313,9 @@ function Header({ children, className, ...props }: DataTableHeaderProps) {
  * </DataTable.Root>
  * ```
  */
-const Body = forwardRef<
-	ComponentRef<typeof Table.Body>,
-	ComponentPropsWithoutRef<typeof Table.Body>
->((props, ref) => <Table.Body ref={ref} data-slot="data-table-body" {...props} />);
-Body.displayName = "DataTableBody";
+const Body = (props: ComponentProps<typeof Table.Body>) => (
+	<Table.Body data-slot="data-table-body" {...props} />
+);
 
 type DataTableHeadProps = Omit<ComponentProps<typeof Table.Head>, "children">;
 

--- a/packages/mantle/src/components/description-list/description-list.tsx
+++ b/packages/mantle/src/components/description-list/description-list.tsx
@@ -1,5 +1,4 @@
-import type { ComponentProps, ComponentRef } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { WithAsChild } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -24,25 +23,23 @@ type DescriptionListProps = ComponentProps<"dl"> & WithAsChild;
  * </DescriptionList.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"dl">, DescriptionListProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "dl";
+const Root = ({ asChild = false, className, children, ref, ...rest }: DescriptionListProps) => {
+	const Component = asChild ? Slot : "dl";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="description-list"
-				className={cx(
-					"relative scrollbar overflow-x-auto overscroll-x-none rounded-lg border border-card grid grid-cols-[auto_1fr] gap-x-4 [&>*:nth-child(odd)]:bg-neutral-500/5 p-1",
-					className,
-				)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="description-list"
+			className={cx(
+				"relative scrollbar overflow-x-auto overscroll-x-none rounded-lg border border-card grid grid-cols-[auto_1fr] gap-x-4 [&>*:nth-child(odd)]:bg-neutral-500/5 p-1",
+				className,
+			)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Root.displayName = "DescriptionList";
 
 type DescriptionListItemProps = ComponentProps<"div"> & WithAsChild;
@@ -62,22 +59,20 @@ type DescriptionListItemProps = ComponentProps<"div"> & WithAsChild;
  * </DescriptionList.Item>
  * ```
  */
-const Item = forwardRef<ComponentRef<"div">, DescriptionListItemProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Item = ({ asChild = false, className, children, ref, ...rest }: DescriptionListItemProps) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="description-list-item"
-				className={cx("rounded-sm col-span-full grid grid-cols-subgrid items-center", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="description-list-item"
+			className={cx("rounded-sm col-span-full grid grid-cols-subgrid items-center", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Item.displayName = "DescriptionListItem";
 
 type DescriptionListLabelProps = ComponentProps<"dt"> & WithAsChild;
@@ -92,22 +87,26 @@ type DescriptionListLabelProps = ComponentProps<"dt"> & WithAsChild;
  * <DescriptionList.Label>Name</DescriptionList.Label>
  * ```
  */
-const Label = forwardRef<ComponentRef<"dt">, DescriptionListLabelProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "dt";
+const Label = ({
+	asChild = false,
+	className,
+	children,
+	ref,
+	...rest
+}: DescriptionListLabelProps) => {
+	const Component = asChild ? Slot : "dt";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="description-list-label"
-				className={cx("text-muted text-sm font-sans font-medium min-w-36 p-2", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="description-list-label"
+			className={cx("text-muted text-sm font-sans font-medium min-w-36 p-2", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Label.displayName = "DescriptionListLabel";
 
 type DescriptionListValueProps = ComponentProps<"dd"> & WithAsChild;
@@ -126,22 +125,26 @@ type DescriptionListValueProps = ComponentProps<"dd"> & WithAsChild;
  * </DescriptionList.Value>
  * ```
  */
-const Value = forwardRef<ComponentRef<"dd">, DescriptionListValueProps>(
-	({ asChild = false, className, children, ...rest }, ref) => {
-		const Component = asChild ? Slot : "dd";
+const Value = ({
+	asChild = false,
+	className,
+	children,
+	ref,
+	...rest
+}: DescriptionListValueProps) => {
+	const Component = asChild ? Slot : "dd";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="description-list-value"
-				className={cx("text-body font-mono text-mono py-2 px-3", className)}
-				{...rest}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="description-list-value"
+			className={cx("text-body font-mono text-mono py-2 px-3", className)}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
+};
 Value.displayName = "DescriptionListValue";
 
 /**

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -1,6 +1,5 @@
 import { XIcon } from "@phosphor-icons/react/X";
-import type { ComponentProps, ComponentPropsWithoutRef, ComponentRef } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import {
 	IconButton,
@@ -78,10 +77,9 @@ Root.displayName = "Dialog";
  * </Dialog.Root>
  * ```
  */
-const Trigger = forwardRef<
-	ComponentRef<typeof DialogPrimitive.Trigger>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>
->((props, ref) => <DialogPrimitive.Trigger ref={ref} data-slot="dialog-trigger" {...props} />);
+const Trigger = (props: ComponentProps<typeof DialogPrimitive.Trigger>) => (
+	<DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+);
 Trigger.displayName = "DialogTrigger";
 
 /**
@@ -156,10 +154,9 @@ Portal.displayName = "DialogPortal";
  * </Dialog.Root>
  * ```
  */
-const Close = forwardRef<
-	ComponentRef<typeof DialogPrimitive.Close>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
->((props, ref) => <DialogPrimitive.Close ref={ref} data-slot="dialog-close" {...props} />);
+const Close = (props: ComponentProps<typeof DialogPrimitive.Close>) => (
+	<DialogPrimitive.Close data-slot="dialog-close" {...props} />
+);
 Close.displayName = "DialogClose";
 
 /**
@@ -200,10 +197,7 @@ Close.displayName = "DialogClose";
  * </Dialog.Root>
  * ```
  */
-const Overlay = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const Overlay = ({ className, ref, ...props }: ComponentProps<typeof DialogPrimitive.Overlay>) => (
 	<DialogPrimitive.Overlay
 		ref={ref}
 		data-slot="dialog-overlay"
@@ -213,10 +207,10 @@ const Overlay = forwardRef<
 		)}
 		{...props}
 	/>
-));
+);
 Overlay.displayName = "DialogOverlay";
 
-type ContentProps = ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+type ContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
 	/**
 	 * The preferred width of the `Dialog.Content` as a tailwind `max-w-` class.
 	 *
@@ -263,30 +257,34 @@ type ContentProps = ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
  * </Dialog.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<"div">, ContentProps>(
-	({ children, className, preferredWidth = "max-w-lg", ...props }, ref) => (
-		<Portal>
-			<Overlay />
-			<div className="fixed inset-4 z-50 flex items-center justify-center">
-				<DialogPrimitive.Content
-					data-mantle-modal-content
-					data-slot="dialog-content"
-					className={cx(
-						"flex max-h-full w-full flex-1 flex-col",
-						"outline-hidden focus-within:outline-hidden",
-						"border-dialog bg-dialog rounded-xl border shadow-lg transition-transform duration-200",
-						"data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95",
-						preferredWidth,
-						className,
-					)}
-					ref={ref}
-					{...props}
-				>
-					{children}
-				</DialogPrimitive.Content>
-			</div>
-		</Portal>
-	),
+const Content = ({
+	children,
+	className,
+	preferredWidth = "max-w-lg",
+	ref,
+	...props
+}: ContentProps) => (
+	<Portal>
+		<Overlay />
+		<div className="fixed inset-4 z-50 flex items-center justify-center">
+			<DialogPrimitive.Content
+				data-mantle-modal-content
+				data-slot="dialog-content"
+				className={cx(
+					"flex max-h-full w-full flex-1 flex-col",
+					"outline-hidden focus-within:outline-hidden",
+					"border-dialog bg-dialog rounded-xl border shadow-lg transition-transform duration-200",
+					"data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95",
+					preferredWidth,
+					className,
+				)}
+				ref={ref}
+				{...props}
+			>
+				{children}
+			</DialogPrimitive.Content>
+		</div>
+	</Portal>
 );
 Content.displayName = "DialogContent";
 
@@ -521,17 +519,14 @@ Footer.displayName = "DialogFooter";
  * </Dialog.Root>
  * ```
  */
-const Title = forwardRef<
-	ComponentRef<typeof DialogPrimitive.Title>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+const Title = ({ className, ref, ...props }: ComponentProps<typeof DialogPrimitive.Title>) => (
 	<DialogPrimitive.Title
 		ref={ref}
 		data-slot="dialog-title"
 		className={cx("text-strong truncate text-lg font-medium", className)}
 		{...props}
 	/>
-));
+);
 Title.displayName = "DialogTitle";
 
 /**
@@ -566,17 +561,18 @@ Title.displayName = "DialogTitle";
  * </Dialog.Root>
  * ```
  */
-const Description = forwardRef<
-	ComponentRef<typeof DialogPrimitive.Description>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
+const Description = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof DialogPrimitive.Description>) => (
 	<DialogPrimitive.Description
 		ref={ref}
 		data-slot="dialog-description"
 		className={cx("text-muted", className)}
 		{...props}
 	/>
-));
+);
 Description.displayName = "DialogDescription";
 
 /**

--- a/packages/mantle/src/components/dialog/primitive.tsx
+++ b/packages/mantle/src/components/dialog/primitive.tsx
@@ -2,10 +2,10 @@
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
+	type ComponentProps,
 	type ComponentPropsWithoutRef,
-	type ComponentRef,
 	createContext,
-	forwardRef,
+	type Ref,
 	useContext,
 	useEffect,
 	useMemo,
@@ -15,7 +15,7 @@ import { Slot } from "../slot/index.js";
 import { preventCloseOnPromptInteraction } from "../toast/toast.js";
 import { parseBooleanish } from "../../types/booleanish.js";
 
-type DialogPrimitiveContentProps = ComponentPropsWithoutRef<typeof DialogPrimitive.Content>;
+type DialogPrimitiveContentProps = ComponentProps<typeof DialogPrimitive.Content>;
 
 type InternalDialogContextValue = {
 	hasDescription: boolean;
@@ -48,48 +48,48 @@ Portal.displayName = "DialogPrimitivePortal";
 const Close = DialogPrimitive.Close;
 Close.displayName = "DialogPrimitiveClose";
 
-const Overlay = forwardRef<
-	ComponentRef<typeof DialogPrimitive.Overlay>,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->((props, ref) => (
+const Overlay = (props: ComponentProps<typeof DialogPrimitive.Overlay>) => (
 	<DialogPrimitive.Overlay
 		/**
 		 * Mark the overlay with a data attribute so we can target it, e.g. in
 		 * event handlers
 		 */
 		data-overlay
-		ref={ref}
 		{...props}
 	/>
-));
+);
 Overlay.displayName = "DialogPrimitiveOverlay";
 
-const Content = forwardRef<ComponentRef<"div">, DialogPrimitiveContentProps>(
-	({ onEscapeKeyDown, onInteractOutside, onPointerDownOutside, ...props }, ref) => {
-		const ctx = useContext(InternalDialogContext);
+const Content = ({
+	onEscapeKeyDown,
+	onInteractOutside,
+	onPointerDownOutside,
+	ref,
+	...props
+}: DialogPrimitiveContentProps) => {
+	const ctx = useContext(InternalDialogContext);
 
-		return (
-			<DialogPrimitive.Content
-				ref={ref}
-				onEscapeKeyDown={(event) => {
-					preventCloseOnNestedPopupEscape(event);
-					onEscapeKeyDown?.(event);
-				}}
-				onInteractOutside={(event) => {
-					preventCloseOnPromptInteraction(event);
-					onInteractOutside?.(event);
-				}}
-				onPointerDownOutside={(event) => {
-					preventCloseOnPromptInteraction(event);
-					onPointerDownOutside?.(event);
-				}}
-				// If there's no description, we remove the default applied aria-describedby attribute from radix dialog
-				{...(!ctx.hasDescription ? { "aria-describedby": undefined } : {})}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<DialogPrimitive.Content
+			ref={ref}
+			onEscapeKeyDown={(event) => {
+				preventCloseOnNestedPopupEscape(event);
+				onEscapeKeyDown?.(event);
+			}}
+			onInteractOutside={(event) => {
+				preventCloseOnPromptInteraction(event);
+				onInteractOutside?.(event);
+			}}
+			onPointerDownOutside={(event) => {
+				preventCloseOnPromptInteraction(event);
+				onPointerDownOutside?.(event);
+			}}
+			// If there's no description, we remove the default applied aria-describedby attribute from radix dialog
+			{...(!ctx.hasDescription ? { "aria-describedby": undefined } : {})}
+			{...props}
+		/>
+	);
+};
 Content.displayName = "DialogPrimitiveContent";
 
 const Title = DialogPrimitive.Title;
@@ -99,10 +99,14 @@ const Title = DialogPrimitive.Title;
  * This is a low-level primitive used by higher-level dialog components.
  * Renders as a `div` by default, but can be changed to any other element using the `asChild` prop.
  */
-const Description = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ asChild, children, ...props }, ref) => {
+const Description = ({
+	asChild,
+	children,
+	ref,
+	...props
+}: ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
+	ref?: Ref<HTMLDivElement>;
+}) => {
 	const ctx = useContext(InternalDialogContext);
 
 	useEffect(() => {
@@ -117,7 +121,7 @@ const Description = forwardRef<
 			<Component {...props}>{children}</Component>
 		</DialogPrimitive.Description>
 	);
-});
+};
 Description.displayName = "DialogPrimitiveDescription";
 
 /**

--- a/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,8 +1,7 @@
 import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
 import { CheckIcon } from "@phosphor-icons/react/Check";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import type { ComponentProps, ComponentPropsWithoutRef, ComponentRef } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
@@ -56,25 +55,18 @@ Root.displayName = "DropdownMenu";
  * </DropdownMenu.Root>
  * ```
  */
-const Trigger = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
->((props, ref) => (
-	<DropdownMenuPrimitive.Trigger ref={ref} data-slot="dropdown-menu-trigger" {...props} />
-));
+const Trigger = (props: ComponentProps<typeof DropdownMenuPrimitive.Trigger>) => (
+	<DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+);
 Trigger.displayName = "DropdownMenuTrigger";
 
-const Group = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.Group>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group>
->(({ className, ...props }, ref) => (
+const Group = ({ className, ...props }: ComponentProps<typeof DropdownMenuPrimitive.Group>) => (
 	<DropdownMenuPrimitive.Group
-		ref={ref}
 		data-slot="dropdown-menu-group"
 		className={cx("space-y-px", className)}
 		{...props}
 	/>
-));
+);
 Group.displayName = "DropdownMenuGroup";
 
 /**
@@ -86,17 +78,16 @@ Portal.displayName = "DropdownMenuPortal";
 const Sub = DropdownMenuPrimitive.Sub;
 Sub.displayName = "DropdownMenuSub";
 
-const RadioGroup = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.RadioGroup>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioGroup>
->(({ className, ...props }, ref) => (
+const RadioGroup = ({
+	className,
+	...props
+}: ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) => (
 	<DropdownMenuPrimitive.RadioGroup
-		ref={ref}
 		data-slot="dropdown-menu-radio-group"
 		className={cx("space-y-px", className)}
 		{...props}
 	/>
-));
+);
 RadioGroup.displayName = "DropdownMenuRadioGroup";
 
 /**
@@ -104,12 +95,14 @@ RadioGroup.displayName = "DropdownMenuRadioGroup";
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenusubtrigger
  */
-const SubTrigger = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-		inset?: boolean;
-	}
->(({ className, inset, children, ...props }, ref) => (
+const SubTrigger = ({
+	className,
+	inset,
+	children,
+	...props
+}: ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+	inset?: boolean;
+}) => (
 	<DropdownMenuPrimitive.SubTrigger
 		data-slot="dropdown-menu-sub-trigger"
 		className={cx(
@@ -119,7 +112,6 @@ const SubTrigger = forwardRef<
 			inset && "pl-8",
 			className,
 		)}
-		ref={ref}
 		{...props}
 	>
 		{children}
@@ -127,7 +119,7 @@ const SubTrigger = forwardRef<
 			<Icon svg={<CaretRightIcon weight="bold" />} className="size-4" />
 		</span>
 	</DropdownMenuPrimitive.SubTrigger>
-));
+);
 SubTrigger.displayName = "DropdownMenuSubTrigger";
 
 /**
@@ -139,10 +131,11 @@ SubTrigger.displayName = "DropdownMenuSubTrigger";
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenusubcontent
  */
-const SubContent = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, loop = true, ...props }, ref) => (
+const SubContent = ({
+	className,
+	loop = true,
+	...props
+}: ComponentProps<typeof DropdownMenuPrimitive.SubContent>) => (
 	<Portal>
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
@@ -153,14 +146,13 @@ const SubContent = forwardRef<
 				className,
 			)}
 			loop={loop}
-			ref={ref}
 			{...props}
 		/>
 	</Portal>
-));
+);
 SubContent.displayName = "DropdownMenuSubContent";
 
-type DropdownMenuContentProps = ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> &
+type DropdownMenuContentProps = ComponentProps<typeof DropdownMenuPrimitive.Content> &
 	WithDataSlot & {
 		/**
 		 * Whether the DropdownMenuContent should match the width of the trigger or use the intrinsic content width.
@@ -192,13 +184,16 @@ type DropdownMenuContentProps = ComponentPropsWithoutRef<typeof DropdownMenuPrim
  * </DropdownMenu.Root>
  * ```
  */
-const Content = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.Content>,
-	DropdownMenuContentProps
->(({ className, "data-slot": dataSlot, onClick, loop = true, width, ...props }, ref) => (
+const Content = ({
+	className,
+	"data-slot": dataSlot,
+	onClick,
+	loop = true,
+	width,
+	...props
+}: DropdownMenuContentProps) => (
 	<Portal>
 		<DropdownMenuPrimitive.Content
-			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "dropdown-menu-content")}
 			className={cx(
 				"scrollbar",
@@ -220,7 +215,7 @@ const Content = forwardRef<
 			{...props}
 		/>
 	</Portal>
-));
+);
 Content.displayName = "DropdownMenuContent";
 
 /**
@@ -243,14 +238,14 @@ Content.displayName = "DropdownMenuContent";
  * </DropdownMenu.Root>
  * ```
  */
-const Item = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.Item>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-		inset?: boolean;
-	}
->(({ className, inset, ...props }, ref) => (
+const Item = ({
+	className,
+	inset,
+	...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+	inset?: boolean;
+}) => (
 	<DropdownMenuPrimitive.Item
-		ref={ref}
 		data-slot="dropdown-menu-item"
 		className={cx(
 			"relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-strong text-sm font-normal outline-hidden transition-colors",
@@ -263,7 +258,7 @@ const Item = forwardRef<
 		)}
 		{...props}
 	/>
-));
+);
 Item.displayName = "DropdownMenuItem";
 
 /**
@@ -271,12 +266,13 @@ Item.displayName = "DropdownMenuItem";
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenucheckboxitem
  */
-const CheckboxItem = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+const CheckboxItem = ({
+	className,
+	children,
+	checked,
+	...props
+}: ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) => (
 	<DropdownMenuPrimitive.CheckboxItem
-		ref={ref}
 		data-slot="dropdown-menu-checkbox-item"
 		className={cx(
 			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 pl-2 pr-9 text-sm font-normal outline-hidden",
@@ -296,12 +292,10 @@ const CheckboxItem = forwardRef<
 		</span>
 		{children}
 	</DropdownMenuPrimitive.CheckboxItem>
-));
+);
 CheckboxItem.displayName = "DropdownMenuCheckboxItem";
 
-type DropdownMenuRadioItemProps = ComponentPropsWithoutRef<
-	typeof DropdownMenuPrimitive.RadioItem
-> & {
+type DropdownMenuRadioItemProps = ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
 	name?: string;
 	id?: string;
 };
@@ -312,30 +306,27 @@ type DropdownMenuRadioItemProps = ComponentPropsWithoutRef<
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenuradioitem
  */
-const RadioItem = forwardRef<ComponentRef<"input">, DropdownMenuRadioItemProps>(
-	({ className, children, ...props }, ref) => (
-		<DropdownMenuPrimitive.RadioItem
-			data-slot="dropdown-menu-radio-item"
-			className={cx(
-				"group/dropdown-menu-radio-item",
-				"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none",
-				"data-highlighted:bg-active-menu-item",
-				"aria-checked:bg-selected-menu-item aria-checked:pr-9",
-				"data-highlighted:aria-checked:bg-active-selected-menu-item!",
-				"[&>svg]:size-5 [&_svg]:shrink-0",
-				className,
-			)}
-			ref={ref}
-			{...props}
-		>
-			<span className="absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex">
-				<DropdownMenuPrimitive.ItemIndicator>
-					<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
-				</DropdownMenuPrimitive.ItemIndicator>
-			</span>
-			{children}
-		</DropdownMenuPrimitive.RadioItem>
-	),
+const RadioItem = ({ className, children, ...props }: DropdownMenuRadioItemProps) => (
+	<DropdownMenuPrimitive.RadioItem
+		data-slot="dropdown-menu-radio-item"
+		className={cx(
+			"group/dropdown-menu-radio-item",
+			"text-strong data-disabled:pointer-events-none data-disabled:opacity-50 relative flex cursor-pointer select-none items-center gap-2 rounded-md py-1.5 px-2 text-sm font-normal outline-none",
+			"data-highlighted:bg-active-menu-item",
+			"aria-checked:bg-selected-menu-item aria-checked:pr-9",
+			"data-highlighted:aria-checked:bg-active-selected-menu-item!",
+			"[&>svg]:size-5 [&_svg]:shrink-0",
+			className,
+		)}
+		{...props}
+	>
+		<span className="absolute right-2 items-center hidden group-aria-checked/dropdown-menu-radio-item:flex">
+			<DropdownMenuPrimitive.ItemIndicator>
+				<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
+			</DropdownMenuPrimitive.ItemIndicator>
+		</span>
+		{children}
+	</DropdownMenuPrimitive.RadioItem>
 );
 RadioItem.displayName = "DropdownMenuRadioItem";
 
@@ -344,19 +335,19 @@ RadioItem.displayName = "DropdownMenuRadioItem";
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenulabel
  */
-const Label = forwardRef<
-	ComponentRef<typeof DropdownMenuPrimitive.Label>,
-	ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-		inset?: boolean;
-	}
->(({ className, inset, ...props }, ref) => (
+const Label = ({
+	className,
+	inset,
+	...props
+}: ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+	inset?: boolean;
+}) => (
 	<DropdownMenuPrimitive.Label
-		ref={ref}
 		data-slot="dropdown-menu-label"
 		className={cx("px-2 py-1.5 text-sm font-medium", inset && "pl-8", className)}
 		{...props}
 	/>
-));
+);
 Label.displayName = "DropdownMenuLabel";
 
 /**
@@ -364,17 +355,13 @@ Label.displayName = "DropdownMenuLabel";
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenuseparator
  */
-const DropdownSeparator = forwardRef<
-	ComponentRef<typeof Separator>,
-	ComponentPropsWithoutRef<typeof Separator>
->(({ className, ...props }, ref) => (
+const DropdownSeparator = ({ className, ...props }: ComponentProps<typeof Separator>) => (
 	<Separator
-		ref={ref}
 		data-slot="dropdown-menu-separator"
 		className={cx("-mx-1.25 my-1 w-auto", className)}
 		{...props}
 	/>
-));
+);
 DropdownSeparator.displayName = "DropdownMenuSeparator";
 
 const Shortcut = ({ className, ...props }: ComponentProps<"span">) => {

--- a/packages/mantle/src/components/field/field.tsx
+++ b/packages/mantle/src/components/field/field.tsx
@@ -1,9 +1,7 @@
 import { QuestionIcon } from "@phosphor-icons/react/Question";
 import {
 	cloneElement,
-	type ComponentRef,
 	type ComponentProps,
-	forwardRef,
 	isValidElement,
 	type ReactElement,
 	type ReactNode,
@@ -65,19 +63,16 @@ import { FieldValidationProvider, resolveValidation, type WithValidation } from 
  * </Field.Set>
  * ```
  */
-const FieldSet = forwardRef<ComponentRef<"fieldset">, ComponentProps<"fieldset">>(
-	({ className, ...props }, ref) => {
-		return (
-			<fieldset
-				ref={ref}
-				data-slot="field-set"
-				className={cx("flex w-full min-w-0 flex-col gap-4 border-0 p-0", className)}
-				{...props}
-			/>
-		);
-	},
-);
-FieldSet.displayName = "FieldSet";
+const FieldSet = ({ className, ref, ...props }: ComponentProps<"fieldset">) => {
+	return (
+		<fieldset
+			ref={ref}
+			data-slot="field-set"
+			className={cx("flex w-full min-w-0 flex-col gap-4 border-0 p-0", className)}
+			{...props}
+		/>
+	);
+};
 
 /**
  * The caption for a `Field.Set`. Always renders a semantic `<legend>` styled
@@ -104,23 +99,21 @@ FieldSet.displayName = "FieldSet";
  * </Field.Set>
  * ```
  */
-const Legend = forwardRef<ComponentRef<"legend">, ComponentProps<"legend">>(
-	({ className, ...props }, ref) => {
-		return (
-			<legend
-				ref={ref}
-				data-slot="field-legend"
-				// `mb-1.5` (not the parent's `gap-*`) drives the Legend ↔ next-sibling
-				// spacing because `<legend>` has special browser rendering inside a
-				// `<fieldset>` that ignores the parent's flex `gap`. Pairs with
-				// RadioGroup.Item's own `py-1` for a 10px text-bottom-to-radio rhythm
-				// matching the figma. Override with any `mb-*` utility on Field.Legend.
-				className={cx("text-strong mb-1.5 text-sm font-medium font-sans", className)}
-				{...props}
-			/>
-		);
-	},
-);
+const Legend = ({ className, ref, ...props }: ComponentProps<"legend">) => {
+	return (
+		<legend
+			ref={ref}
+			data-slot="field-legend"
+			// `mb-1.5` (not the parent's `gap-*`) drives the Legend ↔ next-sibling
+			// spacing because `<legend>` has special browser rendering inside a
+			// `<fieldset>` that ignores the parent's flex `gap`. Pairs with
+			// RadioGroup.Item's own `py-1` for a 10px text-bottom-to-radio rhythm
+			// matching the figma. Override with any `mb-*` utility on Field.Legend.
+			className={cx("text-strong mb-1.5 text-sm font-medium font-sans", className)}
+			{...props}
+		/>
+	);
+};
 Legend.displayName = "FieldLegend";
 
 /**
@@ -156,14 +149,11 @@ Legend.displayName = "FieldLegend";
  * </Field.Item>
  * ```
  */
-const FieldLabel = forwardRef<ComponentRef<"label">, ComponentProps<typeof Label>>(
-	({ htmlFor, ...props }, ref) => {
-		const context = useContext(FieldItemContext);
+const FieldLabel = ({ htmlFor, ref, ...props }: ComponentProps<typeof Label>) => {
+	const context = useContext(FieldItemContext);
 
-		return <Label ref={ref} htmlFor={htmlFor ?? context?.controlId} {...props} />;
-	},
-);
-FieldLabel.displayName = "FieldLabel";
+	return <Label ref={ref} htmlFor={htmlFor ?? context?.controlId} {...props} />;
+};
 
 /**
  * Static, label-styled text for a `Field.Item` row that does **not** caption a
@@ -201,20 +191,18 @@ FieldLabel.displayName = "FieldLabel";
  * </Field.Item>
  * ```
  */
-const LabelText = forwardRef<ComponentRef<"p">, ComponentProps<"p"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "p";
+const LabelText = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "p";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="field-label-text"
-				className={cx("text-strong text-sm font-medium font-sans", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="field-label-text"
+			className={cx("text-strong text-sm font-medium font-sans", className)}
+			{...props}
+		/>
+	);
+};
 LabelText.displayName = "FieldLabelText";
 
 /**
@@ -255,20 +243,18 @@ LabelText.displayName = "FieldLabelText";
  * </Field.Group>
  * ```
  */
-const LabelRow = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const LabelRow = ({ asChild, className, ref, ...props }: ComponentProps<"div"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="field-label-row"
-				className={cx("flex items-center gap-1", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="field-label-row"
+			className={cx("flex items-center gap-1", className)}
+			{...props}
+		/>
+	);
+};
 LabelRow.displayName = "FieldLabelRow";
 
 /**
@@ -377,38 +363,34 @@ type FieldHelpTriggerProps = Partial<
  * </Field.Group>
  * ```
  */
-const HelpTrigger = forwardRef<ComponentRef<"button">, FieldHelpTriggerProps>(
-	(
-		{
-			appearance = "ghost",
-			className,
-			icon = defaultHelpTriggerIcon,
-			intent = "neutral",
-			label,
-			size = "xs",
-			type = "button",
-			...props
-		},
-		ref,
-	) => (
-		<Popover.Trigger asChild>
-			<IconButton
-				ref={ref}
-				appearance={appearance}
-				// `-my-0.5` keeps the 24px (`size-6`) `xs` IconButton click target while
-				// trimming 4px (2px each side) off its flex-line contribution so the row
-				// height matches the label's 20px line-height. Without this the trigger
-				// drives the LabelRow to 24px and pushes the label text down 2px.
-				className={cx("text-body -my-0.5", className)}
-				icon={icon}
-				intent={intent}
-				label={label}
-				size={size}
-				type={type}
-				{...props}
-			/>
-		</Popover.Trigger>
-	),
+const HelpTrigger = ({
+	appearance = "ghost",
+	className,
+	icon = defaultHelpTriggerIcon,
+	intent = "neutral",
+	label,
+	ref,
+	size = "xs",
+	type = "button",
+	...props
+}: FieldHelpTriggerProps) => (
+	<Popover.Trigger asChild>
+		<IconButton
+			ref={ref}
+			appearance={appearance}
+			// `-my-0.5` keeps the 24px (`size-6`) `xs` IconButton click target while
+			// trimming 4px (2px each side) off its flex-line contribution so the row
+			// height matches the label's 20px line-height. Without this the trigger
+			// drives the LabelRow to 24px and pushes the label text down 2px.
+			className={cx("text-body -my-0.5", className)}
+			icon={icon}
+			intent={intent}
+			label={label}
+			size={size}
+			type={type}
+			{...props}
+		/>
+	</Popover.Trigger>
 );
 HelpTrigger.displayName = "FieldHelpTrigger";
 
@@ -443,8 +425,8 @@ HelpTrigger.displayName = "FieldHelpTrigger";
  * </Field.Group>
  * ```
  */
-const HelpContent = forwardRef<ComponentRef<"div">, ComponentProps<typeof Popover.Content>>(
-	(props, ref) => <Popover.Content ref={ref} data-slot="field-help-content" {...props} />,
+const HelpContent = ({ ref, ...props }: ComponentProps<typeof Popover.Content>) => (
+	<Popover.Content ref={ref} data-slot="field-help-content" {...props} />
 );
 HelpContent.displayName = "FieldHelpContent";
 
@@ -483,22 +465,26 @@ HelpContent.displayName = "FieldHelpContent";
  * </Field.Group>
  * ```
  */
-const Optional = forwardRef<ComponentRef<"span">, ComponentProps<"span"> & WithAsChild>(
-	({ asChild, children, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "span";
+const Optional = ({
+	asChild,
+	children,
+	className,
+	ref,
+	...props
+}: ComponentProps<"span"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "span";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="field-optional"
-				className={cx("text-muted text-sm font-normal font-sans", className)}
-				{...props}
-			>
-				{children ?? "(Optional)"}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="field-optional"
+			className={cx("text-muted text-sm font-normal font-sans", className)}
+			{...props}
+		>
+			{children ?? "(Optional)"}
+		</Comp>
+	);
+};
 Optional.displayName = "FieldOptional";
 
 /**
@@ -532,20 +518,18 @@ Optional.displayName = "FieldOptional";
  * </Field.Group>
  * ```
  */
-const Group = forwardRef<ComponentRef<"div">, ComponentProps<"div"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Group = ({ asChild, className, ref, ...props }: ComponentProps<"div"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="field-group"
-				className={cx("flex w-full flex-col gap-4", className)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="field-group"
+			className={cx("flex w-full flex-col gap-4", className)}
+			{...props}
+		/>
+	);
+};
 Group.displayName = "FieldGroup";
 
 /**
@@ -603,53 +587,59 @@ type FieldItemProps = ComponentProps<"div"> &
 		name: string;
 	};
 
-const Item = forwardRef<ComponentRef<"div">, FieldItemProps>(
-	({ asChild, children, className, name, validation: validationProp, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
-		const controlId = useId();
-		const descriptionId = useId();
-		const errorId = useId();
-		const [hasErrors, setHasErrors] = useState(false);
-		const validation = resolveValidation(validationProp ?? (hasErrors ? "error" : undefined));
+const Item = ({
+	asChild,
+	children,
+	className,
+	name,
+	ref,
+	validation: validationProp,
+	...props
+}: FieldItemProps) => {
+	const Comp = asChild ? Slot : "div";
+	const controlId = useId();
+	const descriptionId = useId();
+	const errorId = useId();
+	const [hasErrors, setHasErrors] = useState(false);
+	const validation = resolveValidation(validationProp ?? (hasErrors ? "error" : undefined));
 
-		const registerError = useCallback(() => {
-			setHasErrors(true);
+	const registerError = useCallback(() => {
+		setHasErrors(true);
 
-			return () => {
-				setHasErrors(false);
-			};
-		}, []);
+		return () => {
+			setHasErrors(false);
+		};
+	}, []);
 
-		const context = useMemo(
-			() => ({
-				controlId,
-				descriptionId,
-				errorId,
-				hasErrors,
-				name,
-				registerError,
-				validation,
-			}),
-			[controlId, descriptionId, errorId, hasErrors, name, registerError, validation],
-		);
+	const context = useMemo(
+		() => ({
+			controlId,
+			descriptionId,
+			errorId,
+			hasErrors,
+			name,
+			registerError,
+			validation,
+		}),
+		[controlId, descriptionId, errorId, hasErrors, name, registerError, validation],
+	);
 
-		return (
-			<FieldItemContext.Provider value={context}>
-				<FieldValidationProvider validation={validation}>
-					<Comp
-						ref={ref}
-						data-slot="field-item"
-						data-validation={validation}
-						className={cx("flex w-full flex-col gap-1.5", className)}
-						{...props}
-					>
-						{children}
-					</Comp>
-				</FieldValidationProvider>
-			</FieldItemContext.Provider>
-		);
-	},
-);
+	return (
+		<FieldItemContext.Provider value={context}>
+			<FieldValidationProvider validation={validation}>
+				<Comp
+					ref={ref}
+					data-slot="field-item"
+					data-validation={validation}
+					className={cx("flex w-full flex-col gap-1.5", className)}
+					{...props}
+				>
+					{children}
+				</Comp>
+			</FieldValidationProvider>
+		</FieldItemContext.Provider>
+	);
+};
 Item.displayName = "FieldItem";
 
 type FieldControlSlotProps = Omit<
@@ -659,7 +649,7 @@ type FieldControlSlotProps = Omit<
 
 /**
  * Element-child form of `Field.Control`. Renders via `Slot`, so it accepts
- * any HTML/Slot props and a forwarded ref — those land on the single child
+ * any HTML/Slot props, including `ref` — those land on the single child
  * element along with the generated ARIA props.
  */
 type FieldControlElementProps = FieldControlSlotProps & {
@@ -691,7 +681,7 @@ type FieldControlRenderProps = {
  *
  * - `FieldControlElementProps` — pass a single React element child and
  *   `Field.Control` clones the generated ARIA props onto it via `Slot`.
- *   Accepts the full Slot prop surface plus a forwarded ref.
+ *   Accepts the full Slot prop surface, including `ref`.
  * - `FieldControlRenderProps` — pass a render function that receives the
  *   ARIA props and places them on a control of the caller's choosing. The
  *   caller owns the rendered element, so DOM/Slot props and `ref` are
@@ -760,7 +750,7 @@ type FieldControlProps = FieldControlElementProps | FieldControlRenderProps;
  * </Field.Group>
  * ```
  */
-const Control = forwardRef<HTMLElement, FieldControlProps>(({ children, ...props }, ref) => {
+const Control = ({ children, ref, ...props }: FieldControlProps) => {
 	const context = useContext(FieldItemContext);
 	// Field.Item owns id, name, aria-*, and validation — `cloneElement` below
 	// overwrites whatever the child supplied, and the resolver no longer reads
@@ -797,7 +787,7 @@ const Control = forwardRef<HTMLElement, FieldControlProps>(({ children, ...props
 			</FieldControlContext.Provider>
 		</FieldValidationProvider>
 	);
-});
+};
 Control.displayName = "FieldControl";
 
 /**
@@ -839,32 +829,35 @@ Control.displayName = "FieldControl";
  * </Field.Group>
  * ```
  */
-const Description = forwardRef<ComponentRef<"p">, Omit<ComponentProps<"p">, "id"> & WithAsChild>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "p";
-		const context = useContext(FieldItemContext);
+const Description = ({
+	asChild,
+	className,
+	ref,
+	...props
+}: Omit<ComponentProps<"p">, "id"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "p";
+	const context = useContext(FieldItemContext);
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="field-description"
-				id={context?.descriptionId}
-				className={cx(
-					"text-body text-sm leading-4",
-					// When this description sits directly after a Field.ErrorList
-					// sibling, collapse the parent's gap-1.5 with a matching negative
-					// top margin so the list + helper read as one tight block.
-					// Wrapping the matched selector in :where() flattens its specificity
-					// to (0,1,0) so a user-supplied margin utility (mt-2, mt-0, etc.)
-					// passed on Field.Description still overrides cleanly.
-					"[:where([data-slot=field-error-list]+&)]:-mt-1.5",
-					className,
-				)}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="field-description"
+			id={context?.descriptionId}
+			className={cx(
+				"text-body text-sm leading-4",
+				// When this description sits directly after a Field.ErrorList
+				// sibling, collapse the parent's gap-1.5 with a matching negative
+				// top margin so the list + helper read as one tight block.
+				// Wrapping the matched selector in :where() flattens its specificity
+				// to (0,1,0) so a user-supplied margin utility (mt-2, mt-0, etc.)
+				// passed on Field.Description still overrides cleanly.
+				"[:where([data-slot=field-error-list]+&)]:-mt-1.5",
+				className,
+			)}
+			{...props}
+		/>
+	);
+};
 Description.displayName = "FieldDescription";
 
 /**
@@ -892,25 +885,22 @@ Description.displayName = "FieldDescription";
  * </Field.Group>
  * ```
  */
-const FieldErrorItem = forwardRef<ComponentRef<"li">, ComponentProps<"li">>(
-	({ children, className, ...props }, ref) => {
-		if (!isErrorItemRenderable(children)) {
-			return null;
-		}
+const FieldErrorItem = ({ children, className, ref, ...props }: ComponentProps<"li">) => {
+	if (!isErrorItemRenderable(children)) {
+		return null;
+	}
 
-		return (
-			<li
-				ref={ref}
-				data-slot="field-error"
-				className={cx("text-danger-600 text-sm leading-4", className)}
-				{...props}
-			>
-				{children}
-			</li>
-		);
-	},
-);
-FieldErrorItem.displayName = "FieldErrorItem";
+	return (
+		<li
+			ref={ref}
+			data-slot="field-error"
+			className={cx("text-danger-600 text-sm leading-4", className)}
+			{...props}
+		>
+			{children}
+		</li>
+	);
+};
 
 /**
  * Props for the `Field.Errors` convenience renderer. It owns its generated
@@ -964,16 +954,13 @@ type FieldErrorsProps = Omit<ComponentProps<"ul">, "children" | "id"> & {
  * </Field.Group>
  * ```
  */
-const FieldErrors = forwardRef<ComponentRef<"ul">, FieldErrorsProps>(
-	({ messages, ...props }, ref) => (
-		<FieldErrorList ref={ref} {...props}>
-			{normalizeErrorMessages(messages).map((message) => (
-				<FieldErrorItem key={message}>{message}</FieldErrorItem>
-			))}
-		</FieldErrorList>
-	),
+const FieldErrors = ({ messages, ref, ...props }: FieldErrorsProps) => (
+	<FieldErrorList ref={ref} {...props}>
+		{normalizeErrorMessages(messages).map((message) => (
+			<FieldErrorItem key={message}>{message}</FieldErrorItem>
+		))}
+	</FieldErrorList>
 );
-FieldErrors.displayName = "FieldErrors";
 
 /**
  * Wraps one or more `Field.ErrorItem` children in a semantic `<ul>` with
@@ -1010,10 +997,13 @@ FieldErrors.displayName = "FieldErrors";
  * </Field.Group>
  * ```
  */
-const FieldErrorList = forwardRef<
-	ComponentRef<"ul">,
-	Omit<ComponentProps<"ul">, "id"> & WithAsChild
->(({ asChild, children, className, ...props }, ref) => {
+const FieldErrorList = ({
+	asChild,
+	children,
+	className,
+	ref,
+	...props
+}: Omit<ComponentProps<"ul">, "id"> & WithAsChild) => {
 	const hasRenderableChildren = hasRenderableErrorListChildren({
 		children,
 		errorItemType: FieldErrorItem,
@@ -1047,8 +1037,7 @@ const FieldErrorList = forwardRef<
 			{children}
 		</Comp>
 	);
-});
-FieldErrorList.displayName = "FieldErrorList";
+};
 
 /**
  * Compound component for semantic, accessible form fields. Composes a

--- a/packages/mantle/src/components/flag/flag.tsx
+++ b/packages/mantle/src/components/flag/flag.tsx
@@ -117,7 +117,6 @@ function Flag({
 		</div>
 	);
 }
-Flag.displayName = "Flag";
 
 export {
 	//,

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
-import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -33,7 +32,7 @@ const Root = ({
 	closeDelay = 300,
 	openDelay = 100,
 	...props
-}: ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root>) => (
+}: ComponentProps<typeof HoverCardPrimitive.Root>) => (
 	<HoverCardPrimitive.Root closeDelay={closeDelay} openDelay={openDelay} {...props} />
 );
 Root.displayName = "HoverCard";
@@ -57,12 +56,9 @@ Root.displayName = "HoverCard";
  * </HoverCard.Root>
  * ```
  */
-const Trigger = forwardRef<
-	ComponentRef<typeof HoverCardPrimitive.Trigger>,
-	ComponentPropsWithoutRef<typeof HoverCardPrimitive.Trigger>
->((props, ref) => (
-	<HoverCardPrimitive.Trigger ref={ref} data-slot="hover-card-trigger" {...props} />
-));
+const Trigger = (props: ComponentProps<typeof HoverCardPrimitive.Trigger>) => (
+	<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+);
 Trigger.displayName = "HoverCardTrigger";
 
 /**
@@ -116,13 +112,15 @@ Portal.displayName = "HoverCardPortal";
  * </HoverCard.Root>
  * ```
  */
-const Content = forwardRef<
-	ComponentRef<typeof HoverCardPrimitive.Content>,
-	ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, onClick, align = "center", sideOffset = 4, ...props }, ref) => (
+const Content = ({
+	className,
+	onClick,
+	align = "center",
+	sideOffset = 4,
+	...props
+}: ComponentProps<typeof HoverCardPrimitive.Content>) => (
 	<Portal>
 		<HoverCardPrimitive.Content
-			ref={ref}
 			data-slot="hover-card-content"
 			align={align}
 			sideOffset={sideOffset}
@@ -141,7 +139,7 @@ const Content = forwardRef<
 			{...props}
 		/>
 	</Portal>
-));
+);
 Content.displayName = HoverCardPrimitive.Content.displayName;
 
 /**

--- a/packages/mantle/src/components/icon/icon.tsx
+++ b/packages/mantle/src/components/icon/icon.tsx
@@ -1,4 +1,4 @@
-import { type ComponentRef, type ReactNode, forwardRef } from "react";
+import type { ReactNode } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import { SvgOnly } from "./svg-only.js";
 import type { SvgAttributes } from "./types.js";
@@ -22,19 +22,16 @@ type IconProps = Omit<SvgAttributes, "children"> & {
  * <Icon svg={<ShrimpIcon />} />
  * ```
  */
-const Icon = forwardRef<ComponentRef<"svg">, IconProps>(
-	({ className, style, svg, ...props }, ref) => (
-		<SvgOnly
-			ref={ref}
-			data-slot="icon"
-			className={cx("size-5", className)}
-			style={style}
-			svg={svg}
-			{...props}
-		/>
-	),
+const Icon = ({ className, style, svg, ref, ...props }: IconProps) => (
+	<SvgOnly
+		ref={ref}
+		data-slot="icon"
+		className={cx("size-5", className)}
+		style={style}
+		svg={svg}
+		{...props}
+	/>
 );
-Icon.displayName = "Icon";
 
 export {
 	//,

--- a/packages/mantle/src/components/icon/svg-only.tsx
+++ b/packages/mantle/src/components/icon/svg-only.tsx
@@ -1,5 +1,5 @@
-import type { ComponentRef, ReactNode } from "react";
-import { Children, cloneElement, forwardRef, isValidElement } from "react";
+import type { ReactNode } from "react";
+import { Children, cloneElement, isValidElement } from "react";
 import invariant from "tiny-invariant";
 import { cx } from "../../utils/cx/cx.js";
 import type { SvgAttributes } from "./types.js";
@@ -24,27 +24,24 @@ type SvgOnlyProps = Omit<SvgAttributes, "children"> & {
  * <SvgOnly svg={<ShrimpIcon />} />
  * ```
  */
-const SvgOnly = forwardRef<ComponentRef<"svg">, SvgOnlyProps>(
-	({ className, style, svg, ...props }, ref) => {
-		invariant(
-			isValidElement<SvgAttributes>(svg) && Children.only(svg),
-			"SvgOnly must be passed a single SVG icon as a JSX tag.",
-		);
+const SvgOnly = ({ className, style, svg, ref, ...props }: SvgOnlyProps) => {
+	invariant(
+		isValidElement<SvgAttributes>(svg) && Children.only(svg),
+		"SvgOnly must be passed a single SVG icon as a JSX tag.",
+	);
 
-		return cloneElement(svg, {
-			"data-slot": "svg-only",
-			...props,
-			className: cx(
-				"shrink-0", // the SvgOnly base classes
-				className, // the SvgOnly className
-				svg.props.className, // the svg className
-			),
-			style: { ...style, ...svg.props.style },
-			ref,
-		});
-	},
-);
-SvgOnly.displayName = "SvgOnly";
+	return cloneElement(svg, {
+		"data-slot": "svg-only",
+		...props,
+		className: cx(
+			"shrink-0", // the SvgOnly base classes
+			className, // the SvgOnly className
+			svg.props.className, // the svg className
+		),
+		style: { ...style, ...svg.props.style },
+		ref,
+	});
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/icons/sort.tsx
+++ b/packages/mantle/src/components/icons/sort.tsx
@@ -61,8 +61,6 @@ const SortIcon = ({ mode, direction, ...props }: Props) => {
 		}
 	}
 };
-SortIcon.displayName = "SortIcon";
-
 export {
 	//,
 	SortIcon,

--- a/packages/mantle/src/components/icons/theme.tsx
+++ b/packages/mantle/src/components/icons/theme.tsx
@@ -17,8 +17,6 @@ function AutoThemeIcon(props: SvgAttributes) {
 
 	return <ThemeIcon theme={appliedTheme} {...props} />;
 }
-AutoThemeIcon.displayName = "AutoThemeIcon";
-
 type ThemeIconProps = SvgAttributes & { theme: Theme };
 
 /**
@@ -44,8 +42,6 @@ function ThemeIcon({ theme, ...props }: ThemeIconProps) {
 			return <MoonIcon {...props} weight="fill" />;
 	}
 }
-ThemeIcon.displayName = "ThemeIcon";
-
 export {
 	//,
 	AutoThemeIcon,

--- a/packages/mantle/src/components/icons/traffic-policy-file.tsx
+++ b/packages/mantle/src/components/icons/traffic-policy-file.tsx
@@ -12,8 +12,6 @@ function TrafficPolicyFileIcon(props: SvgAttributes) {
 		</svg>
 	);
 }
-TrafficPolicyFileIcon.displayName = "TrafficPolicyFileIcon";
-
 export {
 	//,
 	TrafficPolicyFileIcon,

--- a/packages/mantle/src/components/input/input.tsx
+++ b/packages/mantle/src/components/input/input.tsx
@@ -4,13 +4,14 @@ import { CheckCircleIcon } from "@phosphor-icons/react/CheckCircle";
 import { WarningIcon } from "@phosphor-icons/react/Warning";
 import { WarningDiamondIcon } from "@phosphor-icons/react/WarningDiamond";
 import type {
+	ComponentProps,
 	ComponentRef,
-	ForwardedRef,
 	InputHTMLAttributes,
 	MutableRefObject,
 	PropsWithChildren,
+	Ref,
 } from "react";
-import { createContext, forwardRef, useContext, useMemo, useRef } from "react";
+import { createContext, useContext, useMemo, useRef } from "react";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -24,7 +25,7 @@ type BaseProps = WithAutoComplete & WithInputType & WithValidation;
 /**
  * The props for the `Input` component.
  */
-type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComplete" | "type"> &
+type InputProps = Omit<ComponentProps<"input">, "autoComplete" | "type"> &
 	BaseProps &
 	PropsWithChildren;
 
@@ -43,40 +44,26 @@ type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComplete" | "
  * />
  * ```
  */
-const Input = forwardRef<HTMLInputElement, InputProps>(
-	({ children, className, ...props }, forwardedRef) => {
-		const hasChildren = Boolean(children);
-		const innerRef = useRef<ComponentRef<"input">>(null);
+const Input = ({ children, className, ref, ...props }: InputProps) => {
+	const hasChildren = Boolean(children);
+	const innerRef = useRef<ComponentRef<"input">>(null);
 
-		if (hasChildren) {
-			return (
-				<InputContainer
-					className={className}
-					forwardedRef={forwardedRef}
-					innerRef={innerRef}
-					{...props}
-				>
-					{children}
-				</InputContainer>
-			);
-		}
-
+	if (hasChildren) {
 		return (
-			<InputContainer
-				{...props}
-				className={className}
-				forwardedRef={forwardedRef}
-				innerRef={innerRef}
-			>
-				<InputCapture {...props} />
+			<InputContainer className={className} forwardedRef={ref} innerRef={innerRef} {...props}>
+				{children}
 			</InputContainer>
 		);
-	},
-);
-Input.displayName = "Input";
+	}
 
-type InputCaptureProps = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComplete" | "type"> &
-	BaseProps;
+	return (
+		<InputContainer {...props} className={className} forwardedRef={ref} innerRef={innerRef}>
+			<InputCapture {...props} />
+		</InputContainer>
+	);
+};
+
+type InputCaptureProps = Omit<ComponentProps<"input">, "autoComplete" | "type"> & BaseProps;
 
 /**
  * The actual <input /> element that captures user input.
@@ -92,43 +79,46 @@ type InputCaptureProps = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComple
  * </Input>
  * ```
  */
-const InputCapture = forwardRef<HTMLInputElement, InputCaptureProps>(
-	({ "aria-invalid": _ariaInvalid, className, validation: _validation, ...restProps }, ref) => {
-		const {
-			"aria-invalid": ctxAriaInvalid,
-			forwardedRef: ctxForwardedRef,
-			innerRef: ctxInnerRef,
-			validation: ctxValidation,
-			...ctx
-		} = useContext(InputContext);
-		const fieldValidation = useFieldValidation();
+const InputCapture = ({
+	"aria-invalid": _ariaInvalid,
+	className,
+	ref,
+	validation: _validation,
+	...restProps
+}: InputCaptureProps) => {
+	const {
+		"aria-invalid": ctxAriaInvalid,
+		forwardedRef: ctxForwardedRef,
+		innerRef: ctxInnerRef,
+		validation: ctxValidation,
+		...ctx
+	} = useContext(InputContext);
+	const fieldValidation = useFieldValidation();
 
-		const { ariaInvalid, validation } = parseValidation({
-			"aria-invalid": ctxAriaInvalid ?? _ariaInvalid,
-			validation: ctxValidation ?? _validation ?? fieldValidation,
-		});
-		const props = {
-			...ctx,
-			...restProps,
-			type: restProps.type ?? ctx.type ?? "text",
-		};
+	const { ariaInvalid, validation } = parseValidation({
+		"aria-invalid": ctxAriaInvalid ?? _ariaInvalid,
+		validation: ctxValidation ?? _validation ?? fieldValidation,
+	});
+	const props = {
+		...ctx,
+		...restProps,
+		type: restProps.type ?? ctx.type ?? "text",
+	};
 
-		return (
-			<input
-				aria-invalid={ariaInvalid}
-				data-slot="input-capture"
-				data-validation={validation}
-				className={cx(
-					"placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden",
-					className,
-				)}
-				ref={composeRefs(ref, ctxForwardedRef, ctxInnerRef)}
-				{...props}
-			/>
-		);
-	},
-);
-InputCapture.displayName = "InputCapture";
+	return (
+		<input
+			aria-invalid={ariaInvalid}
+			data-slot="input-capture"
+			data-validation={validation}
+			className={cx(
+				"placeholder:text-placeholder min-w-0 flex-1 bg-transparent text-left autofill:shadow-[inset_0_0_0px_1000px_var(--color-blue-50)] focus:outline-hidden",
+				className,
+			)}
+			ref={composeRefs(ref, ctxForwardedRef, ctxInnerRef)}
+			{...props}
+		/>
+	);
+};
 
 type InputContextType = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComplete" | "type"> &
 	BaseProps & {
@@ -137,9 +127,9 @@ type InputContextType = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComplet
 		 */
 		innerRef: MutableRefObject<HTMLInputElement | null>;
 		/**
-		 * forwarded ref to the input element, forwarded from `Input` to `InputCapture`
+		 * ref to the input element, passed from `Input` to `InputCapture`
 		 */
-		forwardedRef?: ForwardedRef<HTMLInputElement>;
+		forwardedRef?: Ref<HTMLInputElement>;
 	};
 
 const InputContext = createContext<InputContextType>({
@@ -154,9 +144,9 @@ type InputContainerProps = InputHTMLAttributes<HTMLInputElement> &
 		 */
 		innerRef: MutableRefObject<HTMLInputElement | null>;
 		/**
-		 * @private ref to the input element, forwarded from `Input` to `InputCapture`
+		 * @private ref to the input element, passed from `Input` to `InputCapture`
 		 */
-		forwardedRef: ForwardedRef<HTMLInputElement>;
+		forwardedRef: Ref<HTMLInputElement> | undefined;
 	};
 
 /**
@@ -236,7 +226,6 @@ const InputContainer = ({
 		</InputContext.Provider>
 	);
 };
-InputContainer.displayName = "InputContainer";
 
 export { Input, InputCapture };
 export type { InputProps, InputCaptureProps };
@@ -274,4 +263,3 @@ const ValidationFeedback = ({
 			return null;
 	}
 };
-ValidationFeedback.displayName = "ValidationFeedback";

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -2,8 +2,8 @@
 
 import { EyeIcon } from "@phosphor-icons/react/Eye";
 import { EyeClosedIcon } from "@phosphor-icons/react/EyeClosed";
-import { forwardRef, useEffect, useRef, useState } from "react";
-import type { InputHTMLAttributes } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { ComponentProps } from "react";
 import { flushSync } from "react-dom";
 import { getPrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 import type { WithValidation } from "../field/validation.js";
@@ -11,7 +11,7 @@ import { Icon } from "../icon/icon.js";
 import { Input, InputCapture } from "./input.js";
 import type { InputType, WithAutoComplete } from "./types.js";
 
-type PasswordInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "autoComplete" | "type"> &
+type PasswordInputProps = Omit<ComponentProps<"input">, "autoComplete" | "type"> &
 	WithValidation &
 	WithAutoComplete & {
 		/**
@@ -85,59 +85,61 @@ type PasswordInputType = Extract<InputType, "text" | "password">;
  * }
  * ```
  */
-const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
-	({ onValueVisibilityChange, showValue = false, ...props }, ref) => {
-		const [showPassword, setShowPassword] = useState<boolean>(showValue);
-		const type: PasswordInputType = showPassword ? "text" : "password";
-		const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
-		const iconRef = useRef<SVGSVGElement>(null);
-		const animationRef = useRef<Animation | null>(null);
+const PasswordInput = ({
+	onValueVisibilityChange,
+	ref,
+	showValue = false,
+	...props
+}: PasswordInputProps) => {
+	const [showPassword, setShowPassword] = useState<boolean>(showValue);
+	const type: PasswordInputType = showPassword ? "text" : "password";
+	const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
+	const iconRef = useRef<SVGSVGElement>(null);
+	const animationRef = useRef<Animation | null>(null);
 
-		useEffect(() => {
-			setShowPassword(showValue);
-		}, [showValue]);
+	useEffect(() => {
+		setShowPassword(showValue);
+	}, [showValue]);
 
-		return (
-			<Input data-slot="password-input" type={type} ref={ref} {...props}>
-				<InputCapture />
-				<button
-					type="button"
-					tabIndex={-1}
-					className="text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
-					onClick={() => {
-						// Cancel any in-flight animation so rapid clicks are never blocked
-						if (animationRef.current) {
-							animationRef.current.cancel();
+	return (
+		<Input data-slot="password-input" type={type} ref={ref} {...props}>
+			<InputCapture />
+			<button
+				type="button"
+				tabIndex={-1}
+				className="text-body hover:text-strong ml-1 cursor-pointer bg-inherit p-0"
+				onClick={() => {
+					// Cancel any in-flight animation so rapid clicks are never blocked
+					if (animationRef.current) {
+						animationRef.current.cancel();
+						animationRef.current = null;
+					}
+
+					// Flush synchronously so React commits the new icon to the DOM before we animate
+					const nextShowPassword = !showPassword;
+					flushSync(() => {
+						setShowPassword(nextShowPassword);
+					});
+					onValueVisibilityChange?.(nextShowPassword);
+
+					const icon = iconRef.current;
+					if (icon && !getPrefersReducedMotion()) {
+						animationRef.current = icon.animate(
+							[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
+							{ duration: 200, easing: "ease-out" },
+						);
+						animationRef.current.onfinish = () => {
 							animationRef.current = null;
-						}
-
-						// Flush synchronously so React commits the new icon to the DOM before we animate
-						const nextShowPassword = !showPassword;
-						flushSync(() => {
-							setShowPassword(nextShowPassword);
-						});
-						onValueVisibilityChange?.(nextShowPassword);
-
-						const icon = iconRef.current;
-						if (icon && !getPrefersReducedMotion()) {
-							animationRef.current = icon.animate(
-								[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
-								{ duration: 200, easing: "ease-out" },
-							);
-							animationRef.current.onfinish = () => {
-								animationRef.current = null;
-							};
-						}
-					}}
-				>
-					<span className="sr-only">Turn password visibility {showPassword ? "off" : "on"}</span>
-					<Icon ref={iconRef} svg={<EyeCon aria-hidden />} />
-				</button>
-			</Input>
-		);
-	},
-);
-PasswordInput.displayName = "PasswordInput";
+						};
+					}
+				}}
+			>
+				<span className="sr-only">Turn password visibility {showPassword ? "off" : "on"}</span>
+				<Icon ref={iconRef} svg={<EyeCon aria-hidden />} />
+			</button>
+		</Input>
+	);
+};
 
 export { PasswordInput };
 export type { PasswordInputProps };

--- a/packages/mantle/src/components/label/label.tsx
+++ b/packages/mantle/src/components/label/label.tsx
@@ -1,8 +1,7 @@
-import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
-type LabelProps = ComponentPropsWithoutRef<"label"> & {
+type LabelProps = ComponentProps<"label"> & {
 	/**
 	 * If set, the label will appear disabled.
 	 */
@@ -69,47 +68,49 @@ type LabelProps = ComponentPropsWithoutRef<"label"> & {
  * </Label>
  * ```
  */
-const Label = forwardRef<ComponentRef<"label">, LabelProps>(
-	(
-		{ "aria-disabled": _ariaDisabled, children, className, disabled, onMouseDown, ...props },
-		ref,
-	) => (
-		<label
-			aria-disabled={disabled ?? _ariaDisabled}
-			data-slot="label"
-			className={cx(
-				"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans",
-				// Default to font-medium when the label isn't wrapping a form control. The
-				// arbitrary variant wraps the *entire* matched selector — class + the
-				// `:not(:has(...))` check — in `:where()`, flattening total specificity to 0.
-				// That lets a user-supplied font-weight utility (`font-bold`, `font-normal`,
-				// etc.) at (0,1,0) override cleanly, even though `[contenteditable]` is an
-				// attribute selector that would otherwise lift the rule to (0,1,0) and tie.
-				"[:where(&:not(:has(input,textarea,select,button,[contenteditable])))]:font-medium",
-				className,
-			)}
-			onMouseDown={(event) => {
-				// only prevent text selection if clicking inside the label itself
-				const target = event.target as HTMLElement;
-				if (target.closest("button, input, select, textarea")) {
-					return;
-				}
+const Label = ({
+	"aria-disabled": _ariaDisabled,
+	children,
+	className,
+	disabled,
+	onMouseDown,
+	ref,
+	...props
+}: LabelProps) => (
+	<label
+		aria-disabled={disabled ?? _ariaDisabled}
+		data-slot="label"
+		className={cx(
+			"text-strong cursor-pointer text-sm peer-disabled:cursor-default has-disabled:cursor-default aria-disabled:cursor-default font-sans",
+			// Default to font-medium when the label isn't wrapping a form control. The
+			// arbitrary variant wraps the *entire* matched selector — class + the
+			// `:not(:has(...))` check — in `:where()`, flattening total specificity to 0.
+			// That lets a user-supplied font-weight utility (`font-bold`, `font-normal`,
+			// etc.) at (0,1,0) override cleanly, even though `[contenteditable]` is an
+			// attribute selector that would otherwise lift the rule to (0,1,0) and tie.
+			"[:where(&:not(:has(input,textarea,select,button,[contenteditable])))]:font-medium",
+			className,
+		)}
+		onMouseDown={(event) => {
+			// only prevent text selection if clicking inside the label itself
+			const target = event.target as HTMLElement;
+			if (target.closest("button, input, select, textarea")) {
+				return;
+			}
 
-				onMouseDown?.(event);
+			onMouseDown?.(event);
 
-				// prevent text selection when double clicking label
-				if (!event.defaultPrevented && event.detail > 1) {
-					event.preventDefault();
-				}
-			}}
-			ref={ref}
-			{...props}
-		>
-			{children}
-		</label>
-	),
+			// prevent text selection when double clicking label
+			if (!event.defaultPrevented && event.detail > 1) {
+				event.preventDefault();
+			}
+		}}
+		ref={ref}
+		{...props}
+	>
+		{children}
+	</label>
 );
-Label.displayName = "Label";
 
 export {
 	//

--- a/packages/mantle/src/components/list/list.tsx
+++ b/packages/mantle/src/components/list/list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { forwardRef } from "react";
-import type { ComponentProps, ComponentRef, MouseEvent } from "react";
+import type { ComponentProps, MouseEvent } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Root as ListPrimitiveRoot, Item as ListPrimitiveItem } from "./primitive.js";
@@ -60,9 +59,7 @@ type ListRootProps = Omit<
  * </List.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, ListRootProps>((props, ref) => (
-	<ListPrimitiveRoot ref={ref} semantics="list" {...props} />
-));
+const Root = (props: ListRootProps) => <ListPrimitiveRoot semantics="list" {...props} />;
 Root.displayName = "ListRoot";
 
 /**
@@ -109,9 +106,9 @@ type ListVirtualRootProps = Omit<
  * </List.VirtualRoot>
  * ```
  */
-const VirtualRoot = forwardRef<ComponentRef<"div">, ListVirtualRootProps>((props, ref) => (
-	<ListPrimitiveVirtualRoot ref={ref} semantics="list" {...props} />
-));
+const VirtualRoot = (props: ListVirtualRootProps) => (
+	<ListPrimitiveVirtualRoot semantics="list" {...props} />
+);
 VirtualRoot.displayName = "ListVirtualRoot";
 
 /**
@@ -178,72 +175,70 @@ type ListItemProps = Omit<ComponentProps<"button">, "type"> &
  * </List.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<"button">, ListItemProps>(
-	({ asChild, className, current, disabled, onClick, ...props }, ref) => {
-		const Comp = asChild ? Slot : "button";
+const Item = ({ asChild, className, current, disabled, onClick, ref, ...props }: ListItemProps) => {
+	const Comp = asChild ? Slot : "button";
 
-		return (
-			<ListPrimitiveItem selected={current} disabled={disabled}>
-				<Comp
-					ref={ref}
-					data-slot="list-item-control"
-					// `role="list"` items carry no aria-selected; announce the current
-					// item (e.g. the active account) with aria-current so the state isn't
-					// conveyed by the pill tint alone.
-					aria-current={current || undefined}
-					// A real <button> for the default (fully inert when `disabled`). For asChild
-					// the consumer owns the element (e.g. <a>), where the `disabled` attribute
-					// isn't valid — so convey state with `aria-disabled` and actually make it
-					// inert: drop it from the tab order (`tabIndex={-1}`), block pointer events
-					// (`aria-disabled:pointer-events-none` below), and swallow the click in the
-					// onClick handler below, because assistive tech dispatches clicks directly
-					// (no hit testing) so `pointer-events` alone wouldn't stop an SR-activated
-					// link.
-					{...(asChild
-						? { "aria-disabled": disabled || undefined, tabIndex: disabled ? -1 : undefined }
-						: { type: "button", disabled })}
-					// Why: the asChild union (Slot | "button") no longer infers a single
-					// event type; React event handlers are bivariant, so pin the param.
-					onClick={(event: MouseEvent<HTMLButtonElement>) => {
-						if (asChild && disabled) {
-							event.preventDefault();
-							event.stopPropagation();
-							return;
-						}
-						onClick?.(event);
-					}}
-					className={cx(
-						// The hover / selected tint lives on the enclosing listitem; this is the
-						// transparent, clickable content area that fills it. Keyboard focus is
-						// conveyed by the listitem's tint (it lights up like hover via
-						// `has-[:focus-visible]`), so the control suppresses its own outline
-						// instead of drawing a focus ring.
-						"flex w-full cursor-pointer flex-col gap-0.5 rounded-md bg-transparent px-2 py-1.5 text-left text-sm",
-						"disabled:cursor-default disabled:opacity-50 aria-disabled:cursor-default aria-disabled:opacity-50 aria-disabled:pointer-events-none",
-						"focus-visible:outline-hidden",
-						className,
-					)}
-					{...props}
-					// After the spread so a consumer's own capture handler can't shadow the
-					// disabled guard. Radix Slot composes the child's own onClick FIRST (in
-					// the bubble phase), so the bubble-phase swallow above lands too late to
-					// stop a router <Link> / consumer handler on the child. A capture-phase
-					// preventDefault runs before any bubble onClick, so the child sees
-					// defaultPrevented — blocking screen-reader / programmatic clicks (which
-					// bypass the `pointer-events:none` hit-test block) from navigating.
-					onClickCapture={
-						asChild && disabled
-							? (event) => {
-									event.preventDefault();
-									event.stopPropagation();
-								}
-							: props.onClickCapture
+	return (
+		<ListPrimitiveItem selected={current} disabled={disabled}>
+			<Comp
+				ref={ref}
+				data-slot="list-item-control"
+				// `role="list"` items carry no aria-selected; announce the current
+				// item (e.g. the active account) with aria-current so the state isn't
+				// conveyed by the pill tint alone.
+				aria-current={current || undefined}
+				// A real <button> for the default (fully inert when `disabled`). For asChild
+				// the consumer owns the element (e.g. <a>), where the `disabled` attribute
+				// isn't valid — so convey state with `aria-disabled` and actually make it
+				// inert: drop it from the tab order (`tabIndex={-1}`), block pointer events
+				// (`aria-disabled:pointer-events-none` below), and swallow the click in the
+				// onClick handler below, because assistive tech dispatches clicks directly
+				// (no hit testing) so `pointer-events` alone wouldn't stop an SR-activated
+				// link.
+				{...(asChild
+					? { "aria-disabled": disabled || undefined, tabIndex: disabled ? -1 : undefined }
+					: { type: "button", disabled })}
+				// Why: the asChild union (Slot | "button") no longer infers a single
+				// event type; React event handlers are bivariant, so pin the param.
+				onClick={(event: MouseEvent<HTMLButtonElement>) => {
+					if (asChild && disabled) {
+						event.preventDefault();
+						event.stopPropagation();
+						return;
 					}
-				/>
-			</ListPrimitiveItem>
-		);
-	},
-);
+					onClick?.(event);
+				}}
+				className={cx(
+					// The hover / selected tint lives on the enclosing listitem; this is the
+					// transparent, clickable content area that fills it. Keyboard focus is
+					// conveyed by the listitem's tint (it lights up like hover via
+					// `has-[:focus-visible]`), so the control suppresses its own outline
+					// instead of drawing a focus ring.
+					"flex w-full cursor-pointer flex-col gap-0.5 rounded-md bg-transparent px-2 py-1.5 text-left text-sm",
+					"disabled:cursor-default disabled:opacity-50 aria-disabled:cursor-default aria-disabled:opacity-50 aria-disabled:pointer-events-none",
+					"focus-visible:outline-hidden",
+					className,
+				)}
+				{...props}
+				// After the spread so a consumer's own capture handler can't shadow the
+				// disabled guard. Radix Slot composes the child's own onClick FIRST (in
+				// the bubble phase), so the bubble-phase swallow above lands too late to
+				// stop a router <Link> / consumer handler on the child. A capture-phase
+				// preventDefault runs before any bubble onClick, so the child sees
+				// defaultPrevented — blocking screen-reader / programmatic clicks (which
+				// bypass the `pointer-events:none` hit-test block) from navigating.
+				onClickCapture={
+					asChild && disabled
+						? (event) => {
+								event.preventDefault();
+								event.stopPropagation();
+							}
+						: props.onClickCapture
+				}
+			/>
+		</ListPrimitiveItem>
+	);
+};
 Item.displayName = "ListItem";
 
 /**
@@ -264,15 +259,13 @@ Item.displayName = "ListItem";
  * </List.Root>
  * ```
  */
-const ItemTitle = forwardRef<ComponentRef<"span">, ComponentProps<"span">>(
-	({ className, ...props }, ref) => (
-		<span
-			ref={ref}
-			data-slot="list-item-title"
-			className={cx("text-strong font-medium", className)}
-			{...props}
-		/>
-	),
+const ItemTitle = ({ className, ref, ...props }: ComponentProps<"span">) => (
+	<span
+		ref={ref}
+		data-slot="list-item-title"
+		className={cx("text-strong font-medium", className)}
+		{...props}
+	/>
 );
 ItemTitle.displayName = "ListItemTitle";
 
@@ -294,15 +287,13 @@ ItemTitle.displayName = "ListItemTitle";
  * </List.Root>
  * ```
  */
-const ItemDescription = forwardRef<ComponentRef<"span">, ComponentProps<"span">>(
-	({ className, ...props }, ref) => (
-		<span
-			ref={ref}
-			data-slot="list-item-description"
-			className={cx("text-body leading-4", className)}
-			{...props}
-		/>
-	),
+const ItemDescription = ({ className, ref, ...props }: ComponentProps<"span">) => (
+	<span
+		ref={ref}
+		data-slot="list-item-description"
+		className={cx("text-body leading-4", className)}
+		{...props}
+	/>
 );
 ItemDescription.displayName = "ListItemDescription";
 

--- a/packages/mantle/src/components/list/primitive.tsx
+++ b/packages/mantle/src/components/list/primitive.tsx
@@ -3,7 +3,6 @@
 import {
 	Children,
 	createContext,
-	forwardRef,
 	isValidElement,
 	useCallback,
 	useContext,
@@ -15,7 +14,6 @@ import {
 } from "react";
 import type {
 	ComponentProps,
-	ComponentRef,
 	CSSProperties,
 	FocusEvent,
 	KeyboardEvent,
@@ -724,7 +722,7 @@ function ListShell({
 	gridNav,
 	listContext,
 	viewportProps,
-	viewportRef,
+	ref,
 }: {
 	"aria-label": string | undefined;
 	"aria-labelledby": string | undefined;
@@ -735,14 +733,13 @@ function ListShell({
 	gridNav: GridNavContextValue;
 	listContext: ListContextValue;
 	viewportProps: ComponentProps<"div">;
-	/** A plain prop (not `ref`) so the internal shell stays React 18-compatible without forwardRef ceremony. */
-	viewportRef: Ref<HTMLDivElement>;
+	ref: Ref<HTMLDivElement>;
 }) {
 	return (
 		<ListContext.Provider value={listContext}>
 			<GridNavContext.Provider value={gridNav}>
 				<div
-					ref={viewportRef}
+					ref={ref}
 					data-slot="list"
 					className={cx(listViewportClassName, className)}
 					{...viewportProps}
@@ -811,69 +808,76 @@ type ListItemProps = Omit<ComponentProps<"div">, "role"> &
  * </Item>
  * ```
  */
-const Item = forwardRef<ComponentRef<"div">, ListItemProps>(
-	({ asChild, children, className, disabled = false, selected = false, style, ...props }, ref) => {
-		const { semantics } = useListContext("Item");
-		const itemContext = useContext(ListItemContext);
-		const gridNav = useContext(GridNavContext);
-		const isGrid = semantics === "grid";
-		const Comp = asChild ? Slot : "div";
-		const placement = itemContext?.placement ?? null;
-		const index = itemContext?.index;
-		const isActive = isGrid && gridNav != null && index != null && gridNav.activeIndex === index;
-		const measureRef = placement?.measureRef ?? null;
-		// Identity-stable composition so a keyboard-nav re-render doesn't cycle the
-		// virtualizer's measureElement (detaching + reattaching it per render).
-		const composedRef = useComposedRefs(ref, measureRef);
+const Item = ({
+	asChild,
+	children,
+	className,
+	disabled = false,
+	ref,
+	selected = false,
+	style,
+	...props
+}: ListItemProps) => {
+	const { semantics } = useListContext("Item");
+	const itemContext = useContext(ListItemContext);
+	const gridNav = useContext(GridNavContext);
+	const isGrid = semantics === "grid";
+	const Comp = asChild ? Slot : "div";
+	const placement = itemContext?.placement ?? null;
+	const index = itemContext?.index;
+	const isActive = isGrid && gridNav != null && index != null && gridNav.activeIndex === index;
+	const measureRef = placement?.measureRef ?? null;
+	// Identity-stable composition so a keyboard-nav re-render doesn't cycle the
+	// virtualizer's measureElement (detaching + reattaching it per render).
+	const composedRef = useComposedRefs(ref, measureRef);
 
-		return (
-			<Comp
-				ref={composedRef}
-				// Before the spread so a wrapping component can brand its rows (e.g.
-				// SelectableItem passes "selectable-list-item"); `data-index` and the
-				// role/ARIA wiring below stay enforced.
-				data-slot="list-item"
-				{...props}
-				// Stamp the grid's default aria-activedescendant target id; when the
-				// collection doesn't own row ids (a consumer `itemId` override), keep the
-				// row's own `id` prop instead.
-				id={
-					isGrid && index != null && gridNav?.stampItemId != null
-						? gridNav.stampItemId(index)
-						: props.id
-				}
-				data-index={index}
-				data-state={selected ? "selected" : "unselected"}
-				data-disabled={disabled || undefined}
-				data-active={isActive || undefined}
-				role={isGrid ? "row" : "listitem"}
-				aria-selected={isGrid ? selected : undefined}
-				aria-disabled={isGrid && disabled ? true : props["aria-disabled"]}
-				// Windowed placement: listitems take aria-posinset/aria-setsize; grid
-				// rows take aria-rowindex (posinset/setsize are invalid on grid rows per
-				// WAI-ARIA 1.2 — the collection carries aria-rowcount instead).
-				aria-rowindex={isGrid ? placement?.posInSet : undefined}
-				aria-posinset={isGrid ? undefined : placement?.posInSet}
-				aria-setsize={isGrid ? undefined : placement?.setSize}
-				className={cx(
-					listItemClassName,
+	return (
+		<Comp
+			ref={composedRef}
+			// Before the spread so a wrapping component can brand its rows (e.g.
+			// SelectableItem passes "selectable-list-item"); `data-index` and the
+			// role/ARIA wiring below stay enforced.
+			data-slot="list-item"
+			{...props}
+			// Stamp the grid's default aria-activedescendant target id; when the
+			// collection doesn't own row ids (a consumer `itemId` override), keep the
+			// row's own `id` prop instead.
+			id={
+				isGrid && index != null && gridNav?.stampItemId != null
+					? gridNav.stampItemId(index)
+					: props.id
+			}
+			data-index={index}
+			data-state={selected ? "selected" : "unselected"}
+			data-disabled={disabled || undefined}
+			data-active={isActive || undefined}
+			role={isGrid ? "row" : "listitem"}
+			aria-selected={isGrid ? selected : undefined}
+			aria-disabled={isGrid && disabled ? true : props["aria-disabled"]}
+			// Windowed placement: listitems take aria-posinset/aria-setsize; grid
+			// rows take aria-rowindex (posinset/setsize are invalid on grid rows per
+			// WAI-ARIA 1.2 — the collection carries aria-rowcount instead).
+			aria-rowindex={isGrid ? placement?.posInSet : undefined}
+			aria-posinset={isGrid ? undefined : placement?.posInSet}
+			aria-setsize={isGrid ? undefined : placement?.setSize}
+			className={cx(
+				listItemClassName,
+				!disabled &&
+					"hover:bg-active-menu-item hover:data-[state=selected]:bg-active-selected-menu-item",
+				// List rows convey keyboard focus with the same tint as hover (matching
+				// the grid's active row) rather than a focus ring on the inner control —
+				// the control suppresses its own outline and the row lights up instead.
+				!isGrid &&
 					!disabled &&
-						"hover:bg-active-menu-item hover:data-[state=selected]:bg-active-selected-menu-item",
-					// List rows convey keyboard focus with the same tint as hover (matching
-					// the grid's active row) rather than a focus ring on the inner control —
-					// the control suppresses its own outline and the row lights up instead.
-					!isGrid &&
-						!disabled &&
-						"has-[:focus-visible]:bg-active-menu-item has-[:focus-visible]:data-[state=selected]:bg-active-selected-menu-item",
-					className,
-				)}
-				style={placement ? { ...style, ...placement.style } : style}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+					"has-[:focus-visible]:bg-active-menu-item has-[:focus-visible]:data-[state=selected]:bg-active-selected-menu-item",
+				className,
+			)}
+			style={placement ? { ...style, ...placement.style } : style}
+		>
+			{children}
+		</Comp>
+	);
+};
 Item.displayName = "ListPrimitiveItem";
 
 /**
@@ -909,104 +913,97 @@ PlainItem.displayName = "ListPrimitivePlainItem";
  * </Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, ListRootProps>(
-	(
-		{
-			"aria-label": ariaLabel,
-			"aria-labelledby": ariaLabelledby,
-			"aria-multiselectable": ariaMultiselectable,
-			children,
-			className,
-			isItemDisabled,
-			onActivate,
-			itemId,
-			semantics = "list",
-			...props
-		},
-		ref,
-	) => {
-		const viewportRef = useRef<HTMLDivElement>(null);
-		const composedViewportRef = useComposedRefs(viewportRef, ref);
-		// The row elements, in order — the single array we both render from and read
-		// each row's `disabled` prop off (the `isItemDisabled` default), so the
-		// disabled lookup by index always lines up with what's rendered. Filtered to
-		// elements (as `VirtualRoot` does) so a non-element child — a bare string, or
-		// a render-prop that returned `null` for an option — can't be counted/indexed
-		// as a navigable row here while the windowed shell drops it, which would
-		// desync grid navigation between the two. Memoized so a keyboard-nav
-		// re-render (which only changes `activeIndex`) doesn't re-walk the children.
-		const itemChildren = useMemo(
-			() => Children.toArray(children).filter(isValidElement),
-			[children],
-		);
-		const scrollToIndex = useCallback((index: number) => {
-			// Reveal the whole row (every Item stamps `data-index`, so this holds for
-			// default and custom `itemId` alike) — scrolling just its control could
-			// leave the row's edges clipped against the viewport.
-			viewportRef.current
-				?.querySelector(`[data-index="${index}"]`)
-				?.scrollIntoView({ block: "nearest" });
-		}, []);
-		const focusItemAt = useCallback(
-			(index: number, step: number) => {
-				const viewport = viewportRef.current;
-				if (viewport == null) {
+const Root = ({
+	"aria-label": ariaLabel,
+	"aria-labelledby": ariaLabelledby,
+	"aria-multiselectable": ariaMultiselectable,
+	children,
+	className,
+	isItemDisabled,
+	onActivate,
+	itemId,
+	ref,
+	semantics = "list",
+	...props
+}: ListRootProps) => {
+	const viewportRef = useRef<HTMLDivElement>(null);
+	const composedViewportRef = useComposedRefs(viewportRef, ref);
+	// The row elements, in order — the single array we both render from and read
+	// each row's `disabled` prop off (the `isItemDisabled` default), so the
+	// disabled lookup by index always lines up with what's rendered. Filtered to
+	// elements (as `VirtualRoot` does) so a non-element child — a bare string, or
+	// a render-prop that returned `null` for an option — can't be counted/indexed
+	// as a navigable row here while the windowed shell drops it, which would
+	// desync grid navigation between the two. Memoized so a keyboard-nav
+	// re-render (which only changes `activeIndex`) doesn't re-walk the children.
+	const itemChildren = useMemo(() => Children.toArray(children).filter(isValidElement), [children]);
+	const scrollToIndex = useCallback((index: number) => {
+		// Reveal the whole row (every Item stamps `data-index`, so this holds for
+		// default and custom `itemId` alike) — scrolling just its control could
+		// leave the row's edges clipped against the viewport.
+		viewportRef.current
+			?.querySelector(`[data-index="${index}"]`)
+			?.scrollIntoView({ block: "nearest" });
+	}, []);
+	const focusItemAt = useCallback(
+		(index: number, step: number) => {
+			const viewport = viewportRef.current;
+			if (viewport == null) {
+				return;
+			}
+			// Walk in the travel direction to the first row that actually hosts a
+			// focusable control. A static row (a bare divider, an `asChild` link with
+			// no href, a consumer wrapper whose disabled control is out of the tab
+			// order) is not a keyboard stop, so step past it — otherwise navigation
+			// dead-ends there and every row beyond it is silently unreachable.
+			for (let current = index; current >= 0 && current < itemChildren.length; current += step) {
+				const item = viewport.querySelector(`[data-index="${current}"]`);
+				if (item == null) {
+					continue;
+				}
+				const control = findItemControl(item);
+				if (control != null) {
+					control.focus({ preventScroll: true });
+					// Reveal the whole row, not just its control (mirrors the grid's scroll fix).
+					item.scrollIntoView({ block: "nearest" });
 					return;
 				}
-				// Walk in the travel direction to the first row that actually hosts a
-				// focusable control. A static row (a bare divider, an `asChild` link with
-				// no href, a consumer wrapper whose disabled control is out of the tab
-				// order) is not a keyboard stop, so step past it — otherwise navigation
-				// dead-ends there and every row beyond it is silently unreachable.
-				for (let current = index; current >= 0 && current < itemChildren.length; current += step) {
-					const item = viewport.querySelector(`[data-index="${current}"]`);
-					if (item == null) {
-						continue;
-					}
-					const control = findItemControl(item);
-					if (control != null) {
-						control.focus({ preventScroll: true });
-						// Reveal the whole row, not just its control (mirrors the grid's scroll fix).
-						item.scrollIntoView({ block: "nearest" });
-						return;
-					}
-				}
-			},
-			[itemChildren.length],
-		);
-		const { collectionProps, gridNav, listContext } = useListShell({
-			count: itemChildren.length,
-			focusItemAt,
-			isItemDisabled: isItemDisabled ?? ((index) => isItemChildDisabled(itemChildren[index])),
-			onActivate,
-			itemId,
-			scrollToIndex,
-			semantics,
-		});
+			}
+		},
+		[itemChildren.length],
+	);
+	const { collectionProps, gridNav, listContext } = useListShell({
+		count: itemChildren.length,
+		focusItemAt,
+		isItemDisabled: isItemDisabled ?? ((index) => isItemChildDisabled(itemChildren[index])),
+		onActivate,
+		itemId,
+		scrollToIndex,
+		semantics,
+	});
 
-		return (
-			<ListShell
-				aria-label={ariaLabel}
-				aria-labelledby={ariaLabelledby}
-				aria-multiselectable={ariaMultiselectable}
-				className={className}
-				collectionProps={collectionProps}
-				gridNav={gridNav}
-				listContext={listContext}
-				viewportProps={props}
-				viewportRef={composedViewportRef}
-			>
-				{itemChildren.map((item, index) => (
-					// Key off the child's own key (assigned by `Children.toArray`) so
-					// reconciliation follows the consumer's keys across reorder/filter.
-					<PlainItem key={item.key ?? index} index={index}>
-						{item}
-					</PlainItem>
-				))}
-			</ListShell>
-		);
-	},
-);
+	return (
+		<ListShell
+			aria-label={ariaLabel}
+			aria-labelledby={ariaLabelledby}
+			aria-multiselectable={ariaMultiselectable}
+			className={className}
+			collectionProps={collectionProps}
+			gridNav={gridNav}
+			listContext={listContext}
+			viewportProps={props}
+			ref={composedViewportRef}
+		>
+			{itemChildren.map((item, index) => (
+				// Key off the child's own key (assigned by `Children.toArray`) so
+				// reconciliation follows the consumer's keys across reorder/filter.
+				<PlainItem key={item.key ?? index} index={index}>
+					{item}
+				</PlainItem>
+			))}
+		</ListShell>
+	);
+};
 Root.displayName = "ListPrimitiveRoot";
 
 export {

--- a/packages/mantle/src/components/list/virtual.tsx
+++ b/packages/mantle/src/components/list/virtual.tsx
@@ -2,16 +2,8 @@
 
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { VirtualItem, Virtualizer } from "@tanstack/react-virtual";
-import {
-	Children,
-	forwardRef,
-	isValidElement,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-} from "react";
-import type { ComponentRef, ReactNode } from "react";
+import { Children, isValidElement, useCallback, useEffect, useMemo, useRef } from "react";
+import type { ReactNode } from "react";
 import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import {
 	findItemControl,
@@ -139,161 +131,157 @@ WindowedItem.displayName = "ListPrimitiveWindowedItem";
  * </VirtualRoot>
  * ```
  */
-const VirtualRoot = forwardRef<ComponentRef<"div">, VirtualRootProps>(
-	(
-		{
-			"aria-label": ariaLabel,
-			"aria-labelledby": ariaLabelledby,
-			"aria-multiselectable": ariaMultiselectable,
-			children,
-			className,
-			estimateItemHeight = 44,
-			isItemDisabled,
-			onActivate,
-			overscan = 8,
-			itemId,
-			semantics = "list",
-			...props
+const VirtualRoot = ({
+	"aria-label": ariaLabel,
+	"aria-labelledby": ariaLabelledby,
+	"aria-multiselectable": ariaMultiselectable,
+	children,
+	className,
+	estimateItemHeight = 44,
+	isItemDisabled,
+	onActivate,
+	overscan = 8,
+	itemId,
+	ref,
+	semantics = "list",
+	...props
+}: VirtualRootProps) => {
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const composedViewportRef = useComposedRefs(scrollRef, ref);
+	// Memoized so a scroll or keyboard-nav re-render (`useVirtualizer` re-renders
+	// on every offset change) doesn't re-walk + re-filter the full child set each
+	// frame — only the windowed slice below needs to re-render.
+	const items = useMemo(() => Children.toArray(children).filter(isValidElement), [children]);
+	const count = items.length;
+	const virtualizer = useVirtualizer({
+		count,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => estimateItemHeight,
+		// Key windowed rows by the child's own key (assigned by `Children.toArray`)
+		// so row identity — React reconciliation via `virtualItem.key` below AND
+		// the virtualizer's measurement cache — follows the consumer's keys across
+		// reorder/filter, matching the plain `Root`, instead of tracking position.
+		getItemKey: (index) => items[index]?.key ?? index,
+		overscan,
+		// Reproduce the plain collection's `gap-px` between windowed rows, which
+		// are out of flow and so can't inherit the flex gap.
+		gap: 1,
+	});
+	const scrollToIndex = useCallback(
+		(index: number) => virtualizer.scrollToIndex(index, { align: "auto" }),
+		[virtualizer],
+	);
+	const focusFrameRef = useRef<number | null>(null);
+	// Cancel any in-flight focus poll when the list unmounts, so a row that was
+	// still mounting can't schedule frames (or steal focus) after teardown.
+	useEffect(
+		() => () => {
+			if (focusFrameRef.current != null) {
+				cancelAnimationFrame(focusFrameRef.current);
+			}
 		},
-		ref,
-	) => {
-		const scrollRef = useRef<HTMLDivElement>(null);
-		const composedViewportRef = useComposedRefs(scrollRef, ref);
-		// Memoized so a scroll or keyboard-nav re-render (`useVirtualizer` re-renders
-		// on every offset change) doesn't re-walk + re-filter the full child set each
-		// frame — only the windowed slice below needs to re-render.
-		const items = useMemo(() => Children.toArray(children).filter(isValidElement), [children]);
-		const count = items.length;
-		const virtualizer = useVirtualizer({
-			count,
-			getScrollElement: () => scrollRef.current,
-			estimateSize: () => estimateItemHeight,
-			// Key windowed rows by the child's own key (assigned by `Children.toArray`)
-			// so row identity — React reconciliation via `virtualItem.key` below AND
-			// the virtualizer's measurement cache — follows the consumer's keys across
-			// reorder/filter, matching the plain `Root`, instead of tracking position.
-			getItemKey: (index) => items[index]?.key ?? index,
-			overscan,
-			// Reproduce the plain collection's `gap-px` between windowed rows, which
-			// are out of flow and so can't inherit the flex gap.
-			gap: 1,
-		});
-		const scrollToIndex = useCallback(
-			(index: number) => virtualizer.scrollToIndex(index, { align: "auto" }),
-			[virtualizer],
-		);
-		const focusFrameRef = useRef<number | null>(null);
-		// Cancel any in-flight focus poll when the list unmounts, so a row that was
-		// still mounting can't schedule frames (or steal focus) after teardown.
-		useEffect(
-			() => () => {
-				if (focusFrameRef.current != null) {
-					cancelAnimationFrame(focusFrameRef.current);
+		[],
+	);
+	const focusItemAt = useCallback(
+		(index: number, step: number) => {
+			// Supersede any focus poll still chasing an earlier target so overlapping
+			// keypresses don't race to move focus.
+			if (focusFrameRef.current != null) {
+				cancelAnimationFrame(focusFrameRef.current);
+				focusFrameRef.current = null;
+			}
+			let target = index;
+			let attempts = 0;
+			const tryFocus = () => {
+				focusFrameRef.current = null;
+				const viewport = scrollRef.current;
+				if (viewport == null || target < 0 || target >= count) {
+					return;
 				}
-			},
-			[],
-		);
-		const focusItemAt = useCallback(
-			(index: number, step: number) => {
-				// Supersede any focus poll still chasing an earlier target so overlapping
-				// keypresses don't race to move focus.
-				if (focusFrameRef.current != null) {
-					cancelAnimationFrame(focusFrameRef.current);
-					focusFrameRef.current = null;
-				}
-				let target = index;
-				let attempts = 0;
-				const tryFocus = () => {
-					focusFrameRef.current = null;
-					const viewport = scrollRef.current;
-					if (viewport == null || target < 0 || target >= count) {
+				// A jump target (Home/End) may not be mounted until the virtualizer
+				// renders the new window — scroll it in, then poll for its control.
+				virtualizer.scrollToIndex(target, { align: "auto" });
+				const item = viewport.querySelector(`[data-index="${target}"]`);
+				if (item != null) {
+					const control = findItemControl(item);
+					if (control != null) {
+						control.focus({ preventScroll: true });
 						return;
 					}
-					// A jump target (Home/End) may not be mounted until the virtualizer
-					// renders the new window — scroll it in, then poll for its control.
-					virtualizer.scrollToIndex(target, { align: "auto" });
-					const item = viewport.querySelector(`[data-index="${target}"]`);
-					if (item != null) {
-						const control = findItemControl(item);
-						if (control != null) {
-							control.focus({ preventScroll: true });
-							return;
-						}
-						// The row is mounted but hosts no focusable control (a static row):
-						// step to the next candidate rather than dead-ending on it.
-						target += step;
-						attempts = 0;
-					}
-					attempts += 1;
-					// Bounded so a row that never mounts (or a run of static rows) can't
-					// loop forever.
-					if (attempts < 10) {
-						focusFrameRef.current = requestAnimationFrame(tryFocus);
-					}
-				};
-				tryFocus();
-			},
-			[count, virtualizer],
-		);
-		const { collectionProps, gridNav, listContext } = useListShell({
-			count,
-			focusItemAt,
-			// Windowed items aren't all mounted, so the default reads `disabled` off
-			// the item elements (which we hold in full) rather than the DOM.
-			isItemDisabled: isItemDisabled ?? ((index) => isItemChildDisabled(items[index])),
-			onActivate,
-			itemId,
-			scrollToIndex,
-			semantics,
-		});
-		const virtualItems = virtualizer.getVirtualItems();
-		// `aria-activedescendant` must reference an element in the DOM: when the
-		// user mouse-scrolls the active row outside the mounted window, drop the
-		// reference rather than leave a dangling IDREF (the active index is kept, so
-		// the next arrow key scrolls the row back into view and restores it).
-		const activeItemIsMounted = virtualItems.some((item) => item.index === gridNav.activeIndex);
+					// The row is mounted but hosts no focusable control (a static row):
+					// step to the next candidate rather than dead-ending on it.
+					target += step;
+					attempts = 0;
+				}
+				attempts += 1;
+				// Bounded so a row that never mounts (or a run of static rows) can't
+				// loop forever.
+				if (attempts < 10) {
+					focusFrameRef.current = requestAnimationFrame(tryFocus);
+				}
+			};
+			tryFocus();
+		},
+		[count, virtualizer],
+	);
+	const { collectionProps, gridNav, listContext } = useListShell({
+		count,
+		focusItemAt,
+		// Windowed items aren't all mounted, so the default reads `disabled` off
+		// the item elements (which we hold in full) rather than the DOM.
+		isItemDisabled: isItemDisabled ?? ((index) => isItemChildDisabled(items[index])),
+		onActivate,
+		itemId,
+		scrollToIndex,
+		semantics,
+	});
+	const virtualItems = virtualizer.getVirtualItems();
+	// `aria-activedescendant` must reference an element in the DOM: when the
+	// user mouse-scrolls the active row outside the mounted window, drop the
+	// reference rather than leave a dangling IDREF (the active index is kept, so
+	// the next arrow key scrolls the row back into view and restores it).
+	const activeItemIsMounted = virtualItems.some((item) => item.index === gridNav.activeIndex);
 
-		return (
-			<ListShell
-				aria-label={ariaLabel}
-				aria-labelledby={ariaLabelledby}
-				aria-multiselectable={ariaMultiselectable}
-				className={className}
-				collectionProps={{
-					...collectionProps,
-					"aria-activedescendant": activeItemIsMounted
-						? collectionProps["aria-activedescendant"]
-						: undefined,
-					// Only the windowed slice is in the DOM, so tell AT how many rows
-					// the grid really has (rows carry the matching aria-rowindex).
-					"aria-rowcount": semantics === "grid" ? count : undefined,
-					style: { height: `${virtualizer.getTotalSize()}px` },
-				}}
-				gridNav={gridNav}
-				listContext={listContext}
-				viewportProps={props}
-				viewportRef={composedViewportRef}
-			>
-				{virtualItems.map((virtualItem) => {
-					const item = items[virtualItem.index];
-					if (item == null) {
-						return null;
-					}
-					return (
-						<WindowedItem
-							key={virtualItem.key}
-							virtualItem={virtualItem}
-							count={count}
-							measureRef={virtualizer.measureElement}
-						>
-							{item}
-						</WindowedItem>
-					);
-				})}
-			</ListShell>
-		);
-	},
-);
+	return (
+		<ListShell
+			aria-label={ariaLabel}
+			aria-labelledby={ariaLabelledby}
+			aria-multiselectable={ariaMultiselectable}
+			className={className}
+			collectionProps={{
+				...collectionProps,
+				"aria-activedescendant": activeItemIsMounted
+					? collectionProps["aria-activedescendant"]
+					: undefined,
+				// Only the windowed slice is in the DOM, so tell AT how many rows
+				// the grid really has (rows carry the matching aria-rowindex).
+				"aria-rowcount": semantics === "grid" ? count : undefined,
+				style: { height: `${virtualizer.getTotalSize()}px` },
+			}}
+			gridNav={gridNav}
+			listContext={listContext}
+			viewportProps={props}
+			ref={composedViewportRef}
+		>
+			{virtualItems.map((virtualItem) => {
+				const item = items[virtualItem.index];
+				if (item == null) {
+					return null;
+				}
+				return (
+					<WindowedItem
+						key={virtualItem.key}
+						virtualItem={virtualItem}
+						count={count}
+						measureRef={virtualizer.measureElement}
+					>
+						{item}
+					</WindowedItem>
+				);
+			})}
+		</ListShell>
+	);
+};
 VirtualRoot.displayName = "ListPrimitiveVirtualRoot";
 
 export {

--- a/packages/mantle/src/components/main/main.tsx
+++ b/packages/mantle/src/components/main/main.tsx
@@ -31,8 +31,6 @@ const Main = ({ className, ...props }: ComponentProps<"main">) => {
 		/>
 	);
 };
-Main.displayName = "Main";
-
 export {
 	//,
 	Main,

--- a/packages/mantle/src/components/media-object/media-object.tsx
+++ b/packages/mantle/src/components/media-object/media-object.tsx
@@ -1,5 +1,4 @@
 import type { ComponentProps } from "react";
-import { forwardRef } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -11,64 +10,58 @@ type Props = ComponentProps<"div"> & WithAsChild;
  * content (title and subtitle/description) to the right. This is the root
  * component of the media object.
  */
-const Root = forwardRef<HTMLDivElement, Props>(
-	({ asChild = false, className, children, style }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Root = ({ asChild = false, className, children, style, ref }: Props) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="media-object"
-				className={cx("flex gap-4", className)}
-				style={style}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="media-object"
+			className={cx("flex gap-4", className)}
+			style={style}
+		>
+			{children}
+		</Component>
+	);
+};
 Root.displayName = "MediaObject";
 
 /**
  * The container for an image or icon to display in the media slot of the media object.
  */
-const Media = forwardRef<HTMLDivElement, Props>(
-	({ asChild = false, className, children, style }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Media = ({ asChild = false, className, children, style, ref }: Props) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="media-object-media"
-				className={cx("shrink-0 leading-none", className)}
-				style={style}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="media-object-media"
+			className={cx("shrink-0 leading-none", className)}
+			style={style}
+		>
+			{children}
+		</Component>
+	);
+};
 Media.displayName = "MediaObjectMedia";
 
 /**
  * The container for the content slot of a media object.
  */
-const Content = forwardRef<HTMLDivElement, Props>(
-	({ asChild = false, className, children, style }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Content = ({ asChild = false, className, children, style, ref }: Props) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				data-slot="media-object-content"
-				className={cx("min-w-0 flex-1", className)}
-				style={style}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
+	return (
+		<Component
+			ref={ref}
+			data-slot="media-object-content"
+			className={cx("min-w-0 flex-1", className)}
+			style={style}
+		>
+			{children}
+		</Component>
+	);
+};
 Content.displayName = "MediaObject.Content";
 
 /**

--- a/packages/mantle/src/components/multi-select/multi-select.tsx
+++ b/packages/mantle/src/components/multi-select/multi-select.tsx
@@ -4,17 +4,9 @@ import * as Primitive from "@ariakit/react";
 import { CheckIcon } from "@phosphor-icons/react/Check";
 import { LockIcon } from "@phosphor-icons/react/Lock";
 import { XIcon } from "@phosphor-icons/react/X";
-import type {
-	ComponentProps,
-	ComponentPropsWithoutRef,
-	ComponentRef,
-	KeyboardEvent,
-	ReactNode,
-	RefObject,
-} from "react";
+import type { ComponentProps, KeyboardEvent, ReactNode, RefObject } from "react";
 import {
 	createContext,
-	forwardRef,
 	useCallback,
 	useContext,
 	useEffect,
@@ -127,7 +119,7 @@ const Root = ({ children, defaultSelectedValue = EMPTY_ARRAY, ...props }: MultiS
 };
 Root.displayName = "MultiSelect";
 
-type MultiSelectTriggerProps = ComponentPropsWithoutRef<"div"> & WithValidation;
+type MultiSelectTriggerProps = ComponentProps<"div"> & WithValidation;
 
 /**
  * The trigger container for the multi-select. Wraps the input and selected
@@ -148,71 +140,67 @@ type MultiSelectTriggerProps = ComponentPropsWithoutRef<"div"> & WithValidation;
  * </MultiSelect.Root>
  * ```
  */
-const Trigger = forwardRef<HTMLDivElement, MultiSelectTriggerProps>(
-	(
-		{
-			"aria-invalid": _ariaInvalid,
-			className,
-			children,
-			onKeyDown,
-			onMouseDown,
-			validation: _validation,
-			...props
-		},
-		ref,
-	) => {
-		const triggerRef = useContext(TriggerRefContext);
-		const { inputRef } = useContext(TagBridgeContext);
-		const store = Primitive.useComboboxContext();
-		const fieldValidation = useFieldValidation();
-		const { validation } = parseValidation({
-			"aria-invalid": _ariaInvalid,
-			validation: _validation ?? fieldValidation,
-		});
+const Trigger = ({
+	"aria-invalid": _ariaInvalid,
+	className,
+	children,
+	onKeyDown,
+	onMouseDown,
+	ref,
+	validation: _validation,
+	...props
+}: MultiSelectTriggerProps) => {
+	const triggerRef = useContext(TriggerRefContext);
+	const { inputRef } = useContext(TagBridgeContext);
+	const store = Primitive.useComboboxContext();
+	const fieldValidation = useFieldValidation();
+	const { validation } = parseValidation({
+		"aria-invalid": _ariaInvalid,
+		validation: _validation ?? fieldValidation,
+	});
 
-		return (
-			<div
-				role="group"
-				data-slot="multi-select-trigger"
-				className={cx(
-					"cursor-text select-none font-sans text-sm",
-					"border-form bg-form text-strong flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border px-3 py-1 has-[[data-slot=multi-select-tag]]:px-1",
-					"has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4",
-					"has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent",
-					"data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success",
-					"data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning",
-					"data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger",
-					className,
-				)}
-				data-validation={validation || undefined}
-				onKeyDown={(event) => {
-					if (event.key === "Escape" && store?.getState().open) {
-						event.preventDefault();
-						store.hide();
-					}
-					onKeyDown?.(event);
-				}}
-				onMouseDown={(event) => {
-					// When clicking on non-interactive areas (padding, flex gaps between tags), prevent the
-					// default mousedown behavior (which would cause text selection) and explicitly focus the
-					// input. Clicks on buttons, the input itself, or tag spans are handled by those elements.
-					if (
-						event.target instanceof HTMLElement &&
-						!event.target.closest("button, input, [role='option']")
-					) {
-						event.preventDefault();
-						inputRef.current?.focus();
-					}
-					onMouseDown?.(event);
-				}}
-				ref={composeRefs(triggerRef, ref)}
-				{...props}
-			>
-				{children}
-			</div>
-		);
-	},
-);
+	return (
+		<div
+			role="group"
+			data-slot="multi-select-trigger"
+			className={cx(
+				"cursor-text select-none font-sans text-sm",
+				"border-form bg-form text-strong flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border px-3 py-1 has-[[data-slot=multi-select-tag]]:px-1",
+				"has-focus:outline-hidden has-focus-within:ring-4 has-aria-expanded:ring-4",
+				"has-focus-within:border-accent-600 has-focus-within:ring-focus-accent has-aria-expanded:border-accent-600 has-aria-expanded:ring-focus-accent",
+				"data-validation-success:border-success-600 data-validation-success:has-focus-within:border-success-600 data-validation-success:has-focus-within:ring-focus-success data-validation-success:has-aria-expanded:border-success-600 data-validation-success:has-aria-expanded:ring-focus-success",
+				"data-validation-warning:border-warning-600 data-validation-warning:has-focus-within:border-warning-600 data-validation-warning:has-focus-within:ring-focus-warning data-validation-warning:has-aria-expanded:border-warning-600 data-validation-warning:has-aria-expanded:ring-focus-warning",
+				"data-validation-error:border-danger-600 data-validation-error:has-focus-within:border-danger-600 data-validation-error:has-focus-within:ring-focus-danger data-validation-error:has-aria-expanded:border-danger-600 data-validation-error:has-aria-expanded:ring-focus-danger",
+				className,
+			)}
+			data-validation={validation || undefined}
+			onKeyDown={(event) => {
+				if (event.key === "Escape" && store?.getState().open) {
+					event.preventDefault();
+					store.hide();
+				}
+				onKeyDown?.(event);
+			}}
+			onMouseDown={(event) => {
+				// When clicking on non-interactive areas (padding, flex gaps between tags), prevent the
+				// default mousedown behavior (which would cause text selection) and explicitly focus the
+				// input. Clicks on buttons, the input itself, or tag spans are handled by those elements.
+				if (
+					event.target instanceof HTMLElement &&
+					!event.target.closest("button, input, [role='option']")
+				) {
+					event.preventDefault();
+					inputRef.current?.focus();
+				}
+				onMouseDown?.(event);
+			}}
+			ref={composeRefs(triggerRef, ref)}
+			{...props}
+		>
+			{children}
+		</div>
+	);
+};
 Trigger.displayName = "MultiSelectTrigger";
 
 type TagProps = Omit<ComponentProps<"span">, "children"> & {
@@ -255,67 +243,73 @@ type TagProps = Omit<ComponentProps<"span">, "children"> & {
  * </MultiSelect.Root>
  * ```
  */
-const Tag = forwardRef<HTMLSpanElement, TagProps>(
-	({ className, value, onRemove, locked = false, onKeyDown, ...props }, ref) => {
-		const internalRef = useRef<HTMLSpanElement | null>(null);
+const Tag = ({
+	className,
+	value,
+	onRemove,
+	locked = false,
+	onKeyDown,
+	ref,
+	...props
+}: TagProps) => {
+	const internalRef = useRef<HTMLSpanElement | null>(null);
 
-		return (
-			<span
-				ref={composeRefs(internalRef, ref)}
-				role="option"
-				aria-selected
+	return (
+		<span
+			ref={composeRefs(internalRef, ref)}
+			role="option"
+			aria-selected
+			tabIndex={-1}
+			data-slot="multi-select-tag"
+			data-locked={locked || undefined}
+			className={cx(
+				"cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal",
+				"focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent",
+				className,
+			)}
+			onKeyDown={(event) => {
+				if (locked && (event.key === "Backspace" || event.key === "Delete")) {
+					event.preventDefault();
+					shakeElement(event.currentTarget);
+					return;
+				}
+				onKeyDown?.(event);
+			}}
+			{...props}
+		>
+			{value}
+			<button
+				type="button"
+				aria-label={`Remove ${value}`}
 				tabIndex={-1}
-				data-slot="multi-select-tag"
-				data-locked={locked || undefined}
+				aria-disabled={locked || undefined}
 				className={cx(
-					"cursor-default bg-neutral-500/10 border border-neutral-500/20 rounded-xs text-strong inline-flex items-center gap-1 pl-2 pr-0.5 py-0.5 text-sm font-normal",
-					"focus-visible:outline-hidden focus-visible:border-accent-600/50 focus-visible:ring-3 focus-visible:ring-focus-accent",
-					className,
+					"cursor-pointer text-strong/40 hover:bg-neutral-500/15 hover:text-strong rounded-xs p-0.5",
+					"aria-disabled:cursor-default aria-disabled:hover:bg-transparent aria-disabled:hover:text-strong/40",
 				)}
-				onKeyDown={(event) => {
-					if (locked && (event.key === "Backspace" || event.key === "Delete")) {
-						event.preventDefault();
-						shakeElement(event.currentTarget);
+				onClick={(event) => {
+					// Prevent the click from bubbling to the trigger, which would reopen or refocus the combobox
+					event.stopPropagation();
+					if (locked) {
+						// Shake the tag to signal that removal is blocked
+						const tagElement = internalRef.current;
+						if (tagElement) {
+							shakeElement(tagElement);
+						}
 						return;
 					}
-					onKeyDown?.(event);
+					onRemove?.();
 				}}
-				{...props}
+				onMouseDown={(event) => {
+					// Prevent the input from losing focus on click, which would close the popover before the remove fires
+					event.preventDefault();
+				}}
 			>
-				{value}
-				<button
-					type="button"
-					aria-label={`Remove ${value}`}
-					tabIndex={-1}
-					aria-disabled={locked || undefined}
-					className={cx(
-						"cursor-pointer text-strong/40 hover:bg-neutral-500/15 hover:text-strong rounded-xs p-0.5",
-						"aria-disabled:cursor-default aria-disabled:hover:bg-transparent aria-disabled:hover:text-strong/40",
-					)}
-					onClick={(event) => {
-						// Prevent the click from bubbling to the trigger, which would reopen or refocus the combobox
-						event.stopPropagation();
-						if (locked) {
-							// Shake the tag to signal that removal is blocked
-							const tagElement = internalRef.current;
-							if (tagElement) {
-								shakeElement(tagElement);
-							}
-							return;
-						}
-						onRemove?.();
-					}}
-					onMouseDown={(event) => {
-						// Prevent the input from losing focus on click, which would close the popover before the remove fires
-						event.preventDefault();
-					}}
-				>
-					<Icon svg={locked ? <LockIcon /> : <XIcon weight="bold" />} className="size-4" />
-				</button>
-			</span>
-		);
-	},
-);
+				<Icon svg={locked ? <LockIcon /> : <XIcon weight="bold" />} className="size-4" />
+			</button>
+		</span>
+	);
+};
 Tag.displayName = "MultiSelectTag";
 
 /**
@@ -639,70 +633,75 @@ type MultiSelectInputProps = Omit<Primitive.ComboboxProps, "render"> & {
  * </MultiSelect.Root>
  * ```
  */
-const Input = forwardRef<ComponentRef<"input">, MultiSelectInputProps>(
-	(
-		{ className, onBlur, onChange, onFocus, onKeyDown, onValueChange, placeholder, ...props },
-		ref,
-	) => {
-		const store = Primitive.useComboboxContext();
-		const { onInputKeyDownRef, inputRef } = useContext(TagBridgeContext);
-		const fieldControl = useContext(FieldControlContext);
-		const rawSelectedValue = Primitive.useStoreState(store, "selectedValue");
-		const selectedValues = isStringArray(rawSelectedValue) ? rawSelectedValue : undefined;
-		const hasSelectedValues = (selectedValues?.length ?? 0) > 0;
+const Input = ({
+	className,
+	onBlur,
+	onChange,
+	onFocus,
+	onKeyDown,
+	onValueChange,
+	placeholder,
+	ref,
+	...props
+}: MultiSelectInputProps) => {
+	const store = Primitive.useComboboxContext();
+	const { onInputKeyDownRef, inputRef } = useContext(TagBridgeContext);
+	const fieldControl = useContext(FieldControlContext);
+	const rawSelectedValue = Primitive.useStoreState(store, "selectedValue");
+	const selectedValues = isStringArray(rawSelectedValue) ? rawSelectedValue : undefined;
+	const hasSelectedValues = (selectedValues?.length ?? 0) > 0;
 
-		return (
-			<Primitive.Combobox
-				autoSelect
-				data-slot="multi-select-input"
-				className={cx(
-					"pointer-coarse:text-base min-w-20 flex-1 select-text border-0 bg-transparent text-sm outline-hidden",
-					"placeholder:select-none placeholder:text-placeholder",
-					className,
-				)}
-				onChange={(event) => {
-					onValueChange?.(event.target.value);
-					onChange?.(event);
-				}}
-				onKeyDown={(event) => {
-					onInputKeyDownRef.current?.(event);
-					onKeyDown?.(event);
-				}}
-				onBlur={(event) => {
-					// When focus moves from the input to a tag, Ariakit would normally
-					// close the popover because the combobox input lost focus. Keep it
-					// open so the user can see the list while navigating tags.
-					if (
-						event.relatedTarget instanceof HTMLElement &&
-						event.relatedTarget.closest('[data-slot="multi-select-tag"]')
-					) {
-						store?.show();
-					}
-					onBlur?.(event);
-				}}
-				onFocus={(event) => {
-					// Ariakit doesn't always open the popover on focus when the input is
-					// already mounted (e.g. returning focus from a tag). Force it open.
+	return (
+		<Primitive.Combobox
+			autoSelect
+			data-slot="multi-select-input"
+			className={cx(
+				"pointer-coarse:text-base min-w-20 flex-1 select-text border-0 bg-transparent text-sm outline-hidden",
+				"placeholder:select-none placeholder:text-placeholder",
+				className,
+			)}
+			onChange={(event) => {
+				onValueChange?.(event.target.value);
+				onChange?.(event);
+			}}
+			onKeyDown={(event) => {
+				onInputKeyDownRef.current?.(event);
+				onKeyDown?.(event);
+			}}
+			onBlur={(event) => {
+				// When focus moves from the input to a tag, Ariakit would normally
+				// close the popover because the combobox input lost focus. Keep it
+				// open so the user can see the list while navigating tags.
+				if (
+					event.relatedTarget instanceof HTMLElement &&
+					event.relatedTarget.closest('[data-slot="multi-select-tag"]')
+				) {
 					store?.show();
-					onFocus?.(event);
-				}}
-				placeholder={hasSelectedValues ? undefined : placeholder}
-				// Register the input's DOM node in the bridge so TagValues can focus it for keyboard nav.
-				ref={composeRefs(inputRef, ref)}
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-							"aria-invalid": fieldControl["aria-invalid"],
-							id: fieldControl.id,
-							name: fieldControl.name,
-						}
-					: undefined)}
-			/>
-		);
-	},
-);
+				}
+				onBlur?.(event);
+			}}
+			onFocus={(event) => {
+				// Ariakit doesn't always open the popover on focus when the input is
+				// already mounted (e.g. returning focus from a tag). Force it open.
+				store?.show();
+				onFocus?.(event);
+			}}
+			placeholder={hasSelectedValues ? undefined : placeholder}
+			// Register the input's DOM node in the bridge so TagValues can focus it for keyboard nav.
+			ref={composeRefs(inputRef, ref)}
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+						"aria-invalid": fieldControl["aria-invalid"],
+						id: fieldControl.id,
+						name: fieldControl.name,
+					}
+				: undefined)}
+		/>
+	);
+};
 Input.displayName = "MultiSelectInput";
 
 type MultiSelectContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & WithAsChild;
@@ -736,94 +735,88 @@ type MultiSelectContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & 
  * </MultiSelect.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<"div">, MultiSelectContentProps>(
-	(
-		{
-			asChild = false,
-			backdrop = false,
-			children,
-			className,
-			modal = true,
-			portalElement,
-			preventBodyScroll,
-			sameWidth = true,
-			unmountOnHide = true,
-			...props
+const Content = ({
+	asChild = false,
+	backdrop = false,
+	children,
+	className,
+	modal = true,
+	portalElement,
+	preventBodyScroll,
+	ref,
+	sameWidth = true,
+	unmountOnHide = true,
+	...props
+}: MultiSelectContentProps) => {
+	const triggerRef = useContext(TriggerRefContext);
+
+	// When the trigger lives inside a mantle modal (Dialog/Sheet), the modal
+	// already scroll-locks the body. Ariakit's own body scroll lock must stay
+	// off in that case: it snapshots body's inline style (including the
+	// modal's transient `pointer-events: none`) and re-applies that stale
+	// snapshot on an animation frame after unmount, permanently freezing the
+	// page (see multi-select.browser.test.tsx regression test).
+	const [isInsideModal, setIsInsideModal] = useState(false);
+	useEffect(() => {
+		setIsInsideModal(triggerRef.current?.closest("[data-mantle-modal-content]") != null);
+	}, [triggerRef]);
+
+	const getAnchorRect = useCallback(() => {
+		return triggerRef.current?.getBoundingClientRect() ?? null;
+	}, [triggerRef]);
+
+	const getPortalElement = useCallback(
+		(element: HTMLElement) => {
+			if (typeof portalElement === "function") {
+				return portalElement(element);
+			}
+
+			return (
+				portalElement ??
+				triggerRef.current?.closest<HTMLElement>("[data-mantle-modal-content]") ??
+				element.ownerDocument.body
+			);
 		},
-		ref,
-	) => {
-		const triggerRef = useContext(TriggerRefContext);
+		[portalElement, triggerRef],
+	);
 
-		// When the trigger lives inside a mantle modal (Dialog/Sheet), the modal
-		// already scroll-locks the body. Ariakit's own body scroll lock must stay
-		// off in that case: it snapshots body's inline style (including the
-		// modal's transient `pointer-events: none`) and re-applies that stale
-		// snapshot on an animation frame after unmount, permanently freezing the
-		// page (see multi-select.browser.test.tsx regression test).
-		const [isInsideModal, setIsInsideModal] = useState(false);
-		useEffect(() => {
-			setIsInsideModal(triggerRef.current?.closest("[data-mantle-modal-content]") != null);
-		}, [triggerRef]);
+	const hideOnInteractOutside = useCallback(
+		(event: Event) => {
+			// Keep the popover open when interacting with any part of the trigger
+			// (tags, buttons, input, padding). Ariakit would otherwise close on any
+			// mousedown outside the popover — including tag clicks.
+			if (event.target instanceof Node && triggerRef.current?.contains(event.target)) {
+				return false;
+			}
+			return true;
+		},
+		[triggerRef],
+	);
 
-		const getAnchorRect = useCallback(() => {
-			return triggerRef.current?.getBoundingClientRect() ?? null;
-		}, [triggerRef]);
-
-		const getPortalElement = useCallback(
-			(element: HTMLElement) => {
-				if (typeof portalElement === "function") {
-					return portalElement(element);
-				}
-
-				return (
-					portalElement ??
-					triggerRef.current?.closest<HTMLElement>("[data-mantle-modal-content]") ??
-					element.ownerDocument.body
-				);
-			},
-			[portalElement, triggerRef],
-		);
-
-		const hideOnInteractOutside = useCallback(
-			(event: Event) => {
-				// Keep the popover open when interacting with any part of the trigger
-				// (tags, buttons, input, padding). Ariakit would otherwise close on any
-				// mousedown outside the popover — including tag clicks.
-				if (event.target instanceof Node && triggerRef.current?.contains(event.target)) {
-					return false;
-				}
-				return true;
-			},
-			[triggerRef],
-		);
-
-		return (
-			<Primitive.ComboboxPopover
-				data-slot="multi-select-content"
-				className={cx(
-					"border-popover bg-popover relative z-50 max-h-96 min-w-32 scrollbar overflow-y-scroll overflow-x-hidden overscroll-y-none rounded-md border shadow-md pt-1 pb-1 has-data-content-footer:pb-0 font-sans flex flex-col gap-px focus:outline-hidden",
-					className,
-				)}
-				backdrop={backdrop}
-				getAnchorRect={getAnchorRect}
-				gutter={4}
-				hideOnInteractOutside={hideOnInteractOutside}
-				modal={modal}
-				portalElement={getPortalElement}
-				preventBodyScroll={preventBodyScroll ?? !isInsideModal}
-				ref={ref}
-				render={
-					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
-				}
-				sameWidth={sameWidth}
-				unmountOnHide={unmountOnHide}
-				{...props}
-			>
-				{children}
-			</Primitive.ComboboxPopover>
-		);
-	},
-);
+	return (
+		<Primitive.ComboboxPopover
+			data-slot="multi-select-content"
+			className={cx(
+				"border-popover bg-popover relative z-50 max-h-96 min-w-32 scrollbar overflow-y-scroll overflow-x-hidden overscroll-y-none rounded-md border shadow-md pt-1 pb-1 has-data-content-footer:pb-0 font-sans flex flex-col gap-px focus:outline-hidden",
+				className,
+			)}
+			backdrop={backdrop}
+			getAnchorRect={getAnchorRect}
+			gutter={4}
+			hideOnInteractOutside={hideOnInteractOutside}
+			modal={modal}
+			portalElement={getPortalElement}
+			preventBodyScroll={preventBodyScroll ?? !isInsideModal}
+			ref={ref}
+			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
+			sameWidth={sameWidth}
+			unmountOnHide={unmountOnHide}
+			{...props}
+		>
+			{children}
+		</Primitive.ComboboxPopover>
+	);
+};
 Content.displayName = "MultiSelectContent";
 
 type MultiSelectItemProps = Omit<Primitive.ComboboxItemProps, "render"> & WithAsChild;
@@ -848,51 +841,53 @@ type MultiSelectItemProps = Omit<Primitive.ComboboxItemProps, "render"> & WithAs
  * </MultiSelect.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<"div">, MultiSelectItemProps>(
-	(
-		{ asChild = false, children, className, focusOnHover = true, value, onClick, ...props },
-		ref,
-	) => {
-		const lockedValuesRef = useContext(LockedValuesContext);
-		const isLocked = value != null && lockedValuesRef.current.includes(value);
+const Item = ({
+	asChild = false,
+	children,
+	className,
+	focusOnHover = true,
+	value,
+	onClick,
+	ref,
+	...props
+}: MultiSelectItemProps) => {
+	const lockedValuesRef = useContext(LockedValuesContext);
+	const isLocked = value != null && lockedValuesRef.current.includes(value);
 
-		return (
-			<Primitive.ComboboxItem
-				data-slot="multi-select-item"
-				className={cx(
-					"relative mx-1 cursor-pointer rounded-md pl-2 pr-8 py-1.5 text-strong text-sm font-normal flex min-w-0 items-center gap-2",
-					"[[role=option]+&]:mt-px",
-					"data-active-item:bg-active-menu-item",
-					"aria-disabled:opacity-50",
-					"aria-selected:bg-selected-menu-item aria-selected:data-active-item:bg-active-selected-menu-item",
-					className,
-				)}
-				focusOnHover={focusOnHover}
-				onClick={(event) => {
-					// Prevent Ariakit from toggling off a locked value.
-					// Ariakit checks event.defaultPrevented before executing its selection logic.
-					if (isLocked) {
-						event.preventDefault();
-						return;
-					}
-					onClick?.(event);
-				}}
-				ref={ref}
-				render={
-					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
+	return (
+		<Primitive.ComboboxItem
+			data-slot="multi-select-item"
+			className={cx(
+				"relative mx-1 cursor-pointer rounded-md pl-2 pr-8 py-1.5 text-strong text-sm font-normal flex min-w-0 items-center gap-2",
+				"[[role=option]+&]:mt-px",
+				"data-active-item:bg-active-menu-item",
+				"aria-disabled:opacity-50",
+				"aria-selected:bg-selected-menu-item aria-selected:data-active-item:bg-active-selected-menu-item",
+				className,
+			)}
+			focusOnHover={focusOnHover}
+			onClick={(event) => {
+				// Prevent Ariakit from toggling off a locked value.
+				// Ariakit checks event.defaultPrevented before executing its selection logic.
+				if (isLocked) {
+					event.preventDefault();
+					return;
 				}
-				resetValueOnSelect
-				value={value}
-				{...props}
-			>
-				{children}
-				<Primitive.ComboboxItemCheck className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-					<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
-				</Primitive.ComboboxItemCheck>
-			</Primitive.ComboboxItem>
-		);
-	},
-);
+				onClick?.(event);
+			}}
+			ref={ref}
+			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
+			resetValueOnSelect
+			value={value}
+			{...props}
+		>
+			{children}
+			<Primitive.ComboboxItemCheck className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+				<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
+			</Primitive.ComboboxItemCheck>
+		</Primitive.ComboboxItem>
+	);
+};
 Item.displayName = "MultiSelectItem";
 
 type MultiSelectGroupProps = Omit<Primitive.ComboboxGroupProps, "render"> & WithAsChild;
@@ -919,23 +914,19 @@ type MultiSelectGroupProps = Omit<Primitive.ComboboxGroupProps, "render"> & With
  * </MultiSelect.Root>
  * ```
  */
-const Group = forwardRef<ComponentRef<"div">, MultiSelectGroupProps>(
-	({ asChild = false, children, ...props }, ref) => {
-		return (
-			<Primitive.ComboboxGroup
-				data-slot="multi-select-group"
-				className="mx-1"
-				ref={ref}
-				render={
-					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
-				}
-				{...props}
-			>
-				{children}
-			</Primitive.ComboboxGroup>
-		);
-	},
-);
+const Group = ({ asChild = false, children, ref, ...props }: MultiSelectGroupProps) => {
+	return (
+		<Primitive.ComboboxGroup
+			data-slot="multi-select-group"
+			className="mx-1"
+			ref={ref}
+			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
+			{...props}
+		>
+			{children}
+		</Primitive.ComboboxGroup>
+	);
+};
 Group.displayName = "MultiSelectGroup";
 
 type MultiSelectGroupLabelProps = Omit<Primitive.ComboboxGroupLabelProps, "render"> & WithAsChild;
@@ -961,26 +952,28 @@ type MultiSelectGroupLabelProps = Omit<Primitive.ComboboxGroupLabelProps, "rende
  * </MultiSelect.Root>
  * ```
  */
-const GroupLabel = forwardRef<ComponentRef<"div">, MultiSelectGroupLabelProps>(
-	({ asChild = false, children, className, ...props }, ref) => {
-		return (
-			<Primitive.ComboboxGroupLabel
-				data-slot="multi-select-group-label"
-				className={cx("text-muted px-2 py-1 text-xs font-medium", className)}
-				ref={ref}
-				render={
-					asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined
-				}
-				{...props}
-			>
-				{children}
-			</Primitive.ComboboxGroupLabel>
-		);
-	},
-);
+const GroupLabel = ({
+	asChild = false,
+	children,
+	className,
+	ref,
+	...props
+}: MultiSelectGroupLabelProps) => {
+	return (
+		<Primitive.ComboboxGroupLabel
+			data-slot="multi-select-group-label"
+			className={cx("text-muted px-2 py-1 text-xs font-medium", className)}
+			ref={ref}
+			render={asChild ? ({ ref, ...childProps }) => <Slot ref={ref} {...childProps} /> : undefined}
+			{...props}
+		>
+			{children}
+		</Primitive.ComboboxGroupLabel>
+	);
+};
 GroupLabel.displayName = "MultiSelectGroupLabel";
 
-type MultiSelectGroupDescriptionProps = ComponentPropsWithoutRef<"p">;
+type MultiSelectGroupDescriptionProps = ComponentProps<"p">;
 
 /**
  * Renders a description below a `MultiSelect.GroupLabel` inside a `MultiSelect.Group`.
@@ -1007,20 +1000,23 @@ type MultiSelectGroupDescriptionProps = ComponentPropsWithoutRef<"p">;
  * </MultiSelect.Root>
  * ```
  */
-const GroupDescription = forwardRef<HTMLParagraphElement, MultiSelectGroupDescriptionProps>(
-	({ className, children, ...props }, ref) => {
-		return (
-			<p
-				data-slot="multi-select-group-description"
-				className={cx("text-muted px-2 pb-1 text-xs", className)}
-				ref={ref}
-				{...props}
-			>
-				{children}
-			</p>
-		);
-	},
-);
+const GroupDescription = ({
+	className,
+	children,
+	ref,
+	...props
+}: MultiSelectGroupDescriptionProps) => {
+	return (
+		<p
+			data-slot="multi-select-group-description"
+			className={cx("text-muted px-2 pb-1 text-xs", className)}
+			ref={ref}
+			{...props}
+		>
+			{children}
+		</p>
+	);
+};
 GroupDescription.displayName = "MultiSelectGroupDescription";
 
 /**
@@ -1047,20 +1043,21 @@ GroupDescription.displayName = "MultiSelectGroupDescription";
  * </MultiSelect.Root>
  * ```
  */
-const MultiSelectSeparatorComponent = forwardRef<
-	ComponentRef<"div">,
-	ComponentPropsWithoutRef<typeof Separator>
->(({ className, ...props }, ref) => (
+const MultiSelectSeparatorComponent = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof Separator>) => (
 	<Separator
 		data-slot="multi-select-separator"
 		ref={ref}
 		className={cx("my-1 w-auto", className)}
 		{...props}
 	/>
-));
+);
 MultiSelectSeparatorComponent.displayName = "MultiSelectSeparator";
 
-type MultiSelectEmptyProps = ComponentPropsWithoutRef<"div">;
+type MultiSelectEmptyProps = ComponentProps<"div">;
 
 /**
  * Renders a message when no items match the current filter.
@@ -1082,24 +1079,22 @@ type MultiSelectEmptyProps = ComponentPropsWithoutRef<"div">;
  * </MultiSelect.Root>
  * ```
  */
-const Empty = forwardRef<HTMLDivElement, MultiSelectEmptyProps>(
-	({ className, children, ...props }, ref) => {
-		return (
-			<div
-				data-slot="multi-select-empty"
-				className={cx("mx-1 text-muted px-2 py-6 text-center text-sm", className)}
-				ref={ref}
-				role="presentation"
-				{...props}
-			>
-				{children}
-			</div>
-		);
-	},
-);
+const Empty = ({ className, children, ref, ...props }: MultiSelectEmptyProps) => {
+	return (
+		<div
+			data-slot="multi-select-empty"
+			className={cx("mx-1 text-muted px-2 py-6 text-center text-sm", className)}
+			ref={ref}
+			role="presentation"
+			{...props}
+		>
+			{children}
+		</div>
+	);
+};
 Empty.displayName = "MultiSelectEmpty";
 
-type MultiSelectContentFooterProps = ComponentPropsWithoutRef<"div">;
+type MultiSelectContentFooterProps = ComponentProps<"div">;
 
 /**
  * Renders a sticky footer pinned to the bottom inside `MultiSelect.Content`,
@@ -1124,21 +1119,19 @@ type MultiSelectContentFooterProps = ComponentPropsWithoutRef<"div">;
  * </MultiSelect.Root>
  * ```
  */
-const ContentFooter = forwardRef<HTMLDivElement, MultiSelectContentFooterProps>(
-	({ className, children, ...props }, ref) => {
-		return (
-			<div
-				ref={ref}
-				data-slot="multi-select-content-footer"
-				data-content-footer
-				className={cx("bg-popover sticky bottom-0 border-t border-popover", className)}
-				{...props}
-			>
-				{children}
-			</div>
-		);
-	},
-);
+const ContentFooter = ({ className, children, ref, ...props }: MultiSelectContentFooterProps) => {
+	return (
+		<div
+			ref={ref}
+			data-slot="multi-select-content-footer"
+			data-content-footer
+			className={cx("bg-popover sticky bottom-0 border-t border-popover", className)}
+			{...props}
+		>
+			{children}
+		</div>
+	);
+};
 ContentFooter.displayName = "MultiSelectContentFooter";
 
 /**

--- a/packages/mantle/src/components/otp-input/otp-input.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.tsx
@@ -2,8 +2,8 @@
 
 import { MinusIcon } from "@phosphor-icons/react/Minus";
 import { OTPInput, OTPInputContext } from "input-otp";
-import type { ComponentProps, ComponentRef, ReactNode } from "react";
-import { forwardRef, useContext } from "react";
+import type { ComponentProps, ReactNode } from "react";
+import { useContext } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { $cssProperties } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -162,51 +162,44 @@ type OtpInputRootProps = Omit<ComponentProps<typeof OTPInput>, "render" | "child
 // `OtpInput.Root` does not support `asChild`: the underlying `OTPInput`
 // owns its hidden `<input>` and its render contract — swapping the element
 // would break input-otp's internal focus and selection management.
-const Root = forwardRef<ComponentRef<typeof OTPInput>, OtpInputRootProps>(
-	(
-		{
-			"aria-invalid": ariaInvalid,
-			children,
-			className,
-			containerClassName,
-			validation: _validation,
-			...props
-		},
-		ref,
-	) => {
-		const fieldValidation = useFieldValidation();
-		const fieldControl = useContext(FieldControlContext);
-		const { ariaInvalid: resolvedAriaInvalid, validation } = parseValidation({
-			"aria-invalid": ariaInvalid,
-			defaultAriaInvalid: false,
-			validation: _validation ?? fieldValidation,
-		});
+const Root = ({
+	"aria-invalid": ariaInvalid,
+	children,
+	className,
+	containerClassName,
+	ref,
+	validation: _validation,
+	...props
+}: OtpInputRootProps) => {
+	const fieldValidation = useFieldValidation();
+	const fieldControl = useContext(FieldControlContext);
+	const { ariaInvalid: resolvedAriaInvalid, validation } = parseValidation({
+		"aria-invalid": ariaInvalid,
+		defaultAriaInvalid: false,
+		validation: _validation ?? fieldValidation,
+	});
 
-		return (
-			<OTPInput
-				ref={ref}
-				aria-invalid={resolvedAriaInvalid}
-				data-slot="otp-input"
-				containerClassName={cx(
-					"flex items-center gap-2 has-disabled:opacity-50",
-					containerClassName,
-				)}
-				className={cx("disabled:cursor-not-allowed", className)}
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-							id: fieldControl.id,
-							name: fieldControl.name,
-						}
-					: undefined)}
-			>
-				<MantleOtpBridge validation={validation}>{children}</MantleOtpBridge>
-			</OTPInput>
-		);
-	},
-);
+	return (
+		<OTPInput
+			ref={ref}
+			aria-invalid={resolvedAriaInvalid}
+			data-slot="otp-input"
+			containerClassName={cx("flex items-center gap-2 has-disabled:opacity-50", containerClassName)}
+			className={cx("disabled:cursor-not-allowed", className)}
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+						id: fieldControl.id,
+						name: fieldControl.name,
+					}
+				: undefined)}
+		>
+			<MantleOtpBridge validation={validation}>{children}</MantleOtpBridge>
+		</OTPInput>
+	);
+};
 Root.displayName = "OtpInput";
 
 type OtpInputGroupProps = ComponentProps<"div"> & WithAsChild;
@@ -235,37 +228,35 @@ type OtpInputGroupProps = ComponentProps<"div"> & WithAsChild;
  * </OtpInput.Root>
  * ```
  */
-const Group = forwardRef<HTMLDivElement, OtpInputGroupProps>(
-	({ asChild, children, className, ...props }, ref) => {
-		const Comp = asChild ? AsChildSlot : "div";
+const Group = ({ asChild, children, className, ref, ...props }: OtpInputGroupProps) => {
+	const Comp = asChild ? AsChildSlot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="otp-input-group"
-				className={cx(
-					"relative flex items-center rounded-md",
-					// A "range" selection within this group means two or more
-					// slots are simultaneously active. CSS `:has()` with the
-					// general sibling combinator catches that without us
-					// having to count: if any active slot is preceded by
-					// another active slot at the same nesting level, the
-					// group has at least 2 actives → draw the ring.
-					"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4",
-					// Validation override for the group-level range/all ring.
-					// `--otp-validation-ring` is set on the bridge based on
-					// the validation value, so a single class covers
-					// error/success/warning instead of one per hue.
-					"group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="otp-input-group"
+			className={cx(
+				"relative flex items-center rounded-md",
+				// A "range" selection within this group means two or more
+				// slots are simultaneously active. CSS `:has()` with the
+				// general sibling combinator catches that without us
+				// having to count: if any active slot is preceded by
+				// another active slot at the same nesting level, the
+				// group has at least 2 actives → draw the ring.
+				"has-[[data-active]~[data-active]]:ring-focus-accent has-[[data-active]~[data-active]]:ring-4",
+				// Validation override for the group-level range/all ring.
+				// `--otp-validation-ring` is set on the bridge based on
+				// the validation value, so a single class covers
+				// error/success/warning instead of one per hue.
+				"group-data-validation/otp:has-[[data-active]~[data-active]]:ring-(--otp-validation-ring)",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
 Group.displayName = "OtpInputGroup";
 
 type OtpInputSlotProps = ComponentProps<"div"> & {
@@ -305,84 +296,82 @@ type OtpInputSlotProps = ComponentProps<"div"> & {
 // state (char, fake caret, active) from `OTPInputContext` and renders that
 // state into a fixed visual structure. Letting consumers swap the element
 // would lose the caret overlay and the active-ring focus styling.
-const OtpInputSlotImpl = forwardRef<HTMLDivElement, OtpInputSlotProps>(
-	({ className, index, ...props }, ref) => {
-		const context = useContext(OTPInputContext);
-		const slot = context.slots[index];
-		const char = slot?.char ?? null;
-		const hasFakeCaret = slot?.hasFakeCaret ?? false;
-		const isActive = slot?.isActive ?? false;
+const OtpInputSlotImpl = ({ className, index, ref, ...props }: OtpInputSlotProps) => {
+	const context = useContext(OTPInputContext);
+	const slot = context.slots[index];
+	const char = slot?.char ?? null;
+	const hasFakeCaret = slot?.hasFakeCaret ?? false;
+	const isActive = slot?.isActive ?? false;
 
-		return (
-			<div
-				ref={ref}
-				data-slot="otp-input-slot"
-				data-active={isActive ? "" : undefined}
-				className={cx(
-					"border-form bg-form text-strong relative flex h-10 w-10 items-center justify-center border-y border-r text-sm shadow-sm outline-hidden transition-all duration-150 ease-out",
-					"first:rounded-l-md first:border-l last:rounded-r-md",
-					// When this slot is immediately followed by the caret
-					// slot, hide our `border-r` so the active slot's
-					// `border-l` is the only line at the boundary — without
-					// this, the two adjacent 1px borders read as a doubled
-					// edge. We use an arbitrary `&:has(+ ...)` variant
-					// because Tailwind's `has-[...]` shorthand doesn't
-					// parse the nested bracketed attribute selector here.
-					"[&:has(+[data-active])]:group-data-[otp-state=caret]/otp:border-r-transparent",
-					// Per-slot ring renders only in `caret` state (single
-					// active slot). When more than one slot is active, the
-					// surrounding `OtpInput.Group` draws a single ring
-					// around the whole group — see Group's `:has()` rule.
-					// We also recolor the slot's own borders to accent and
-					// fill in `border-l` (groups normally only render
-					// `border-l` on `:first-child`), so the slot reads as
-					// one cohesive highlighted box rather than a ring with
-					// a gray box inside.
-					"data-active:group-data-[otp-state=caret]/otp:border-accent-600",
-					"data-active:group-data-[otp-state=caret]/otp:border-l",
-					"data-active:group-data-[otp-state=caret]/otp:ring-focus-accent",
-					"data-active:group-data-[otp-state=caret]/otp:z-20",
-					"data-active:group-data-[otp-state=caret]/otp:ring-4",
-					// Select-all: tint *every* border on the slot accent.
-					// Tinting only the outside edges leaves the internal
-					// vertical divider (gray `border-r`) meeting the
-					// accent top/bottom borders at the corner, producing a
-					// visible 1px miter spike. Coloring all borders the
-					// same accent-600 hue makes the corner blend
-					// seamlessly while still keeping the slot grid
-					// readable at full opacity.
-					"group-data-[otp-state=all]/otp:border-accent-600",
-					// Validation overrides. Only the *outer* edges of the
-					// group are tinted (top + bottom on every slot, left on
-					// the first slot, right on the last slot) so adjacent
-					// slots still join with a neutral divider — matching how
-					// `Input` tints the container border, not the internal
-					// elements. The all-state and caret-active overrides
-					// still recolor every border so a fully-active slot or
-					// select-all reads as a solid tinted box. The bridge
-					// sets `--otp-validation-{border,ring}` per validation
-					// value, so a single set of classes covers
-					// error/success/warning.
-					"group-data-validation/otp:border-y-(--otp-validation-border)",
-					"group-data-validation/otp:first:border-l-(--otp-validation-border)",
-					"group-data-validation/otp:last:border-r-(--otp-validation-border)",
-					"group-data-validation/otp:data-active:group-data-[otp-state=caret]/otp:border-(--otp-validation-border)",
-					"group-data-validation/otp:data-active:group-data-[otp-state=caret]/otp:ring-(--otp-validation-ring)",
-					"group-data-validation/otp:group-data-[otp-state=all]/otp:border-(--otp-validation-border)",
-					className,
-				)}
-				{...props}
-			>
-				{char}
-				{hasFakeCaret && (
-					<div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-						<div className="bg-strong h-4 w-px animate-pulse" />
-					</div>
-				)}
-			</div>
-		);
-	},
-);
+	return (
+		<div
+			ref={ref}
+			data-slot="otp-input-slot"
+			data-active={isActive ? "" : undefined}
+			className={cx(
+				"border-form bg-form text-strong relative flex h-10 w-10 items-center justify-center border-y border-r text-sm shadow-sm outline-hidden transition-all duration-150 ease-out",
+				"first:rounded-l-md first:border-l last:rounded-r-md",
+				// When this slot is immediately followed by the caret
+				// slot, hide our `border-r` so the active slot's
+				// `border-l` is the only line at the boundary — without
+				// this, the two adjacent 1px borders read as a doubled
+				// edge. We use an arbitrary `&:has(+ ...)` variant
+				// because Tailwind's `has-[...]` shorthand doesn't
+				// parse the nested bracketed attribute selector here.
+				"[&:has(+[data-active])]:group-data-[otp-state=caret]/otp:border-r-transparent",
+				// Per-slot ring renders only in `caret` state (single
+				// active slot). When more than one slot is active, the
+				// surrounding `OtpInput.Group` draws a single ring
+				// around the whole group — see Group's `:has()` rule.
+				// We also recolor the slot's own borders to accent and
+				// fill in `border-l` (groups normally only render
+				// `border-l` on `:first-child`), so the slot reads as
+				// one cohesive highlighted box rather than a ring with
+				// a gray box inside.
+				"data-active:group-data-[otp-state=caret]/otp:border-accent-600",
+				"data-active:group-data-[otp-state=caret]/otp:border-l",
+				"data-active:group-data-[otp-state=caret]/otp:ring-focus-accent",
+				"data-active:group-data-[otp-state=caret]/otp:z-20",
+				"data-active:group-data-[otp-state=caret]/otp:ring-4",
+				// Select-all: tint *every* border on the slot accent.
+				// Tinting only the outside edges leaves the internal
+				// vertical divider (gray `border-r`) meeting the
+				// accent top/bottom borders at the corner, producing a
+				// visible 1px miter spike. Coloring all borders the
+				// same accent-600 hue makes the corner blend
+				// seamlessly while still keeping the slot grid
+				// readable at full opacity.
+				"group-data-[otp-state=all]/otp:border-accent-600",
+				// Validation overrides. Only the *outer* edges of the
+				// group are tinted (top + bottom on every slot, left on
+				// the first slot, right on the last slot) so adjacent
+				// slots still join with a neutral divider — matching how
+				// `Input` tints the container border, not the internal
+				// elements. The all-state and caret-active overrides
+				// still recolor every border so a fully-active slot or
+				// select-all reads as a solid tinted box. The bridge
+				// sets `--otp-validation-{border,ring}` per validation
+				// value, so a single set of classes covers
+				// error/success/warning.
+				"group-data-validation/otp:border-y-(--otp-validation-border)",
+				"group-data-validation/otp:first:border-l-(--otp-validation-border)",
+				"group-data-validation/otp:last:border-r-(--otp-validation-border)",
+				"group-data-validation/otp:data-active:group-data-[otp-state=caret]/otp:border-(--otp-validation-border)",
+				"group-data-validation/otp:data-active:group-data-[otp-state=caret]/otp:ring-(--otp-validation-ring)",
+				"group-data-validation/otp:group-data-[otp-state=all]/otp:border-(--otp-validation-border)",
+				className,
+			)}
+			{...props}
+		>
+			{char}
+			{hasFakeCaret && (
+				<div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+					<div className="bg-strong h-4 w-px animate-pulse" />
+				</div>
+			)}
+		</div>
+	);
+};
 OtpInputSlotImpl.displayName = "OtpInputSlot";
 
 type OtpInputSeparatorProps = ComponentProps<"div"> &
@@ -422,24 +411,29 @@ type OtpInputSeparatorProps = ComponentProps<"div"> &
  * </OtpInput.Root>
  * ```
  */
-const Separator = forwardRef<HTMLDivElement, OtpInputSeparatorProps>(
-	({ asChild, children, className, semantic = false, ...props }, ref) => {
-		const Comp = asChild ? AsChildSlot : "div";
-		const semanticProps = semantic ? { role: "separator" } : { "aria-hidden": true, role: "none" };
+const Separator = ({
+	asChild,
+	children,
+	className,
+	ref,
+	semantic = false,
+	...props
+}: OtpInputSeparatorProps) => {
+	const Comp = asChild ? AsChildSlot : "div";
+	const semanticProps = semantic ? { role: "separator" } : { "aria-hidden": true, role: "none" };
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="otp-input-separator"
-				className={cx("text-separator flex items-center", className)}
-				{...semanticProps}
-				{...props}
-			>
-				{children ?? <MinusIcon weight="bold" />}
-			</Comp>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			data-slot="otp-input-separator"
+			className={cx("text-separator flex items-center", className)}
+			{...semanticProps}
+			{...props}
+		>
+			{children ?? <MinusIcon weight="bold" />}
+		</Comp>
+	);
+};
 Separator.displayName = "OtpInputSeparator";
 
 /**

--- a/packages/mantle/src/components/pagination/cursor-pagination.tsx
+++ b/packages/mantle/src/components/pagination/cursor-pagination.tsx
@@ -2,15 +2,7 @@
 
 import { CaretLeftIcon } from "@phosphor-icons/react/CaretLeft";
 import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
-import {
-	type ComponentProps,
-	type ComponentRef,
-	createContext,
-	forwardRef,
-	useContext,
-	useMemo,
-	useState,
-} from "react";
+import { type ComponentProps, createContext, useContext, useMemo, useState } from "react";
 import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -67,28 +59,26 @@ type CursorPaginationProps = ComponentProps<"div"> & {
  * </CursorPagination>
  * ```
  */
-const Root = forwardRef<HTMLDivElement, CursorPaginationProps>(
-	({ className, children, defaultPageSize, ...props }, ref) => {
-		const [pageSize, setPageSize] = useState<number>(defaultPageSize);
-		const contextValue = useMemo(
-			() => ({ defaultPageSize, pageSize, setPageSize }),
-			[defaultPageSize, pageSize],
-		);
+const Root = ({ className, children, defaultPageSize, ref, ...props }: CursorPaginationProps) => {
+	const [pageSize, setPageSize] = useState<number>(defaultPageSize);
+	const contextValue = useMemo(
+		() => ({ defaultPageSize, pageSize, setPageSize }),
+		[defaultPageSize, pageSize],
+	);
 
-		return (
-			<CursorPaginationContext.Provider value={contextValue}>
-				<div
-					data-slot="cursor-pagination"
-					className={cx("inline-flex items-center justify-between gap-2", className)}
-					ref={ref}
-					{...props}
-				>
-					{children}
-				</div>
-			</CursorPaginationContext.Provider>
-		);
-	},
-);
+	return (
+		<CursorPaginationContext.Provider value={contextValue}>
+			<div
+				data-slot="cursor-pagination"
+				className={cx("inline-flex items-center justify-between gap-2", className)}
+				ref={ref}
+				{...props}
+			>
+				{children}
+			</div>
+		</CursorPaginationContext.Provider>
+	);
+};
 Root.displayName = "CursorPagination";
 
 type CursorButtonsProps = Omit<ComponentProps<typeof ButtonGroup>, "appearance"> & {
@@ -125,43 +115,48 @@ type CursorButtonsProps = Omit<ComponentProps<typeof ButtonGroup>, "appearance">
  * />
  * ```
  */
-const Buttons = forwardRef<ComponentRef<typeof ButtonGroup>, CursorButtonsProps>(
-	({ hasNextPage, hasPreviousPage, onNextPage, onPreviousPage, ...props }, ref) => {
-		// TODO(cody): this _feels_ like a good spot for left and right arrow keys to navigate between pages when focused on the buttons
+const Buttons = ({
+	hasNextPage,
+	hasPreviousPage,
+	onNextPage,
+	onPreviousPage,
+	ref,
+	...props
+}: CursorButtonsProps) => {
+	// TODO(cody): this _feels_ like a good spot for left and right arrow keys to navigate between pages when focused on the buttons
 
-		return (
-			<ButtonGroup data-slot="cursor-pagination-buttons" appearance="panel" ref={ref} {...props}>
-				<IconButton
-					data-slot="cursor-pagination-previous"
-					appearance="ghost"
-					disabled={!hasPreviousPage}
-					icon={<CaretLeftIcon />}
-					intent="neutral"
-					label="Previous page"
-					onClick={onPreviousPage}
-					size="sm"
-					type="button"
-				/>
-				<Separator
-					data-slot="cursor-pagination-separator"
-					orientation="vertical"
-					className="min-h-5"
-				/>
-				<IconButton
-					data-slot="cursor-pagination-next"
-					appearance="ghost"
-					disabled={!hasNextPage}
-					icon={<CaretRightIcon />}
-					intent="neutral"
-					label="Next page"
-					onClick={onNextPage}
-					size="sm"
-					type="button"
-				/>
-			</ButtonGroup>
-		);
-	},
-);
+	return (
+		<ButtonGroup data-slot="cursor-pagination-buttons" appearance="panel" ref={ref} {...props}>
+			<IconButton
+				data-slot="cursor-pagination-previous"
+				appearance="ghost"
+				disabled={!hasPreviousPage}
+				icon={<CaretLeftIcon />}
+				intent="neutral"
+				label="Previous page"
+				onClick={onPreviousPage}
+				size="sm"
+				type="button"
+			/>
+			<Separator
+				data-slot="cursor-pagination-separator"
+				orientation="vertical"
+				className="min-h-5"
+			/>
+			<IconButton
+				data-slot="cursor-pagination-next"
+				appearance="ghost"
+				disabled={!hasNextPage}
+				icon={<CaretRightIcon />}
+				intent="neutral"
+				label="Next page"
+				onClick={onNextPage}
+				size="sm"
+				type="button"
+			/>
+		</ButtonGroup>
+	);
+};
 Buttons.displayName = "CursorButtons";
 
 const defaultPageSizes = [5, 10, 20, 50, 100] as const;
@@ -190,54 +185,58 @@ type CursorPageSizeSelectProps = Omit<ComponentProps<typeof Select.Trigger>, "ch
  * />
  * ```
  */
-const PageSizeSelect = forwardRef<ComponentRef<typeof Select.Trigger>, CursorPageSizeSelectProps>(
-	({ className, pageSizes = defaultPageSizes, onChangePageSize, ...rest }, ref) => {
-		const ctx = useContext(CursorPaginationContext);
+const PageSizeSelect = ({
+	className,
+	pageSizes = defaultPageSizes,
+	onChangePageSize,
+	ref,
+	...rest
+}: CursorPageSizeSelectProps) => {
+	const ctx = useContext(CursorPaginationContext);
 
-		invariant(ctx, "CursorPageSizeSelect must be used as a child of a CursorPagination component");
+	invariant(ctx, "CursorPageSizeSelect must be used as a child of a CursorPagination component");
 
-		invariant(
-			pageSizes.includes(ctx.defaultPageSize),
-			"CursorPagination.defaultPageSize must be included in CursorPageSizeSelect.pageSizes",
-		);
+	invariant(
+		pageSizes.includes(ctx.defaultPageSize),
+		"CursorPagination.defaultPageSize must be included in CursorPageSizeSelect.pageSizes",
+	);
 
-		invariant(
-			pageSizes.includes(ctx.pageSize),
-			"CursorPagination.pageSize must be included in CursorPageSizeSelect.pageSizes",
-		);
+	invariant(
+		pageSizes.includes(ctx.pageSize),
+		"CursorPagination.pageSize must be included in CursorPageSizeSelect.pageSizes",
+	);
 
-		return (
-			<Select.Root
-				defaultValue={`${ctx.pageSize}`}
-				onValueChange={(value) => {
-					let newPageSize = Number.parseInt(value, 10);
-					if (Number.isNaN(newPageSize)) {
-						newPageSize = ctx.defaultPageSize;
-					}
-					ctx.setPageSize(newPageSize);
-					onChangePageSize?.(newPageSize);
-				}}
+	return (
+		<Select.Root
+			defaultValue={`${ctx.pageSize}`}
+			onValueChange={(value) => {
+				let newPageSize = Number.parseInt(value, 10);
+				if (Number.isNaN(newPageSize)) {
+					newPageSize = ctx.defaultPageSize;
+				}
+				ctx.setPageSize(newPageSize);
+				onChangePageSize?.(newPageSize);
+			}}
+		>
+			<Select.Trigger
+				ref={ref}
+				data-slot="cursor-pagination-page-size-select"
+				className={cx("w-auto min-w-36", className)}
+				value={ctx.pageSize}
+				{...rest}
 			>
-				<Select.Trigger
-					ref={ref}
-					data-slot="cursor-pagination-page-size-select"
-					className={cx("w-auto min-w-36", className)}
-					value={ctx.pageSize}
-					{...rest}
-				>
-					<Select.Value />
-				</Select.Trigger>
-				<Select.Content width="trigger">
-					{pageSizes.map((size) => (
-						<Select.Item key={size} value={`${size}`}>
-							{size} per page
-						</Select.Item>
-					))}
-				</Select.Content>
-			</Select.Root>
-		);
-	},
-);
+				<Select.Value />
+			</Select.Trigger>
+			<Select.Content width="trigger">
+				{pageSizes.map((size) => (
+					<Select.Item key={size} value={`${size}`}>
+						{size} per page
+					</Select.Item>
+				))}
+			</Select.Content>
+		</Select.Root>
+	);
+};
 PageSizeSelect.displayName = "CursorPageSizeSelect";
 
 type CursorPageSizeValueProps = Omit<ComponentProps<"span">, "children"> & WithAsChild;

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -1,6 +1,5 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -102,7 +101,7 @@ Anchor.displayName = "PopoverAnchor";
 const Close = PopoverPrimitive.Close;
 Close.displayName = "PopoverClose";
 
-type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+type PopoverContentProps = ComponentProps<typeof PopoverPrimitive.Content> & {
 	/**
 	 * The preferred width of the `PopoverContent` as a tailwind `max-w-` class.
 	 *
@@ -137,42 +136,38 @@ type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Cont
  * </Popover.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<"div">, PopoverContentProps>(
-	(
-		{
-			//,
-			align = "center",
-			className,
-			onClick,
-			preferredWidth = "max-w-72",
-			sideOffset = 4,
-			...props
-		},
-		ref,
-	) => (
-		<PopoverPrimitive.Portal>
-			<PopoverPrimitive.Content
-				align={align}
-				data-slot="popover-content"
-				className={cx(
-					"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
-					preferredWidth,
-					className,
-				)}
-				onClick={(event) => {
-					/**
-					 * Prevent the click event from propagating up to parent/containing elements
-					 * of the PopoverContent
-					 */
-					event.stopPropagation();
-					onClick?.(event);
-				}}
-				ref={ref}
-				sideOffset={sideOffset}
-				{...props}
-			/>
-		</PopoverPrimitive.Portal>
-	),
+const Content = ({
+	//,
+	align = "center",
+	className,
+	onClick,
+	preferredWidth = "max-w-72",
+	ref,
+	sideOffset = 4,
+	...props
+}: PopoverContentProps) => (
+	<PopoverPrimitive.Portal>
+		<PopoverPrimitive.Content
+			align={align}
+			data-slot="popover-content"
+			className={cx(
+				"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
+				preferredWidth,
+				className,
+			)}
+			onClick={(event) => {
+				/**
+				 * Prevent the click event from propagating up to parent/containing elements
+				 * of the PopoverContent
+				 */
+				event.stopPropagation();
+				onClick?.(event);
+			}}
+			ref={ref}
+			sideOffset={sideOffset}
+			{...props}
+		/>
+	</PopoverPrimitive.Portal>
 );
 Content.displayName = "PopoverContent";
 

--- a/packages/mantle/src/components/progress/progress-bar.tsx
+++ b/packages/mantle/src/components/progress/progress-bar.tsx
@@ -101,8 +101,6 @@ function Root({ className, children, max: _max = defaultMax, value: _value, ...p
 		</ProgressContext.Provider>
 	);
 }
-Root.displayName = "Root";
-
 type IndicatorProps = ComponentProps<typeof ProgressPrimitive.Indicator>;
 
 /**
@@ -140,8 +138,6 @@ function Indicator({ className, style, ...props }: IndicatorProps) {
 		/>
 	);
 }
-Indicator.displayName = "Indicator";
-
 /**
  * Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
  *

--- a/packages/mantle/src/components/qr-code/qr-code.tsx
+++ b/packages/mantle/src/components/qr-code/qr-code.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import { createContext, forwardRef, useContext, useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 import invariant from "tiny-invariant";
 import { encode } from "uqr";
 import { cx } from "../../utils/cx/cx.js";
@@ -144,43 +144,45 @@ type QrCodeRootProps = ComponentProps<"div"> &
  * </QrCode.Root>
  * ```
  */
-const Root = forwardRef<HTMLDivElement, QrCodeRootProps>(
-	(
-		{ value, ecc = "L", pixelSize = 10, quietZone = 4, asChild, className, children, ...props },
-		ref,
-	) => {
-		assertValidRootProps(pixelSize, quietZone);
+const Root = ({
+	value,
+	ecc = "L",
+	pixelSize = 10,
+	quietZone = 4,
+	asChild,
+	className,
+	children,
+	ref,
+	...props
+}: QrCodeRootProps) => {
+	assertValidRootProps(pixelSize, quietZone);
 
-		// The quiet zone is the QR spec's required margin (light modules on each
-		// side). It's part of the code itself — the scannable margin — not cosmetic
-		// padding. The spec recommends 4; lowering it tightens the whitespace at
-		// the cost of scannability.
-		const encoded = useMemo(
-			() => encode(value, { ecc, border: quietZone }),
-			[value, ecc, quietZone],
-		);
-		const path = useMemo(() => buildPath(encoded.data, pixelSize), [encoded, pixelSize]);
-		const context = useMemo<QrCodeContextValue>(
-			() => ({ path, dimension: encoded.size * pixelSize }),
-			[path, encoded.size, pixelSize],
-		);
+	// The quiet zone is the QR spec's required margin (light modules on each
+	// side). It's part of the code itself — the scannable margin — not cosmetic
+	// padding. The spec recommends 4; lowering it tightens the whitespace at
+	// the cost of scannability.
+	const encoded = useMemo(() => encode(value, { ecc, border: quietZone }), [value, ecc, quietZone]);
+	const path = useMemo(() => buildPath(encoded.data, pixelSize), [encoded, pixelSize]);
+	const context = useMemo<QrCodeContextValue>(
+		() => ({ path, dimension: encoded.size * pixelSize }),
+		[path, encoded.size, pixelSize],
+	);
 
-		const Comp = asChild ? Slot : "div";
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<QrCodeContext.Provider value={context}>
-				<Comp
-					ref={ref}
-					{...props}
-					data-slot="qr-code"
-					className={cx("relative inline-flex bg-static-white text-static-black", className)}
-				>
-					{children}
-				</Comp>
-			</QrCodeContext.Provider>
-		);
-	},
-);
+	return (
+		<QrCodeContext.Provider value={context}>
+			<Comp
+				ref={ref}
+				{...props}
+				data-slot="qr-code"
+				className={cx("relative inline-flex bg-static-white text-static-black", className)}
+			>
+				{children}
+			</Comp>
+		</QrCodeContext.Provider>
+	);
+};
 Root.displayName = "QrCode";
 
 /**
@@ -211,25 +213,23 @@ type QrCodeFrameProps = ComponentProps<"svg">;
  * </QrCode.Root>
  * ```
  */
-const Frame = forwardRef<SVGSVGElement, QrCodeFrameProps>(
-	({ className, children, ...props }, ref) => {
-		const { dimension } = useQrCodeContext();
+const Frame = ({ className, children, ref, ...props }: QrCodeFrameProps) => {
+	const { dimension } = useQrCodeContext();
 
-		return (
-			<svg
-				ref={ref}
-				{...props}
-				data-slot="qr-code-frame"
-				xmlns="http://www.w3.org/2000/svg"
-				viewBox={`0 0 ${dimension} ${dimension}`}
-				shapeRendering="crispEdges"
-				className={cx("block size-48", className)}
-			>
-				{children}
-			</svg>
-		);
-	},
-);
+	return (
+		<svg
+			ref={ref}
+			{...props}
+			data-slot="qr-code-frame"
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox={`0 0 ${dimension} ${dimension}`}
+			shapeRendering="crispEdges"
+			className={cx("block size-48", className)}
+		>
+			{children}
+		</svg>
+	);
+};
 Frame.displayName = "QrCodeFrame";
 
 /**
@@ -260,7 +260,7 @@ type QrCodePatternProps = ComponentProps<"path">;
  * </QrCode.Root>
  * ```
  */
-const Pattern = forwardRef<SVGPathElement, QrCodePatternProps>(({ className, ...props }, ref) => {
+const Pattern = ({ className, ref, ...props }: QrCodePatternProps) => {
 	const { path } = useQrCodeContext();
 
 	return (
@@ -272,7 +272,7 @@ const Pattern = forwardRef<SVGPathElement, QrCodePatternProps>(({ className, ...
 			className={cx("fill-static-black", className)}
 		/>
 	);
-});
+};
 Pattern.displayName = "QrCodePattern";
 
 /**
@@ -301,23 +301,21 @@ type QrCodeOverlayProps = ComponentProps<"div"> & WithAsChild;
  * </QrCode.Root>
  * ```
  */
-const Overlay = forwardRef<HTMLDivElement, QrCodeOverlayProps>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Overlay = ({ asChild, className, ref, ...props }: QrCodeOverlayProps) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				{...props}
-				data-slot="qr-code-overlay"
-				className={cx(
-					"absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-md bg-static-white text-static-black p-1.5",
-					className,
-				)}
-			/>
-		);
-	},
-);
+	return (
+		<Comp
+			ref={ref}
+			{...props}
+			data-slot="qr-code-overlay"
+			className={cx(
+				"absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-md bg-static-white text-static-black p-1.5",
+				className,
+			)}
+		/>
+	);
+};
 Overlay.displayName = "QrCodeOverlay";
 
 /**

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -5,16 +5,8 @@ import type {
 	RadioGroupProps as HeadlessRadioGroupProps,
 	RadioProps as HeadlessRadioProps,
 } from "@headlessui/react";
-import {
-	Children,
-	cloneElement,
-	createContext,
-	forwardRef,
-	isValidElement,
-	useContext,
-	useRef,
-} from "react";
-import type { ComponentRef, HTMLAttributes, PropsWithChildren, ReactNode } from "react";
+import { Children, cloneElement, createContext, isValidElement, useContext, useRef } from "react";
+import type { HTMLAttributes, PropsWithChildren, ReactNode, Ref } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
@@ -22,7 +14,9 @@ import { FieldControlContext } from "../field/field-context.js";
 import { isInput } from "../input/is-input.js";
 import { Slot } from "../slot/index.js";
 
-type RadioGroupProps = PropsWithChildren<Omit<HeadlessRadioGroupProps, "as" | "children">>;
+type RadioGroupProps = PropsWithChildren<Omit<HeadlessRadioGroupProps, "as" | "children">> & {
+	ref?: Ref<HTMLElement>;
+};
 
 /**
  * A group of radio items. It manages the state of the children radios. Unstyled and simple.
@@ -52,9 +46,9 @@ type RadioGroupProps = PropsWithChildren<Omit<HeadlessRadioGroupProps, "as" | "c
  * </RadioGroup.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<typeof HeadlessRadioGroup>, RadioGroupProps>((props, ref) => (
+const Root = ({ ref, ...props }: RadioGroupProps) => (
 	<HeadlessRadioGroup data-slot="radio-group" {...props} ref={ref} />
-));
+);
 Root.displayName = "RadioGroup";
 
 /**
@@ -81,7 +75,10 @@ const RadioStateContext = createContext<RadioStateContextValue>({
 	hover: false,
 });
 
-type RadioItemProps = Omit<HeadlessRadioProps, "children"> & PropsWithChildren;
+type RadioItemProps = Omit<HeadlessRadioProps, "children"> &
+	PropsWithChildren & {
+		ref?: Ref<HTMLDivElement>;
+	};
 
 /**
  * A simple radio item that can be used inside a radio group. The "conventional" use-case.
@@ -104,32 +101,30 @@ type RadioItemProps = Omit<HeadlessRadioProps, "children"> & PropsWithChildren;
  * </RadioGroup.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<"div">, RadioItemProps>(
-	({ children, className, ...props }, ref) => {
-		const fieldControl = useContext(FieldControlContext);
-		return (
-			<HeadlessRadio
-				data-slot="radio-group-item"
-				className={cx(
-					"group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden",
-					className,
-				)}
-				as="div"
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-							"aria-invalid": fieldControl["aria-invalid"],
-						}
-					: undefined)}
-				ref={ref}
-			>
-				{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
-			</HeadlessRadio>
-		);
-	},
-);
+const Item = ({ children, className, ref, ...props }: RadioItemProps) => {
+	const fieldControl = useContext(FieldControlContext);
+	return (
+		<HeadlessRadio
+			data-slot="radio-group-item"
+			className={cx(
+				"group/radio cursor-pointer aria-disabled:cursor-default [&_label]:cursor-inherit flex gap-2 py-1 text-sm focus:outline-hidden",
+				className,
+			)}
+			as="div"
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+						"aria-invalid": fieldControl["aria-invalid"],
+					}
+				: undefined)}
+			ref={ref}
+		>
+			{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
+		</HeadlessRadio>
+	);
+};
 Item.displayName = "RadioItem";
 
 type RadioIndicatorProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
@@ -199,18 +194,16 @@ Indicator.displayName = "RadioIndicator";
 /**
  * A group of radio list items. Use RadioGroup.ListItem as direct children.
  */
-const List = forwardRef<ComponentRef<typeof Root>, RadioGroupProps>(
-	({ className, ...props }, ref) => {
-		return (
-			<Root
-				data-slot="radio-group-list"
-				className={clsx("-space-y-px", className)}
-				{...props}
-				ref={ref}
-			/>
-		);
-	},
-);
+const List = ({ className, ref, ...props }: RadioGroupProps) => {
+	return (
+		<Root
+			data-slot="radio-group-list"
+			className={clsx("-space-y-px", className)}
+			{...props}
+			ref={ref}
+		/>
+	);
+};
 List.displayName = "RadioGroupList";
 
 type RadioListItemProps = RadioItemProps;
@@ -223,38 +216,36 @@ type RadioListItemProps = RadioItemProps;
  * `aria-errormessage` from `FieldControlContext`. `aria-describedby` is owned
  * by Headless UI's Radio primitive and does not propagate.
  */
-const ListItem = forwardRef<ComponentRef<"div">, RadioListItemProps>(
-	({ children, className, ...props }, ref) => {
-		const fieldControl = useContext(FieldControlContext);
-		return (
-			<HeadlessRadio
-				as="div"
-				data-slot="radio-group-list-item"
-				className={cx(
-					"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm",
-					"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
-					"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
-					"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
-					"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600",
-					"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600",
-					"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2",
-					className,
-				)}
-				ref={ref}
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-							"aria-invalid": fieldControl["aria-invalid"],
-						}
-					: undefined)}
-			>
-				{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
-			</HeadlessRadio>
-		);
-	},
-);
+const ListItem = ({ children, className, ref, ...props }: RadioListItemProps) => {
+	const fieldControl = useContext(FieldControlContext);
+	return (
+		<HeadlessRadio
+			as="div"
+			data-slot="radio-group-list-item"
+			className={cx(
+				"group/radio border-form [&_label]:cursor-inherit relative flex select-none gap-2 border px-3 py-2 text-sm",
+				"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
+				"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
+				"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
+				"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600",
+				"aria-checked:z-1 aria-checked:border-accent-500/40 aria-checked:bg-accent-500/10 dark-high-contrast:aria-checked:border-accent-400 high-contrast:aria-checked:border-accent-400 not-aria-disabled:hover:aria-checked:border-accent-600",
+				"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2",
+				className,
+			)}
+			ref={ref}
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+						"aria-invalid": fieldControl["aria-invalid"],
+					}
+				: undefined)}
+		>
+			{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
+		</HeadlessRadio>
+	);
+};
 ListItem.displayName = "RadioListItem";
 
 type RadioItemContentProps = HTMLAttributes<HTMLDivElement> & WithAsChild;
@@ -269,37 +260,35 @@ type RadioCardProps = RadioItemProps;
  * `aria-errormessage` from `FieldControlContext`. `aria-describedby` is owned
  * by Headless UI's Radio primitive and does not propagate.
  */
-const Card = forwardRef<ComponentRef<"div">, RadioCardProps>(
-	({ children, className, ...props }, ref) => {
-		const fieldControl = useContext(FieldControlContext);
-		return (
-			<HeadlessRadio
-				as="div"
-				data-slot="radio-group-card"
-				className={clsx(
-					"group/radio border-card bg-card [&_label]:cursor-inherit relative rounded-md border p-4 text-sm",
-					"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
-					"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
-					"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
-					"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600",
-					"aria-checked:z-1 aria-checked:border-accent-600/50 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600 dark-high-contrast:aria-checked:border-accent-600 high-contrast:aria-checked:border-accent-600",
-					className,
-				)}
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-							"aria-invalid": fieldControl["aria-invalid"],
-						}
-					: undefined)}
-				ref={ref}
-			>
-				{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
-			</HeadlessRadio>
-		);
-	},
-);
+const Card = ({ children, className, ref, ...props }: RadioCardProps) => {
+	const fieldControl = useContext(FieldControlContext);
+	return (
+		<HeadlessRadio
+			as="div"
+			data-slot="radio-group-card"
+			className={clsx(
+				"group/radio border-card bg-card [&_label]:cursor-inherit relative rounded-md border p-4 text-sm",
+				"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
+				"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
+				"first-of-type:rounded-tl-md first-of-type:rounded-tr-md last-of-type:rounded-bl-md last-of-type:rounded-br-md",
+				"aria-disabled:border-form/50 not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600",
+				"aria-checked:z-1 aria-checked:border-accent-600/50 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600 dark-high-contrast:aria-checked:border-accent-600 high-contrast:aria-checked:border-accent-600",
+				className,
+			)}
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+						"aria-invalid": fieldControl["aria-invalid"],
+					}
+				: undefined)}
+			ref={ref}
+		>
+			{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
+		</HeadlessRadio>
+	);
+};
 Card.displayName = "RadioCard";
 
 /**
@@ -328,18 +317,16 @@ ItemContent.displayName = "RadioItemContent";
  * `RadioGroup.Root`, never nested inside one, or the buttons bind to an
  * inner, uncontrolled group and outer `value`/`onChange` props are ignored.
  */
-const ButtonGroup = forwardRef<ComponentRef<typeof Root>, RadioGroupProps>(
-	({ className, ...props }, ref) => {
-		return (
-			<Root
-				data-slot="radio-group-button-group"
-				className={clsx("flex flex-row flex-nowrap -space-x-px", className)}
-				{...props}
-				ref={ref}
-			/>
-		);
-	},
-);
+const ButtonGroup = ({ className, ref, ...props }: RadioGroupProps) => {
+	return (
+		<Root
+			data-slot="radio-group-button-group"
+			className={clsx("flex flex-row flex-nowrap -space-x-px", className)}
+			{...props}
+			ref={ref}
+		/>
+	);
+};
 ButtonGroup.displayName = "RadioButtonGroup";
 
 type RadioButtonProps = RadioItemProps;
@@ -352,39 +339,37 @@ type RadioButtonProps = RadioItemProps;
  * `aria-errormessage` from `FieldControlContext`. `aria-describedby` is owned
  * by Headless UI's Radio primitive and does not propagate.
  */
-const Button = forwardRef<ComponentRef<"div">, RadioButtonProps>(
-	({ children, className, ...props }, ref) => {
-		const fieldControl = useContext(FieldControlContext);
-		return (
-			<HeadlessRadio
-				as="div"
-				data-slot="radio-group-button"
-				className={cx(
-					"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm",
-					"h-9",
-					"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
-					"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
-					"first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md",
-					"not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50",
-					"aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600",
-					"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2",
-					className,
-				)}
-				ref={ref}
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-							"aria-invalid": fieldControl["aria-invalid"],
-						}
-					: undefined)}
-			>
-				{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
-			</HeadlessRadio>
-		);
-	},
-);
+const Button = ({ children, className, ref, ...props }: RadioButtonProps) => {
+	const fieldControl = useContext(FieldControlContext);
+	return (
+		<HeadlessRadio
+			as="div"
+			data-slot="radio-group-button"
+			className={cx(
+				"group/radio border-form [&_label]:cursor-inherit relative flex flex-1 select-none items-center justify-center gap-2 border px-3 text-sm",
+				"h-9",
+				"focus-visible:ring-focus-accent not-aria-disabled:focus-visible:border-accent-600 focus-visible:ring-4",
+				"cursor-pointer aria-disabled:cursor-default focus:outline-hidden",
+				"first-of-type:rounded-bl-md first-of-type:rounded-tl-md last-of-type:rounded-br-md last-of-type:rounded-tr-md",
+				"not-aria-disabled:hover:z-1 not-aria-disabled:hover:border-accent-600 aria-disabled:opacity-50",
+				"aria-checked:z-1 aria-checked:border-accent-600/40 aria-checked:bg-accent-500/10 not-aria-disabled:hover:aria-checked:border-accent-600",
+				"has-[.radio-indicator:first-child]:pl-2 has-[.radio-indicator:last-child]:pr-2",
+				className,
+			)}
+			ref={ref}
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+						"aria-invalid": fieldControl["aria-invalid"],
+					}
+				: undefined)}
+		>
+			{(ctx) => <RadioStateContext.Provider value={ctx}>{children}</RadioStateContext.Provider>}
+		</HeadlessRadio>
+	);
+};
 Button.displayName = "RadioButton";
 
 type RadioInputSandboxProps = HTMLAttributes<HTMLDivElement>;

--- a/packages/mantle/src/components/sandboxed-on-click/sandboxed-on-click.tsx
+++ b/packages/mantle/src/components/sandboxed-on-click/sandboxed-on-click.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import type { ComponentProps, ComponentRef, HTMLAttributes, MouseEventHandler } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps, HTMLAttributes, MouseEventHandler } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { Slot } from "../slot/index.js";
 
@@ -87,32 +86,23 @@ type Props = ComponentProps<"div"> & WithAsChild & BaseProps;
  * </TableRow>
  * ```
  */
-const SandboxedOnClick = forwardRef<ComponentRef<"div">, Props>(
-	(
-		{
-			//,
-			allowClickEventDefault = false,
-			asChild = false,
-			children,
-			onClick,
-			...props
-		},
-		ref,
-	) => {
-		const Component = asChild ? Slot : "div";
+const SandboxedOnClick = ({
+	//,
+	allowClickEventDefault = false,
+	asChild = false,
+	children,
+	onClick,
+	ref,
+	...props
+}: Props) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				ref={ref}
-				{...props}
-				{...sandboxedOnClickProps({ allowClickEventDefault, onClick })}
-			>
-				{children}
-			</Component>
-		);
-	},
-);
-SandboxedOnClick.displayName = "SandboxedOnClick";
+	return (
+		<Component ref={ref} {...props} {...sandboxedOnClickProps({ allowClickEventDefault, onClick })}>
+			{children}
+		</Component>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -6,15 +6,13 @@ import { CheckIcon } from "@phosphor-icons/react/Check";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import type {
 	ComponentProps,
-	ComponentPropsWithoutRef,
-	ComponentRef,
 	FocusEvent,
 	PropsWithChildren,
 	ReactNode,
 	Ref,
 	SelectHTMLAttributes,
 } from "react";
-import { createContext, forwardRef, useContext, useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import { FieldControlContext } from "../field/field-context.js";
@@ -61,6 +59,10 @@ type SelectProps = PropsWithChildren & {
 	onOpenChange?(open: boolean): void;
 	onValueChange?(value: string): void;
 	open?: boolean;
+	/**
+	 * Ref for the trigger button.
+	 */
+	ref?: Ref<HTMLButtonElement>;
 	required?: boolean;
 	value?: string;
 } & WithValidation &
@@ -110,43 +112,39 @@ type SelectProps = PropsWithChildren & {
  * </Select.Root>
  * ```
  */
-const Root = forwardRef<HTMLButtonElement, SelectProps>(
-	(
-		{
+const Root = ({
+	"aria-invalid": _ariaInvalid,
+	children,
+	id,
+	validation,
+	onBlur,
+	onValueChange,
+	onChange,
+	ref,
+	...props
+}: SelectProps) => {
+	const contextValue = useMemo(
+		() => ({
 			"aria-invalid": _ariaInvalid,
-			children,
 			id,
 			validation,
 			onBlur,
-			onValueChange,
-			onChange,
-			...props
-		},
-		ref,
-	) => {
-		const contextValue = useMemo(
-			() => ({
-				"aria-invalid": _ariaInvalid,
-				id,
-				validation,
-				onBlur,
-				ref,
-			}),
-			[_ariaInvalid, id, validation, onBlur, ref],
-		);
-		return (
-			<SelectPrimitive.Root
-				{...props}
-				onValueChange={(value) => {
-					onChange?.(value);
-					onValueChange?.(value);
-				}}
-			>
-				<SelectContext.Provider value={contextValue}>{children}</SelectContext.Provider>
-			</SelectPrimitive.Root>
-		);
-	},
-);
+			ref,
+		}),
+		[_ariaInvalid, id, validation, onBlur, ref],
+	);
+	return (
+		<SelectPrimitive.Root
+			{...props}
+			onValueChange={(value) => {
+				onChange?.(value);
+				onValueChange?.(value);
+			}}
+		>
+			<SelectContext.Provider value={contextValue}>{children}</SelectContext.Provider>
+		</SelectPrimitive.Root>
+	);
+};
 Root.displayName = "Select";
 
 /**
@@ -178,17 +176,14 @@ Root.displayName = "Select";
  * </Select.Root>
  * ```
  */
-const Group = forwardRef<
-	ComponentRef<typeof SelectPrimitive.Group>,
-	ComponentPropsWithoutRef<typeof SelectPrimitive.Group>
->(({ className, ...props }, ref) => (
+const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimitive.Group>) => (
 	<SelectPrimitive.Group
 		ref={ref}
 		data-slot="select-group"
 		className={cx("space-y-px", className)}
 		{...props}
 	/>
-));
+);
 Group.displayName = "SelectGroup";
 
 /**
@@ -222,7 +217,7 @@ Group.displayName = "SelectGroup";
 const Value = SelectPrimitive.Value;
 Value.displayName = "SelectValue";
 
-type SelectTriggerProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
+type SelectTriggerProps = ComponentProps<typeof SelectPrimitive.Trigger> &
 	WithAriaInvalid &
 	WithValidation;
 
@@ -258,78 +253,75 @@ type SelectTriggerProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Trigge
  * </Select.Root>
  * ```
  */
-const Trigger = forwardRef<ComponentRef<typeof SelectPrimitive.Trigger>, SelectTriggerProps>(
-	(
-		{
-			"aria-invalid": ariaInValidProp,
-			className,
-			children,
-			id: propId,
-			validation: propValidation,
-			...props
-		},
-		ref,
-	) => {
-		const ctx = useContext(SelectContext);
-		const fieldControl = useContext(FieldControlContext);
-		const fieldValidation = useFieldValidation();
-		const rawAriaInvalid = fieldControl
-			? fieldControl["aria-invalid"]
-			: (ctx["aria-invalid"] ?? ariaInValidProp);
-		// Explicit Select props win over ambient Field validation. This lets
-		// Field.Control override Field.Item while preserving Select.Root as the
-		// highest-precedence select-level state.
-		const rawValidation = ctx.validation ?? propValidation ?? fieldValidation;
-		const { ariaInvalid, validation } = parseValidation({
-			"aria-invalid": rawAriaInvalid,
-			validation: rawValidation,
-		});
-		const id = fieldControl ? fieldControl.id : (ctx.id ?? propId);
+const Trigger = ({
+	"aria-invalid": ariaInValidProp,
+	className,
+	children,
+	id: propId,
+	ref,
+	validation: propValidation,
+	...props
+}: SelectTriggerProps) => {
+	const ctx = useContext(SelectContext);
+	const fieldControl = useContext(FieldControlContext);
+	const fieldValidation = useFieldValidation();
+	const rawAriaInvalid = fieldControl
+		? fieldControl["aria-invalid"]
+		: (ctx["aria-invalid"] ?? ariaInValidProp);
+	// Explicit Select props win over ambient Field validation. This lets
+	// Field.Control override Field.Item while preserving Select.Root as the
+	// highest-precedence select-level state.
+	const rawValidation = ctx.validation ?? propValidation ?? fieldValidation;
+	const { ariaInvalid, validation } = parseValidation({
+		"aria-invalid": rawAriaInvalid,
+		validation: rawValidation,
+	});
+	const id = fieldControl ? fieldControl.id : (ctx.id ?? propId);
 
-		return (
-			<SelectPrimitive.Trigger
-				data-slot="select-trigger"
-				className={cx(
-					"h-9 text-sm",
-					"border-form bg-form text-strong font-sans placeholder:text-placeholder hover:bg-form-hover hover:text-strong flex w-full items-center justify-between gap-1.5 rounded-md border px-3 py-2 disabled:pointer-events-none disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left",
-					"hover:border-neutral-400",
-					"focus:outline-hidden focus:ring-4 aria-expanded:ring-4",
-					"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent",
-					"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success",
-					"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning",
-					"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger",
-					className,
-				)}
-				data-validation={validation || undefined}
-				id={id}
-				ref={composeRefs(ref, ctx.ref)}
-				{...props}
-				{...(fieldControl
-					? {
-							"aria-describedby": fieldControl["aria-describedby"],
-							"aria-errormessage": fieldControl["aria-errormessage"],
-						}
-					: undefined)}
-				aria-invalid={ariaInvalid}
-			>
-				{children}
-				<SelectPrimitive.Icon asChild>
-					<Icon svg={<CaretDownIcon weight="bold" />} className="size-4" />
-				</SelectPrimitive.Icon>
-			</SelectPrimitive.Trigger>
-		);
-	},
-);
+	return (
+		<SelectPrimitive.Trigger
+			data-slot="select-trigger"
+			className={cx(
+				"h-9 text-sm",
+				"border-form bg-form text-strong font-sans placeholder:text-placeholder hover:bg-form-hover hover:text-strong flex w-full items-center justify-between gap-1.5 rounded-md border px-3 py-2 disabled:pointer-events-none disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left",
+				"hover:border-neutral-400",
+				"focus:outline-hidden focus:ring-4 aria-expanded:ring-4",
+				"focus:border-accent-600 focus:ring-focus-accent aria-expanded:border-accent-600 aria-expanded:ring-focus-accent",
+				"data-validation-success:border-success-600 data-validation-success:focus:border-success-600 data-validation-success:focus:ring-focus-success data-validation-success:aria-expanded:border-success-600 data-validation-success:aria-expanded:ring-focus-success",
+				"data-validation-warning:border-warning-600 data-validation-warning:focus:border-warning-600 data-validation-warning:focus:ring-focus-warning data-validation-warning:aria-expanded:border-warning-600 data-validation-warning:aria-expanded:ring-focus-warning",
+				"data-validation-error:border-danger-600 data-validation-error:focus:border-danger-600 data-validation-error:focus:ring-focus-danger data-validation-error:aria-expanded:border-danger-600 data-validation-error:aria-expanded:ring-focus-danger",
+				className,
+			)}
+			data-validation={validation || undefined}
+			id={id}
+			ref={composeRefs(ref, ctx.ref)}
+			{...props}
+			{...(fieldControl
+				? {
+						"aria-describedby": fieldControl["aria-describedby"],
+						"aria-errormessage": fieldControl["aria-errormessage"],
+					}
+				: undefined)}
+			aria-invalid={ariaInvalid}
+		>
+			{children}
+			<SelectPrimitive.Icon asChild>
+				<Icon svg={<CaretDownIcon weight="bold" />} className="size-4" />
+			</SelectPrimitive.Icon>
+		</SelectPrimitive.Trigger>
+	);
+};
 Trigger.displayName = "SelectTrigger";
 
 /**
  * The button that scrolls the select content up.
  * @private
  */
-const SelectScrollUpButton = forwardRef<
-	ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
-	ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
+const SelectScrollUpButton = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof SelectPrimitive.ScrollUpButton>) => (
 	<SelectPrimitive.ScrollUpButton
 		ref={ref}
 		className={cx("flex cursor-default items-center justify-center py-1", className)}
@@ -337,17 +329,17 @@ const SelectScrollUpButton = forwardRef<
 	>
 		<Icon svg={<CaretUpIcon weight="bold" />} className="size-4" />
 	</SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = "SelectScrollUpButton";
+);
 
 /**
  * The button that scrolls the select content down.
  * @private
  */
-const SelectScrollDownButton = forwardRef<
-	ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
-	ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
+const SelectScrollDownButton = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof SelectPrimitive.ScrollDownButton>) => (
 	<SelectPrimitive.ScrollDownButton
 		ref={ref}
 		className={cx("flex cursor-default items-center justify-center py-1", className)}
@@ -355,10 +347,9 @@ const SelectScrollDownButton = forwardRef<
 	>
 		<Icon svg={<CaretDownIcon weight="bold" />} className="size-4" />
 	</SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName = "SelectScrollDownButton";
+);
 
-type SelectContentProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+type SelectContentProps = ComponentProps<typeof SelectPrimitive.Content> & {
 	/**
 	 * The width of the content. Defaults to the width of the trigger.
 	 * If set to "content", the content will use the intrinsic content width; it will be the width of the longest/widest item.
@@ -400,36 +391,41 @@ type SelectContentProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Conten
  * </Select.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<typeof SelectPrimitive.Content>, SelectContentProps>(
-	({ className, children, position = "popper", width = "trigger", ...props }, ref) => (
-		<SelectPrimitive.Portal>
-			<SelectPrimitive.Content
-				ref={ref}
-				data-slot="select-content"
+const Content = ({
+	className,
+	children,
+	position = "popper",
+	ref,
+	width = "trigger",
+	...props
+}: SelectContentProps) => (
+	<SelectPrimitive.Portal>
+		<SelectPrimitive.Content
+			ref={ref}
+			data-slot="select-content"
+			className={cx(
+				"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
+				"bg-popover font-sans",
+				position === "popper" &&
+					"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)",
+				width === "trigger" && "w-(--radix-select-trigger-width)",
+				className,
+			)}
+			position={position}
+			{...props}
+		>
+			<SelectScrollUpButton />
+			<SelectPrimitive.Viewport
 				className={cx(
-					"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
-					"bg-popover font-sans",
-					position === "popper" &&
-						"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)",
-					width === "trigger" && "w-(--radix-select-trigger-width)",
-					className,
+					"p-1 space-y-px",
+					position === "popper" && "h-(--radix-select-trigger-height) w-full",
 				)}
-				position={position}
-				{...props}
 			>
-				<SelectScrollUpButton />
-				<SelectPrimitive.Viewport
-					className={cx(
-						"p-1 space-y-px",
-						position === "popper" && "h-(--radix-select-trigger-height) w-full",
-					)}
-				>
-					{children}
-				</SelectPrimitive.Viewport>
-				<SelectScrollDownButton />
-			</SelectPrimitive.Content>
-		</SelectPrimitive.Portal>
-	),
+				{children}
+			</SelectPrimitive.Viewport>
+			<SelectScrollDownButton />
+		</SelectPrimitive.Content>
+	</SelectPrimitive.Portal>
 );
 Content.displayName = "SelectContent";
 
@@ -461,20 +457,17 @@ Content.displayName = "SelectContent";
  * </Select.Root>
  * ```
  */
-const Label = forwardRef<
-	ComponentRef<typeof SelectPrimitive.Label>,
-	ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
+const Label = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimitive.Label>) => (
 	<SelectPrimitive.Label
 		ref={ref}
 		data-slot="select-label"
 		className={cx("px-2 py-1.5 text-sm font-medium", className)}
 		{...props}
 	/>
-));
+);
 Label.displayName = "SelectLabel";
 
-type SelectItemProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> & {
 	icon?: ReactNode;
 };
 
@@ -508,28 +501,26 @@ type SelectItemProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
  * </Select.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<typeof SelectPrimitive.Item>, SelectItemProps>(
-	({ className, children, icon, ...props }, ref) => (
-		<SelectPrimitive.Item
-			ref={ref}
-			data-slot="select-item"
-			className={cx(
-				"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden",
-				"focus:bg-active-menu-item",
-				"data-disabled:pointer-events-none data-disabled:opacity-50",
-				"data-state-checked:bg-selected-menu-item",
-				"focus:data-state-checked:bg-active-selected-menu-item",
-				className,
-			)}
-			{...props}
-		>
-			{icon && <Icon svg={icon} />}
-			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-			<SelectPrimitive.ItemIndicator className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-				<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
-			</SelectPrimitive.ItemIndicator>
-		</SelectPrimitive.Item>
-	),
+const Item = ({ className, children, icon, ref, ...props }: SelectItemProps) => (
+	<SelectPrimitive.Item
+		ref={ref}
+		data-slot="select-item"
+		className={cx(
+			"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden",
+			"focus:bg-active-menu-item",
+			"data-disabled:pointer-events-none data-disabled:opacity-50",
+			"data-state-checked:bg-selected-menu-item",
+			"focus:data-state-checked:bg-active-selected-menu-item",
+			className,
+		)}
+		{...props}
+	>
+		{icon && <Icon svg={icon} />}
+		<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		<SelectPrimitive.ItemIndicator className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+			<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
+		</SelectPrimitive.ItemIndicator>
+	</SelectPrimitive.Item>
 );
 Item.displayName = "SelectItem";
 
@@ -561,17 +552,18 @@ Item.displayName = "SelectItem";
  * </Select.Root>
  * ```
  */
-const SelectSeparatorComponent = forwardRef<
-	ComponentRef<typeof Separator>,
-	ComponentPropsWithoutRef<typeof Separator>
->(({ className, ...props }, ref) => (
+const SelectSeparatorComponent = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof Separator>) => (
 	<Separator
 		ref={ref}
 		data-slot="select-separator"
 		className={cx("-mx-1 my-1 h-px w-auto", className)}
 		{...props}
 	/>
-));
+);
 SelectSeparatorComponent.displayName = "SelectSeparator";
 
 /**

--- a/packages/mantle/src/components/selectable-list/selectable-list.tsx
+++ b/packages/mantle/src/components/selectable-list/selectable-list.tsx
@@ -4,7 +4,6 @@ import { MagnifyingGlassIcon } from "@phosphor-icons/react/MagnifyingGlass";
 import {
 	cloneElement,
 	createContext,
-	forwardRef,
 	isValidElement,
 	useCallback,
 	useContext,
@@ -12,13 +11,7 @@ import {
 	useMemo,
 	useState,
 } from "react";
-import type {
-	ComponentProps,
-	ComponentPropsWithoutRef,
-	ComponentRef,
-	ReactElement,
-	ReactNode,
-} from "react";
+import type { ComponentProps, ReactElement, ReactNode } from "react";
 import invariant from "tiny-invariant";
 import { cx } from "../../utils/cx/cx.js";
 import { Checkbox, selectAllChecked } from "../checkbox/checkbox.js";
@@ -293,105 +286,101 @@ const EMPTY_SELECTION: readonly string[] = [];
  * </SelectableList.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, SelectableListRootProps>(
-	(
-		{
-			className,
-			defaultQuery,
-			defaultValue,
-			filter,
-			onQueryChange,
-			onValueChange,
-			options,
-			query: queryProp,
-			value,
-			...props
+const Root = ({
+	className,
+	defaultQuery,
+	defaultValue,
+	filter,
+	onQueryChange,
+	onValueChange,
+	options,
+	query: queryProp,
+	ref,
+	value,
+	...props
+}: SelectableListRootProps) => {
+	const listId = useId();
+	const isControlled = value != null;
+	const [internalValue, setInternalValue] = useState<readonly string[]>(
+		defaultValue ?? EMPTY_SELECTION,
+	);
+	const selectedValues = isControlled ? value : internalValue;
+	const isQueryControlled = queryProp != null;
+	const [internalQuery, setInternalQuery] = useState(defaultQuery ?? "");
+	const query = isQueryControlled ? queryProp : internalQuery;
+
+	const commitSelection = useCallback(
+		(next: string[]) => {
+			if (!isControlled) {
+				setInternalValue(next);
+			}
+			onValueChange?.(next);
 		},
-		ref,
-	) => {
-		const listId = useId();
-		const isControlled = value != null;
-		const [internalValue, setInternalValue] = useState<readonly string[]>(
-			defaultValue ?? EMPTY_SELECTION,
-		);
-		const selectedValues = isControlled ? value : internalValue;
-		const isQueryControlled = queryProp != null;
-		const [internalQuery, setInternalQuery] = useState(defaultQuery ?? "");
-		const query = isQueryControlled ? queryProp : internalQuery;
+		[isControlled, onValueChange],
+	);
+	const setQuery = useCallback(
+		(next: string) => {
+			if (!isQueryControlled) {
+				setInternalQuery(next);
+			}
+			onQueryChange?.(next);
+		},
+		[isQueryControlled, onQueryChange],
+	);
 
-		const commitSelection = useCallback(
-			(next: string[]) => {
-				if (!isControlled) {
-					setInternalValue(next);
+	const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
+	const disabledSet = useMemo(
+		() => new Set(options.filter((option) => option.disabled).map((option) => option.value)),
+		[options],
+	);
+	const filteredOptions = useMemo(
+		() =>
+			filter != null
+				? options.filter((option) => filter(option, query))
+				: filterSelectableOptions(options, query),
+		[options, query, filter],
+	);
+
+	const context = useMemo<SelectableListContextValue>(
+		() => ({
+			listId,
+			filteredOptions,
+			query,
+			setQuery,
+			selectedValues,
+			selectedSet,
+			disabledSet,
+			toggle: (toggledValue) => {
+				if (disabledSet.has(toggledValue)) {
+					return;
 				}
-				onValueChange?.(next);
+				commitSelection(toggleSelectionValue(selectedValues, toggledValue));
 			},
-			[isControlled, onValueChange],
-		);
-		const setQuery = useCallback(
-			(next: string) => {
-				if (!isQueryControlled) {
-					setInternalQuery(next);
-				}
-				onQueryChange?.(next);
-			},
-			[isQueryControlled, onQueryChange],
-		);
+			setSelection: commitSelection,
+		}),
+		[
+			listId,
+			filteredOptions,
+			query,
+			setQuery,
+			selectedValues,
+			selectedSet,
+			disabledSet,
+			commitSelection,
+		],
+	);
 
-		const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
-		const disabledSet = useMemo(
-			() => new Set(options.filter((option) => option.disabled).map((option) => option.value)),
-			[options],
-		);
-		const filteredOptions = useMemo(
-			() =>
-				filter != null
-					? options.filter((option) => filter(option, query))
-					: filterSelectableOptions(options, query),
-			[options, query, filter],
-		);
-
-		const context = useMemo<SelectableListContextValue>(
-			() => ({
-				listId,
-				filteredOptions,
-				query,
-				setQuery,
-				selectedValues,
-				selectedSet,
-				disabledSet,
-				toggle: (toggledValue) => {
-					if (disabledSet.has(toggledValue)) {
-						return;
-					}
-					commitSelection(toggleSelectionValue(selectedValues, toggledValue));
-				},
-				setSelection: commitSelection,
-			}),
-			[
-				listId,
-				filteredOptions,
-				query,
-				setQuery,
-				selectedValues,
-				selectedSet,
-				disabledSet,
-				commitSelection,
-			],
-		);
-
-		return (
-			<SelectableListContext.Provider value={context}>
-				<div
-					ref={ref}
-					data-slot="selectable-list"
-					className={cx("flex w-full flex-col gap-3", className)}
-					{...props}
-				/>
-			</SelectableListContext.Provider>
-		);
-	},
-);
+	return (
+		<SelectableListContext.Provider value={context}>
+			<div
+				ref={ref}
+				data-slot="selectable-list"
+				className={cx("flex w-full flex-col gap-3", className)}
+				{...props}
+			/>
+		</SelectableListContext.Provider>
+	);
+};
 Root.displayName = "SelectableListRoot";
 
 /**
@@ -412,15 +401,16 @@ Root.displayName = "SelectableListRoot";
  * </SelectableList.Root>
  * ```
  */
-const Filter = forwardRef<
-	ComponentRef<typeof Input>,
-	Omit<
-		ComponentPropsWithoutRef<typeof Input>,
-		// The input is always controlled by the list's `query`, so `defaultValue`
-		// would typecheck yet be silently ignored — omit it too.
-		"value" | "defaultValue" | "onChange" | "type" | "children"
-	>
->(({ "aria-label": ariaLabel = "Filter", ...props }, ref) => {
+const Filter = ({
+	"aria-label": ariaLabel = "Filter",
+	ref,
+	...props
+}: Omit<
+	ComponentProps<typeof Input>,
+	// The input is always controlled by the list's `query`, so `defaultValue`
+	// would typecheck yet be silently ignored — omit it too.
+	"value" | "defaultValue" | "onChange" | "type" | "children"
+>) => {
 	const { query, setQuery } = useSelectableListContext("Filter");
 
 	return (
@@ -437,7 +427,7 @@ const Filter = forwardRef<
 			<InputCapture />
 		</Input>
 	);
-});
+};
 Filter.displayName = "SelectableListFilter";
 
 /**
@@ -458,53 +448,56 @@ Filter.displayName = "SelectableListFilter";
  * </SelectableList.Root>
  * ```
  */
-const SelectAll = forwardRef<ComponentRef<"label">, Omit<ComponentProps<"label">, "htmlFor">>(
-	({ children, className, ...props }, ref) => {
-		const { filteredOptions, selectedValues, selectedSet, setSelection } =
-			useSelectableListContext("SelectAll");
-		const controlId = useId();
+const SelectAll = ({
+	children,
+	className,
+	ref,
+	...props
+}: Omit<ComponentProps<"label">, "htmlFor">) => {
+	const { filteredOptions, selectedValues, selectedSet, setSelection } =
+		useSelectableListContext("SelectAll");
+	const controlId = useId();
 
-		const { allSelected, someSelected } = summarizeSelection(filteredOptions, selectedSet);
-		const checked = selectAllChecked({ allSelected, someSelected });
-		const hasSelectable = filteredOptions.some((option) => !option.disabled);
+	const { allSelected, someSelected } = summarizeSelection(filteredOptions, selectedSet);
+	const checked = selectAllChecked({ allSelected, someSelected });
+	const hasSelectable = filteredOptions.some((option) => !option.disabled);
 
-		const handleChange = () => {
-			// Materialize the selectable values only on toggle, not on every render.
-			const selectableFilteredValues = filteredOptions
-				.filter((option) => !option.disabled)
-				.map((option) => option.value);
-			if (allSelected) {
-				// Clear only the filtered values, preserving any selection outside the filter.
-				const filteredSet = new Set(selectableFilteredValues);
-				setSelection(selectedValues.filter((value) => !filteredSet.has(value)));
-				return;
-			}
-			// Union the current selection with every filtered value.
-			setSelection([...new Set([...selectedValues, ...selectableFilteredValues])]);
-		};
+	const handleChange = () => {
+		// Materialize the selectable values only on toggle, not on every render.
+		const selectableFilteredValues = filteredOptions
+			.filter((option) => !option.disabled)
+			.map((option) => option.value);
+		if (allSelected) {
+			// Clear only the filtered values, preserving any selection outside the filter.
+			const filteredSet = new Set(selectableFilteredValues);
+			setSelection(selectedValues.filter((value) => !filteredSet.has(value)));
+			return;
+		}
+		// Union the current selection with every filtered value.
+		setSelection([...new Set([...selectedValues, ...selectableFilteredValues])]);
+	};
 
-		return (
-			<label
-				ref={ref}
-				htmlFor={controlId}
-				data-slot="selectable-list-select-all"
-				className={cx(
-					"text-strong flex cursor-pointer items-center gap-2 text-sm font-medium font-sans",
-					className,
-				)}
-				{...props}
-			>
-				<Checkbox
-					id={controlId}
-					checked={checked}
-					onChange={handleChange}
-					disabled={!hasSelectable}
-				/>
-				{children}
-			</label>
-		);
-	},
-);
+	return (
+		<label
+			ref={ref}
+			htmlFor={controlId}
+			data-slot="selectable-list-select-all"
+			className={cx(
+				"text-strong flex cursor-pointer items-center gap-2 text-sm font-medium font-sans",
+				className,
+			)}
+			{...props}
+		>
+			<Checkbox
+				id={controlId}
+				checked={checked}
+				onChange={handleChange}
+				disabled={!hasSelectable}
+			/>
+			{children}
+		</label>
+	);
+};
 SelectAll.displayName = "SelectableListSelectAll";
 
 /**
@@ -579,45 +572,43 @@ type SelectableListItemProps = Omit<ComponentProps<"div">, "children" | "id"> & 
  * </SelectableList.Root>
  * ```
  */
-const Item = forwardRef<ComponentRef<"div">, SelectableListItemProps>(
-	({ children, className, value, ...props }, ref) => {
-		const { listId, selectedSet, disabledSet, toggle } = useSelectableListContext("Item");
-		const controlId = controlIdFor(listId, value);
-		const selected = selectedSet.has(value);
-		const disabled = disabledSet.has(value);
+const Item = ({ children, className, ref, value, ...props }: SelectableListItemProps) => {
+	const { listId, selectedSet, disabledSet, toggle } = useSelectableListContext("Item");
+	const controlId = controlIdFor(listId, value);
+	const selected = selectedSet.has(value);
+	const disabled = disabledSet.has(value);
 
-		// Click-to-toggle lives on the enclosing grid (the list primitive's
-		// click-to-activate → the viewport's `onActivate` → `toggle`), which already
-		// defers to the checkbox/label/nested controls and skips disabled rows. A
-		// consumer `onClick` spread onto the row composes naturally: it runs first
-		// in the bubble and can `preventDefault` to opt out of the toggle.
-		return (
-			<ListItem
-				ref={ref}
-				asChild
-				selected={selected}
-				disabled={disabled}
-				className={cx(
-					"px-2 py-1.5 text-sm",
-					"cursor-pointer aria-disabled:cursor-default",
-					className,
-				)}
-				{...props}
-				data-slot="selectable-list-item"
-				data-value={value}
-			>
-				<Choice.Root id={controlId} disabled={disabled}>
-					<Choice.Indicator role="gridcell">
-						{/* tabIndex -1: the grid collection is the single tab stop; Space/Enter there
-						    activates the active row. The checkbox stays click-toggleable. */}
-						<Checkbox checked={selected} onChange={() => toggle(value)} tabIndex={-1} />
-					</Choice.Indicator>
-					<Choice.Content role="gridcell">{children}</Choice.Content>
-				</Choice.Root>
-			</ListItem>
-		);
-	},
-);
+	// Click-to-toggle lives on the enclosing grid (the list primitive's
+	// click-to-activate → the viewport's `onActivate` → `toggle`), which already
+	// defers to the checkbox/label/nested controls and skips disabled rows. A
+	// consumer `onClick` spread onto the row composes naturally: it runs first
+	// in the bubble and can `preventDefault` to opt out of the toggle.
+	return (
+		<ListItem
+			ref={ref}
+			asChild
+			selected={selected}
+			disabled={disabled}
+			className={cx(
+				"px-2 py-1.5 text-sm",
+				"cursor-pointer aria-disabled:cursor-default",
+				className,
+			)}
+			{...props}
+			data-slot="selectable-list-item"
+			data-value={value}
+		>
+			<Choice.Root id={controlId} disabled={disabled}>
+				<Choice.Indicator role="gridcell">
+					{/* tabIndex -1: the grid collection is the single tab stop; Space/Enter there
+					    activates the active row. The checkbox stays click-toggleable. */}
+					<Checkbox checked={selected} onChange={() => toggle(value)} tabIndex={-1} />
+				</Choice.Indicator>
+				<Choice.Content role="gridcell">{children}</Choice.Content>
+			</Choice.Root>
+		</ListItem>
+	);
+};
 Item.displayName = "SelectableListItem";
 
 /**
@@ -644,10 +635,9 @@ Item.displayName = "SelectableListItem";
  * </SelectableList.Root>
  * ```
  */
-const ItemTitle = forwardRef<
-	ComponentRef<typeof Choice.Label>,
-	ComponentProps<typeof Choice.Label>
->((props, ref) => <Choice.Label ref={ref} data-slot="selectable-list-item-title" {...props} />);
+const ItemTitle = (props: ComponentProps<typeof Choice.Label>) => (
+	<Choice.Label data-slot="selectable-list-item-title" {...props} />
+);
 ItemTitle.displayName = "SelectableListItemTitle";
 
 /**
@@ -674,12 +664,9 @@ ItemTitle.displayName = "SelectableListItemTitle";
  * </SelectableList.Root>
  * ```
  */
-const ItemDescription = forwardRef<
-	ComponentRef<typeof Choice.Description>,
-	ComponentProps<typeof Choice.Description>
->((props, ref) => (
-	<Choice.Description ref={ref} data-slot="selectable-list-item-description" {...props} />
-));
+const ItemDescription = (props: ComponentProps<typeof Choice.Description>) => (
+	<Choice.Description data-slot="selectable-list-item-description" {...props} />
+);
 ItemDescription.displayName = "SelectableListItemDescription";
 
 /**
@@ -824,33 +811,31 @@ type SelectableListViewportProps = Omit<ComponentProps<"div">, "children"> & {
  * </SelectableList.Root>
  * ```
  */
-const Viewport = forwardRef<ComponentRef<"div">, SelectableListViewportProps>(
-	({ children, ...props }, ref) => {
-		const { isEmpty, isItemDisabled, onActivate, itemId, items } = useViewportItems(
-			"Viewport",
-			children,
-		);
+const Viewport = ({ children, ref, ...props }: SelectableListViewportProps) => {
+	const { isEmpty, isItemDisabled, onActivate, itemId, items } = useViewportItems(
+		"Viewport",
+		children,
+	);
 
-		if (isEmpty) {
-			return null;
-		}
+	if (isEmpty) {
+		return null;
+	}
 
-		return (
-			<ListRoot
-				ref={ref}
-				data-slot="selectable-list-viewport"
-				semantics="grid"
-				{...props}
-				aria-multiselectable
-				isItemDisabled={isItemDisabled}
-				onActivate={onActivate}
-				itemId={itemId}
-			>
-				{items}
-			</ListRoot>
-		);
-	},
-);
+	return (
+		<ListRoot
+			ref={ref}
+			data-slot="selectable-list-viewport"
+			semantics="grid"
+			{...props}
+			aria-multiselectable
+			isItemDisabled={isItemDisabled}
+			onActivate={onActivate}
+			itemId={itemId}
+		>
+			{items}
+		</ListRoot>
+	);
+};
 Viewport.displayName = "SelectableListViewport";
 
 /**
@@ -890,33 +875,31 @@ type SelectableListVirtualViewportProps = SelectableListViewportProps & {
  * </SelectableList.Root>
  * ```
  */
-const VirtualViewport = forwardRef<ComponentRef<"div">, SelectableListVirtualViewportProps>(
-	({ children, ...props }, ref) => {
-		const { isEmpty, isItemDisabled, onActivate, itemId, items } = useViewportItems(
-			"VirtualViewport",
-			children,
-		);
+const VirtualViewport = ({ children, ref, ...props }: SelectableListVirtualViewportProps) => {
+	const { isEmpty, isItemDisabled, onActivate, itemId, items } = useViewportItems(
+		"VirtualViewport",
+		children,
+	);
 
-		if (isEmpty) {
-			return null;
-		}
+	if (isEmpty) {
+		return null;
+	}
 
-		return (
-			<ListVirtualRoot
-				ref={ref}
-				data-slot="selectable-list-viewport"
-				semantics="grid"
-				{...props}
-				aria-multiselectable
-				isItemDisabled={isItemDisabled}
-				onActivate={onActivate}
-				itemId={itemId}
-			>
-				{items}
-			</ListVirtualRoot>
-		);
-	},
-);
+	return (
+		<ListVirtualRoot
+			ref={ref}
+			data-slot="selectable-list-viewport"
+			semantics="grid"
+			{...props}
+			aria-multiselectable
+			isItemDisabled={isItemDisabled}
+			onActivate={onActivate}
+			itemId={itemId}
+		>
+			{items}
+		</ListVirtualRoot>
+	);
+};
 VirtualViewport.displayName = "SelectableListVirtualViewport";
 
 /**
@@ -938,32 +921,30 @@ VirtualViewport.displayName = "SelectableListVirtualViewport";
  * </SelectableList.Root>
  * ```
  */
-const Empty = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
-	({ children, className, ...props }, ref) => {
-		const { filteredOptions } = useSelectableListContext("Empty");
-		const isEmpty = filteredOptions.length === 0;
+const Empty = ({ children, className, ref, ...props }: ComponentProps<"div">) => {
+	const { filteredOptions } = useSelectableListContext("Empty");
+	const isEmpty = filteredOptions.length === 0;
 
-		return (
-			// Always mounted: a live region only announces reliably when it exists in
-			// the tree *before* its content changes. While options match, it renders
-			// empty and `sr-only` (absolutely positioned, so it adds no layout gap).
-			<div
-				ref={ref}
-				data-slot="selectable-list-empty"
-				role="status"
-				className={cx(
-					!isEmpty && "sr-only",
-					isEmpty &&
-						"text-muted border-popover bg-popover flex items-center justify-center rounded-md border px-3 py-8 text-center text-sm",
-					className,
-				)}
-				{...props}
-			>
-				{isEmpty ? children : null}
-			</div>
-		);
-	},
-);
+	return (
+		// Always mounted: a live region only announces reliably when it exists in
+		// the tree *before* its content changes. While options match, it renders
+		// empty and `sr-only` (absolutely positioned, so it adds no layout gap).
+		<div
+			ref={ref}
+			data-slot="selectable-list-empty"
+			role="status"
+			className={cx(
+				!isEmpty && "sr-only",
+				isEmpty &&
+					"text-muted border-popover bg-popover flex items-center justify-center rounded-md border px-3 py-8 text-center text-sm",
+				className,
+			)}
+			{...props}
+		>
+			{isEmpty ? children : null}
+		</div>
+	);
+};
 Empty.displayName = "SelectableListEmpty";
 
 /**

--- a/packages/mantle/src/components/separator/separator.tsx
+++ b/packages/mantle/src/components/separator/separator.tsx
@@ -1,5 +1,5 @@
-import type { ComponentProps, ComponentRef, HTMLAttributes } from "react";
-import { createContext, forwardRef, useContext } from "react";
+import type { ComponentProps, HTMLAttributes } from "react";
+import { createContext, useContext } from "react";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -67,7 +67,6 @@ const HorizontalSeparatorGroup = ({
 		</SeparatorGroupContext.Provider>
 	);
 };
-HorizontalSeparatorGroup.displayName = "HorizontalSeparatorGroup";
 
 type SeparatorProps = ComponentProps<"div"> &
 	WithAsChild & {
@@ -112,51 +111,46 @@ type SeparatorProps = ComponentProps<"div"> &
  * </div>
  * ```
  */
-const Separator = forwardRef<ComponentRef<"div">, SeparatorProps>(
-	(
-		{
-			asChild = false,
-			children,
-			className,
-			orientation: propOrientation,
-			semantic = false,
-			...props
-		},
-		ref,
-	) => {
-		const Component = asChild ? Slot : "div";
-		const ctx = useContext(SeparatorGroupContext);
-		// Prefer the orientation from the context if it's set, else fallback to the prop and then to "horizontal".
-		const orientation =
-			ctx.orientation ?? (isOrientation(propOrientation) ? propOrientation : "horizontal");
-		// `aria-orientation` defaults to `horizontal` so we only need it if `orientation` is vertical
-		const ariaOrientation = orientation === "vertical" ? orientation : undefined;
-		const semanticProps = semantic
-			? { "aria-orientation": ariaOrientation, role: "separator" }
-			: { role: "none" };
+const Separator = ({
+	asChild = false,
+	children,
+	className,
+	orientation: propOrientation,
+	ref,
+	semantic = false,
+	...props
+}: SeparatorProps) => {
+	const Component = asChild ? Slot : "div";
+	const ctx = useContext(SeparatorGroupContext);
+	// Prefer the orientation from the context if it's set, else fallback to the prop and then to "horizontal".
+	const orientation =
+		ctx.orientation ?? (isOrientation(propOrientation) ? propOrientation : "horizontal");
+	// `aria-orientation` defaults to `horizontal` so we only need it if `orientation` is vertical
+	const ariaOrientation = orientation === "vertical" ? orientation : undefined;
+	const semanticProps = semantic
+		? { "aria-orientation": ariaOrientation, role: "separator" }
+		: { role: "none" };
 
-		return (
-			<Component
-				data-slot="separator"
-				className={cx(
-					"separator",
-					"bg-separator",
-					orientation === "horizontal"
-						? "h-px w-full group-data-horizontal-separator-group:flex-1"
-						: "h-full w-px",
-					className,
-				)}
-				data-orientation={orientation}
-				data-separator
-				{...semanticProps}
-				ref={ref}
-				{...(asChild ? { children } : {})} // only pass children if asChild is true
-				{...props}
-			/>
-		);
-	},
-);
-Separator.displayName = "Separator";
+	return (
+		<Component
+			data-slot="separator"
+			className={cx(
+				"separator",
+				"bg-separator",
+				orientation === "horizontal"
+					? "h-px w-full group-data-horizontal-separator-group:flex-1"
+					: "h-full w-px",
+				className,
+			)}
+			data-orientation={orientation}
+			data-separator
+			{...semanticProps}
+			ref={ref}
+			{...(asChild ? { children } : {})} // only pass children if asChild is true
+			{...props}
+		/>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/sheet/sheet.tsx
+++ b/packages/mantle/src/components/sheet/sheet.tsx
@@ -1,7 +1,6 @@
 import { XIcon } from "@phosphor-icons/react/X";
 import { type VariantProps, cva } from "class-variance-authority";
-import type { ComponentPropsWithoutRef, ComponentRef, HTMLAttributes } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps, HTMLAttributes } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import {
 	IconButton,
@@ -214,10 +213,11 @@ SheetPortal.displayName = "SheetPortal";
  *
  * @private
  */
-const SheetOverlay = forwardRef<
-	ComponentRef<typeof SheetPrimitive.Overlay>,
-	ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const SheetOverlay = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof SheetPrimitive.Overlay>) => (
 	<SheetPrimitive.Overlay
 		data-slot="sheet-overlay"
 		className={cx(
@@ -227,7 +227,7 @@ const SheetOverlay = forwardRef<
 		{...props}
 		ref={ref}
 	/>
-));
+);
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const SheetVariants = cva(
@@ -249,7 +249,7 @@ const SheetVariants = cva(
 	},
 );
 
-type SheetContentProps = ComponentPropsWithoutRef<typeof SheetPrimitive.Content> &
+type SheetContentProps = ComponentProps<typeof SheetPrimitive.Content> &
 	VariantProps<typeof SheetVariants> & {
 		/**
 		 * The preferred width of the `Sheet.Content` as a tailwind `max-w-` class.
@@ -318,21 +318,26 @@ type SheetContentProps = ComponentPropsWithoutRef<typeof SheetPrimitive.Content>
  * </Sheet.Root>
  * ```
  */
-const Content = forwardRef<ComponentRef<"div">, SheetContentProps>(
-	({ children, className, preferredWidth = "sm:max-w-[30rem]", side = "right", ...props }, ref) => (
-		<SheetPortal>
-			<SheetOverlay />
-			<SheetPrimitive.Content
-				data-slot="sheet-content"
-				data-mantle-modal-content
-				className={cx(SheetVariants({ side }), preferredWidth, className)}
-				ref={ref}
-				{...props}
-			>
-				{children}
-			</SheetPrimitive.Content>
-		</SheetPortal>
-	),
+const Content = ({
+	children,
+	className,
+	preferredWidth = "sm:max-w-[30rem]",
+	side = "right",
+	ref,
+	...props
+}: SheetContentProps) => (
+	<SheetPortal>
+		<SheetOverlay />
+		<SheetPrimitive.Content
+			data-slot="sheet-content"
+			data-mantle-modal-content
+			className={cx(SheetVariants({ side }), preferredWidth, className)}
+			ref={ref}
+			{...props}
+		>
+			{children}
+		</SheetPrimitive.Content>
+	</SheetPortal>
 );
 Content.displayName = SheetPrimitive.Content.displayName;
 
@@ -669,17 +674,14 @@ Footer.displayName = "SheetFooter";
  * </Sheet.Root>
  * ```
  */
-const Title = forwardRef<
-	ComponentRef<typeof SheetPrimitive.Title>,
-	ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
->(({ className, ...props }, ref) => (
+const Title = ({ className, ref, ...props }: ComponentProps<typeof SheetPrimitive.Title>) => (
 	<SheetPrimitive.Title
 		data-slot="sheet-title"
 		ref={ref}
 		className={cx("text-strong flex-1 truncate text-lg font-medium", className)}
 		{...props}
 	/>
-));
+);
 Title.displayName = SheetPrimitive.Title.displayName;
 
 /**
@@ -731,17 +733,15 @@ Title.displayName = SheetPrimitive.Title.displayName;
  * </Sheet.Root>
  * ```
  */
-const TitleGroup = forwardRef<ComponentRef<"div">, HTMLAttributes<HTMLDivElement>>(
-	({ children, className, ...props }, ref) => (
-		<div
-			data-slot="sheet-title-group"
-			className={cx("flex items-center justify-between gap-2", className)}
-			{...props}
-			ref={ref}
-		>
-			{children}
-		</div>
-	),
+const TitleGroup = ({ children, className, ref, ...props }: ComponentProps<"div">) => (
+	<div
+		data-slot="sheet-title-group"
+		className={cx("flex items-center justify-between gap-2", className)}
+		{...props}
+		ref={ref}
+	>
+		{children}
+	</div>
 );
 TitleGroup.displayName = "SheetTitleGroup";
 
@@ -794,17 +794,18 @@ TitleGroup.displayName = "SheetTitleGroup";
  * </Sheet.Root>
  * ```
  */
-const Description = forwardRef<
-	ComponentRef<typeof SheetPrimitive.Description>,
-	ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
->(({ className, ...props }, ref) => (
+const Description = ({
+	className,
+	ref,
+	...props
+}: ComponentProps<typeof SheetPrimitive.Description>) => (
 	<SheetPrimitive.Description
 		data-slot="sheet-description"
 		ref={ref}
 		className={cx("text-body text-sm", className)}
 		{...props}
 	/>
-));
+);
 Description.displayName = SheetPrimitive.Description.displayName;
 
 /**
@@ -856,17 +857,15 @@ Description.displayName = SheetPrimitive.Description.displayName;
  * </Sheet.Root>
  * ```
  */
-const Actions = forwardRef<ComponentRef<"div">, HTMLAttributes<HTMLDivElement>>(
-	({ children, className, ...props }, ref) => (
-		<div
-			data-slot="sheet-actions"
-			className={cx("flex h-full items-center gap-2", className)}
-			{...props}
-			ref={ref}
-		>
-			{children}
-		</div>
-	),
+const Actions = ({ children, className, ref, ...props }: ComponentProps<"div">) => (
+	<div
+		data-slot="sheet-actions"
+		className={cx("flex h-full items-center gap-2", className)}
+		{...props}
+		ref={ref}
+	>
+		{children}
+	</div>
 );
 Actions.displayName = "SheetActions";
 

--- a/packages/mantle/src/components/skeleton/skeleton.tsx
+++ b/packages/mantle/src/components/skeleton/skeleton.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type ComponentRef, forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { SelfClosingWithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -50,24 +50,21 @@ type Props = Exclude<ComponentProps<"div">, "children"> & SelfClosingWithAsChild
  * </div>
  * ```
  */
-const Skeleton = forwardRef<ComponentRef<"div">, Props>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
+const Skeleton = ({ asChild = false, className, ref, ...props }: Props) => {
+	const Component = asChild ? Slot : "div";
 
-		return (
-			<Component
-				data-slot="skeleton"
-				className={cx(
-					"dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10",
-					className,
-				)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
-Skeleton.displayName = "Skeleton";
+	return (
+		<Component
+			data-slot="skeleton"
+			className={cx(
+				"dark-high-contrast:bg-black/30 high-contrast:bg-black/30 h-4 animate-pulse rounded-md bg-gray-300/25 dark:bg-gray-950/10",
+				className,
+			)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/skip-to-main-link/skip-to-main-link.tsx
+++ b/packages/mantle/src/components/skip-to-main-link/skip-to-main-link.tsx
@@ -63,8 +63,6 @@ const SkipToMainLink = ({
 		</Anchor>
 	);
 };
-SkipToMainLink.displayName = "SkipToMainLink";
-
 export {
 	//,
 	SkipToMainLink,

--- a/packages/mantle/src/components/slot/slot.tsx
+++ b/packages/mantle/src/components/slot/slot.tsx
@@ -1,5 +1,5 @@
 import { Slot as RadixSlot } from "@radix-ui/react-slot";
-import { Children, type ComponentProps, cloneElement, forwardRef, isValidElement } from "react";
+import { Children, type ComponentProps, cloneElement, isValidElement } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
@@ -23,16 +23,13 @@ type Props = ComponentProps<typeof RadixSlot> & WithDataSlot;
  * </Slot>
  * ```
  */
-const Slot = forwardRef<HTMLElement, Props>(function Slot(
-	{ children, className, "data-slot": dataSlot, ...props },
-	forwardedRef,
-) {
+const Slot = ({ children, className, "data-slot": dataSlot, ref, ...props }: Props) => {
 	if (!isValidElement<{ className?: string } & WithDataSlot>(children)) {
 		return Children.only(children);
 	}
 
 	return (
-		<RadixSlot ref={forwardedRef} {...props}>
+		<RadixSlot ref={ref} {...props}>
 			{cloneElement(children, {
 				...children.props,
 				/**
@@ -56,7 +53,7 @@ const Slot = forwardRef<HTMLElement, Props>(function Slot(
 			})}
 		</RadixSlot>
 	);
-});
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/split-button/split-button.tsx
+++ b/packages/mantle/src/components/split-button/split-button.tsx
@@ -1,13 +1,5 @@
 import { CaretDownIcon } from "@phosphor-icons/react/CaretDown";
-import {
-	createContext,
-	forwardRef,
-	useContext,
-	useMemo,
-	type ComponentProps,
-	type ComponentRef,
-	type ReactNode,
-} from "react";
+import { createContext, useContext, useMemo, type ComponentProps, type ReactNode } from "react";
 import { cx } from "../../utils/cx/cx.js";
 import { Button } from "../button/button.js";
 import { IconButton } from "../button/icon-button.js";
@@ -41,49 +33,55 @@ type RootProps = ComponentProps<typeof DropdownMenu.Root> &
 		size?: ButtonSize;
 	};
 
-const Root = forwardRef<ComponentRef<"div">, RootProps>(
-	(
-		{ className, children, dir, open, defaultOpen, onOpenChange, modal, size = "md", ...props },
-		ref,
-	) => {
-		const context: SplitButtonContextValue = useMemo(() => ({ size }), [size]);
+const Root = ({
+	className,
+	children,
+	dir,
+	open,
+	defaultOpen,
+	onOpenChange,
+	modal,
+	size = "md",
+	ref,
+	...props
+}: RootProps) => {
+	const context: SplitButtonContextValue = useMemo(() => ({ size }), [size]);
 
-		return (
-			<DropdownMenu.Root
-				dir={dir}
-				open={open}
-				defaultOpen={defaultOpen}
-				onOpenChange={onOpenChange}
-				modal={modal}
-			>
-				<SplitButtonContext.Provider value={context}>
-					<div
-						data-slot="split-button"
-						data-size={size}
-						className={cx(
-							"flex flex-row [&>*:first-child]:rounded-r-none [&>*:last-child]:rounded-l-none [&>*:not(:first-child):not(:last-child)]:rounded-none [&>*:not(:first-child)]:-ml-px [&>*:focus]:relative [&>*:focus]:z-10 [&>*:hover]:relative [&>*:hover]:z-10 *:active:scale-100!",
-							className,
-						)}
-						ref={ref}
-						{...props}
-					>
-						{children}
-					</div>
-				</SplitButtonContext.Provider>
-			</DropdownMenu.Root>
-		);
-	},
-);
+	return (
+		<DropdownMenu.Root
+			dir={dir}
+			open={open}
+			defaultOpen={defaultOpen}
+			onOpenChange={onOpenChange}
+			modal={modal}
+		>
+			<SplitButtonContext.Provider value={context}>
+				<div
+					data-slot="split-button"
+					data-size={size}
+					className={cx(
+						"flex flex-row [&>*:first-child]:rounded-r-none [&>*:last-child]:rounded-l-none [&>*:not(:first-child):not(:last-child)]:rounded-none [&>*:not(:first-child)]:-ml-px [&>*:focus]:relative [&>*:focus]:z-10 [&>*:hover]:relative [&>*:hover]:z-10 *:active:scale-100!",
+						className,
+					)}
+					ref={ref}
+					{...props}
+				>
+					{children}
+				</div>
+			</SplitButtonContext.Provider>
+		</DropdownMenu.Root>
+	);
+};
 Root.displayName = "SplitButton";
 
 type PrimaryActionProps = Omit<ComponentProps<typeof Button>, "appearance" | "intent" | "size">;
 
-const PrimaryAction = forwardRef<ComponentRef<"button">, PrimaryActionProps>((props, ref) => {
+const PrimaryAction = (props: PrimaryActionProps) => {
 	const { size } = useContext(SplitButtonContext);
 
-	// `type` flows through; `Button` defaults it to "button".
-	return <Button appearance="outlined" intent="neutral" ref={ref} size={size} {...props} />;
-});
+	// `type` and `ref` flow through; `Button` defaults `type` to "button".
+	return <Button appearance="outlined" intent="neutral" size={size} {...props} />;
+};
 PrimaryAction.displayName = "SplitButtonPrimaryAction";
 
 type MenuTriggerProps = Omit<
@@ -93,51 +91,42 @@ type MenuTriggerProps = Omit<
 	icon?: ReactNode;
 };
 
-const MenuTrigger = forwardRef<ComponentRef<"button">, MenuTriggerProps>(
-	({ icon, ...props }, ref) => {
-		const { size } = useContext(SplitButtonContext);
+const MenuTrigger = ({ icon, ...props }: MenuTriggerProps) => {
+	const { size } = useContext(SplitButtonContext);
 
-		return (
-			<DropdownMenu.Trigger asChild className="group">
-				<IconButton
-					icon={
-						icon ?? (
-							<Icon
-								svg={
-									<CaretDownIcon
-										weight="bold"
-										className="size-4 group-data-[state=open]:-rotate-180 transition-transform ease-out duration-150"
-									/>
-								}
-							/>
-						)
-					}
-					appearance="outlined"
-					intent="neutral"
-					ref={ref}
-					size={size}
-					{...props}
-				/>
-			</DropdownMenu.Trigger>
-		);
-	},
-);
+	return (
+		<DropdownMenu.Trigger asChild className="group">
+			<IconButton
+				icon={
+					icon ?? (
+						<Icon
+							svg={
+								<CaretDownIcon
+									weight="bold"
+									className="size-4 group-data-[state=open]:-rotate-180 transition-transform ease-out duration-150"
+								/>
+							}
+						/>
+					)
+				}
+				appearance="outlined"
+				intent="neutral"
+				size={size}
+				{...props}
+			/>
+		</DropdownMenu.Trigger>
+	);
+};
 MenuTrigger.displayName = "SplitButtonMenuTrigger";
 
-const MenuContent = forwardRef<
-	ComponentRef<typeof DropdownMenu.Content>,
-	ComponentProps<typeof DropdownMenu.Content>
->(({ align = "end", ...props }, ref) => {
-	return <DropdownMenu.Content align={align} ref={ref} {...props} />;
-});
+const MenuContent = ({ align = "end", ...props }: ComponentProps<typeof DropdownMenu.Content>) => {
+	return <DropdownMenu.Content align={align} {...props} />;
+};
 MenuContent.displayName = "SplitButtonMenuContent";
 
-const MenuItem = forwardRef<
-	ComponentRef<typeof DropdownMenu.Item>,
-	ComponentProps<typeof DropdownMenu.Item>
->(({ className, ...props }, ref) => {
-	return <DropdownMenu.Item className={cx("gap-2", className)} ref={ref} {...props} />;
-});
+const MenuItem = ({ className, ...props }: ComponentProps<typeof DropdownMenu.Item>) => {
+	return <DropdownMenu.Item className={cx("gap-2", className)} {...props} />;
+};
 MenuItem.displayName = "SplitButtonMenuItem";
 
 /**

--- a/packages/mantle/src/components/switch/switch.tsx
+++ b/packages/mantle/src/components/switch/switch.tsx
@@ -1,13 +1,12 @@
 import { Root as SwitchPrimitiveRoot, Thumb as SwitchPrimitiveThumb } from "@radix-ui/react-switch";
-import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentProps } from "react";
 import { parseBooleanish } from "../../types/booleanish.js";
 import { clsx } from "../../utils/cx/clsx.js";
 import { cx } from "../../utils/cx/cx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
 import type { WithValidation } from "../field/validation.js";
 
-type SwitchProps = ComponentPropsWithoutRef<typeof SwitchPrimitiveRoot> &
+type SwitchProps = ComponentProps<typeof SwitchPrimitiveRoot> &
 	WithValidation & {
 		/**
 		 * Makes the switch immutable, meaning the user can not edit the control.
@@ -34,64 +33,59 @@ type SwitchProps = ComponentPropsWithoutRef<typeof SwitchPrimitiveRoot> &
  * </form>
  * ```
  */
-const Switch = forwardRef<ComponentRef<typeof SwitchPrimitiveRoot>, SwitchProps>(
-	(
-		{
-			"aria-invalid": _ariaInvalid,
-			"aria-readonly": _ariaReadOnly,
-			className,
-			readOnly: _readOnly,
-			onClick,
-			validation: _validation,
-			...props
-		},
-		ref,
-	) => {
-		const readOnly = parseBooleanish(_readOnly ?? _ariaReadOnly);
-		const fieldValidation = useFieldValidation();
-		const { ariaInvalid, validation } = parseValidation({
-			"aria-invalid": _ariaInvalid,
-			validation: _validation ?? fieldValidation,
-		});
+const Switch = ({
+	"aria-invalid": _ariaInvalid,
+	"aria-readonly": _ariaReadOnly,
+	className,
+	readOnly: _readOnly,
+	onClick,
+	ref,
+	validation: _validation,
+	...props
+}: SwitchProps) => {
+	const readOnly = parseBooleanish(_readOnly ?? _ariaReadOnly);
+	const fieldValidation = useFieldValidation();
+	const { ariaInvalid, validation } = parseValidation({
+		"aria-invalid": _ariaInvalid,
+		validation: _validation ?? fieldValidation,
+	});
 
-		return (
-			<SwitchPrimitiveRoot
-				aria-invalid={ariaInvalid}
-				aria-readonly={readOnly}
-				data-slot="switch"
-				data-validation={validation || undefined}
-				className={cx(
-					"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden",
-					"disabled:cursor-default disabled:opacity-50",
-					"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4",
-					"data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400",
-					"data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success",
-					"data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning",
-					"data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger",
-					className,
+	return (
+		<SwitchPrimitiveRoot
+			aria-invalid={ariaInvalid}
+			aria-readonly={readOnly}
+			data-slot="switch"
+			data-validation={validation || undefined}
+			className={cx(
+				"peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full outline-hidden",
+				"disabled:cursor-default disabled:opacity-50",
+				"focus-visible:border-accent-600 focus-visible:ring-focus-accent focus-visible:outline-hidden focus-visible:ring-4",
+				"data-state-checked:bg-accent-600 data-state-unchecked:bg-gray-400",
+				"data-validation-success:data-state-checked:bg-success-600 focus-visible:data-validation-success:ring-focus-success",
+				"data-validation-warning:data-state-checked:bg-warning-600 focus-visible:data-validation-warning:ring-focus-warning",
+				"data-validation-error:data-state-checked:bg-danger-600 focus-visible:data-validation-error:ring-focus-danger",
+				className,
+			)}
+			onClick={(event) => {
+				if (readOnly) {
+					event.preventDefault();
+					event.stopPropagation();
+					return;
+				}
+				onClick?.(event);
+			}}
+			ref={ref}
+			{...props}
+		>
+			<SwitchPrimitiveThumb
+				className={clsx(
+					"pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform",
+					"data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5",
 				)}
-				onClick={(event) => {
-					if (readOnly) {
-						event.preventDefault();
-						event.stopPropagation();
-						return;
-					}
-					onClick?.(event);
-				}}
-				ref={ref}
-				{...props}
-			>
-				<SwitchPrimitiveThumb
-					className={clsx(
-						"pointer-events-none block size-4 rounded-full bg-[#fff] shadow-md ring-0 transition-transform",
-						"data-state-checked:translate-x-4.5 data-state-unchecked:translate-x-0.5",
-					)}
-				/>
-			</SwitchPrimitiveRoot>
-		);
-	},
-);
-Switch.displayName = "Switch";
+			/>
+		</SwitchPrimitiveRoot>
+	);
+};
 
 export {
 	//

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentRef } from "react";
-import { forwardRef, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 
@@ -45,46 +45,44 @@ import { cx } from "../../utils/cx/cx.js";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tableroot
  */
-const Root = forwardRef<ComponentRef<"div">, ComponentProps<"div">>(
-	({ children, className, ...props }, ref) => {
-		const horizontalOverflow = useHorizontalOverflowObserver<ComponentRef<"div">>();
+const Root = ({ children, className, ref, ...props }: ComponentProps<"div">) => {
+	const horizontalOverflow = useHorizontalOverflowObserver<ComponentRef<"div">>();
 
-		return (
+	return (
+		<div
+			data-slot="table"
+			className={cx(
+				"group/table relative w-full overflow-hidden rounded-lg border border-card bg-white dark:bg-gray-100",
+				className,
+			)}
+			data-sticky-active={
+				(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
+				undefined
+			}
+			data-x-overflow={horizontalOverflow.state.hasOverflow}
+			data-x-scroll-end={
+				horizontalOverflow.state.hasOverflow && horizontalOverflow.state.scrolledToEnd
+			}
+			{...props}
+		>
 			<div
-				data-slot="table"
 				className={cx(
-					"group/table relative w-full overflow-hidden rounded-lg border border-card bg-white dark:bg-gray-100",
-					className,
+					"scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-x-none",
+					// The edge fade is driven by the `scroll-fade-x` utility (a CSS
+					// scroll-driven animation). When the table contains a sticky right column
+					// (e.g., DataTable.ActionCell / DataTable.ActionHeader), suppress the
+					// container's right-side fade so the pinned column stays fully opaque. The
+					// pinned column provides its own left-side gradient for the scroll-under
+					// effect.
+					"has-data-mantle-table-sticky-right:[--_fade-right:black]",
 				)}
-				data-sticky-active={
-					(horizontalOverflow.state.hasOverflow && !horizontalOverflow.state.scrolledToEnd) ||
-					undefined
-				}
-				data-x-overflow={horizontalOverflow.state.hasOverflow}
-				data-x-scroll-end={
-					horizontalOverflow.state.hasOverflow && horizontalOverflow.state.scrolledToEnd
-				}
-				{...props}
+				ref={composeRefs(horizontalOverflow.ref, ref)}
 			>
-				<div
-					className={cx(
-						"scrollbar scroll-fade-x overflow-x-auto overflow-y-clip overscroll-x-none",
-						// The edge fade is driven by the `scroll-fade-x` utility (a CSS
-						// scroll-driven animation). When the table contains a sticky right column
-						// (e.g., DataTable.ActionCell / DataTable.ActionHeader), suppress the
-						// container's right-side fade so the pinned column stays fully opaque. The
-						// pinned column provides its own left-side gradient for the scroll-under
-						// effect.
-						"has-data-mantle-table-sticky-right:[--_fade-right:black]",
-					)}
-					ref={composeRefs(horizontalOverflow.ref, ref)}
-				>
-					{children}
-				</div>
+				{children}
 			</div>
-		);
-	},
-);
+		</div>
+	);
+};
 Root.displayName = "TableRoot";
 
 /**
@@ -152,23 +150,21 @@ Root.displayName = "TableRoot";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tableelement
  */
-const Element = forwardRef<ComponentRef<"table">, ComponentProps<"table">>(
-	({ children, className, ...props }, ref) => {
-		return (
-			<table
-				data-slot="table-element"
-				ref={ref}
-				className={cx(
-					"table-auto border-separate border-spacing-0 caption-bottom w-full min-w-full text-left",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-			</table>
-		);
-	},
-);
+const Element = ({ children, className, ref, ...props }: ComponentProps<"table">) => {
+	return (
+		<table
+			data-slot="table-element"
+			ref={ref}
+			className={cx(
+				"table-auto border-separate border-spacing-0 caption-bottom w-full min-w-full text-left",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</table>
+	);
+};
 Element.displayName = "TableElement";
 
 /**
@@ -218,26 +214,24 @@ Element.displayName = "TableElement";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tableheader
  */
-const Head = forwardRef<ComponentRef<"thead">, ComponentProps<"thead">>(
-	({ children, className, ...props }, ref) => (
-		<thead
-			data-slot="table-head"
-			ref={ref}
-			className={cx(
-				//,
-				// In border-separate, <tr>/<thead> borders don't render, so apply
-				// dividers directly to cells.
-				"[&>tr:last-child>*]:border-b [&>tr:last-child>*]:border-card-muted",
-				"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
-				"text-muted bg-base",
-				"[&>tr]:bg-base", // Row styling
-				className,
-			)}
-			{...props}
-		>
-			{children}
-		</thead>
-	),
+const Head = ({ children, className, ref, ...props }: ComponentProps<"thead">) => (
+	<thead
+		data-slot="table-head"
+		ref={ref}
+		className={cx(
+			//,
+			// In border-separate, <tr>/<thead> borders don't render, so apply
+			// dividers directly to cells.
+			"[&>tr:last-child>*]:border-b [&>tr:last-child>*]:border-card-muted",
+			"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
+			"text-muted bg-base",
+			"[&>tr]:bg-base", // Row styling
+			className,
+		)}
+		{...props}
+	>
+		{children}
+	</thead>
 );
 Head.displayName = "TableHead";
 
@@ -286,25 +280,23 @@ Head.displayName = "TableHead";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tablebody
  */
-const Body = forwardRef<ComponentRef<"tbody">, ComponentProps<"tbody">>(
-	({ children, className, ...props }, ref) => (
-		<tbody
-			data-slot="table-body"
-			className={cx(
-				//,
-				// In border-separate, <tr>/<tbody> borders don't render, so apply
-				// dividers directly to cells.
-				"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
-				"text-body",
-				"[&>tr]:bg-card [&>tr]:not-only:hover:bg-card-hover", // Body row styling
-				className,
-			)}
-			ref={ref}
-			{...props}
-		>
-			{children}
-		</tbody>
-	),
+const Body = ({ children, className, ref, ...props }: ComponentProps<"tbody">) => (
+	<tbody
+		data-slot="table-body"
+		className={cx(
+			//,
+			// In border-separate, <tr>/<tbody> borders don't render, so apply
+			// dividers directly to cells.
+			"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
+			"text-body",
+			"[&>tr]:bg-card [&>tr]:not-only:hover:bg-card-hover", // Body row styling
+			className,
+		)}
+		ref={ref}
+		{...props}
+	>
+		{children}
+	</tbody>
 );
 Body.displayName = "TableBody";
 
@@ -355,26 +347,24 @@ Body.displayName = "TableBody";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tablefoot
  */
-const Foot = forwardRef<ComponentRef<"tfoot">, ComponentProps<"tfoot">>(
-	({ children, className, ...props }, ref) => (
-		<tfoot
-			data-slot="table-foot"
-			ref={ref}
-			className={cx(
-				//,
-				"font-medium text-body",
-				// In border-separate, <tr>/<tfoot> borders don't render, so apply
-				// dividers directly to cells.
-				"[&>tr:first-child>*]:border-t [&>tr:first-child>*]:border-card-muted",
-				"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
-				"[&>tr]:bg-gray-50/50 [&>tr]:hover:bg-card-hover", // Row styling
-				className,
-			)}
-			{...props}
-		>
-			{children}
-		</tfoot>
-	),
+const Foot = ({ children, className, ref, ...props }: ComponentProps<"tfoot">) => (
+	<tfoot
+		data-slot="table-foot"
+		ref={ref}
+		className={cx(
+			//,
+			"font-medium text-body",
+			// In border-separate, <tr>/<tfoot> borders don't render, so apply
+			// dividers directly to cells.
+			"[&>tr:first-child>*]:border-t [&>tr:first-child>*]:border-card-muted",
+			"[&>tr+tr>*]:border-t [&>tr+tr>*]:border-card-muted",
+			"[&>tr]:bg-gray-50/50 [&>tr]:hover:bg-card-hover", // Row styling
+			className,
+		)}
+		{...props}
+	>
+		{children}
+	</tfoot>
 );
 Foot.displayName = "TableFoot";
 
@@ -422,20 +412,18 @@ Foot.displayName = "TableFoot";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tablerow
  */
-const Row = forwardRef<ComponentRef<"tr">, ComponentProps<"tr">>(
-	({ children, className, ...props }, ref) => (
-		<tr
-			data-slot="table-row"
-			ref={ref}
-			className={cx(
-				// This could be removed, or simplified
-				className,
-			)}
-			{...props}
-		>
-			{children}
-		</tr>
-	),
+const Row = ({ children, className, ref, ...props }: ComponentProps<"tr">) => (
+	<tr
+		data-slot="table-row"
+		ref={ref}
+		className={cx(
+			// This could be removed, or simplified
+			className,
+		)}
+		{...props}
+	>
+		{children}
+	</tr>
 );
 Row.displayName = "TableRow";
 
@@ -485,20 +473,18 @@ Row.displayName = "TableRow";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tableheader
  */
-const Header = forwardRef<ComponentRef<"th">, ComponentProps<"th">>(
-	({ children, className, ...props }, ref) => (
-		<th
-			data-slot="table-header"
-			ref={ref}
-			className={cx(
-				"h-11 px-4 text-left align-middle text-sm font-medium [&:has([role=checkbox])]:pr-0",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-		</th>
-	),
+const Header = ({ children, className, ref, ...props }: ComponentProps<"th">) => (
+	<th
+		data-slot="table-header"
+		ref={ref}
+		className={cx(
+			"h-11 px-4 text-left align-middle text-sm font-medium [&:has([role=checkbox])]:pr-0",
+			className,
+		)}
+		{...props}
+	>
+		{children}
+	</th>
 );
 Header.displayName = "TableHeader";
 
@@ -546,20 +532,15 @@ Header.displayName = "TableHeader";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tablecell
  */
-const Cell = forwardRef<ComponentRef<"td">, ComponentProps<"td">>(
-	({ children, className, ...props }, ref) => (
-		<td
-			data-slot="table-cell"
-			ref={ref}
-			className={cx(
-				"p-3 align-middle [&:has([role=checkbox])]:pr-0 font-mono text-mono",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-		</td>
-	),
+const Cell = ({ children, className, ref, ...props }: ComponentProps<"td">) => (
+	<td
+		data-slot="table-cell"
+		ref={ref}
+		className={cx("p-3 align-middle [&:has([role=checkbox])]:pr-0 font-mono text-mono", className)}
+		{...props}
+	>
+		{children}
+	</td>
 );
 Cell.displayName = "TableCell";
 
@@ -607,17 +588,15 @@ Cell.displayName = "TableCell";
  *
  * @see https://mantle.ngrok.com/components/data-display/table#tablecaption
  */
-const Caption = forwardRef<ComponentRef<"caption">, ComponentProps<"caption">>(
-	({ children, className, ...props }, ref) => (
-		<caption
-			data-slot="table-caption"
-			ref={ref}
-			className={cx("py-4 text-sm text-gray-500", "border-t border-card-muted", className)}
-			{...props}
-		>
-			{children}
-		</caption>
-	),
+const Caption = ({ children, className, ref, ...props }: ComponentProps<"caption">) => (
+	<caption
+		data-slot="table-caption"
+		ref={ref}
+		className={cx("py-4 text-sm text-gray-500", "border-t border-card-muted", className)}
+		{...props}
+	>
+		{children}
+	</caption>
 );
 Caption.displayName = "TableCaption";
 

--- a/packages/mantle/src/components/tabs/tabs.tsx
+++ b/packages/mantle/src/components/tabs/tabs.tsx
@@ -5,12 +5,11 @@ import {
 	Trigger as TabsPrimitiveTrigger,
 } from "@radix-ui/react-tabs";
 import { cva } from "class-variance-authority";
-import type { ComponentPropsWithoutRef, ComponentRef, HTMLAttributes } from "react";
+import type { ComponentProps, ComponentRef, HTMLAttributes } from "react";
 import {
 	Children,
 	cloneElement,
 	createContext,
-	forwardRef,
 	isValidElement,
 	useContext,
 	useEffect,
@@ -60,17 +59,20 @@ const TabsStateContext = createContext<TabsStateContextValue>({
  * </Tabs.Root>
  * ```
  */
-const Root = forwardRef<
-	ComponentRef<typeof TabsPrimitiveRoot>,
-	ComponentPropsWithoutRef<typeof TabsPrimitiveRoot> & {
-		/**
-		 * The appearance of the tabs. Classic appearance shows the tab
-		 * list with an underline; pill appearance shows each tab as a pill.
-		 * @default "classic"
-		 */
-		appearance?: "classic" | "pill";
-	}
->(({ className, children, orientation = "horizontal", appearance = "classic", ...props }, ref) => {
+const Root = ({
+	className,
+	children,
+	orientation = "horizontal",
+	appearance = "classic",
+	...props
+}: ComponentProps<typeof TabsPrimitiveRoot> & {
+	/**
+	 * The appearance of the tabs. Classic appearance shows the tab
+	 * list with an underline; pill appearance shows each tab as a pill.
+	 * @default "classic"
+	 */
+	appearance?: "classic" | "pill";
+}) => {
 	const contextValue = useMemo(() => ({ orientation, appearance }), [orientation, appearance]);
 	return (
 		<TabsPrimitiveRoot
@@ -82,13 +84,12 @@ const Root = forwardRef<
 				className,
 			)}
 			orientation={orientation}
-			ref={ref}
 			{...props}
 		>
 			<TabsStateContext.Provider value={contextValue}>{children}</TabsStateContext.Provider>
 		</TabsPrimitiveRoot>
 	);
-});
+};
 Root.displayName = "Tabs";
 
 /**
@@ -204,19 +205,21 @@ const listVariants = cva("flex", {
  * </Tabs.List>
  * ```
  */
-const List = forwardRef<
-	ComponentRef<typeof TabsPrimitiveList>,
-	ComponentPropsWithoutRef<typeof TabsPrimitiveList> & {
-		/**
-		 * Hide the tablist's border — the bottom border of a horizontal classic
-		 * tablist, or the side border of a vertical one. Also rendered as a
-		 * `data-hide-border` attribute on the tablist element. Has no effect on
-		 * the pill appearance, which never draws a border.
-		 * @default false
-		 */
-		hideBorder?: boolean;
-	}
->(({ className, hideBorder = false, ...props }, ref) => {
+const List = ({
+	className,
+	hideBorder = false,
+	ref,
+	...props
+}: ComponentProps<typeof TabsPrimitiveList> & {
+	/**
+	 * Hide the tablist's border — the bottom border of a horizontal classic
+	 * tablist, or the side border of a vertical one. Also rendered as a
+	 * `data-hide-border` attribute on the tablist element. Has no effect on
+	 * the pill appearance, which never draws a border.
+	 * @default false
+	 */
+	hideBorder?: boolean;
+}) => {
 	const { orientation, appearance } = useContext(TabsStateContext);
 	const scrollRef = useRef<ComponentRef<typeof TabsPrimitiveList>>(null);
 
@@ -268,10 +271,10 @@ const List = forwardRef<
 			{...props}
 		/>
 	);
-});
+};
 List.displayName = "TabsList";
 
-type TabsTriggerProps = ComponentPropsWithoutRef<typeof TabsPrimitiveTrigger>;
+type TabsTriggerProps = ComponentProps<typeof TabsPrimitiveTrigger>;
 
 /**
  * Variants for the TabsTriggerDecoration component
@@ -296,7 +299,6 @@ const TabsTriggerDecoration = () => {
 		<span aria-hidden className={clsx(triggerDecorationVariants({ orientation, appearance }))} />
 	);
 };
-TabsTriggerDecoration.displayName = "TabsTriggerDecoration";
 
 /**
  * Variants for the Trigger component
@@ -352,74 +354,70 @@ const triggerVariants = cva(
  * </Tabs.Root>
  * ```
  */
-const Trigger = forwardRef<ComponentRef<typeof TabsPrimitiveTrigger>, TabsTriggerProps>(
-	(
-		{
-			"aria-disabled": _ariaDisabled,
-			asChild = false,
-			children,
-			className,
-			disabled: _disabled,
-			...props
-		},
-		ref,
-	) => {
-		const { orientation, appearance } = useContext(TabsStateContext);
-		const disabled = parseBooleanish(_ariaDisabled ?? _disabled);
+const Trigger = ({
+	"aria-disabled": _ariaDisabled,
+	asChild = false,
+	children,
+	className,
+	disabled: _disabled,
+	ref,
+	...props
+}: TabsTriggerProps) => {
+	const { orientation, appearance } = useContext(TabsStateContext);
+	const disabled = parseBooleanish(_ariaDisabled ?? _disabled);
 
-		const tabsTriggerProps = {
-			"aria-disabled": _ariaDisabled ?? _disabled,
-			className: cx(triggerVariants({ orientation, appearance }), className),
-			disabled,
-			...props,
-		};
+	const tabsTriggerProps = {
+		"aria-disabled": _ariaDisabled ?? _disabled,
+		className: cx(triggerVariants({ orientation, appearance }), className),
+		disabled,
+		...props,
+	};
 
-		if (asChild) {
-			const singleChild = Children.only(children);
-			invariant(
-				isValidElement<TabsTriggerProps>(singleChild),
-				"When using `asChild`, TabsTrigger must be passed a single child as a JSX tag.",
-			);
-			const grandchildren = singleChild.props?.children;
+	if (asChild) {
+		const singleChild = Children.only(children);
+		invariant(
+			isValidElement<TabsTriggerProps>(singleChild),
+			"When using `asChild`, TabsTrigger must be passed a single child as a JSX tag.",
+		);
+		const grandchildren = singleChild.props?.children;
 
-			const cloneProps = disabled
-				? /**
-					 * When disabled, prevent anchor/link children from being clickable by
-					 * removing their href/to props!
-					 * This is necessary because `<a>` doesn't support the `disabled`
-					 * attribute and would be navigable. We could use `pointer-events-none`
-					 * instead, but don't by default because it would also prevent tooltip
-					 * interactions, which may be surprising.
-					 */
-					{ href: undefined, to: undefined }
-				: /**
-					 * when NOT disabled, allow keyboard navigation to the trigger,
-					 * even for asChild anchors/links
-					 */
-					{ tabIndex: 0 };
-
-			return (
-				<TabsPrimitiveTrigger asChild data-slot="tabs-trigger" {...tabsTriggerProps} ref={ref}>
-					{cloneElement(
-						disabled ? <button type="button" /> : singleChild,
-						cloneProps,
-						<>
-							<TabsTriggerDecoration />
-							{grandchildren}
-						</>,
-					)}
-				</TabsPrimitiveTrigger>
-			);
-		}
+		const cloneProps = disabled
+			? /**
+				 * When disabled, prevent anchor/link children from being clickable by
+				 * removing their href/to props!
+				 * This is necessary because `<a>` doesn't support the `disabled`
+				 * attribute and would be navigable. We could use `pointer-events-none`
+				 * instead, but don't by default because it would also prevent tooltip
+				 * interactions, which may be surprising.
+				 */
+				{ href: undefined, to: undefined }
+			: /**
+				 * when NOT disabled, allow keyboard navigation to the trigger,
+				 * even for asChild anchors/links
+				 */
+				{ tabIndex: 0 };
 
 		return (
-			<TabsPrimitiveTrigger data-slot="tabs-trigger" ref={ref} {...tabsTriggerProps}>
-				<TabsTriggerDecoration />
-				{children}
+			<TabsPrimitiveTrigger asChild data-slot="tabs-trigger" {...tabsTriggerProps} ref={ref}>
+				{cloneElement(
+					disabled ? <button type="button" /> : singleChild,
+					cloneProps,
+					<>
+						<TabsTriggerDecoration />
+						{grandchildren}
+					</>,
+				)}
 			</TabsPrimitiveTrigger>
 		);
-	},
-);
+	}
+
+	return (
+		<TabsPrimitiveTrigger data-slot="tabs-trigger" ref={ref} {...tabsTriggerProps}>
+			<TabsTriggerDecoration />
+			{children}
+		</TabsPrimitiveTrigger>
+	);
+};
 Trigger.displayName = "TabsTrigger";
 
 /**
@@ -478,17 +476,13 @@ Badge.displayName = "TabBadge";
  * </Tabs.Root>
  * ```
  */
-const Content = forwardRef<
-	ComponentRef<typeof TabsPrimitiveContent>,
-	ComponentPropsWithoutRef<typeof TabsPrimitiveContent>
->(({ className, ...props }, ref) => (
+const Content = ({ className, ...props }: ComponentProps<typeof TabsPrimitiveContent>) => (
 	<TabsPrimitiveContent
-		ref={ref}
 		data-slot="tabs-content"
 		className={cx("focus-visible:ring-focus-accent outline-hidden focus-visible:ring-4", className)}
 		{...props}
 	/>
-));
+);
 Content.displayName = "TabsContent";
 
 /**

--- a/packages/mantle/src/components/text-area/text-area.tsx
+++ b/packages/mantle/src/components/text-area/text-area.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComponentProps, ComponentRef } from "react";
-import { forwardRef, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
@@ -36,65 +36,59 @@ type Props = ComponentProps<"textarea"> &
  * </form>
  * ```
  */
-const TextArea = forwardRef<ComponentRef<"textarea">, Props>(
-	(
-		{
-			appearance,
-			"aria-invalid": _ariaInvalid,
-			className,
-			onDragEnter,
-			onDragLeave,
-			onDropCapture,
-			validation: _validation,
-			...props
-		},
-		ref,
-	) => {
-		const fieldValidation = useFieldValidation();
-		const { ariaInvalid, validation } = parseValidation({
-			"aria-invalid": _ariaInvalid,
-			validation: _validation ?? fieldValidation,
-		});
-		const [isDragOver, setIsDragOver] = useState(false);
-		const innerRef = useRef<ComponentRef<"textarea">>(null);
+const TextArea = ({
+	appearance,
+	"aria-invalid": _ariaInvalid,
+	className,
+	onDragEnter,
+	onDragLeave,
+	onDropCapture,
+	ref,
+	validation: _validation,
+	...props
+}: Props) => {
+	const fieldValidation = useFieldValidation();
+	const { ariaInvalid, validation } = parseValidation({
+		"aria-invalid": _ariaInvalid,
+		validation: _validation ?? fieldValidation,
+	});
+	const [isDragOver, setIsDragOver] = useState(false);
+	const innerRef = useRef<ComponentRef<"textarea">>(null);
 
-		return (
-			<textarea
-				aria-invalid={ariaInvalid}
-				data-validation={validation || undefined}
-				data-slot="text-area"
-				className={cx(
-					appearance === "monospaced" &&
-						"pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]",
-					"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
-					"placeholder:text-placeholder data-drag-over:border-dashed",
-					"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600",
-					"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600",
-					"data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600",
-					"data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600",
-					className,
-				)}
-				data-drag-over={isDragOver}
-				onDragEnter={(event) => {
-					setIsDragOver(true);
-					onDragEnter?.(event);
-				}}
-				onDragLeave={(event) => {
-					setIsDragOver(false);
-					onDragLeave?.(event);
-				}}
-				onDropCapture={(event) => {
-					setIsDragOver(false);
-					innerRef.current?.focus();
-					onDropCapture?.(event);
-				}}
-				ref={composeRefs(innerRef, ref)}
-				{...props}
-			/>
-		);
-	},
-);
-TextArea.displayName = "TextArea";
+	return (
+		<textarea
+			aria-invalid={ariaInvalid}
+			data-validation={validation || undefined}
+			data-slot="text-area"
+			className={cx(
+				appearance === "monospaced" && "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]",
+				"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
+				"placeholder:text-placeholder data-drag-over:border-dashed",
+				"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600",
+				"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600",
+				"data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600",
+				"data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600",
+				className,
+			)}
+			data-drag-over={isDragOver}
+			onDragEnter={(event) => {
+				setIsDragOver(true);
+				onDragEnter?.(event);
+			}}
+			onDragLeave={(event) => {
+				setIsDragOver(false);
+				onDragLeave?.(event);
+			}}
+			onDropCapture={(event) => {
+				setIsDragOver(false);
+				innerRef.current?.focus();
+				onDropCapture?.(event);
+			}}
+			ref={composeRefs(innerRef, ref)}
+			{...props}
+		/>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/components/theme-switcher/theme-switcher.tsx
+++ b/packages/mantle/src/components/theme-switcher/theme-switcher.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import type { ComponentProps, ComponentPropsWithoutRef, ComponentRef } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { WithStyleProps } from "../../types/with-style-props.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
@@ -107,7 +106,6 @@ const ThemeDropdownMenuRadioGroup = ({ className, style }: ThemeDropdownMenuRadi
 		</DropdownMenu.RadioGroup>
 	);
 };
-ThemeDropdownMenuRadioGroup.displayName = "ThemeDropdownMenuRadioGroup";
 
 /**
  * The props for the `ThemeSwitcher.Root` component. Identical to
@@ -182,31 +180,33 @@ type ThemeSwitcherTriggerProps = Omit<
  * </ThemeSwitcher.Root>
  * ```
  */
-const Trigger = forwardRef<HTMLButtonElement, ThemeSwitcherTriggerProps>(
-	(
-		{ appearance = "ghost", "data-slot": dataSlot, disabled, label = "Change Theme", ...props },
-		ref,
-	) => (
-		// `disabled` must reach DropdownMenu.Trigger too: Radix owns the open
-		// behavior, and a disabled trigger that only disables the button DOM
-		// node would still open the menu on synthesized pointer events.
-		<DropdownMenu.Trigger asChild disabled={disabled}>
-			<IconButton
-				ref={ref}
-				appearance={appearance}
-				disabled={disabled}
-				data-slot={joinDataSlot(dataSlot, "theme-switcher-trigger")}
-				intent="neutral"
-				icon={
-					<BrowserOnly fallback={<Skeleton className="rounded-full size-5" />}>
-						{() => <AutoThemeIcon className="size-5" />}
-					</BrowserOnly>
-				}
-				label={label}
-				{...props}
-			/>
-		</DropdownMenu.Trigger>
-	),
+const Trigger = ({
+	appearance = "ghost",
+	"data-slot": dataSlot,
+	disabled,
+	label = "Change Theme",
+	ref,
+	...props
+}: ThemeSwitcherTriggerProps) => (
+	// `disabled` must reach DropdownMenu.Trigger too: Radix owns the open
+	// behavior, and a disabled trigger that only disables the button DOM
+	// node would still open the menu on synthesized pointer events.
+	<DropdownMenu.Trigger asChild disabled={disabled}>
+		<IconButton
+			ref={ref}
+			appearance={appearance}
+			disabled={disabled}
+			data-slot={joinDataSlot(dataSlot, "theme-switcher-trigger")}
+			intent="neutral"
+			icon={
+				<BrowserOnly fallback={<Skeleton className="rounded-full size-5" />}>
+					{() => <AutoThemeIcon className="size-5" />}
+				</BrowserOnly>
+			}
+			label={label}
+			{...props}
+		/>
+	</DropdownMenu.Trigger>
 );
 Trigger.displayName = "ThemeSwitcherTrigger";
 
@@ -216,8 +216,7 @@ Trigger.displayName = "ThemeSwitcherTrigger";
  * (`align`, `side`, `collisionPadding`, …) plus `className`/`style` all
  * forward through.
  */
-type ThemeSwitcherContentProps = ComponentPropsWithoutRef<typeof DropdownMenu.Content> &
-	WithDataSlot;
+type ThemeSwitcherContentProps = ComponentProps<typeof DropdownMenu.Content> & WithDataSlot;
 
 /**
  * The popover the trigger opens: a thin forwarding wrapper over
@@ -249,16 +248,10 @@ type ThemeSwitcherContentProps = ComponentPropsWithoutRef<typeof DropdownMenu.Co
  * </ThemeSwitcher.Content>
  * ```
  */
-const Content = forwardRef<ComponentRef<typeof DropdownMenu.Content>, ThemeSwitcherContentProps>(
-	({ children, "data-slot": dataSlot, ...props }, ref) => (
-		<DropdownMenu.Content
-			ref={ref}
-			data-slot={joinDataSlot(dataSlot, "theme-switcher-content")}
-			{...props}
-		>
-			{children ?? <ThemeDropdownMenuRadioGroup />}
-		</DropdownMenu.Content>
-	),
+const Content = ({ children, "data-slot": dataSlot, ...props }: ThemeSwitcherContentProps) => (
+	<DropdownMenu.Content data-slot={joinDataSlot(dataSlot, "theme-switcher-content")} {...props}>
+		{children ?? <ThemeDropdownMenuRadioGroup />}
+	</DropdownMenu.Content>
 );
 Content.displayName = "ThemeSwitcherContent";
 

--- a/packages/mantle/src/components/theme/fonts.tsx
+++ b/packages/mantle/src/components/theme/fonts.tsx
@@ -133,8 +133,6 @@ const PreloadFont = ({ name }: PreloadFontProps) => (
 		crossOrigin="anonymous"
 	/>
 );
-PreloadFont.displayName = "PreloadFont";
-
 export type { CoreFontName };
 
 export {

--- a/packages/mantle/src/components/theme/mantle-style-sheets.tsx
+++ b/packages/mantle/src/components/theme/mantle-style-sheets.tsx
@@ -373,8 +373,6 @@ function MantleStyleSheets({
 		</>
 	);
 }
-MantleStyleSheets.displayName = "MantleStyleSheets";
-
 export {
 	//,
 	fixMediaScriptContent,

--- a/packages/mantle/src/components/theme/theme-provider.tsx
+++ b/packages/mantle/src/components/theme/theme-provider.tsx
@@ -167,8 +167,6 @@ function ThemeProvider({ children }: ThemeProviderProps) {
 
 	return <ThemeProviderContext.Provider value={value}>{children}</ThemeProviderContext.Provider>;
 }
-ThemeProvider.displayName = "ThemeProvider";
-
 /**
  * useTheme returns the current theme and a function to set the theme.
  *
@@ -550,8 +548,6 @@ const PreventWrongThemeFlashScript = ({ nonce }: PreventWrongThemeFlashScriptPro
 		suppressHydrationWarning
 	/>
 );
-PreventWrongThemeFlashScript.displayName = "PreventWrongThemeFlashScript";
-
 type InitialThemeProps = {
 	className: string;
 	"data-applied-theme": ResolvedTheme;

--- a/packages/mantle/src/components/toast/toast.tsx
+++ b/packages/mantle/src/components/toast/toast.tsx
@@ -6,11 +6,9 @@ import { WarningIcon } from "@phosphor-icons/react/Warning";
 import { WarningDiamondIcon } from "@phosphor-icons/react/WarningDiamond";
 import {
 	type ComponentProps,
-	type ComponentRef,
 	type MouseEvent,
 	type ReactNode,
 	createContext,
-	forwardRef,
 	useContext,
 	useMemo,
 } from "react";
@@ -80,7 +78,6 @@ const Toaster = ({
 		/>
 	);
 };
-Toaster.displayName = "Toaster";
 
 const ToastIdContext = createContext<string | number>("");
 
@@ -190,36 +187,34 @@ type ToastProps = ComponentProps<"div"> &
  * </Toast.Root>
  * ```
  */
-const Root = forwardRef<ComponentRef<"div">, ToastProps>(
-	({ asChild, children, className, intent, ...props }, ref) => {
-		const Component = asChild ? Slot : "div";
-		const contextValue = useMemo(() => ({ intent }), [intent]);
+const Root = ({ asChild, children, className, intent, ref, ...props }: ToastProps) => {
+	const Component = asChild ? Slot : "div";
+	const contextValue = useMemo(() => ({ intent }), [intent]);
 
-		return (
-			<ToastStateContext.Provider value={contextValue}>
-				<Component
-					data-slot="toast"
-					className={cx(
-						"relative flex items-start gap-2 text-sm font-sans",
-						"p-3 pl-3.75",
-						"bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg",
-						/**
-						 * Do not apply overflow-hidden because we want the intent bar accent
-						 * to overlap the toast border, else the border flows over the
-						 * intent bar.
-						 */
-						className,
-					)}
-					ref={ref}
-					{...props}
-				>
-					<IntentBarAccent intent={intent} />
-					{children}
-				</Component>
-			</ToastStateContext.Provider>
-		);
-	},
-);
+	return (
+		<ToastStateContext.Provider value={contextValue}>
+			<Component
+				data-slot="toast"
+				className={cx(
+					"relative flex items-start gap-2 text-sm font-sans",
+					"p-3 pl-3.75",
+					"bg-popover high-contrast:border-popover rounded rounded-r-[0.3125rem] border border-gray-500/35 shadow-lg",
+					/**
+					 * Do not apply overflow-hidden because we want the intent bar accent
+					 * to overlap the toast border, else the border flows over the
+					 * intent bar.
+					 */
+					className,
+				)}
+				ref={ref}
+				{...props}
+			>
+				<IntentBarAccent intent={intent} />
+				{children}
+			</Component>
+		</ToastStateContext.Provider>
+	);
+};
 Root.displayName = "Toast";
 
 type ToastIconProps = Partial<SvgOnlyProps>;
@@ -238,57 +233,55 @@ type ToastIconProps = Partial<SvgOnlyProps>;
  * </Toast.Root>
  * ```
  */
-const Icon = forwardRef<ComponentRef<"svg">, ToastIconProps>(
-	({ className, svg, ...props }, ref) => {
-		const ctx = useContext(ToastStateContext);
+const Icon = ({ className, svg, ref, ...props }: ToastIconProps) => {
+	const ctx = useContext(ToastStateContext);
 
-		switch (ctx.intent) {
-			case "danger":
-				return (
-					<IconComponent
-						data-slot="toast-icon"
-						className={cx("text-danger-600", className)}
-						ref={ref}
-						svg={svg ?? <WarningIcon weight="fill" />}
-						{...props}
-					/>
-				);
-			case "warning":
-				return (
-					<IconComponent
-						data-slot="toast-icon"
-						className={cx("text-warning-600", className)}
-						ref={ref}
-						svg={svg ?? <WarningDiamondIcon weight="fill" />}
-						{...props}
-					/>
-				);
-			case "success":
-				return (
-					<IconComponent
-						data-slot="toast-icon"
-						className={cx("text-success-600", className)}
-						ref={ref}
-						svg={svg ?? <CheckCircleIcon weight="fill" />}
-						{...props}
-					/>
-				);
-			case "info":
-				return (
-					<IconComponent
-						//
-						data-slot="toast-icon"
-						className={cx("text-accent-600", className)}
-						ref={ref}
-						svg={<InfoIcon weight="fill" />}
-						{...props}
-					/>
-				);
-			default:
-				throw new Error(`Unreachable Case: ${ctx.intent}`);
-		}
-	},
-);
+	switch (ctx.intent) {
+		case "danger":
+			return (
+				<IconComponent
+					data-slot="toast-icon"
+					className={cx("text-danger-600", className)}
+					ref={ref}
+					svg={svg ?? <WarningIcon weight="fill" />}
+					{...props}
+				/>
+			);
+		case "warning":
+			return (
+				<IconComponent
+					data-slot="toast-icon"
+					className={cx("text-warning-600", className)}
+					ref={ref}
+					svg={svg ?? <WarningDiamondIcon weight="fill" />}
+					{...props}
+				/>
+			);
+		case "success":
+			return (
+				<IconComponent
+					data-slot="toast-icon"
+					className={cx("text-success-600", className)}
+					ref={ref}
+					svg={svg ?? <CheckCircleIcon weight="fill" />}
+					{...props}
+				/>
+			);
+		case "info":
+			return (
+				<IconComponent
+					//
+					data-slot="toast-icon"
+					className={cx("text-accent-600", className)}
+					ref={ref}
+					svg={<InfoIcon weight="fill" />}
+					{...props}
+				/>
+			);
+		default:
+			throw new Error(`Unreachable Case: ${ctx.intent}`);
+	}
+};
 Icon.displayName = "ToastIcon";
 
 type ToastActionProps = ComponentProps<"button"> & WithAsChild;
@@ -308,37 +301,35 @@ type ToastActionProps = ComponentProps<"button"> & WithAsChild;
  * </Toast.Root>
  * ```
  */
-const Action = forwardRef<ComponentRef<"button">, ToastActionProps>(
-	({ asChild, className, onClick, ...props }, ref) => {
-		const ctx = useContext(ToastIdContext);
+const Action = ({ asChild, className, onClick, ref, ...props }: ToastActionProps) => {
+	const ctx = useContext(ToastIdContext);
 
-		const Component = asChild ? Slot : "button";
+	const Component = asChild ? Slot : "button";
 
-		return (
-			<Component
-				data-slot="toast-action"
-				className={cx(
-					//,
-					"shrink-0",
-					// 👇 wiggle the bits so that icon buttons toast actions are aligned with the toast icon
-					"data-icon-button:-mr-0.5 data-icon-button:-mt-0.5 data-icon-button:rounded-xs",
-					className,
-				)}
-				// Why: the asChild union (Slot | "button") no longer infers a single
-				// event type; React event handlers are bivariant, so pin the param.
-				onClick={(event: MouseEvent<HTMLButtonElement>) => {
-					onClick?.(event);
-					if (event.defaultPrevented) {
-						return;
-					}
-					ToastPrimitive.toast.dismiss(ctx);
-				}}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			data-slot="toast-action"
+			className={cx(
+				//,
+				"shrink-0",
+				// 👇 wiggle the bits so that icon buttons toast actions are aligned with the toast icon
+				"data-icon-button:-mr-0.5 data-icon-button:-mt-0.5 data-icon-button:rounded-xs",
+				className,
+			)}
+			// Why: the asChild union (Slot | "button") no longer infers a single
+			// event type; React event handlers are bivariant, so pin the param.
+			onClick={(event: MouseEvent<HTMLButtonElement>) => {
+				onClick?.(event);
+				if (event.defaultPrevented) {
+					return;
+				}
+				ToastPrimitive.toast.dismiss(ctx);
+			}}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Action.displayName = "ToastAction";
 
 type ToastMessageProps = ComponentProps<"p"> & WithAsChild;
@@ -356,21 +347,19 @@ type ToastMessageProps = ComponentProps<"p"> & WithAsChild;
  * </Toast.Root>
  * ```
  */
-const Message = forwardRef<ComponentRef<"p">, ToastMessageProps>(
-	({ asChild, className, ...props }, ref) => {
-		const Component = asChild ? Slot : "p";
+const Message = ({ asChild, className, ref, ...props }: ToastMessageProps) => {
+	const Component = asChild ? Slot : "p";
 
-		return (
-			<Component
-				//
-				data-slot="toast-message"
-				className={cx("text-strong flex-1 text-sm font-body", className)}
-				ref={ref}
-				{...props}
-			/>
-		);
-	},
-);
+	return (
+		<Component
+			//
+			data-slot="toast-message"
+			className={cx("text-strong flex-1 text-sm font-body", className)}
+			ref={ref}
+			{...props}
+		/>
+	);
+};
 Message.displayName = "ToastMessage";
 
 /**

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -1,6 +1,5 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import { forwardRef } from "react";
-import type { ComponentProps, ComponentPropsWithoutRef, ComponentRef } from "react";
+import type { ComponentProps, ComponentPropsWithoutRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
 
 /**
@@ -117,10 +116,13 @@ Trigger.displayName = "Tooltip.Trigger";
  * </Tooltip.Root>
  * ```
  */
-const Content = forwardRef<
-	ComponentRef<typeof TooltipPrimitive.Content>,
-	ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ children, className, sideOffset = 4, ...props }, ref) => (
+const Content = ({
+	children,
+	className,
+	ref,
+	sideOffset = 4,
+	...props
+}: ComponentProps<typeof TooltipPrimitive.Content>) => (
 	<TooltipPrimitive.Portal>
 		<TooltipPrimitive.Content
 			className={cx(
@@ -138,7 +140,7 @@ const Content = forwardRef<
 			</TooltipPrimitive.Arrow>
 		</TooltipPrimitive.Content>
 	</TooltipPrimitive.Portal>
-));
+);
 Content.displayName = "Tooltip.Content";
 
 /**

--- a/packages/mantle/src/components/well/well.tsx
+++ b/packages/mantle/src/components/well/well.tsx
@@ -1,5 +1,4 @@
-import type { ComponentProps, ComponentRef } from "react";
-import { forwardRef } from "react";
+import type { ComponentProps } from "react";
 import type { WithAsChild } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Slot } from "../slot/index.js";
@@ -31,24 +30,18 @@ type WellProps = ComponentProps<"div"> & WithAsChild;
  * </Well>
  * ```
  */
-const Well = forwardRef<ComponentRef<"div">, WellProps>(
-	({ asChild = false, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "div";
+const Well = ({ asChild = false, className, ref, ...props }: WellProps) => {
+	const Comp = asChild ? Slot : "div";
 
-		return (
-			<Comp
-				ref={ref}
-				data-slot="well"
-				className={cx(
-					"border-card-muted bg-base relative rounded-md border shadow-inner",
-					className,
-				)}
-				{...props}
-			/>
-		);
-	},
-);
-Well.displayName = "Well";
+	return (
+		<Comp
+			ref={ref}
+			data-slot="well"
+			className={cx("border-card-muted bg-base relative rounded-md border shadow-inner", className)}
+			{...props}
+		/>
+	);
+};
 
 export {
 	//,

--- a/packages/mantle/src/hooks/use-breakpoint.tsx
+++ b/packages/mantle/src/hooks/use-breakpoint.tsx
@@ -77,9 +77,8 @@ type Breakpoint = (typeof breakpoints)[number];
 /**
  * React hook that returns the current breakpoint based on the viewport width.
  *
- * Uses a singleton subscription to a set of min-width media queries and returns
- * the largest matching breakpoint. Designed for React 18+ with
- * `useSyncExternalStore`.
+ * Uses a singleton subscription to a set of min-width media queries via
+ * `useSyncExternalStore` and returns the largest matching breakpoint.
  *
  * @returns {Breakpoint} The current breakpoint that matches the viewport width.
  *

--- a/packages/mantle/src/utils/compose-refs/compose-refs.test.tsx
+++ b/packages/mantle/src/utils/compose-refs/compose-refs.test.tsx
@@ -1,5 +1,6 @@
-import { renderHook } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
 import { createRef } from "react";
+import type { Ref } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { composeRefs, useComposedRefs } from "./compose-refs.js";
 
@@ -21,6 +22,68 @@ describe("composeRefs", () => {
 
 		expect(() => composeRefs<HTMLDivElement>(undefined, null, objectRef)(node)).not.toThrow();
 		expect(objectRef.current).toBe(node);
+	});
+
+	test("returns undefined when no inner ref returns a cleanup", () => {
+		const callbackRef = vi.fn<(node: HTMLDivElement | null) => void>();
+		const node = document.createElement("div");
+
+		expect(
+			composeRefs<HTMLDivElement>(callbackRef, createRef<HTMLDivElement>())(node),
+		).toBeUndefined();
+	});
+
+	test("invokes an inner ref's cleanup on unmount instead of calling it with null", () => {
+		const cleanup = vi.fn<() => void>();
+		const callbackRef = vi.fn<(node: HTMLDivElement | null) => () => void>(() => cleanup);
+
+		const { unmount } = render(<div ref={composeRefs<HTMLDivElement>(callbackRef)} />);
+
+		expect(callbackRef).toHaveBeenCalledTimes(1);
+		expect(callbackRef).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+		expect(cleanup).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(callbackRef).toHaveBeenCalledTimes(1);
+		expect(callbackRef).not.toHaveBeenCalledWith(null);
+	});
+
+	test("with mixed refs, null-writes non-cleanup refs and invokes cleanups on unmount", () => {
+		const cleanup = vi.fn<() => void>();
+		const cleanupRef = vi.fn<(node: HTMLDivElement | null) => () => void>(() => cleanup);
+		const plainCallbackRef = vi.fn<(node: HTMLDivElement | null) => void>();
+		const objectRef = createRef<HTMLDivElement>();
+
+		const { unmount } = render(
+			<div ref={composeRefs<HTMLDivElement>(cleanupRef, plainCallbackRef, objectRef)} />,
+		);
+
+		expect(objectRef.current).toBeInstanceOf(HTMLDivElement);
+
+		unmount();
+
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(cleanupRef).toHaveBeenCalledTimes(1);
+		expect(cleanupRef).not.toHaveBeenCalledWith(null);
+		expect(plainCallbackRef).toHaveBeenLastCalledWith(null);
+		expect(objectRef.current).toBeNull();
+	});
+
+	test("legacy path: calls callback refs with null on unmount when no inner ref returns a cleanup", () => {
+		const callbackRef = vi.fn<(node: HTMLDivElement | null) => void>();
+		const objectRef = createRef<HTMLDivElement>();
+
+		const { unmount } = render(<div ref={composeRefs<HTMLDivElement>(callbackRef, objectRef)} />);
+
+		expect(objectRef.current).toBeInstanceOf(HTMLDivElement);
+
+		unmount();
+
+		expect(callbackRef).toHaveBeenCalledTimes(2);
+		expect(callbackRef).toHaveBeenLastCalledWith(null);
+		expect(objectRef.current).toBeNull();
 	});
 });
 
@@ -52,5 +115,31 @@ describe("useComposedRefs", () => {
 
 		expect(latestRef.current).toBe(node);
 		expect(initialRef.current).toBeNull();
+	});
+
+	test("propagates inner ref cleanups and null-writes non-cleanup refs on unmount", () => {
+		const cleanup = vi.fn<() => void>();
+		const cleanupRef = vi.fn<(node: HTMLDivElement | null) => () => void>(() => cleanup);
+		const objectRef = createRef<HTMLDivElement>();
+
+		function TestComponent(props: {
+			cleanupRef: Ref<HTMLDivElement>;
+			objectRef: Ref<HTMLDivElement>;
+		}) {
+			const composedRef = useComposedRefs(props.cleanupRef, props.objectRef);
+			return <div ref={composedRef} />;
+		}
+
+		const { unmount } = render(<TestComponent cleanupRef={cleanupRef} objectRef={objectRef} />);
+
+		expect(objectRef.current).toBeInstanceOf(HTMLDivElement);
+		expect(cleanup).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(cleanupRef).toHaveBeenCalledTimes(1);
+		expect(cleanupRef).not.toHaveBeenCalledWith(null);
+		expect(objectRef.current).toBeNull();
 	});
 });

--- a/packages/mantle/src/utils/compose-refs/compose-refs.tsx
+++ b/packages/mantle/src/utils/compose-refs/compose-refs.tsx
@@ -1,56 +1,85 @@
-import type { Ref } from "react";
+import type { Ref, RefCallback } from "react";
 import { useCallback, useRef } from "react";
 
 type PossibleRef<T> = Ref<T> | undefined;
+
+/**
+ * Write a node to a single ref. Returns the cleanup function when a callback
+ * ref produces one (React 19 ref-cleanup semantics), otherwise `undefined`.
+ */
+function setRef<T>(ref: PossibleRef<T>, node: T | null) {
+	if (typeof ref === "function") {
+		return ref(node);
+	}
+	if (ref != null) {
+		ref.current = node;
+	}
+}
 
 /**
  * A utility that composes multiple refs into a single callback ref. Accepts
  * callback refs and RefObject(s); the returned ref writes the node to every
  * given ref.
  *
+ * Cleanup propagation: if any inner callback ref returns a cleanup function,
+ * the composed ref returns a cleanup which invokes each inner cleanup and
+ * performs the legacy `null` write for inner refs that did not return one.
+ * If no inner ref returns a cleanup, the composed ref returns `undefined`
+ * and React calls it again with `null` on unmount (legacy behavior).
+ *
  * Prefer {@link useComposedRefs} inside components — it keeps a stable
  * function identity across renders.
  *
  * @example
- * const setRefs = composeRefs(internalRef, forwardedRef);
+ * const setRefs = composeRefs(internalRef, props.ref);
  * return <input ref={setRefs} />;
  */
-function composeRefs<T>(...refs: PossibleRef<T>[]) {
-	return (node: T | null) => {
-		for (const ref of refs) {
-			if (typeof ref === "function") {
-				ref(node);
-			} else if (ref != null) {
-				ref.current = node;
+function composeRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T> {
+	return (node) => {
+		let hasCleanup = false;
+		const cleanups = refs.map((ref) => {
+			const cleanup = setRef(ref, node);
+			if (typeof cleanup === "function") {
+				hasCleanup = true;
 			}
+			return cleanup;
+		});
+
+		if (!hasCleanup) {
+			return undefined;
 		}
+
+		return () => {
+			for (let index = 0; index < cleanups.length; index++) {
+				const cleanup = cleanups[index];
+				if (typeof cleanup === "function") {
+					cleanup();
+				} else {
+					setRef(refs[index], null);
+				}
+			}
+		};
 	};
 }
 
 /**
  * A custom hook that composes multiple refs into a single stable callback
  * ref. Accepts callback refs and RefObject(s); the latest refs passed on
- * each render are the ones written to.
+ * each render are the ones written to, and any cleanup the composed ref
+ * returns targets the refs captured when React attached the node (see
+ * {@link composeRefs} for the cleanup propagation contract).
  *
  * @example
- * const MyInput = forwardRef<HTMLInputElement>((props, forwardedRef) => {
+ * function MyInput({ ref, ...props }: ComponentProps<"input">) {
  *   const internalRef = useRef<HTMLInputElement>(null);
- *   const ref = useComposedRefs(internalRef, forwardedRef);
- *   return <input ref={ref} {...props} />;
- * });
+ *   const composedRef = useComposedRefs(internalRef, ref);
+ *   return <input ref={composedRef} {...props} />;
+ * }
  */
-function useComposedRefs<T>(...refs: PossibleRef<T>[]) {
+function useComposedRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T> {
 	const latestRefs = useRef(refs);
 	latestRefs.current = refs;
-	return useCallback((node: T | null) => {
-		for (const ref of latestRefs.current) {
-			if (typeof ref === "function") {
-				ref(node);
-			} else if (ref != null) {
-				ref.current = node;
-			}
-		}
-	}, []);
+	return useCallback((node: T | null) => composeRefs(...latestRefs.current)(node), []);
 }
 
 export { composeRefs, useComposedRefs };


### PR DESCRIPTION
BREAKING CHANGE: @ngrok/mantle now requires react@^19 and react-dom@^19 peers (previously ^18 || ^19).

- Remove every forwardRef wrapper (224 across 55 files); components are plain functions receiving ref as a regular prop, and every public *Props type includes ref via ComponentProps
- composeRefs/useComposedRefs now propagate React 19 ref cleanup functions (return RefCallback<T>), with regression tests
- Delete redundant displayName assignments; keep intentional DevTools names on compound parts and Radix aliases
- Fix DropdownMenu.RadioItem ref element type (HTMLInputElement -> HTMLDivElement, matching the rendered element)
- Update AGENTS.md, CONVENTIONS.md (new never-forwardRef rule), skill templates, and www docs to React 19-only