### PR TITLE
perf(mantle): drop all component displayName assignments

### DIFF
--- a/.changeset/drop-component-display-names.md
+++ b/.changeset/drop-component-display-names.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Remove all `Component.displayName = "..."` assignments. Bundlers (verified with Vite 8 / Rolldown) treat these top-level property assignments as side effects, which pins otherwise-unused components — and their dependencies — into consumer bundles. Dropping them lets dead components tree-shake correctly; e.g. a dialog-only bundle no longer retains the unused Toast components. React DevTools falls back to inferring names from the component function names.

--- a/packages/mantle/src/components/accordion/accordion.tsx
+++ b/packages/mantle/src/components/accordion/accordion.tsx
@@ -253,7 +253,6 @@ const Root = (props: AccordionRootProps) => {
 		</AccordionContext.Provider>
 	);
 };
-Root.displayName = "Accordion";
 
 /**
  * A single collapsible section, rendered as a plain `<div role="group">` — the
@@ -316,7 +315,6 @@ const Item = ({
 		</AccordionItemContext.Provider>
 	);
 };
-Item.displayName = "AccordionItem";
 
 /**
  * The interactive header that toggles its section, rendered as a `<button>` with
@@ -385,7 +383,6 @@ const Trigger = ({
 		</button>
 	);
 };
-Trigger.displayName = "AccordionTrigger";
 
 // Hoisted so the default `svg` is a stable element reference instead of a new
 // element allocated on every render.
@@ -447,7 +444,6 @@ const TriggerIcon = ({
 		)}
 	/>
 );
-TriggerIcon.displayName = "AccordionTriggerIcon";
 
 /**
  * The collapsible region of an {@link Item} — the zero-padding viewport that
@@ -553,7 +549,6 @@ const Content = ({ className, children, ref, ...props }: ComponentProps<"div">) 
 		</div>
 	);
 };
-Content.displayName = "AccordionContent";
 
 /**
  * The padded inner region of an {@link Item}'s {@link Content} — where the
@@ -588,7 +583,6 @@ Content.displayName = "AccordionContent";
 const Body = ({ className, ref, ...props }: ComponentProps<"div">) => (
 	<div ref={ref} {...props} data-slot="accordion-body" className={cx("pt-2 pb-4", className)} />
 );
-Body.displayName = "AccordionBody";
 
 /**
  * A vertically stacked set of disclosure sections styled after the shadcn /

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -87,7 +87,6 @@ function Root({ intent, ...props }: AlertDialogProps) {
 		</AlertDialogContext.Provider>
 	);
 }
-Root.displayName = "AlertDialog";
 
 /**
  * A button that opens the Alert Dialog.
@@ -127,7 +126,6 @@ Root.displayName = "AlertDialog";
 const Trigger = ({ ref, ...props }: ComponentProps<typeof AlertDialogPrimitive.Trigger>) => (
 	<AlertDialogPrimitive.Trigger ref={ref} data-slot="alert-dialog-trigger" {...props} />
 );
-Trigger.displayName = "AlertDialogTrigger";
 
 /**
  * The portal for the Alert Dialog.
@@ -135,7 +133,6 @@ Trigger.displayName = "AlertDialogTrigger";
  * @private
  */
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
-AlertDialogPortal.displayName = "AlertDialogPortal";
 
 /**
  * A layer that covers the inert portion of the view when the dialog is open.
@@ -238,7 +235,6 @@ const Content = ({
 		</div>
 	</AlertDialogPortal>
 );
-Content.displayName = "AlertDialogContent";
 
 /**
  * Contains the main content of the alert dialog.
@@ -292,7 +288,6 @@ const Body = ({
 		/>
 	);
 };
-Body.displayName = "AlertDialogBody";
 
 /**
  * Contains the header content of the dialog, including the title and description.
@@ -346,7 +341,6 @@ const Header = ({
 		/>
 	);
 };
-Header.displayName = "AlertDialogHeader";
 
 /**
  * Contains the footer content of the dialog, including the action and cancel buttons.
@@ -400,7 +394,6 @@ const Footer = ({
 		/>
 	);
 };
-Footer.displayName = "AlertDialogFooter";
 
 /**
  * An accessible name to be announced when the dialog is opened.
@@ -448,7 +441,6 @@ const Title = ({ className, ref, ...props }: ComponentProps<typeof AlertDialogPr
 		{...props}
 	/>
 );
-Title.displayName = "AlertDialogTitle";
 
 /**
  * An accessible description to be announced when the dialog is opened.
@@ -502,7 +494,6 @@ const Description = ({
 		{...props}
 	/>
 );
-Description.displayName = "AlertDialogDescription";
 
 type AlertDialogActionProps = Omit<ButtonProps, "appearance" | "intent"> & {
 	/**
@@ -593,7 +584,6 @@ const Action = ({
 		/>
 	);
 };
-Action.displayName = "AlertDialogAction";
 
 type AlertDialogCancelProps = Omit<ButtonProps, "appearance" | "intent"> & {
 	/**
@@ -672,7 +662,6 @@ const Cancel = ({
 		/>
 	</AlertDialogPrimitive.Close>
 );
-Cancel.displayName = "AlertDialogCancel";
 
 type AlertDialogIconProps = Omit<SvgAttributes, "children"> & {
 	svg?: ReactNode;
@@ -749,7 +738,6 @@ const Icon = ({ className, ref, svg, ...props }: AlertDialogIconProps) => {
 		/>
 	);
 };
-Icon.displayName = "AlertDialogIcon";
 
 /**
  * A button that closes the Alert Dialog. (Unstyled)
@@ -796,7 +784,6 @@ Icon.displayName = "AlertDialogIcon";
 const Close = ({ ref, ...props }: ComponentProps<typeof AlertDialogPrimitive.Close>) => (
 	<AlertDialogPrimitive.Close ref={ref} data-slot="alert-dialog-close" {...props} />
 );
-Close.displayName = "AlertDialogClose";
 
 /**
  * A modal dialog that interrupts the user with important content and expects a

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -132,7 +132,6 @@ const Root = ({ appearance = "default", className, intent, ref, ...props }: Aler
 		</AlertContext.Provider>
 	);
 };
-Root.displayName = "Alert";
 
 type AlertIconProps = Omit<SvgAttributes, "children"> & {
 	/**
@@ -188,7 +187,6 @@ const Icon = ({ className, ref, svg, ...props }: AlertIconProps) => {
 		/>
 	);
 };
-Icon.displayName = "AlertIcon";
 
 /**
  * The container for the content slot of an alert. Place the title and description as direct children.
@@ -217,7 +215,6 @@ const Content = ({ className, ref, ...props }: ComponentProps<"div">) => (
 		{...props}
 	/>
 );
-Content.displayName = "AlertContent";
 
 type AlertTitleProps = ComponentProps<"h5"> & WithAsChild;
 
@@ -252,7 +249,6 @@ const Title = ({ asChild = false, className, ref, ...props }: AlertTitleProps) =
 		/>
 	);
 };
-Title.displayName = "AlertTitle";
 
 type AlertDescriptionProps = ComponentProps<"div"> & WithAsChild;
 
@@ -289,7 +285,6 @@ const Description = ({ asChild = false, className, ref, ...props }: AlertDescrip
 		/>
 	);
 };
-Description.displayName = "AlertDescription";
 
 const dismissTextColor = (intent: AlertIntent) => `var(--color-${intent}-700)`;
 
@@ -356,7 +351,6 @@ const DismissIconButton = ({
 		/>
 	);
 };
-DismissIconButton.displayName = "AlertDismissIconButton";
 
 /**
  * Displays a callout for user attention.

--- a/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
@@ -55,7 +55,6 @@ const Root = ({
 		</Comp>
 	);
 };
-Root.displayName = "Breadcrumb";
 
 /**
  * The ordered list of crumbs. Renders an `<ol>` — an **ordered** list, because
@@ -104,7 +103,6 @@ const List = ({
 		</Comp>
 	);
 };
-List.displayName = "BreadcrumbList";
 
 /**
  * A single crumb. Renders an `<li>` (`role="listitem"`) that lays out its
@@ -152,7 +150,6 @@ const Item = ({
 		</Comp>
 	);
 };
-Item.displayName = "BreadcrumbItem";
 
 /**
  * A link to an ancestor page in the hierarchy. Renders an `<a>` by default;
@@ -209,7 +206,6 @@ const Link = ({
 		</Comp>
 	);
 };
-Link.displayName = "BreadcrumbLink";
 
 /**
  * The current page — the last crumb in the trail. Renders a `<span>` (not a
@@ -266,7 +262,6 @@ const Page = ({
 		</Comp>
 	);
 };
-Page.displayName = "BreadcrumbPage";
 
 /**
  * The props for `Breadcrumb.Separator`. When `asChild` is set, `children` is
@@ -345,7 +340,6 @@ const Separator = ({
 		</Comp>
 	);
 };
-Separator.displayName = "BreadcrumbSeparator";
 
 /**
  * Compound component for WAI-ARIA breadcrumb navigation — the path from a

--- a/packages/mantle/src/components/card/card.tsx
+++ b/packages/mantle/src/components/card/card.tsx
@@ -46,7 +46,6 @@ const Root = ({ asChild = false, className, children, ref, ...rest }: CardProps)
 		</Component>
 	);
 };
-Root.displayName = "Card";
 
 /**
  * The main content of a card. Usually composed as a direct child of a `Card` component.
@@ -88,7 +87,6 @@ const Body = ({ asChild = false, className, children, ref, ...rest }: CardProps)
 		</Component>
 	);
 };
-Body.displayName = "CardBody";
 
 /**
  * The footer container of a card. Usually composed as a direct child of a `Card` component.
@@ -124,7 +122,6 @@ const Footer = ({ asChild = false, className, children, ref, ...rest }: CardProp
 		</Component>
 	);
 };
-Footer.displayName = "CardFooter";
 
 /**
  * The header container of a card. Usually composed as a direct child of a `Card` component.
@@ -160,7 +157,6 @@ const Header = ({ asChild = false, className, children, ref, ...rest }: CardProp
 		</Component>
 	);
 };
-Header.displayName = "CardHeader";
 
 type CardTitleProps = ComponentProps<"h3"> & WithAsChild;
 
@@ -199,7 +195,6 @@ const Title = ({ className, asChild, ref, ...props }: CardTitleProps) => {
 		/>
 	);
 };
-Title.displayName = "CardTitle";
 
 /**
  * A container that can be used to display content in a box resembling a

--- a/packages/mantle/src/components/centered-layout/centered-layout.tsx
+++ b/packages/mantle/src/components/centered-layout/centered-layout.tsx
@@ -56,7 +56,6 @@ const Root = ({
 		</Comp>
 	);
 };
-Root.displayName = "CenteredLayout";
 
 /**
  * A full-window-width strip pinned above everything else in the layout —
@@ -112,7 +111,6 @@ const Notice = ({
 		</Comp>
 	);
 };
-Notice.displayName = "CenteredLayoutNotice";
 
 /**
  * A utility strip at the top of the layout — an account chip, a close/dismiss
@@ -164,7 +162,6 @@ const Header = ({
 		</Comp>
 	);
 };
-Header.displayName = "CenteredLayoutHeader";
 
 /**
  * The growing, centered region of the layout. Renders a `<div>` with
@@ -221,7 +218,6 @@ const Body = ({
 		</Comp>
 	);
 };
-Body.displayName = "CenteredLayoutBody";
 
 /**
  * A pinned utility strip at the bottom of the layout — a theme switcher,
@@ -273,7 +269,6 @@ const Footer = ({
 		</Comp>
 	);
 };
-Footer.displayName = "CenteredLayoutFooter";
 
 /**
  * A viewport-filling centered page flow for sign-in, sign-up, onboarding,

--- a/packages/mantle/src/components/choice/choice.tsx
+++ b/packages/mantle/src/components/choice/choice.tsx
@@ -188,7 +188,6 @@ const Root = ({
 		</ChoiceContext.Provider>
 	);
 };
-Root.displayName = "Choice";
 
 type ChoiceIndicatorProps = ComponentProps<"span">;
 
@@ -253,7 +252,6 @@ const Indicator = ({ children, className, ref, ...props }: ChoiceIndicatorProps)
 		</span>
 	);
 };
-Indicator.displayName = "ChoiceIndicator";
 
 type ChoiceContentProps = ComponentProps<"div"> & WithAsChild;
 
@@ -289,7 +287,6 @@ const Content = ({ asChild, className, ref, ...props }: ChoiceContentProps) => {
 		/>
 	);
 };
-Content.displayName = "ChoiceContent";
 
 /**
  * Props for `Choice.Label`. The mantle `Label` props, minus `htmlFor` and
@@ -386,7 +383,6 @@ const Title = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & With
 		/>
 	);
 };
-Title.displayName = "ChoiceTitle";
 
 /**
  * The de-emphasized supplementary line of a `Choice`, in the muted body color
@@ -422,7 +418,6 @@ const Description = ({ asChild, className, ref, ...props }: ComponentProps<"p"> 
 		/>
 	);
 };
-Description.displayName = "ChoiceDescription";
 
 /**
  * A reusable indicator-left / content-right layout for a single choice: a

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -175,7 +175,6 @@ const Root = ({
 		</CodeBlockContext.Provider>
 	);
 };
-Root.displayName = "CodeBlock";
 
 /**
  * The body of the `CodeBlock`. This is where `CodeBlock.Code` and
@@ -212,7 +211,6 @@ const Body = ({
 		/>
 	);
 };
-Body.displayName = "CodeBlockBody";
 
 /**
  * Matches `SHIKI_VAL_<index>` placeholders injected by the Vite plugin for
@@ -435,7 +433,6 @@ const Code = ({ className, style, value, ref, ...props }: CodeBlockCodeProps) =>
 		</pre>
 	);
 };
-Code.displayName = "CodeBlockCode";
 
 /**
  * The (optional) header slot of the `CodeBlock`. This is where
@@ -475,7 +472,6 @@ const Header = ({
 		/>
 	);
 };
-Header.displayName = "CodeBlockHeader";
 
 /**
  * The (optional) title of the `CodeBlock`. Renders as `h3` by default;
@@ -512,7 +508,6 @@ const Title = ({
 		/>
 	);
 };
-Title.displayName = "CodeBlockTitle";
 
 type CodeBlockCopyButtonProps = Omit<ComponentProps<"button">, "children" | "type"> &
 	SelfClosingWithAsChild & {
@@ -615,7 +610,6 @@ const CopyButton = ({
 		</span>
 	);
 };
-CopyButton.displayName = "CodeBlockCopyButton";
 
 type CodeBlockExpanderButtonProps = Omit<
 	ComponentProps<"button">,
@@ -687,7 +681,6 @@ const ExpanderButton = ({
 		</Component>
 	);
 };
-ExpanderButton.displayName = "CodeBlockExpanderButton";
 
 type CodeBlockIconProps = Omit<SvgAttributes, "children"> &
 	(
@@ -765,7 +758,6 @@ function CodeBlockIconComponent({
 		/>
 	);
 }
-CodeBlockIconComponent.displayName = "CodeBlockIcon";
 
 type CodeBlockTabListProps = Omit<ComponentProps<typeof RadixTabsList>, "asChild" | "loop">;
 
@@ -817,7 +809,6 @@ const TabList = ({ className, ref, ...props }: CodeBlockTabListProps) => (
 		{...props}
 	/>
 );
-TabList.displayName = "CodeBlockTabList";
 
 type CodeBlockTabTriggerProps = Omit<ComponentProps<typeof RadixTabsTrigger>, "asChild">;
 
@@ -848,7 +839,6 @@ const TabTrigger = ({ className, ref, ...props }: CodeBlockTabTriggerProps) => (
 		{...props}
 	/>
 );
-TabTrigger.displayName = "CodeBlockTabTrigger";
 
 type CodeBlockTabContentProps = Omit<
 	ComponentProps<typeof RadixTabsContent>,
@@ -876,7 +866,6 @@ type CodeBlockTabContentProps = Omit<
 const TabContent = (props: CodeBlockTabContentProps) => (
 	<RadixTabsContent data-slot="code-block-tab-content" {...props} />
 );
-TabContent.displayName = "CodeBlockTabContent";
 
 /**
  * Shiki-powered code blocks with build-time syntax highlighting and zero browser bundle.

--- a/packages/mantle/src/components/combobox/combobox.tsx
+++ b/packages/mantle/src/components/combobox/combobox.tsx
@@ -38,7 +38,6 @@ type ComboboxProps = Primitive.ComboboxProviderProps;
 const Root = ({ children, ...props }: ComboboxProps) => {
 	return <Primitive.ComboboxProvider {...props}>{children}</Primitive.ComboboxProvider>;
 };
-Root.displayName = "Combobox";
 
 type ComboboxInputProps = Omit<
 	Primitive.ComboboxProps,
@@ -103,7 +102,6 @@ const Input = ({
 		/>
 	);
 };
-Input.displayName = "ComboboxInput";
 
 type ComboboxContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & WithAsChild;
 
@@ -153,7 +151,6 @@ const Content = ({
 		</Primitive.ComboboxPopover>
 	);
 };
-Content.displayName = "ComboboxContent";
 
 type ComboboxItemProps = Omit<Primitive.ComboboxItemProps, "render"> & WithAsChild;
 
@@ -208,7 +205,6 @@ const Item = ({
 		</ComboboxItemValueContext.Provider>
 	);
 };
-Item.displayName = "ComboboxItem";
 
 type ComboboxGroupProps = Omit<Primitive.ComboboxGroupProps, "render"> & WithAsChild;
 
@@ -248,7 +244,6 @@ const Group = ({ asChild = false, children, className, ref, ...props }: Combobox
 		</Primitive.ComboboxGroup>
 	);
 };
-Group.displayName = "ComboboxGroup";
 
 type ComboboxGroupLabelProps = Omit<Primitive.ComboboxGroupLabelProps, "render"> & WithAsChild;
 
@@ -294,7 +289,6 @@ const GroupLabel = ({
 		</Primitive.ComboboxGroupLabel>
 	);
 };
-GroupLabel.displayName = "ComboboxGroupLabel";
 
 type ComboboxItemValueProps = Omit<Primitive.ComboboxItemValueProps<"span">, "render"> &
 	WithAsChild;
@@ -344,7 +338,6 @@ const ItemValue = ({ asChild = false, className, ref, ...props }: ComboboxItemVa
 		/>
 	);
 };
-ItemValue.displayName = "ComboboxItemValue";
 
 /**
  * Renders a separator between Combobox.Items or Combobox.Groups.
@@ -380,7 +373,6 @@ const ComboboxSeparatorComponent = ({
 		{...props}
 	/>
 );
-ComboboxSeparatorComponent.displayName = "ComboboxSeparator";
 
 /**
  * Fill in a React input field with autocomplete & autosuggest functionalities.

--- a/packages/mantle/src/components/command/command.tsx
+++ b/packages/mantle/src/components/command/command.tsx
@@ -49,7 +49,6 @@ const CommandRoot = ({ className, ...props }: CommandRootProps) => (
 		{...props}
 	/>
 );
-CommandRoot.displayName = "Command";
 
 /**
  * The props for the CommandDialog.Content component.

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -938,20 +938,6 @@ function ExpandedRow<TData>({
 	);
 }
 
-// Set display names to preserve original component names for debugging
-Root.displayName = "DataTable";
-ActionCell.displayName = "DataTableActionCell";
-ActionHeader.displayName = "DataTableActionHeader";
-Body.displayName = "DataTableBody";
-EmptyRow.displayName = "DataTableEmptyRow";
-ExpandHeader.displayName = "DataTableExpandHeader";
-ExpandedRow.displayName = "DataTableExpandedRow";
-Head.displayName = "DataTableHead";
-Header.displayName = "DataTableHeader";
-HeaderSortButton.displayName = "DataTableHeaderSortButton";
-Row.displayName = "DataTableRow";
-RowExpandButton.displayName = "DataTableRowExpandButton";
-
 /**
  * Use `DataTable` for INTERACTIVE tabular data — sorting, filtering, pagination,
  * row selection, and server-side or client-side data. Built on TanStack Table;

--- a/packages/mantle/src/components/description-list/description-list.tsx
+++ b/packages/mantle/src/components/description-list/description-list.tsx
@@ -40,7 +40,6 @@ const Root = ({ asChild = false, className, children, ref, ...rest }: Descriptio
 		</Component>
 	);
 };
-Root.displayName = "DescriptionList";
 
 type DescriptionListItemProps = ComponentProps<"div"> & WithAsChild;
 
@@ -73,7 +72,6 @@ const Item = ({ asChild = false, className, children, ref, ...rest }: Descriptio
 		</Component>
 	);
 };
-Item.displayName = "DescriptionListItem";
 
 type DescriptionListLabelProps = ComponentProps<"dt"> & WithAsChild;
 
@@ -107,7 +105,6 @@ const Label = ({
 		</Component>
 	);
 };
-Label.displayName = "DescriptionListLabel";
 
 type DescriptionListValueProps = ComponentProps<"dd"> & WithAsChild;
 
@@ -145,7 +142,6 @@ const Value = ({
 		</Component>
 	);
 };
-Value.displayName = "DescriptionListValue";
 
 /**
  * A semantically correct description list built on the HTML `<dl>` element.

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -45,7 +45,6 @@ import * as DialogPrimitive from "./primitive.js";
  * ```
  */
 const Root = DialogPrimitive.Root;
-Root.displayName = "Dialog";
 
 /**
  * A button that opens the dialog.
@@ -80,7 +79,6 @@ Root.displayName = "Dialog";
 const Trigger = (props: ComponentProps<typeof DialogPrimitive.Trigger>) => (
 	<DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 );
-Trigger.displayName = "DialogTrigger";
 
 /**
  * The portal container for the dialog. Renders the overlay and content into a
@@ -121,7 +119,6 @@ Trigger.displayName = "DialogTrigger";
  * ```
  */
 const Portal = DialogPrimitive.Portal;
-Portal.displayName = "DialogPortal";
 
 /**
  * A button that closes the dialog when clicked. Wrap an interactive element
@@ -157,7 +154,6 @@ Portal.displayName = "DialogPortal";
 const Close = (props: ComponentProps<typeof DialogPrimitive.Close>) => (
 	<DialogPrimitive.Close data-slot="dialog-close" {...props} />
 );
-Close.displayName = "DialogClose";
 
 /**
  * The backdrop overlay for the dialog. Sits between the page and the dialog
@@ -208,7 +204,6 @@ const Overlay = ({ className, ref, ...props }: ComponentProps<typeof DialogPrimi
 		{...props}
 	/>
 );
-Overlay.displayName = "DialogOverlay";
 
 type ContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
 	/**
@@ -286,7 +281,6 @@ const Content = ({
 		</div>
 	</Portal>
 );
-Content.displayName = "DialogContent";
 
 /**
  * Contains the header content of the dialog, including the title and close button.
@@ -331,7 +325,6 @@ const Header = ({ className, children, ...props }: ComponentProps<"div">) => (
 		{children}
 	</div>
 );
-Header.displayName = "DialogHeader";
 
 type CloseIconButtonProps = Partial<Omit<IconButtonProps, "appearance" | "icon" | "intent">> & {
 	/**
@@ -403,7 +396,6 @@ const CloseIconButton = ({
 		/>
 	</DialogPrimitive.Close>
 );
-CloseIconButton.displayName = "DialogCloseIconButton";
 
 /**
  * Contains the main content of the dialog.
@@ -445,7 +437,6 @@ const Body = ({ className, ...props }: ComponentProps<"div">) => (
 		{...props}
 	/>
 );
-Body.displayName = "DialogBody";
 
 /**
  * Contains the footer content of the dialog, including action buttons.
@@ -487,7 +478,6 @@ const Footer = ({ className, ...props }: ComponentProps<"div">) => (
 		{...props}
 	/>
 );
-Footer.displayName = "DialogFooter";
 
 /**
  * An accessible name to be announced when the dialog is opened.
@@ -527,7 +517,6 @@ const Title = ({ className, ref, ...props }: ComponentProps<typeof DialogPrimiti
 		{...props}
 	/>
 );
-Title.displayName = "DialogTitle";
 
 /**
  * An accessible description to be announced when the dialog is opened.
@@ -573,7 +562,6 @@ const Description = ({
 		{...props}
 	/>
 );
-Description.displayName = "DialogDescription";
 
 /**
  * A window overlaid on either the primary window or another dialog window. Use

--- a/packages/mantle/src/components/dialog/primitive.tsx
+++ b/packages/mantle/src/components/dialog/primitive.tsx
@@ -37,16 +37,12 @@ function Root(props: ComponentPropsWithoutRef<typeof DialogPrimitive.Root>) {
 		</InternalDialogContext.Provider>
 	);
 }
-Root.displayName = "DialogPrimitiveRoot";
 
 const Trigger = DialogPrimitive.Trigger;
-Trigger.displayName = "DialogPrimitiveTrigger";
 
 const Portal = DialogPrimitive.Portal;
-Portal.displayName = "DialogPrimitivePortal";
 
 const Close = DialogPrimitive.Close;
-Close.displayName = "DialogPrimitiveClose";
 
 const Overlay = (props: ComponentProps<typeof DialogPrimitive.Overlay>) => (
 	<DialogPrimitive.Overlay
@@ -58,7 +54,6 @@ const Overlay = (props: ComponentProps<typeof DialogPrimitive.Overlay>) => (
 		{...props}
 	/>
 );
-Overlay.displayName = "DialogPrimitiveOverlay";
 
 const Content = ({
 	onEscapeKeyDown,
@@ -90,7 +85,6 @@ const Content = ({
 		/>
 	);
 };
-Content.displayName = "DialogPrimitiveContent";
 
 const Title = DialogPrimitive.Title;
 
@@ -122,7 +116,6 @@ const Description = ({
 		</DialogPrimitive.Description>
 	);
 };
-Description.displayName = "DialogPrimitiveDescription";
 
 /**
  * Type guard to check if the event target is the overlay component

--- a/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
@@ -34,7 +34,6 @@ import { Separator } from "../separator/separator.js";
  * ```
  */
 const Root = DropdownMenuPrimitive.Root;
-Root.displayName = "DropdownMenu";
 
 /**
  * The trigger button that opens the dropdown menu.
@@ -58,7 +57,6 @@ Root.displayName = "DropdownMenu";
 const Trigger = (props: ComponentProps<typeof DropdownMenuPrimitive.Trigger>) => (
 	<DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
 );
-Trigger.displayName = "DropdownMenuTrigger";
 
 const Group = ({ className, ...props }: ComponentProps<typeof DropdownMenuPrimitive.Group>) => (
 	<DropdownMenuPrimitive.Group
@@ -67,16 +65,13 @@ const Group = ({ className, ...props }: ComponentProps<typeof DropdownMenuPrimit
 		{...props}
 	/>
 );
-Group.displayName = "DropdownMenuGroup";
 
 /**
  * The portal container for rendering dropdown content outside the normal DOM tree.
  */
 const Portal = DropdownMenuPrimitive.Portal;
-Portal.displayName = "DropdownMenuPortal";
 
 const Sub = DropdownMenuPrimitive.Sub;
-Sub.displayName = "DropdownMenuSub";
 
 const RadioGroup = ({
 	className,
@@ -88,7 +83,6 @@ const RadioGroup = ({
 		{...props}
 	/>
 );
-RadioGroup.displayName = "DropdownMenuRadioGroup";
 
 /**
  * A trigger for a dropdown menu sub-menu.
@@ -120,7 +114,6 @@ const SubTrigger = ({
 		</span>
 	</DropdownMenuPrimitive.SubTrigger>
 );
-SubTrigger.displayName = "DropdownMenuSubTrigger";
 
 /**
  * The content container for a dropdown menu sub-menu.
@@ -150,7 +143,6 @@ const SubContent = ({
 		/>
 	</Portal>
 );
-SubContent.displayName = "DropdownMenuSubContent";
 
 type DropdownMenuContentProps = ComponentProps<typeof DropdownMenuPrimitive.Content> &
 	WithDataSlot & {
@@ -216,7 +208,6 @@ const Content = ({
 		/>
 	</Portal>
 );
-Content.displayName = "DropdownMenuContent";
 
 /**
  * An item in the dropdown menu.
@@ -259,7 +250,6 @@ const Item = ({
 		{...props}
 	/>
 );
-Item.displayName = "DropdownMenuItem";
 
 /**
  * A menu item with a checkbox that can be controlled or uncontrolled.
@@ -293,7 +283,6 @@ const CheckboxItem = ({
 		{children}
 	</DropdownMenuPrimitive.CheckboxItem>
 );
-CheckboxItem.displayName = "DropdownMenuCheckboxItem";
 
 type DropdownMenuRadioItemProps = ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
 	name?: string;
@@ -328,7 +317,6 @@ const RadioItem = ({ className, children, ...props }: DropdownMenuRadioItemProps
 		{children}
 	</DropdownMenuPrimitive.RadioItem>
 );
-RadioItem.displayName = "DropdownMenuRadioItem";
 
 /**
  * A label for a group of dropdown menu items.
@@ -348,7 +336,6 @@ const Label = ({
 		{...props}
 	/>
 );
-Label.displayName = "DropdownMenuLabel";
 
 /**
  * A visual separator between dropdown menu items or groups.
@@ -362,7 +349,6 @@ const DropdownSeparator = ({ className, ...props }: ComponentProps<typeof Separa
 		{...props}
 	/>
 );
-DropdownSeparator.displayName = "DropdownMenuSeparator";
 
 const Shortcut = ({ className, ...props }: ComponentProps<"span">) => {
 	return (
@@ -373,7 +359,6 @@ const Shortcut = ({ className, ...props }: ComponentProps<"span">) => {
 		/>
 	);
 };
-Shortcut.displayName = "DropdownMenuShortcut";
 
 /**
  * A menu of options or actions, triggered by a button.

--- a/packages/mantle/src/components/empty/empty.tsx
+++ b/packages/mantle/src/components/empty/empty.tsx
@@ -36,7 +36,6 @@ const Root = ({ asChild, children, className, ...props }: ComponentProps<"div"> 
 		</Comp>
 	);
 };
-Root.displayName = "Empty";
 
 type EmptyIconProps = Omit<SvgAttributes, "children"> & {
 	/**
@@ -73,7 +72,6 @@ const Icon = ({ className, svg, ...props }: EmptyIconProps) => {
 		/>
 	);
 };
-Icon.displayName = "EmptyIcon";
 
 /**
  * The heading text for the empty state. Renders as an `h3` by default. Use the
@@ -115,7 +113,6 @@ const Title = ({
 		</Comp>
 	);
 };
-Title.displayName = "EmptyTitle";
 
 /**
  * Supporting descriptive text below the title. Renders as a `div` with
@@ -159,7 +156,6 @@ const Description = ({
 		</Comp>
 	);
 };
-Description.displayName = "EmptyDescription";
 
 /**
  * A container for action buttons or links in the empty state.
@@ -197,7 +193,6 @@ const Actions = ({
 		</Comp>
 	);
 };
-Actions.displayName = "EmptyActions";
 
 /**
  * Compound component for rendering empty states. Use with `Empty.Root`,

--- a/packages/mantle/src/components/field/field.test.tsx
+++ b/packages/mantle/src/components/field/field.test.tsx
@@ -7,7 +7,6 @@ import type { FieldControlAriaProps } from "./field-context.js";
 import { Field } from "./field.js";
 
 const MockControl = (props: ComponentProps<"input">) => <input {...props} />;
-MockControl.displayName = "Input";
 
 const MockWrapper = ({ children }: { children: ReactNode }) => children;
 

--- a/packages/mantle/src/components/field/field.tsx
+++ b/packages/mantle/src/components/field/field.tsx
@@ -114,7 +114,6 @@ const Legend = ({ className, ref, ...props }: ComponentProps<"legend">) => {
 		/>
 	);
 };
-Legend.displayName = "FieldLegend";
 
 /**
  * Caption for a `Field.Item`. Renders the Mantle `Label` with the same
@@ -203,7 +202,6 @@ const LabelText = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & 
 		/>
 	);
 };
-LabelText.displayName = "FieldLabelText";
 
 /**
  * Horizontal layout container for the label area of a field. Aligns a
@@ -255,7 +253,6 @@ const LabelRow = ({ asChild, className, ref, ...props }: ComponentProps<"div"> &
 		/>
 	);
 };
-LabelRow.displayName = "FieldLabelRow";
 
 /**
  * `Popover.Root` re-export for the help-affordance pattern. Pair with
@@ -392,7 +389,6 @@ const HelpTrigger = ({
 		/>
 	</Popover.Trigger>
 );
-HelpTrigger.displayName = "FieldHelpTrigger";
 
 /**
  * The popover body for a `Field.Help`. Wraps `Popover.Content` so all
@@ -428,7 +424,6 @@ HelpTrigger.displayName = "FieldHelpTrigger";
 const HelpContent = ({ ref, ...props }: ComponentProps<typeof Popover.Content>) => (
 	<Popover.Content ref={ref} data-slot="field-help-content" {...props} />
 );
-HelpContent.displayName = "FieldHelpContent";
 
 /**
  * Inline "(Optional)" suffix to mark a field as optional. Defaults to the
@@ -485,7 +480,6 @@ const Optional = ({
 		</Comp>
 	);
 };
-Optional.displayName = "FieldOptional";
 
 /**
  * Layout container that stacks multiple `Field.Item`s vertically with
@@ -530,7 +524,6 @@ const Group = ({ asChild, className, ref, ...props }: ComponentProps<"div"> & Wi
 		/>
 	);
 };
-Group.displayName = "FieldGroup";
 
 /**
  * A single form field — `Label`, a control (`Input`, `Select`, `Checkbox`,
@@ -640,7 +633,6 @@ const Item = ({
 		</FieldItemContext.Provider>
 	);
 };
-Item.displayName = "FieldItem";
 
 type FieldControlSlotProps = Omit<
 	ComponentProps<typeof Slot>,
@@ -788,7 +780,6 @@ const Control = ({ children, ref, ...props }: FieldControlProps) => {
 		</FieldValidationProvider>
 	);
 };
-Control.displayName = "FieldControl";
 
 /**
  * Helper / hint text. Renders a `<p>` in the muted body color so it reads
@@ -858,7 +849,6 @@ const Description = ({
 		/>
 	);
 };
-Description.displayName = "FieldDescription";
 
 /**
  * A single error message list item for a field. Renders an `<li>` in

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -35,7 +35,6 @@ const Root = ({
 }: ComponentProps<typeof HoverCardPrimitive.Root>) => (
 	<HoverCardPrimitive.Root closeDelay={closeDelay} openDelay={openDelay} {...props} />
 );
-Root.displayName = "HoverCard";
 
 /**
  * The trigger element that opens the hover card when hovered.
@@ -59,7 +58,6 @@ Root.displayName = "HoverCard";
 const Trigger = (props: ComponentProps<typeof HoverCardPrimitive.Trigger>) => (
 	<HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
 );
-Trigger.displayName = "HoverCardTrigger";
 
 /**
  * The portal container for rendering hover card content outside the normal DOM tree.
@@ -87,7 +85,6 @@ Trigger.displayName = "HoverCardTrigger";
  * ```
  */
 const Portal = HoverCardPrimitive.Portal;
-Portal.displayName = "HoverCardPortal";
 
 /**
  * The content to render inside the hover card.
@@ -140,7 +137,6 @@ const Content = ({
 		/>
 	</Portal>
 );
-Content.displayName = HoverCardPrimitive.Content.displayName;
 
 /**
  * A floating card that appears when a user hovers over a trigger element.

--- a/packages/mantle/src/components/list/list.tsx
+++ b/packages/mantle/src/components/list/list.tsx
@@ -60,7 +60,6 @@ type ListRootProps = Omit<
  * ```
  */
 const Root = (props: ListRootProps) => <ListPrimitiveRoot semantics="list" {...props} />;
-Root.displayName = "ListRoot";
 
 /**
  * Props for `List.VirtualRoot` — the internal list primitive's
@@ -109,7 +108,6 @@ type ListVirtualRootProps = Omit<
 const VirtualRoot = (props: ListVirtualRootProps) => (
 	<ListPrimitiveVirtualRoot semantics="list" {...props} />
 );
-VirtualRoot.displayName = "ListVirtualRoot";
 
 /**
  * Props for `List.Item`. Extends `<button>` props (minus `type`, which is fixed
@@ -239,7 +237,6 @@ const Item = ({ asChild, className, current, disabled, onClick, ref, ...props }:
 		</ListPrimitiveItem>
 	);
 };
-Item.displayName = "ListItem";
 
 /**
  * The emphasized title line inside a `List.Item`, in the stronger foreground
@@ -267,7 +264,6 @@ const ItemTitle = ({ className, ref, ...props }: ComponentProps<"span">) => (
 		{...props}
 	/>
 );
-ItemTitle.displayName = "ListItemTitle";
 
 /**
  * The de-emphasized sub-line inside a `List.Item`, in the muted body color. A
@@ -295,7 +291,6 @@ const ItemDescription = ({ className, ref, ...props }: ComponentProps<"span">) =
 		{...props}
 	/>
 );
-ItemDescription.displayName = "ListItemDescription";
 
 /**
  * A scrollable, optionally-virtualized list of clickable items — the action /

--- a/packages/mantle/src/components/list/primitive.tsx
+++ b/packages/mantle/src/components/list/primitive.tsx
@@ -760,7 +760,6 @@ function ListShell({
 		</ListContext.Provider>
 	);
 }
-ListShell.displayName = "ListPrimitiveShell";
 
 /**
  * Props for a {@link Item}. Standard `<div>` props (minus `role`, owned by the
@@ -878,7 +877,6 @@ const Item = ({
 		</Comp>
 	);
 };
-Item.displayName = "ListPrimitiveItem";
 
 /**
  * Provides one non-virtualized row its index through {@link ListItemContext}
@@ -891,7 +889,6 @@ function PlainItem({ children, index }: { children: ReactNode; index: number }) 
 
 	return <ListItemContext.Provider value={value}>{children}</ListItemContext.Provider>;
 }
-PlainItem.displayName = "ListPrimitivePlainItem";
 
 /**
  * The non-virtualized list shell: renders its composed {@link Item} children in
@@ -1004,7 +1001,6 @@ const Root = ({
 		</ListShell>
 	);
 };
-Root.displayName = "ListPrimitiveRoot";
 
 export {
 	//,

--- a/packages/mantle/src/components/list/virtual.tsx
+++ b/packages/mantle/src/components/list/virtual.tsx
@@ -93,7 +93,6 @@ function WindowedItem({
 
 	return <ListItemContext.Provider value={value}>{children}</ListItemContext.Provider>;
 }
-WindowedItem.displayName = "ListPrimitiveWindowedItem";
 
 /**
  * The windowed counterpart to `Root`: renders only the visible slice of its
@@ -282,7 +281,6 @@ const VirtualRoot = ({
 		</ListShell>
 	);
 };
-VirtualRoot.displayName = "ListPrimitiveVirtualRoot";
 
 export {
 	//,

--- a/packages/mantle/src/components/media-object/media-object.tsx
+++ b/packages/mantle/src/components/media-object/media-object.tsx
@@ -24,7 +24,6 @@ const Root = ({ asChild = false, className, children, style, ref }: Props) => {
 		</Component>
 	);
 };
-Root.displayName = "MediaObject";
 
 /**
  * The container for an image or icon to display in the media slot of the media object.
@@ -43,7 +42,6 @@ const Media = ({ asChild = false, className, children, style, ref }: Props) => {
 		</Component>
 	);
 };
-Media.displayName = "MediaObjectMedia";
 
 /**
  * The container for the content slot of a media object.
@@ -62,7 +60,6 @@ const Content = ({ asChild = false, className, children, style, ref }: Props) =>
 		</Component>
 	);
 };
-Content.displayName = "MediaObject.Content";
 
 /**
  * A small, reusable layout primitive for "image/icon on one side,

--- a/packages/mantle/src/components/multi-select/multi-select.tsx
+++ b/packages/mantle/src/components/multi-select/multi-select.tsx
@@ -117,7 +117,6 @@ const Root = ({ children, defaultSelectedValue = EMPTY_ARRAY, ...props }: MultiS
 		</TriggerRefContext.Provider>
 	);
 };
-Root.displayName = "MultiSelect";
 
 type MultiSelectTriggerProps = ComponentProps<"div"> & WithValidation;
 
@@ -201,7 +200,6 @@ const Trigger = ({
 		</div>
 	);
 };
-Trigger.displayName = "MultiSelectTrigger";
 
 type TagProps = Omit<ComponentProps<"span">, "children"> & {
 	/**
@@ -310,7 +308,6 @@ const Tag = ({
 		</span>
 	);
 };
-Tag.displayName = "MultiSelectTag";
 
 /**
  * Props passed to the children render function of `MultiSelect.TagValues`.
@@ -598,7 +595,6 @@ const TagValues = ({ children, lockedValues = EMPTY_ARRAY }: MultiSelectTagValue
 		</>
 	);
 };
-TagValues.displayName = "MultiSelectTagValues";
 
 type MultiSelectInputProps = Omit<Primitive.ComboboxProps, "render"> & {
 	/**
@@ -702,7 +698,6 @@ const Input = ({
 		/>
 	);
 };
-Input.displayName = "MultiSelectInput";
 
 type MultiSelectContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & WithAsChild;
 
@@ -817,7 +812,6 @@ const Content = ({
 		</Primitive.ComboboxPopover>
 	);
 };
-Content.displayName = "MultiSelectContent";
 
 type MultiSelectItemProps = Omit<Primitive.ComboboxItemProps, "render"> & WithAsChild;
 
@@ -888,7 +882,6 @@ const Item = ({
 		</Primitive.ComboboxItem>
 	);
 };
-Item.displayName = "MultiSelectItem";
 
 type MultiSelectGroupProps = Omit<Primitive.ComboboxGroupProps, "render"> & WithAsChild;
 
@@ -927,7 +920,6 @@ const Group = ({ asChild = false, children, ref, ...props }: MultiSelectGroupPro
 		</Primitive.ComboboxGroup>
 	);
 };
-Group.displayName = "MultiSelectGroup";
 
 type MultiSelectGroupLabelProps = Omit<Primitive.ComboboxGroupLabelProps, "render"> & WithAsChild;
 
@@ -971,7 +963,6 @@ const GroupLabel = ({
 		</Primitive.ComboboxGroupLabel>
 	);
 };
-GroupLabel.displayName = "MultiSelectGroupLabel";
 
 type MultiSelectGroupDescriptionProps = ComponentProps<"p">;
 
@@ -1017,7 +1008,6 @@ const GroupDescription = ({
 		</p>
 	);
 };
-GroupDescription.displayName = "MultiSelectGroupDescription";
 
 /**
  * Renders a separator between MultiSelect.Items or MultiSelect.Groups.
@@ -1055,7 +1045,6 @@ const MultiSelectSeparatorComponent = ({
 		{...props}
 	/>
 );
-MultiSelectSeparatorComponent.displayName = "MultiSelectSeparator";
 
 type MultiSelectEmptyProps = ComponentProps<"div">;
 
@@ -1092,7 +1081,6 @@ const Empty = ({ className, children, ref, ...props }: MultiSelectEmptyProps) =>
 		</div>
 	);
 };
-Empty.displayName = "MultiSelectEmpty";
 
 type MultiSelectContentFooterProps = ComponentProps<"div">;
 
@@ -1132,7 +1120,6 @@ const ContentFooter = ({ className, children, ref, ...props }: MultiSelectConten
 		</div>
 	);
 };
-ContentFooter.displayName = "MultiSelectContentFooter";
 
 /**
  * A multi-select combobox that allows users to select multiple values with

--- a/packages/mantle/src/components/otp-input/otp-input.tsx
+++ b/packages/mantle/src/components/otp-input/otp-input.tsx
@@ -200,7 +200,6 @@ const Root = ({
 		</OTPInput>
 	);
 };
-Root.displayName = "OtpInput";
 
 type OtpInputGroupProps = ComponentProps<"div"> & WithAsChild;
 
@@ -257,7 +256,6 @@ const Group = ({ asChild, children, className, ref, ...props }: OtpInputGroupPro
 		</Comp>
 	);
 };
-Group.displayName = "OtpInputGroup";
 
 type OtpInputSlotProps = ComponentProps<"div"> & {
 	/**
@@ -372,7 +370,6 @@ const OtpInputSlotImpl = ({ className, index, ref, ...props }: OtpInputSlotProps
 		</div>
 	);
 };
-OtpInputSlotImpl.displayName = "OtpInputSlot";
 
 type OtpInputSeparatorProps = ComponentProps<"div"> &
 	WithAsChild & {
@@ -434,7 +431,6 @@ const Separator = ({
 		</Comp>
 	);
 };
-Separator.displayName = "OtpInputSeparator";
 
 /**
  * Compound component for capturing one-time passcodes (OTP). Combines a

--- a/packages/mantle/src/components/pagination/cursor-pagination.tsx
+++ b/packages/mantle/src/components/pagination/cursor-pagination.tsx
@@ -79,7 +79,6 @@ const Root = ({ className, children, defaultPageSize, ref, ...props }: CursorPag
 		</CursorPaginationContext.Provider>
 	);
 };
-Root.displayName = "CursorPagination";
 
 type CursorButtonsProps = Omit<ComponentProps<typeof ButtonGroup>, "appearance"> & {
 	/**
@@ -157,7 +156,6 @@ const Buttons = ({
 		</ButtonGroup>
 	);
 };
-Buttons.displayName = "CursorButtons";
 
 const defaultPageSizes = [5, 10, 20, 50, 100] as const;
 
@@ -237,7 +235,6 @@ const PageSizeSelect = ({
 		</Select.Root>
 	);
 };
-PageSizeSelect.displayName = "CursorPageSizeSelect";
 
 type CursorPageSizeValueProps = Omit<ComponentProps<"span">, "children"> & WithAsChild;
 
@@ -271,7 +268,6 @@ function PageSizeValue({ asChild = false, className, ...props }: CursorPageSizeV
 		</Component>
 	);
 }
-PageSizeValue.displayName = "CursorPageSizeValue";
 
 /**
  * A pagination component for use with cursor-based pagination.

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -27,7 +27,6 @@ import { cx } from "../../utils/cx/cx.js";
  * ```
  */
 const Root = PopoverPrimitive.Root;
-Root.displayName = "Popover";
 
 /**
  * The trigger button that opens the popover.
@@ -49,7 +48,6 @@ Root.displayName = "Popover";
  * ```
  */
 const Trigger = PopoverPrimitive.Trigger;
-Trigger.displayName = "PopoverTrigger";
 
 /**
  * An optional element to position the PopoverContent against. If this part is not used, the content will position alongside the PopoverTrigger.
@@ -74,7 +72,6 @@ Trigger.displayName = "PopoverTrigger";
  * ```
  */
 const Anchor = PopoverPrimitive.Anchor;
-Anchor.displayName = "PopoverAnchor";
 
 /**
  * A button that closes an open popover.
@@ -99,7 +96,6 @@ Anchor.displayName = "PopoverAnchor";
  * ```
  */
 const Close = PopoverPrimitive.Close;
-Close.displayName = "PopoverClose";
 
 type PopoverContentProps = ComponentProps<typeof PopoverPrimitive.Content> & {
 	/**
@@ -169,7 +165,6 @@ const Content = ({
 		/>
 	</PopoverPrimitive.Portal>
 );
-Content.displayName = "PopoverContent";
 
 /**
  * A floating overlay that displays rich content in a portal, triggered by a button.

--- a/packages/mantle/src/components/progress/progress-donut.tsx
+++ b/packages/mantle/src/components/progress/progress-donut.tsx
@@ -157,7 +157,6 @@ const Root = ({
 		</ProgressContext.Provider>
 	);
 };
-Root.displayName = "ProgressDonut";
 
 /**
  * Length (value) of the progress indicator tail when the progress bar is indeterminate.
@@ -220,7 +219,6 @@ const Indicator = ({ className, ...props }: ProgressDonutIndicatorProps) => {
 		</g>
 	);
 };
-Indicator.displayName = "ProgressDonutIndicator";
 
 /**
  * A simple circular progress bar which shows the completion progress of a task.

--- a/packages/mantle/src/components/qr-code/qr-code.tsx
+++ b/packages/mantle/src/components/qr-code/qr-code.tsx
@@ -183,7 +183,6 @@ const Root = ({
 		</QrCodeContext.Provider>
 	);
 };
-Root.displayName = "QrCode";
 
 /**
  * Props for `QrCode.Frame`, the fixed SVG element that sizes the encoded QR
@@ -230,7 +229,6 @@ const Frame = ({ className, children, ref, ...props }: QrCodeFrameProps) => {
 		</svg>
 	);
 };
-Frame.displayName = "QrCodeFrame";
 
 /**
  * Props for `QrCode.Pattern`, the fixed SVG `path` element that renders the
@@ -273,7 +271,6 @@ const Pattern = ({ className, ref, ...props }: QrCodePatternProps) => {
 		/>
 	);
 };
-Pattern.displayName = "QrCodePattern";
 
 /**
  * Props for `QrCode.Overlay`, the optional centered logo container rendered on
@@ -316,7 +313,6 @@ const Overlay = ({ asChild, className, ref, ...props }: QrCodeOverlayProps) => {
 		/>
 	);
 };
-Overlay.displayName = "QrCodeOverlay";
 
 /**
  * A QR code. Compose `QrCode.Root` with a `QrCode.Frame` wrapping a

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -49,7 +49,6 @@ type RadioGroupProps = PropsWithChildren<Omit<HeadlessRadioGroupProps, "as" | "c
 const Root = ({ ref, ...props }: RadioGroupProps) => (
 	<HeadlessRadioGroup data-slot="radio-group" {...props} ref={ref} />
 );
-Root.displayName = "RadioGroup";
 
 /**
  * The shape of the radio state context.
@@ -125,7 +124,6 @@ const Item = ({ children, className, ref, ...props }: RadioItemProps) => {
 		</HeadlessRadio>
 	);
 };
-Item.displayName = "RadioItem";
 
 type RadioIndicatorProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
 	children?: ReactNode | ((context: RadioStateContextValue) => ReactNode);
@@ -189,7 +187,6 @@ const Indicator = ({ children, className, ...props }: RadioIndicatorProps) => {
 		</div>
 	);
 };
-Indicator.displayName = "RadioIndicator";
 
 /**
  * A group of radio list items. Use RadioGroup.ListItem as direct children.
@@ -204,7 +201,6 @@ const List = ({ className, ref, ...props }: RadioGroupProps) => {
 		/>
 	);
 };
-List.displayName = "RadioGroupList";
 
 type RadioListItemProps = RadioItemProps;
 
@@ -246,7 +242,6 @@ const ListItem = ({ children, className, ref, ...props }: RadioListItemProps) =>
 		</HeadlessRadio>
 	);
 };
-ListItem.displayName = "RadioListItem";
 
 type RadioItemContentProps = HTMLAttributes<HTMLDivElement> & WithAsChild;
 
@@ -289,7 +284,6 @@ const Card = ({ children, className, ref, ...props }: RadioCardProps) => {
 		</HeadlessRadio>
 	);
 };
-Card.displayName = "RadioCard";
 
 /**
  * The content of any radio item. Use it to wrap any labels, descriptions, or content of a radio item.
@@ -309,7 +303,6 @@ const ItemContent = ({ asChild = false, children, className, ...props }: RadioIt
 		</Component>
 	);
 };
-ItemContent.displayName = "RadioItemContent";
 
 /**
  * An inline group of radio buttons. Use RadioGroup.Button as direct children.
@@ -327,7 +320,6 @@ const ButtonGroup = ({ className, ref, ...props }: RadioGroupProps) => {
 		/>
 	);
 };
-ButtonGroup.displayName = "RadioButtonGroup";
 
 type RadioButtonProps = RadioItemProps;
 
@@ -370,7 +362,6 @@ const Button = ({ children, className, ref, ...props }: RadioButtonProps) => {
 		</HeadlessRadio>
 	);
 };
-Button.displayName = "RadioButton";
 
 type RadioInputSandboxProps = HTMLAttributes<HTMLDivElement>;
 
@@ -432,7 +423,6 @@ const InputSandbox = ({ children, onClick, onKeyDown, ...props }: RadioInputSand
 		</div>
 	);
 };
-InputSandbox.displayName = "RadioInputSandbox";
 
 /**
  * A group of radio items. It manages the state of the children radios.

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -145,7 +145,6 @@ const Root = ({
 		</SelectPrimitive.Root>
 	);
 };
-Root.displayName = "Select";
 
 /**
  * A group of related options within a select menu. Similar to an html `<optgroup>` element.
@@ -184,7 +183,6 @@ const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
 		{...props}
 	/>
 );
-Group.displayName = "SelectGroup";
 
 /**
  * The part that reflects the selected value. By default the selected item's text will be rendered. if you require more control, you can instead control the select and pass your own children. It should not be styled to ensure correct positioning. An optional placeholder prop is also available for when the select has no value.
@@ -215,7 +213,6 @@ Group.displayName = "SelectGroup";
  * ```
  */
 const Value = SelectPrimitive.Value;
-Value.displayName = "SelectValue";
 
 type SelectTriggerProps = ComponentProps<typeof SelectPrimitive.Trigger> &
 	WithAriaInvalid &
@@ -311,7 +308,6 @@ const Trigger = ({
 		</SelectPrimitive.Trigger>
 	);
 };
-Trigger.displayName = "SelectTrigger";
 
 /**
  * The button that scrolls the select content up.
@@ -427,7 +423,6 @@ const Content = ({
 		</SelectPrimitive.Content>
 	</SelectPrimitive.Portal>
 );
-Content.displayName = "SelectContent";
 
 /**
  * Used to render the label of a group. It won't be focusable using arrow keys.
@@ -465,7 +460,6 @@ const Label = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
 		{...props}
 	/>
 );
-Label.displayName = "SelectLabel";
 
 type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> & {
 	icon?: ReactNode;
@@ -522,7 +516,6 @@ const Item = ({ className, children, icon, ref, ...props }: SelectItemProps) => 
 		</SelectPrimitive.ItemIndicator>
 	</SelectPrimitive.Item>
 );
-Item.displayName = "SelectItem";
 
 /**
  * Used to visually separate items or groups of items in the select content.
@@ -564,7 +557,6 @@ const SelectSeparatorComponent = ({
 		{...props}
 	/>
 );
-SelectSeparatorComponent.displayName = "SelectSeparator";
 
 /**
  * Displays a list of options for the user to pick from—triggered by a button.

--- a/packages/mantle/src/components/selectable-list/selectable-list.tsx
+++ b/packages/mantle/src/components/selectable-list/selectable-list.tsx
@@ -381,7 +381,6 @@ const Root = ({
 		</SelectableListContext.Provider>
 	);
 };
-Root.displayName = "SelectableListRoot";
 
 /**
  * The filter/search box for a `SelectableList`. Renders the mantle `Input` with
@@ -428,7 +427,6 @@ const Filter = ({
 		</Input>
 	);
 };
-Filter.displayName = "SelectableListFilter";
 
 /**
  * A tri-state "select all" header for a `SelectableList`. Reflects the selection
@@ -498,7 +496,6 @@ const SelectAll = ({
 		</label>
 	);
 };
-SelectAll.displayName = "SelectableListSelectAll";
 
 /**
  * The DOM id of a row's checkbox, derived from the list id and the option value.
@@ -609,7 +606,6 @@ const Item = ({ children, className, ref, value, ...props }: SelectableListItemP
 		</ListItem>
 	);
 };
-Item.displayName = "SelectableListItem";
 
 /**
  * The emphasized title of a `SelectableList.Item`, rendered as `Choice.Label` —
@@ -638,7 +634,6 @@ Item.displayName = "SelectableListItem";
 const ItemTitle = (props: ComponentProps<typeof Choice.Label>) => (
 	<Choice.Label data-slot="selectable-list-item-title" {...props} />
 );
-ItemTitle.displayName = "SelectableListItemTitle";
 
 /**
  * The de-emphasized sub-line of a `SelectableList.Item`, rendered as
@@ -667,7 +662,6 @@ ItemTitle.displayName = "SelectableListItemTitle";
 const ItemDescription = (props: ComponentProps<typeof Choice.Description>) => (
 	<Choice.Description data-slot="selectable-list-item-description" {...props} />
 );
-ItemDescription.displayName = "SelectableListItemDescription";
 
 /**
  * The default row renderer: a title (and description, if present) from the
@@ -836,7 +830,6 @@ const Viewport = ({ children, ref, ...props }: SelectableListViewportProps) => {
 		</ListRoot>
 	);
 };
-Viewport.displayName = "SelectableListViewport";
 
 /**
  * Props for `SelectableList.VirtualViewport` — the `Viewport` props plus the
@@ -900,7 +893,6 @@ const VirtualViewport = ({ children, ref, ...props }: SelectableListVirtualViewp
 		</ListVirtualRoot>
 	);
 };
-VirtualViewport.displayName = "SelectableListVirtualViewport";
 
 /**
  * Shown in place of the viewport when the active filter matches no options.
@@ -945,7 +937,6 @@ const Empty = ({ children, className, ref, ...props }: ComponentProps<"div">) =>
 		</div>
 	);
 };
-Empty.displayName = "SelectableListEmpty";
 
 /**
  * A filterable, multi-select **grid** of checkbox rows — the inline

--- a/packages/mantle/src/components/sheet/sheet.tsx
+++ b/packages/mantle/src/components/sheet/sheet.tsx
@@ -114,7 +114,6 @@ import * as SheetPrimitive from "../dialog/primitive.js";
  * ```
  */
 const Root = SheetPrimitive.Root;
-Root.displayName = "Sheet";
 
 /**
  * The button trigger for a `Sheet`. Should be rendered as a child of the `Sheet` component.
@@ -154,7 +153,6 @@ Root.displayName = "Sheet";
  * ```
  */
 const Trigger = SheetPrimitive.Trigger;
-Trigger.displayName = "SheetTrigger";
 
 /**
  * The close button for a `Sheet`. Should be rendered as a child of the `Sheet.Content` component.
@@ -195,7 +193,6 @@ Trigger.displayName = "SheetTrigger";
  * ```
  */
 const Close = SheetPrimitive.Close;
-Close.displayName = "SheetClose";
 
 /**
  * The portal for a sheet. Should be rendered as a child of the `Sheet` component.
@@ -204,7 +201,6 @@ Close.displayName = "SheetClose";
  * @private
  */
 const SheetPortal = SheetPrimitive.Portal;
-SheetPortal.displayName = "SheetPortal";
 
 /**
  * The overlay backdrop for a sheet. Should be rendered as a child of the `SheetPortal` component.
@@ -228,7 +224,6 @@ const SheetOverlay = ({
 		ref={ref}
 	/>
 );
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const SheetVariants = cva(
 	"bg-dialog border-dialog inset-y-0 h-full w-full fixed z-50 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in",
@@ -339,7 +334,6 @@ const Content = ({
 		</SheetPrimitive.Content>
 	</SheetPortal>
 );
-Content.displayName = SheetPrimitive.Content.displayName;
 
 type SheetCloseIconButtonProps = Partial<
 	Omit<IconButtonProps, "icon" | "appearance" | "intent">
@@ -435,7 +429,6 @@ const CloseIconButton = ({
 		/>
 	</SheetPrimitive.Close>
 );
-CloseIconButton.displayName = "SheetCloseIconButton";
 
 /**
  * The body container for a `Sheet`. This is where you would typically place the main content of the sheet, such as forms or text.
@@ -497,7 +490,6 @@ const Body = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
 		{...props}
 	/>
 );
-Body.displayName = "SheetBody";
 
 /**
  * The header container for a `Sheet`. This is where you would typically place the title, description, and actions.
@@ -560,7 +552,6 @@ const Header = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
 		{...props}
 	/>
 );
-Header.displayName = "SheetHeader";
 
 /**
  * The footer container for a `Sheet`. This is where you would typically place close and submit buttons.
@@ -622,7 +613,6 @@ const Footer = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
 		{...props}
 	/>
 );
-Footer.displayName = "SheetFooter";
 
 /**
  * The title for a `Sheet`. Typically rendered as a child of `Sheet.TitleGroup`.
@@ -682,7 +672,6 @@ const Title = ({ className, ref, ...props }: ComponentProps<typeof SheetPrimitiv
 		{...props}
 	/>
 );
-Title.displayName = SheetPrimitive.Title.displayName;
 
 /**
  * A group container for the title and actions of a sheet. Typically rendered as a child of `Sheet.Header`.
@@ -743,7 +732,6 @@ const TitleGroup = ({ children, className, ref, ...props }: ComponentProps<"div"
 		{children}
 	</div>
 );
-TitleGroup.displayName = "SheetTitleGroup";
 
 /**
  * A description for a sheet. Typically rendered as a child of `Sheet.Header`.
@@ -806,7 +794,6 @@ const Description = ({
 		{...props}
 	/>
 );
-Description.displayName = SheetPrimitive.Description.displayName;
 
 /**
  * A group container for the actions of a `Sheet`. Typically rendered as a child of `Sheet.TitleGroup`.
@@ -867,7 +854,6 @@ const Actions = ({ children, className, ref, ...props }: ComponentProps<"div">) 
 		{children}
 	</div>
 );
-Actions.displayName = "SheetActions";
 
 /**
  * A container that overlays the current view from the edge of the screen.

--- a/packages/mantle/src/components/split-button/split-button.tsx
+++ b/packages/mantle/src/components/split-button/split-button.tsx
@@ -72,7 +72,6 @@ const Root = ({
 		</DropdownMenu.Root>
 	);
 };
-Root.displayName = "SplitButton";
 
 type PrimaryActionProps = Omit<ComponentProps<typeof Button>, "appearance" | "intent" | "size">;
 
@@ -82,7 +81,6 @@ const PrimaryAction = (props: PrimaryActionProps) => {
 	// `type` and `ref` flow through; `Button` defaults `type` to "button".
 	return <Button appearance="outlined" intent="neutral" size={size} {...props} />;
 };
-PrimaryAction.displayName = "SplitButtonPrimaryAction";
 
 type MenuTriggerProps = Omit<
 	ComponentProps<typeof IconButton>,
@@ -117,17 +115,14 @@ const MenuTrigger = ({ icon, ...props }: MenuTriggerProps) => {
 		</DropdownMenu.Trigger>
 	);
 };
-MenuTrigger.displayName = "SplitButtonMenuTrigger";
 
 const MenuContent = ({ align = "end", ...props }: ComponentProps<typeof DropdownMenu.Content>) => {
 	return <DropdownMenu.Content align={align} {...props} />;
 };
-MenuContent.displayName = "SplitButtonMenuContent";
 
 const MenuItem = ({ className, ...props }: ComponentProps<typeof DropdownMenu.Item>) => {
 	return <DropdownMenu.Item className={cx("gap-2", className)} {...props} />;
 };
-MenuItem.displayName = "SplitButtonMenuItem";
 
 /**
  * A button group which provides a default action with one click while revealing

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -83,7 +83,6 @@ const Root = ({ children, className, ref, ...props }: ComponentProps<"div">) => 
 		</div>
 	);
 };
-Root.displayName = "TableRoot";
 
 /**
  * The `<Table.Element>` is a structured way to display data in rows and columns. The API
@@ -165,7 +164,6 @@ const Element = ({ children, className, ref, ...props }: ComponentProps<"table">
 		</table>
 	);
 };
-Element.displayName = "TableElement";
 
 /**
  * The `<Table.Head>` is a container for the table's column headers.
@@ -233,7 +231,6 @@ const Head = ({ children, className, ref, ...props }: ComponentProps<"thead">) =
 		{children}
 	</thead>
 );
-Head.displayName = "TableHead";
 
 /**
  * The `<Table.Body>` encapsulates a set of `<Table.Row>`s, indicating that they
@@ -298,7 +295,6 @@ const Body = ({ children, className, ref, ...props }: ComponentProps<"tbody">) =
 		{children}
 	</tbody>
 );
-Body.displayName = "TableBody";
 
 /**
  * The `<Table.Foot>` encapsulates a set of `<Table.Row>`s, indicating that they
@@ -366,7 +362,6 @@ const Foot = ({ children, className, ref, ...props }: ComponentProps<"tfoot">) =
 		{children}
 	</tfoot>
 );
-Foot.displayName = "TableFoot";
 
 /**
  * The `<Table.Row>` defines a row of cells in a table. The row's cells can then
@@ -425,7 +420,6 @@ const Row = ({ children, className, ref, ...props }: ComponentProps<"tr">) => (
 		{children}
 	</tr>
 );
-Row.displayName = "TableRow";
 
 /**
  * The `<Table.Header>` defines a cell as the header of a group of table cells
@@ -486,7 +480,6 @@ const Header = ({ children, className, ref, ...props }: ComponentProps<"th">) =>
 		{children}
 	</th>
 );
-Header.displayName = "TableHeader";
 
 /**
  * The `<Table.Cell>` defines a cell of a table that contains data and may be
@@ -542,7 +535,6 @@ const Cell = ({ children, className, ref, ...props }: ComponentProps<"td">) => (
 		{children}
 	</td>
 );
-Cell.displayName = "TableCell";
 
 /**
  * The optional `<Table.Caption>` specifies the caption (or title) of a table,
@@ -598,7 +590,6 @@ const Caption = ({ children, className, ref, ...props }: ComponentProps<"caption
 		{children}
 	</caption>
 );
-Caption.displayName = "TableCaption";
 
 /**
  * Use `Table` for STATIC, layout-driven tabular data — read-only data dumps,

--- a/packages/mantle/src/components/tabs/tabs.tsx
+++ b/packages/mantle/src/components/tabs/tabs.tsx
@@ -90,7 +90,6 @@ const Root = ({
 		</TabsPrimitiveRoot>
 	);
 };
-Root.displayName = "Tabs";
 
 /**
  * The horizontal classic tablist's bottom border, drawn by default and
@@ -272,7 +271,6 @@ const List = ({
 		/>
 	);
 };
-List.displayName = "TabsList";
 
 type TabsTriggerProps = ComponentProps<typeof TabsPrimitiveTrigger>;
 
@@ -418,7 +416,6 @@ const Trigger = ({
 		</TabsPrimitiveTrigger>
 	);
 };
-Trigger.displayName = "TabsTrigger";
 
 /**
  * A badge component that can be used inside tab triggers to display additional information.
@@ -452,7 +449,6 @@ const Badge = ({ className, children, ...props }: HTMLAttributes<HTMLSpanElement
 		{children}
 	</span>
 );
-Badge.displayName = "TabBadge";
 
 /**
  * Contains the content associated with each trigger.
@@ -483,7 +479,6 @@ const Content = ({ className, ...props }: ComponentProps<typeof TabsPrimitiveCon
 		{...props}
 	/>
 );
-Content.displayName = "TabsContent";
 
 /**
  * A set of layered sections of content—known as tab panels—that are displayed one at a time.

--- a/packages/mantle/src/components/theme-switcher/theme-switcher.tsx
+++ b/packages/mantle/src/components/theme-switcher/theme-switcher.tsx
@@ -130,7 +130,6 @@ type ThemeSwitcherRootProps = ComponentProps<typeof DropdownMenu.Root>;
  * ```
  */
 const Root = (props: ThemeSwitcherRootProps) => <DropdownMenu.Root {...props} />;
-Root.displayName = "ThemeSwitcher";
 
 /**
  * The props for the `ThemeSwitcher.Trigger` component. Forwards
@@ -208,7 +207,6 @@ const Trigger = ({
 		/>
 	</DropdownMenu.Trigger>
 );
-Trigger.displayName = "ThemeSwitcherTrigger";
 
 /**
  * The props for the `ThemeSwitcher.Content` component. Identical to
@@ -253,7 +251,6 @@ const Content = ({ children, "data-slot": dataSlot, ...props }: ThemeSwitcherCon
 		{children ?? <ThemeDropdownMenuRadioGroup />}
 	</DropdownMenu.Content>
 );
-Content.displayName = "ThemeSwitcherContent";
 
 /**
  * The canonical picker for mantle's theme system: a compact `IconButton`

--- a/packages/mantle/src/components/toast/toast.tsx
+++ b/packages/mantle/src/components/toast/toast.tsx
@@ -215,7 +215,6 @@ const Root = ({ asChild, children, className, intent, ref, ...props }: ToastProp
 		</ToastStateContext.Provider>
 	);
 };
-Root.displayName = "Toast";
 
 type ToastIconProps = Partial<SvgOnlyProps>;
 
@@ -282,7 +281,6 @@ const Icon = ({ className, svg, ref, ...props }: ToastIconProps) => {
 			throw new Error(`Unreachable Case: ${ctx.intent}`);
 	}
 };
-Icon.displayName = "ToastIcon";
 
 type ToastActionProps = ComponentProps<"button"> & WithAsChild;
 
@@ -330,7 +328,6 @@ const Action = ({ asChild, className, onClick, ref, ...props }: ToastActionProps
 		/>
 	);
 };
-Action.displayName = "ToastAction";
 
 type ToastMessageProps = ComponentProps<"p"> & WithAsChild;
 
@@ -360,7 +357,6 @@ const Message = ({ asChild, className, ref, ...props }: ToastMessageProps) => {
 		/>
 	);
 };
-Message.displayName = "ToastMessage";
 
 /**
  * A succinct message that is displayed temporarily. Toasts are used to provide

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -36,7 +36,6 @@ const TooltipProvider = ({
 		{...props}
 	/>
 );
-TooltipProvider.displayName = "Tooltip.Provider";
 
 /**
  * A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
@@ -67,7 +66,6 @@ TooltipProvider.displayName = "Tooltip.Provider";
 function Root(props: ComponentProps<typeof TooltipPrimitive.Root>) {
 	return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
-Root.displayName = "Tooltip.Root";
 
 /**
  * The trigger button that opens the tooltip.
@@ -91,7 +89,6 @@ Root.displayName = "Tooltip.Root";
 function Trigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) {
 	return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
-Trigger.displayName = "Tooltip.Trigger";
 
 /**
  * The content to render inside the tooltip.
@@ -141,7 +138,6 @@ const Content = ({
 		</TooltipPrimitive.Content>
 	</TooltipPrimitive.Portal>
 );
-Content.displayName = "Tooltip.Content";
 
 /**
  * A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.


### PR DESCRIPTION
## Why

Top-level `Component.displayName = "..."` assignments are property mutations that bundlers treat as side effects, so they pin otherwise-unused components — and everything those components reference — into consumer bundles. This is the same problem Radix fixed in their 1.1.18 releases ("use named render functions instead of `Component.displayName = ...` assignments, which previously prevented dead-code elimination with some bundlers").

Verified empirically against Vite 8 (Rolldown), the bundler used by both www and the frontend apps:

- A minimal repro shows Rolldown drops an unused plain function but **keeps** an identical function once it has a `displayName` assignment.
- A consumer importing only `@ngrok/mantle/dialog` bundles the four dead Toast components (plus their phosphor icons) because the dialog primitive imports one helper from the shared toast chunk. Stripping the assignments shrinks that bundle **117.0 KB → 104.2 KB (−11%)**.

## What

- Delete all 254 `displayName` assignments across 39 component files (plus one stale comment). Nothing reads `displayName` at runtime — not mantle, its tests, www, or the frontend apps.
- The button family already shipped without them; this makes that the uniform convention.
- Also removes the `dialog/primitive.tsx` variants that mutated **Radix's own exports** (`Trigger.displayName = "DialogPrimitiveTrigger"`), which renamed Radix components globally for any co-located direct Radix usage.

React DevTools falls back to inferring names from component function names (`fn.name`).

## Trade-off

Consumers of the *minified* dist previously saw `displayName`-powered names in React DevTools; they'll now see minified names in that context. www is unaffected (it consumes source via the `@ngrok/src-live-types` condition). If this matters, follow-ups are cheap: keep function names in the tsdown minify config, or publish unminified dist.

## Not fixed here (follow-ups)

- `dialog/primitive.tsx` imports `preventCloseOnPromptInteraction` from `toast/toast.tsx`, so dialog-only consumers still retain **sonner** (~25 KB + injected CSS): sonner declares no `sideEffects: false` and injects CSS at import time, so it can't be dropped while any module in the graph imports it. Moving that helper out of `toast.tsx` fixes it.
- Per-module dist output (tsdown `unbundle`) would remove this class of shared-chunk leaks entirely.

## Verification

- `pnpm -w run lint` — 0 errors
- `pnpm -w run fmt` — clean
- `pnpm -w run typecheck` — 0 errors
- `pnpm -w run test -F @ngrok/mantle` — all passing
- Patch changeset included