### PR TITLE
perf(mantle): decouple cross-component helper imports

### DIFF
--- a/.changeset/decouple-cross-component-helper-imports.md
+++ b/.changeset/decouple-cross-component-helper-imports.md
@@ -1,0 +1,10 @@
+---
+"@ngrok/mantle": patch
+---
+
+Decouple cross-component helper imports so importing one component no longer pulls another component's implementation into the bundle:
+
+- `preventCloseOnPromptInteraction` moved out of `toast.tsx` into its own module. The Dialog/Sheet primitive imported it from the Toast implementation, which dragged sonner (and its import-time CSS injection) into every dialog-only consumer bundle — a dialog-only Vite 8 build shrinks from 117.0 KB to 86.0 KB (−26.5%).
+- `iconButtonVariants` moved out of `icon-button.tsx` into its own module, so `Calendar` (which only needs the classes for its nav buttons) no longer imports the `IconButton` implementation.
+
+No public API changes — both helpers were internal.

--- a/packages/mantle/src/components/button/icon-button-variants.ts
+++ b/packages/mantle/src/components/button/icon-button-variants.ts
@@ -1,0 +1,124 @@
+import { cva } from "class-variance-authority";
+import type { VariantProps } from "../../types/index.js";
+import { cx } from "../../utils/cx/cx.js";
+import type { ButtonIntent } from "./intents.js";
+import type { ButtonSize } from "./sizes.js";
+
+/**
+ * The visual style of an `IconButton`: how much visual weight it carries,
+ * independent of its tone (`intent`). IconButton has no `filled` or `link`
+ * appearance — a filled icon-only box reads as a toggle, and an icon-only
+ * link has no text to read as a link.
+ */
+type IconButtonAppearance = "ghost" | "outlined";
+
+const baseIconButtonClasses = cx(
+	"icon-button",
+	"inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border",
+	"focus:outline-hidden focus-visible:ring-4",
+	"disabled:cursor-default disabled:opacity-50",
+	"not-disabled:active:scale-97 ease-out transition-transform duration-150",
+);
+
+/**
+ * Composes the className for an `IconButton` from its variant props. Lives in
+ * its own module (rather than `icon-button.tsx`) so that components which only
+ * need the classes (e.g. `Calendar`'s nav buttons) can import them without
+ * pulling the `IconButton` implementation into their module graph.
+ *
+ * @example
+ * ```tsx
+ * const navButtonClasses = iconButtonVariants({ appearance: "ghost", intent: "neutral", size: "sm" });
+ * ```
+ */
+const iconButtonVariants = cva(baseIconButtonClasses, {
+	variants: {
+		/**
+		 * The visual style of the IconButton. The base classes carry the accent
+		 * tone; danger and neutral tones override via compoundVariants.
+		 */
+		appearance: {
+			ghost:
+				"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 border-transparent",
+			outlined:
+				"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700",
+		} satisfies Record<IconButtonAppearance, string>,
+		/**
+		 * The tone of the IconButton — the purpose its color communicates. The
+		 * accent tone is styled by the appearance base classes; danger and
+		 * neutral override via compoundVariants.
+		 */
+		intent: {
+			accent: "",
+			danger: "",
+			neutral: "",
+		} satisfies Record<ButtonIntent, string>,
+		/**
+		 * Whether or not the button is in a loading state, default `false`. Setting `isLoading` will
+		 * replace the `icon` with a spinner.
+		 * It will also disable user interaction with the button and set `aria-disabled`.
+		 */
+		isLoading: {
+			false: "",
+			true: "opacity-50",
+		},
+		/**
+		 * The size of the IconButton, default `"md"`. Shared scale with
+		 * `Button` — same size name, same box height.
+		 */
+		size: {
+			xs: "size-6",
+			sm: "size-7",
+			md: "size-9",
+			lg: "size-10",
+			xl: "size-12",
+		} satisfies Record<ButtonSize, string>,
+	},
+	defaultVariants: {
+		// Runtime fallback only: `intent` is required in IconButtonProps, but
+		// untyped call sites that still omit it (the compiler cannot flag them)
+		// must keep the pre-intent neutral rendering, not silently flip to the
+		// accent tone the appearance base classes carry.
+		intent: "neutral",
+		size: "md",
+	},
+	compoundVariants: [
+		{
+			appearance: "ghost",
+			intent: "danger",
+			class:
+				"text-danger-600 focus-visible:ring-focus-danger not-disabled:hover:bg-danger-500/10 not-disabled:hover:text-danger-700 border-transparent",
+		},
+		{
+			appearance: "outlined",
+			intent: "danger",
+			class:
+				"border-danger-600 bg-form text-danger-600 focus-visible:ring-focus-danger not-disabled:hover:border-danger-700 not-disabled:hover:bg-danger-500/10 not-disabled:hover:text-danger-700",
+		},
+		{
+			appearance: "ghost",
+			intent: "neutral",
+			class:
+				"text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent",
+		},
+		{
+			appearance: "outlined",
+			intent: "neutral",
+			class:
+				"border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600",
+		},
+	],
+});
+
+type IconButtonVariants = VariantProps<typeof iconButtonVariants>;
+
+export {
+	//,
+	iconButtonVariants,
+};
+
+export type {
+	//,
+	IconButtonAppearance,
+	IconButtonVariants,
+};

--- a/packages/mantle/src/components/button/icon-button.tsx
+++ b/packages/mantle/src/components/button/icon-button.tsx
@@ -1,112 +1,15 @@
 import { CircleNotchIcon } from "@phosphor-icons/react/CircleNotch";
-import { cva } from "class-variance-authority";
 import type { ComponentProps, ReactNode } from "react";
 import { Children, cloneElement, isValidElement } from "react";
 import invariant from "tiny-invariant";
-import type { VariantProps, WithAsChild } from "../../types/index.js";
+import type { WithAsChild } from "../../types/index.js";
 import { parseBooleanish } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Icon } from "../icon/index.js";
 import { Slot } from "../slot/index.js";
+import type { IconButtonAppearance, IconButtonVariants } from "./icon-button-variants.js";
+import { iconButtonVariants } from "./icon-button-variants.js";
 import type { ButtonIntent } from "./intents.js";
-import type { ButtonSize } from "./sizes.js";
-
-/**
- * The visual style of an `IconButton`: how much visual weight it carries,
- * independent of its tone (`intent`). IconButton has no `filled` or `link`
- * appearance — a filled icon-only box reads as a toggle, and an icon-only
- * link has no text to read as a link.
- */
-type IconButtonAppearance = "ghost" | "outlined";
-
-const baseIconButtonClasses = cx(
-	"icon-button",
-	"inline-flex shrink-0 items-center justify-center rounded-[var(--icon-button-border-radius,0.375rem)] border",
-	"focus:outline-hidden focus-visible:ring-4",
-	"disabled:cursor-default disabled:opacity-50",
-	"not-disabled:active:scale-97 ease-out transition-transform duration-150",
-);
-
-const iconButtonVariants = cva(baseIconButtonClasses, {
-	variants: {
-		/**
-		 * The visual style of the IconButton. The base classes carry the accent
-		 * tone; danger and neutral tones override via compoundVariants.
-		 */
-		appearance: {
-			ghost:
-				"text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700 border-transparent",
-			outlined:
-				"border-accent-600 bg-form text-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-accent-700 not-disabled:hover:bg-accent-500/10 not-disabled:hover:text-accent-700",
-		} satisfies Record<IconButtonAppearance, string>,
-		/**
-		 * The tone of the IconButton — the purpose its color communicates. The
-		 * accent tone is styled by the appearance base classes; danger and
-		 * neutral override via compoundVariants.
-		 */
-		intent: {
-			accent: "",
-			danger: "",
-			neutral: "",
-		} satisfies Record<ButtonIntent, string>,
-		/**
-		 * Whether or not the button is in a loading state, default `false`. Setting `isLoading` will
-		 * replace the `icon` with a spinner.
-		 * It will also disable user interaction with the button and set `aria-disabled`.
-		 */
-		isLoading: {
-			false: "",
-			true: "opacity-50",
-		},
-		/**
-		 * The size of the IconButton, default `"md"`. Shared scale with
-		 * `Button` — same size name, same box height.
-		 */
-		size: {
-			xs: "size-6",
-			sm: "size-7",
-			md: "size-9",
-			lg: "size-10",
-			xl: "size-12",
-		} satisfies Record<ButtonSize, string>,
-	},
-	defaultVariants: {
-		// Runtime fallback only: `intent` is required in IconButtonProps, but
-		// untyped call sites that still omit it (the compiler cannot flag them)
-		// must keep the pre-intent neutral rendering, not silently flip to the
-		// accent tone the appearance base classes carry.
-		intent: "neutral",
-		size: "md",
-	},
-	compoundVariants: [
-		{
-			appearance: "ghost",
-			intent: "danger",
-			class:
-				"text-danger-600 focus-visible:ring-focus-danger not-disabled:hover:bg-danger-500/10 not-disabled:hover:text-danger-700 border-transparent",
-		},
-		{
-			appearance: "outlined",
-			intent: "danger",
-			class:
-				"border-danger-600 bg-form text-danger-600 focus-visible:ring-focus-danger not-disabled:hover:border-danger-700 not-disabled:hover:bg-danger-500/10 not-disabled:hover:text-danger-700",
-		},
-		{
-			appearance: "ghost",
-			intent: "neutral",
-			class:
-				"text-strong focus-visible:ring-focus-accent not-disabled:hover:bg-neutral-500/10 not-disabled:hover:text-strong border-transparent",
-		},
-		{
-			appearance: "outlined",
-			intent: "neutral",
-			class:
-				"border-form bg-form text-strong focus-visible:border-accent-600 focus-visible:ring-focus-accent not-disabled:hover:border-neutral-400 not-disabled:hover:bg-form-hover not-disabled:hover:text-strong focus-visible:not-disabled:hover:border-accent-600 focus-visible:not-disabled:active:border-accent-600",
-		},
-	],
-});
-
-type IconButtonVariants = VariantProps<typeof iconButtonVariants>;
 
 /**
  * The props for the `IconButton` component.

--- a/packages/mantle/src/components/calendar/calendar.tsx
+++ b/packages/mantle/src/components/calendar/calendar.tsx
@@ -5,7 +5,7 @@ import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
 import type { ComponentProps } from "react";
 import { DayPicker } from "react-day-picker";
 import { cx } from "../../utils/cx/cx.js";
-import { iconButtonVariants } from "../button/icon-button.js";
+import { iconButtonVariants } from "../button/icon-button-variants.js";
 import { Icon } from "../icon/icon.js";
 
 type CalendarProps = ComponentProps<typeof DayPicker>;

--- a/packages/mantle/src/components/dialog/primitive.tsx
+++ b/packages/mantle/src/components/dialog/primitive.tsx
@@ -12,7 +12,7 @@ import {
 	useState,
 } from "react";
 import { Slot } from "../slot/index.js";
-import { preventCloseOnPromptInteraction } from "../toast/toast.js";
+import { preventCloseOnPromptInteraction } from "../toast/prevent-close-on-prompt-interaction.js";
 import { parseBooleanish } from "../../types/booleanish.js";
 
 type DialogPrimitiveContentProps = ComponentProps<typeof DialogPrimitive.Content>;

--- a/packages/mantle/src/components/toast/prevent-close-on-prompt-interaction.ts
+++ b/packages/mantle/src/components/toast/prevent-close-on-prompt-interaction.ts
@@ -1,0 +1,32 @@
+/**
+ * @private
+ *
+ * Allows any mantle floating prompt (e.g. toasts and notifications) to be interacted with
+ * even when a modaled view (e.g. dialog, sheet, etc) is open and a focus trap is active.
+ *
+ * Without this, interacting with the prompt would close the modaled view.
+ *
+ * This lives in its own module (rather than `toast.tsx`) so that modaled views
+ * can import it without pulling the Toast implementation — and its `sonner`
+ * dependency — into their module graph.
+ *
+ * @example
+ * ```tsx
+ * <Dialog.Root onInteractOutside={preventCloseOnPromptInteraction}>
+ *   <Dialog.Content>
+ *     <p>Dialog content</p>
+ *   </Dialog.Content>
+ * </Dialog.Root>
+ * ```
+ */
+export function preventCloseOnPromptInteraction(
+	event: CustomEvent | PointerEvent | MouseEvent | TouchEvent | FocusEvent,
+) {
+	if (!(event.target instanceof Element)) {
+		return;
+	}
+
+	if (event.target.closest(".overlay-prompt")) {
+		event.preventDefault();
+	}
+}

--- a/packages/mantle/src/components/toast/toast.tsx
+++ b/packages/mantle/src/components/toast/toast.tsx
@@ -461,35 +461,6 @@ export type {
 	ToastIntent,
 };
 
-/**
- * @private
- *
- * Allows any mantle floating prompt (e.g. toasts and notifications) to be interacted with
- * even when a modaled view (e.g. dialog, sheet, etc) is open and a focus trap is active.
- *
- * Without this, interacting with the prompt would close the modaled view.
- *
- * @example
- * ```tsx
- * <Dialog.Root onInteractOutside={preventCloseOnPromptInteraction}>
- *   <Dialog.Content>
- *     <p>Dialog content</p>
- *   </Dialog.Content>
- * </Dialog.Root>
- * ```
- */
-export function preventCloseOnPromptInteraction(
-	event: CustomEvent | PointerEvent | MouseEvent | TouchEvent | FocusEvent,
-) {
-	if (!(event.target instanceof Element)) {
-		return;
-	}
-
-	if (event.target.closest(".overlay-prompt")) {
-		event.preventDefault();
-	}
-}
-
 const intentBackgroundColor = {
 	info: "bg-accent-600",
 	warning: "bg-warning-600",


### PR DESCRIPTION
## Why

When component A imports a helper function from component B's implementation file, A's module graph now contains all of B — including B's dependencies. Bundlers can tree-shake *some* of that, but not dependencies with import-time side effects.

The concrete case (called out as a follow-up in #1346): `dialog/primitive.tsx` imported `preventCloseOnPromptInteraction` — one 10-line DOM helper — from `toast/toast.tsx`. That put the Toast implementation in every Dialog/Sheet consumer's graph, and with it **sonner**, which injects its CSS via a top-level `__insertCSS()` call and declares no `sideEffects` flag, so no bundler is allowed to drop it.

## What

Audited every cross-component import in `packages/mantle/src/components`. Two were accidental coupling; the rest either compose real components (SplitButton → DropdownMenu, Command → Dialog, …) or import from already-standalone helper modules (`field/validation`, `field/field-context`, `theme/themes`, `input/is-input`).

- **`preventCloseOnPromptInteraction`** → own module (`toast/prevent-close-on-prompt-interaction.ts`). It was `@private` (never re-exported from `toast/index.ts`; no references in www or the frontend apps), so this is invisible to consumers.
- **`iconButtonVariants`** → own module (`button/icon-button-variants.ts`). `Calendar` only needs the classes for its nav buttons and no longer imports the `IconButton` implementation. `icon-button.tsx` re-exports it, so its module surface is unchanged.

Evaluated and left alone: the `useTheme`/`useAppliedTheme` imports from `theme/theme-provider.tsx` (theme-switcher, toast, icons). The hooks share `ThemeProviderContext` with the provider, the module has no side-effectful dependencies, and its unused functions tree-shake normally — splitting it buys nothing measurable.

## Measured (Vite 8 / Rolldown, consumer importing only `@ngrok/mantle/dialog`)

| | bundle size |
|---|---|
| main | 117.0 KB |
| this PR | **86.0 KB (−26.5%)** |

Sonner, its injected CSS, and all Toast code are gone from the bundle. In the rebuilt dist, the dialog primitive chunk imports only `booleanish` and `slot` — the shared toast chunk no longer exists. This is independent of (and complementary to) the `displayName` removal in #1346.

## Verification

- `pnpm -w run lint` — 0 errors
- `pnpm -w run fmt:check` — clean
- `pnpm -w run typecheck` — 0 errors
- `pnpm -w run test -F @ngrok/mantle` — all passing
- Patch changeset included