### PR TITLE
Add alert trailing controls

### DIFF
--- a/.changeset/bright-otters-smile.md
+++ b/.changeset/bright-otters-smile.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add composable trailing expand and dismiss controls to Alert.

--- a/apps/www/app/docs/components/feedback/alert.mdx
+++ b/apps/www/app/docs/components/feedback/alert.mdx
@@ -114,10 +114,11 @@ Compose the parts of an `Alert` together to build your own:
 ```text showLineNumbers=false
 Alert.Root
 ├── Alert.Icon
-└── Alert.Content
+├── Alert.Content
     ├── Alert.Title
     ├── Alert.Description
-    └── Alert.DismissIconButton
+    ├── Alert.DismissIconButton
+    └── Alert.ExpandButton
 ```
 
 You can mix and match what you put inside the `Alert` component to create different types of Alert layouts.
@@ -236,6 +237,81 @@ import { Alert } from "@ngrok/mantle/alert";
 </Alert.Root>;
 ```
 
+## Expand Button
+
+Use `Alert.ExpandButton` for a compact control that reveals related alerts. It sits in the same trailing position as the dismiss button and reserves space for the count and caret, so alert copy remains contained on narrow viewports. It shows `+N` on mobile and `+N more` from the `md` (tablet) breakpoint.
+
+<Example>
+	<Alert.Root intent="warning">
+		<Alert.Icon />
+		<Alert.Content>
+			<Alert.Title>Your workspace is approaching its monthly usage limit</Alert.Title>
+			<Alert.ExpandButton count={2} expanded={false} />
+		</Alert.Content>
+	</Alert.Root>
+</Example>
+
+```tsx
+<Alert.Root intent="warning">
+	<Alert.Icon />
+	<Alert.Content>
+		<Alert.Title>Your workspace is approaching its monthly usage limit</Alert.Title>
+		<Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
+	</Alert.Content>
+</Alert.Root>
+```
+
+## Dismiss and Expand
+
+`Alert.DismissIconButton` and `Alert.ExpandButton` compose safely in the same alert. Both stay absolutely positioned at the trailing edge; when both are present, the dismiss button moves to the left of the expander and `Alert.Content` reserves room for the pair. This also handles an alert that first renders dismissable and later gains an expander as more alerts arrive.
+
+<Example>
+	<Alert.Root intent="warning">
+		<Alert.Icon />
+		<Alert.Content>
+			<Alert.Title>Your workspace is approaching its monthly usage limit</Alert.Title>
+			<Alert.DismissIconButton />
+			<Alert.ExpandButton count={2} expanded={false} />
+		</Alert.Content>
+	</Alert.Root>
+</Example>
+
+```tsx
+<Alert.Root intent="warning">
+	<Alert.Icon />
+	<Alert.Content>
+		<Alert.Title>Your workspace is approaching its monthly usage limit</Alert.Title>
+		<Alert.DismissIconButton onClick={dismiss} />
+		<Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
+	</Alert.Content>
+</Alert.Root>
+```
+
+## Trailing control colors
+
+`Alert.DismissIconButton` and `Alert.ExpandButton` share the following CSS custom properties from `Alert.Root`. Each intent supplies the listed defaults; set them once on the root to theme both controls together.
+
+| Variable                      | Default                                                           | Used for                              |
+| ----------------------------- | ----------------------------------------------------------------- | ------------------------------------- |
+| `--alert-control-color`       | `var(--color-<intent>-700)`                                       | Control text and icon color.          |
+| `--alert-control-hover-color` | `var(--color-<intent>-800)`                                       | Control text and icon color on hover. |
+| `--alert-control-hover-bg`    | `color-mix(in oklab, var(--color-<intent>-500) 10%, transparent)` | Control background on hover.          |
+
+```tsx
+import { $cssProperties } from "@ngrok/mantle/types";
+
+<Alert.Root
+	intent="warning"
+	style={$cssProperties({
+		"--alert-control-color": "var(--color-neutral-700)",
+		"--alert-control-hover-color": "var(--color-neutral-900)",
+		"--alert-control-hover-bg": "color-mix(in oklab, var(--color-neutral-500) 10%, transparent)",
+	})}
+>
+	{/* Both Alert.DismissIconButton and Alert.ExpandButton inherit these values. */}
+</Alert.Root>;
+```
+
 ## Custom Dismiss Icon
 
 Use the `icon` prop on `Alert.DismissIconButton` to render a custom icon in place of the default `X`.
@@ -278,11 +354,26 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 | `appearance?` | `"default"` \| `"banner"`                                             | `"default"` | Controls the visual style. `"default"` provides standard rounded corners and borders. `"banner"` creates a banner-style alert with no rounded corners, sticky positioning, and no top, left, or right borders. |
 | `intent`      | `"danger"` \| `"important"` \| `"info"` \| `"success"` \| `"warning"` |             | The tone of the `Alert`. Sets the color, styling, and default icon to communicate the status it reports.                                                                                                       |
 
+#### Trailing control CSS variables
+
+`Alert.Root` defines `--alert-control-color`, `--alert-control-hover-color`, and `--alert-control-hover-bg` from its `intent`. Both `Alert.DismissIconButton` and `Alert.ExpandButton` inherit them. Override the variables on the root to theme both trailing controls together.
+
 ### Alert.Content
 
-The container for the content slot of an `Alert`. Place `Alert.Title`, `Alert.Description`, and `Alert.DismissIconButton` as direct children.
+The container for the content slot of an `Alert`. Place `Alert.Title`, `Alert.Description`, `Alert.DismissIconButton`, and `Alert.ExpandButton` as direct children.
 
 All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes).
+
+### Alert.ExpandButton
+
+Positions a compact expand/collapse control at the trailing edge of an `Alert`. Its `count` is displayed beside a caret that rotates when `expanded` is true. It shares the root-level trailing-control CSS variables with `Alert.DismissIconButton`.
+
+All props from [Button](/components/actions/button#api-reference), plus:
+
+| Prop       | Type      | Default | Description                                                          |
+| ---------- | --------- | ------- | -------------------------------------------------------------------- |
+| `count`    | `number`  | —       | The number of hidden related alerts, displayed with a leading `+`.   |
+| `expanded` | `boolean` | —       | Whether the related alerts are visible; rotates the caret when true. |
 
 ### Alert.Description
 
@@ -316,7 +407,7 @@ All props from [h5](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/He
 
 ### Alert.DismissIconButton
 
-A dismiss icon button that closes the alert when clicked.
+A dismiss icon button that closes the alert when clicked. It shares the root-level trailing-control CSS variables with `Alert.ExpandButton`.
 
 All props from [IconButton](/components/actions/icon-button#api-reference), with the following overridden defaults:
 

--- a/apps/www/app/docs/components/feedback/alert.mdx
+++ b/apps/www/app/docs/components/feedback/alert.mdx
@@ -5,6 +5,7 @@ description: Displays a callout for user attention.
 
 import { Alert } from "@ngrok/mantle/alert";
 import { Card } from "@ngrok/mantle/card";
+import { $cssProperties } from "@ngrok/mantle/types";
 import { ShrimpIcon } from "@phosphor-icons/react/Shrimp";
 import { Example } from "~/components/example";
 
@@ -119,6 +120,40 @@ Alert.Root
     ├── Alert.Description
     ├── Alert.DismissIconButton
     └── Alert.ExpandButton
+```
+
+## Polymorphism
+
+`Alert.Title` and `Alert.Description` support `asChild` when the alert's surrounding document structure needs a different semantic element.
+
+<Example>
+	<Alert.Root intent="info">
+		<Alert.Icon />
+		<Alert.Content>
+			<Alert.Title asChild>
+				<h2>Maintenance window</h2>
+			</Alert.Title>
+			<Alert.Description asChild>
+				<p>Service may be briefly unavailable.</p>
+			</Alert.Description>
+		</Alert.Content>
+	</Alert.Root>
+</Example>
+
+```tsx
+import { Alert } from "@ngrok/mantle/alert";
+
+<Alert.Root intent="info">
+	<Alert.Icon />
+	<Alert.Content>
+		<Alert.Title asChild>
+			<h2>Maintenance window</h2>
+		</Alert.Title>
+		<Alert.Description asChild>
+			<p>Service may be briefly unavailable.</p>
+		</Alert.Description>
+	</Alert.Content>
+</Alert.Root>;
 ```
 
 You can mix and match what you put inside the `Alert` component to create different types of Alert layouts.
@@ -252,13 +287,18 @@ Use `Alert.ExpandButton` for a compact control that reveals related alerts. It s
 </Example>
 
 ```tsx
+import { Alert } from "@ngrok/mantle/alert";
+
+const isExpanded = false;
+const toggle = () => {};
+
 <Alert.Root intent="warning">
 	<Alert.Icon />
 	<Alert.Content>
 		<Alert.Title>Your workspace is approaching its monthly usage limit</Alert.Title>
 		<Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
 	</Alert.Content>
-</Alert.Root>
+</Alert.Root>;
 ```
 
 ## Dismiss and Expand
@@ -277,6 +317,12 @@ Use `Alert.ExpandButton` for a compact control that reveals related alerts. It s
 </Example>
 
 ```tsx
+import { Alert } from "@ngrok/mantle/alert";
+
+const isExpanded = false;
+const dismiss = () => {};
+const toggle = () => {};
+
 <Alert.Root intent="warning">
 	<Alert.Icon />
 	<Alert.Content>
@@ -284,7 +330,7 @@ Use `Alert.ExpandButton` for a compact control that reveals related alerts. It s
 		<Alert.DismissIconButton onClick={dismiss} />
 		<Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
 	</Alert.Content>
-</Alert.Root>
+</Alert.Root>;
 ```
 
 ## Trailing control colors
@@ -297,8 +343,27 @@ Use `Alert.ExpandButton` for a compact control that reveals related alerts. It s
 | `--alert-control-hover-color` | `var(--color-<intent>-800)`                                       | Control text and icon color on hover. |
 | `--alert-control-hover-bg`    | `color-mix(in oklab, var(--color-<intent>-500) 10%, transparent)` | Control background on hover.          |
 
+<Example>
+	<Alert.Root
+		intent="warning"
+		style={$cssProperties({
+			"--alert-control-color": "var(--color-neutral-700)",
+			"--alert-control-hover-color": "var(--color-neutral-900)",
+			"--alert-control-hover-bg": "color-mix(in oklab, var(--color-neutral-500) 10%, transparent)",
+		})}
+	>
+		<Alert.Icon />
+		<Alert.Content>
+			<Alert.Title>Usage limit approaching</Alert.Title>
+			<Alert.DismissIconButton />
+			<Alert.ExpandButton count={2} expanded={false} />
+		</Alert.Content>
+	</Alert.Root>
+</Example>
+
 ```tsx
 import { $cssProperties } from "@ngrok/mantle/types";
+import { Alert } from "@ngrok/mantle/alert";
 
 <Alert.Root
 	intent="warning"
@@ -308,7 +373,12 @@ import { $cssProperties } from "@ngrok/mantle/types";
 		"--alert-control-hover-bg": "color-mix(in oklab, var(--color-neutral-500) 10%, transparent)",
 	})}
 >
-	{/* Both Alert.DismissIconButton and Alert.ExpandButton inherit these values. */}
+	<Alert.Icon />
+	<Alert.Content>
+		<Alert.Title>Usage limit approaching</Alert.Title>
+		<Alert.DismissIconButton />
+		<Alert.ExpandButton count={2} expanded={false} />
+	</Alert.Content>
 </Alert.Root>;
 ```
 
@@ -357,6 +427,12 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 #### Trailing control CSS variables
 
 `Alert.Root` defines `--alert-control-color`, `--alert-control-hover-color`, and `--alert-control-hover-bg` from its `intent`. Both `Alert.DismissIconButton` and `Alert.ExpandButton` inherit them. Override the variables on the root to theme both trailing controls together.
+
+| CSS Variable                  | Default                                                           | Description                           |
+| ----------------------------- | ----------------------------------------------------------------- | ------------------------------------- |
+| `--alert-control-color`       | `var(--color-<intent>-700)`                                       | Control text and icon color.          |
+| `--alert-control-hover-color` | `var(--color-<intent>-800)`                                       | Control text and icon color on hover. |
+| `--alert-control-hover-bg`    | `color-mix(in oklab, var(--color-<intent>-500) 10%, transparent)` | Control background on hover.          |
 
 ### Alert.Content
 

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -24,7 +24,7 @@
     "jsdoc": "Displays a callout for user attention.",
     "examples": [
       "Composition:\n```\nAlert.Root\n├── Alert.Icon\n├── Alert.Content\n    ├── Alert.Title\n    ├── Alert.Description\n    ├── Alert.DismissIconButton\n    └── Alert.ExpandButton\n```",
-      "```tsx\n<Alert intent=\"info\">\n  <AlertIcon />\n  <AlertContent>\n    <AlertTitle>Alert Title</AlertTitle>\n     <AlertDismissIconButton />\n    <AlertDescription>\n      Alert description text.\n    </AlertDescription>\n  </AlertContent>\n</Alert>\n```"
+      "```tsx\n<Alert.Root intent=\"info\">\n  <Alert.Icon />\n  <Alert.Content>\n    <Alert.Title>Alert Title</Alert.Title>\n    <Alert.Description>\n      Alert description text.\n    </Alert.Description>\n    <Alert.DismissIconButton />\n    <Alert.ExpandButton count={2} expanded={false} />\n  </Alert.Content>\n</Alert.Root>\n```"
     ]
   },
   {

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -23,7 +23,7 @@
     "summary": "Displays a callout for user attention.",
     "jsdoc": "Displays a callout for user attention.",
     "examples": [
-      "Composition:\n```\nAlert.Root\n├── Alert.Icon\n└── Alert.Content\n    ├── Alert.Title\n    ├── Alert.Description\n    └── Alert.DismissIconButton\n```",
+      "Composition:\n```\nAlert.Root\n├── Alert.Icon\n├── Alert.Content\n    ├── Alert.Title\n    ├── Alert.Description\n    ├── Alert.DismissIconButton\n    └── Alert.ExpandButton\n```",
       "```tsx\n<Alert intent=\"info\">\n  <AlertIcon />\n  <AlertContent>\n    <AlertTitle>Alert Title</AlertTitle>\n     <AlertDismissIconButton />\n    <AlertDescription>\n      Alert description text.\n    </AlertDescription>\n  </AlertContent>\n</Alert>\n```"
     ]
   },

--- a/packages/mantle/src/components/alert/alert.test.tsx
+++ b/packages/mantle/src/components/alert/alert.test.tsx
@@ -143,6 +143,34 @@ describe("Alert", () => {
 			);
 		});
 
+		test("gives the count a growable min-width so multi-digit counts don't overflow", () => {
+			render(
+				<Alert.Root intent="warning">
+					<Alert.Content>
+						<Alert.Title>Usage limit approaching</Alert.Title>
+						<Alert.ExpandButton count={10} expanded={false} />
+					</Alert.Content>
+				</Alert.Root>,
+			);
+
+			const count = screen.getByText("+10");
+			expect(count).toHaveClass("min-w-[2ch]");
+			expect(count).not.toHaveClass("w-[2ch]");
+		});
+
+		test("`asChild` is not accepted at the type level", () => {
+			const withAsChild = (
+				<Alert.Root intent="warning">
+					<Alert.Content>
+						<Alert.Title>Usage limit approaching</Alert.Title>
+						{/* @ts-expect-error -- asChild is omitted: ExpandButton renders multiple children */}
+						<Alert.ExpandButton count={2} expanded={false} asChild />
+					</Alert.Content>
+				</Alert.Root>
+			);
+			expect(withAsChild).toBeDefined();
+		});
+
 		test("positions dismiss to the left and reserves both controls when composed together", () => {
 			const { container } = render(
 				<Alert.Root intent="warning">

--- a/packages/mantle/src/components/alert/alert.test.tsx
+++ b/packages/mantle/src/components/alert/alert.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
+import { $cssProperties } from "../../types/index.js";
 import { Alert } from "./alert.js";
 
 function getAlertRoot(container: HTMLElement) {
@@ -94,6 +95,78 @@ describe("Alert", () => {
 			expect(button).toHaveAttribute("data-intent", "neutral");
 			await userEvent.click(button);
 			expect(onDismiss).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe("ExpandButton", () => {
+		test("reserves room for its count and rotates the caret when expanded", () => {
+			const { container } = render(
+				<Alert.Root
+					intent="warning"
+					style={$cssProperties({ "--alert-control-color": "var(--color-neutral-700)" })}
+				>
+					<Alert.Icon />
+					<Alert.Content>
+						<Alert.Title>Usage limit approaching</Alert.Title>
+						<Alert.ExpandButton count={2} expanded />
+					</Alert.Content>
+				</Alert.Root>,
+			);
+
+			expect(container.querySelector('[data-slot="alert-expand-button"]')).toHaveAttribute(
+				"aria-expanded",
+				"true",
+			);
+			expect(container.querySelector('[data-slot="alert"]')).toHaveClass(
+				"has-data-alert-expand:[&_[data-slot=alert-content]]:pr-12",
+				"md:has-data-alert-expand:[&_[data-slot=alert-content]]:pr-[5.5rem]",
+			);
+			expect(container.querySelector('[data-slot="alert-content"]')).not.toHaveClass(
+				"has-data-alert-expand:pr-12",
+			);
+			expect(container.querySelector('[data-slot="alert-expand-button"] svg')).toHaveClass(
+				"-rotate-180",
+				"duration-150",
+			);
+			expect(container.querySelector('[data-slot="alert-expand-button"]')).toHaveClass(
+				"top-1.5",
+				"text-(--alert-control-color)",
+				"not-disabled:hover:bg-(--alert-control-hover-bg)",
+				"not-disabled:hover:text-(--alert-control-hover-color)",
+			);
+			const root = container.querySelector('[data-slot="alert"]');
+			expect(root?.getAttribute("style")).toContain("--alert-control-color");
+			expect(root?.getAttribute("style")).toContain("--alert-control-hover-color");
+			expect(root?.getAttribute("style")).toContain("--alert-control-hover-bg");
+			expect(root?.getAttribute("style")).toContain(
+				"--alert-control-color: var(--color-neutral-700)",
+			);
+		});
+
+		test("positions dismiss to the left and reserves both controls when composed together", () => {
+			const { container } = render(
+				<Alert.Root intent="warning">
+					<Alert.Content>
+						<Alert.Title>Usage limit approaching</Alert.Title>
+						<Alert.DismissIconButton />
+						<Alert.ExpandButton count={2} expanded={false} />
+					</Alert.Content>
+				</Alert.Root>,
+			);
+
+			expect(container.querySelector('[data-slot="alert"]')).toHaveClass(
+				"has-data-alert-dismiss:pr-10",
+				"has-data-alert-expand:[&_[data-slot=alert-dismiss-icon-button]]:right-16",
+				"md:has-data-alert-expand:[&_[data-slot=alert-dismiss-icon-button]]:right-24",
+				"has-data-alert-expand:[&_[data-slot=alert-content]]:pr-12",
+				"md:has-data-alert-expand:[&_[data-slot=alert-content]]:pr-[5.5rem]",
+			);
+			expect(container.querySelector('[data-slot="alert-dismiss-icon-button"]')).toHaveClass(
+				"top-1.5",
+				"text-(--alert-control-color)",
+				"not-disabled:hover:bg-(--alert-control-hover-bg)",
+				"not-disabled:hover:text-(--alert-control-hover-color)",
+			);
 		});
 	});
 

--- a/packages/mantle/src/components/alert/alert.test.tsx
+++ b/packages/mantle/src/components/alert/alert.test.tsx
@@ -130,9 +130,9 @@ describe("Alert", () => {
 			);
 			expect(container.querySelector('[data-slot="alert-expand-button"]')).toHaveClass(
 				"top-1.5",
-				"text-(--alert-control-color)",
-				"not-disabled:hover:bg-(--alert-control-hover-bg)",
-				"not-disabled:hover:text-(--alert-control-hover-color)",
+				"text-[var(--alert-control-color,currentColor)]",
+				"not-disabled:hover:bg-[var(--alert-control-hover-bg,transparent)]",
+				"not-disabled:hover:text-[var(--alert-control-hover-color,currentColor)]",
 			);
 			const root = container.querySelector('[data-slot="alert"]');
 			expect(root?.getAttribute("style")).toContain("--alert-control-color");
@@ -163,9 +163,9 @@ describe("Alert", () => {
 			);
 			expect(container.querySelector('[data-slot="alert-dismiss-icon-button"]')).toHaveClass(
 				"top-1.5",
-				"text-(--alert-control-color)",
-				"not-disabled:hover:bg-(--alert-control-hover-bg)",
-				"not-disabled:hover:text-(--alert-control-hover-color)",
+				"text-[var(--alert-control-color,currentColor)]",
+				"not-disabled:hover:bg-[var(--alert-control-hover-bg,transparent)]",
+				"not-disabled:hover:text-[var(--alert-control-hover-color,currentColor)]",
 			);
 		});
 	});

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -9,7 +9,8 @@ import { cva } from "class-variance-authority";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 import invariant from "tiny-invariant";
-import { $cssProperties, type WithAsChild } from "../../types/index.js";
+import { $cssProperties } from "../../types/css-properties.js";
+import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Button, type ButtonProps } from "../button/button.js";
 import {
@@ -104,20 +105,29 @@ type AlertProps = ComponentProps<"div"> & {
 /**
  * Displays a callout for user attention. Root container for all Alert sub-components.
  *
+ * Trailing controls inherit these public CSS variables:
+ *
+ * | Variable | Default | Purpose |
+ * | --- | --- | --- |
+ * | `--alert-control-color` | `var(--color-<intent>-700)` | Control text and icon color. |
+ * | `--alert-control-hover-color` | `var(--color-<intent>-800)` | Control text and icon color on hover. |
+ * | `--alert-control-hover-bg` | `color-mix(in oklab, var(--color-<intent>-500) 10%, transparent)` | Control background on hover. |
+ *
  * @see https://mantle.ngrok.com/components/feedback/alert#alertroot
  *
  * @example
  * ```tsx
- * <Alert intent="info">
- *   <AlertIcon />
- *   <AlertContent>
- *     <AlertTitle>Alert Title</AlertTitle>
- *      <AlertDismissIconButton />
- *     <AlertDescription>
+ * <Alert.Root intent="info">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Alert Title</Alert.Title>
+ *     <Alert.Description>
  *       Alert description text.
- *     </AlertDescription>
- *   </AlertContent>
- * </Alert>
+ *     </Alert.Description>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={false} />
+ *   </Alert.Content>
+ * </Alert.Root>
  *```
  */
 const Root = ({ appearance = "default", className, intent, ref, style, ...props }: AlertProps) => {
@@ -180,16 +190,17 @@ const defaultIcons = {
  *
  * @example
  * ```tsx
- * <Alert intent="info">
- *   <AlertIcon />
- *   <AlertContent>
- *     <AlertTitle>Alert Title</AlertTitle>
- *     <AlertDismissIconButton />
- *     <AlertDescription>
+ * <Alert.Root intent="info">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Alert Title</Alert.Title>
+ *     <Alert.Description>
  *       Alert description text.
- *     </AlertDescription>
- *   </AlertContent>
- * </Alert>
+ *     </Alert.Description>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={false} />
+ *   </Alert.Content>
+ * </Alert.Root>
  * ```
  */
 const Icon = ({ className, ref, svg, ...props }: AlertIconProps) => {
@@ -215,16 +226,17 @@ const Icon = ({ className, ref, svg, ...props }: AlertIconProps) => {
  *
  * @example
  * ```tsx
- * <Alert intent="info">
- *   <AlertIcon />
- *   <AlertContent>
- *     <AlertTitle>Alert Title</AlertTitle>
- *     <AlertDismissIconButton />
- *     <AlertDescription>
+ * <Alert.Root intent="info">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Alert Title</Alert.Title>
+ *     <Alert.Description>
  *       Alert description text.
- *     </AlertDescription>
- *   </AlertContent>
- * </Alert>
+ *     </Alert.Description>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={false} />
+ *   </Alert.Content>
+ * </Alert.Root>
  *```
  */
 const Content = ({ className, ref, ...props }: ComponentProps<"div">) => (
@@ -245,16 +257,17 @@ type AlertTitleProps = ComponentProps<"h5"> & WithAsChild;
  *
  * @example
  * ```tsx
- * <Alert intent="info">
- *   <AlertIcon />
- *   <AlertContent>
- *     <AlertTitle>Alert Title</AlertTitle>
- *     <AlertDismissIconButton />
- *     <AlertDescription>
+ * <Alert.Root intent="info">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Alert Title</Alert.Title>
+ *     <Alert.Description>
  *       Alert description text.
- *     </AlertDescription>
- *   </AlertContent>
- * </Alert>
+ *     </Alert.Description>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={false} />
+ *   </Alert.Content>
+ * </Alert.Root>
  *```
  */
 const Title = ({ asChild = false, className, ref, ...props }: AlertTitleProps) => {
@@ -281,16 +294,17 @@ type AlertDescriptionProps = ComponentProps<"div"> & WithAsChild;
  *
  * @example
  * ```tsx
- * <Alert intent="info">
- *   <AlertIcon />
- *   <AlertContent>
- *     <AlertTitle>Alert Title</AlertTitle>
- *     <AlertDismissIconButton />
- *     <AlertDescription>
+ * <Alert.Root intent="info">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Alert Title</Alert.Title>
+ *     <Alert.Description>
  *       Alert description text.
- *     </AlertDescription>
- *   </AlertContent>
- * </Alert>
+ *     </Alert.Description>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={false} />
+ *   </Alert.Content>
+ * </Alert.Root>
  * ```
  */
 const Description = ({ asChild = false, className, ref, ...props }: AlertDescriptionProps) => {
@@ -338,6 +352,18 @@ type AlertDismissIconButtonProps = Partial<
  * `Alert.ExpandButton` when both controls are composed together.
  *
  * @see https://mantle.ngrok.com/components/feedback/alert#alertdismissiconbutton
+ *
+ * @example
+ * ```tsx
+ * <Alert.Root intent="warning">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Usage limit approaching</Alert.Title>
+ *     <Alert.DismissIconButton onClick={dismiss} />
+ *     <Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
+ *   </Alert.Content>
+ * </Alert.Root>
+ * ```
  */
 const DismissIconButton = ({
 	size = "sm",
@@ -363,8 +389,8 @@ const DismissIconButton = ({
 			data-alert-dismiss
 			className={cx(
 				"right-1.5 top-1.5 absolute",
-				"text-(--alert-control-color)",
-				"not-disabled:hover:bg-(--alert-control-hover-bg) not-disabled:hover:text-(--alert-control-hover-color)",
+				"text-[var(--alert-control-color,currentColor)]",
+				"not-disabled:hover:bg-[var(--alert-control-hover-bg,transparent)] not-disabled:hover:text-[var(--alert-control-hover-color,currentColor)]",
 				className,
 			)}
 			type={type}
@@ -396,14 +422,14 @@ type AlertExpandButtonProps = Omit<
  *
  * @example
  * ```tsx
- * <Alert.Content>
- *   <Alert.Title>Usage limit approaching</Alert.Title>
- *   <Alert.ExpandButton
- *     count={2}
- *     expanded={isExpanded}
- *     onClick={() => setExpanded(!isExpanded)}
- *   />
- * </Alert.Content>
+ * <Alert.Root intent="warning">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Usage limit approaching</Alert.Title>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
+ *   </Alert.Content>
+ * </Alert.Root>
  * ```
  */
 const ExpandButton = ({ count, expanded, className, ...props }: AlertExpandButtonProps) => {
@@ -423,8 +449,8 @@ const ExpandButton = ({ count, expanded, className, ...props }: AlertExpandButto
 			data-alert-expand
 			className={cx(
 				"right-1.5 top-1.5 absolute gap-1 px-1.5",
-				"text-(--alert-control-color)",
-				"not-disabled:hover:bg-(--alert-control-hover-bg) not-disabled:hover:text-(--alert-control-hover-color)",
+				"text-[var(--alert-control-color,currentColor)]",
+				"not-disabled:hover:bg-[var(--alert-control-hover-bg,transparent)] not-disabled:hover:text-[var(--alert-control-hover-color,currentColor)]",
 				className,
 			)}
 			{...props}
@@ -441,6 +467,14 @@ const ExpandButton = ({ count, expanded, className, ...props }: AlertExpandButto
 		</Button>
 	);
 };
+
+Root.displayName = "Alert";
+Content.displayName = "AlertContent";
+Title.displayName = "AlertTitle";
+Description.displayName = "AlertDescription";
+DismissIconButton.displayName = "AlertDismissIconButton";
+ExpandButton.displayName = "AlertExpandButton";
+Icon.displayName = "AlertIcon";
 
 /**
  * Displays a callout for user attention.
@@ -461,16 +495,17 @@ const ExpandButton = ({ count, expanded, className, ...props }: AlertExpandButto
  *
  * @example
  * ```tsx
- * <Alert intent="info">
- *   <AlertIcon />
- *   <AlertContent>
- *     <AlertTitle>Alert Title</AlertTitle>
- *      <AlertDismissIconButton />
- *     <AlertDescription>
+ * <Alert.Root intent="info">
+ *   <Alert.Icon />
+ *   <Alert.Content>
+ *     <Alert.Title>Alert Title</Alert.Title>
+ *     <Alert.Description>
  *       Alert description text.
- *     </AlertDescription>
- *   </AlertContent>
- * </Alert>
+ *     </Alert.Description>
+ *     <Alert.DismissIconButton />
+ *     <Alert.ExpandButton count={2} expanded={false} />
+ *   </Alert.Content>
+ * </Alert.Root>
  *```
  */
 const Alert = {
@@ -486,6 +521,8 @@ const Alert = {
 	 *   <Alert.Content>
 	 *     <Alert.Title>Alert Title</Alert.Title>
 	 *     <Alert.Description>Alert description</Alert.Description>
+	 *     <Alert.DismissIconButton />
+	 *     <Alert.ExpandButton count={2} expanded={false} />
 	 *   </Alert.Content>
 	 * </Alert.Root>
 	 * ```
@@ -503,6 +540,8 @@ const Alert = {
 	 *   <Alert.Content>
 	 *     <Alert.Title>Alert Title</Alert.Title>
 	 *     <Alert.Description>Alert description text.</Alert.Description>
+	 *     <Alert.DismissIconButton />
+	 *     <Alert.ExpandButton count={2} expanded={false} />
 	 *   </Alert.Content>
 	 * </Alert.Root>
 	 * ```
@@ -518,14 +557,14 @@ const Alert = {
 	 *
 	 * @example
 	 * ```tsx
-	 * <Alert.Content>
-	 *   <Alert.Title>Usage limit approaching</Alert.Title>
-	 *   <Alert.ExpandButton
-	 *     count={2}
-	 *     expanded={isExpanded}
-	 *     onClick={() => setExpanded(!isExpanded)}
-	 *   />
-	 * </Alert.Content>
+	 * <Alert.Root intent="warning">
+	 *   <Alert.Icon />
+	 *   <Alert.Content>
+	 *     <Alert.Title>Usage limit approaching</Alert.Title>
+	 *     <Alert.DismissIconButton />
+	 *     <Alert.ExpandButton count={2} expanded={isExpanded} onClick={toggle} />
+	 *   </Alert.Content>
+	 * </Alert.Root>
 	 * ```
 	 */
 	ExpandButton,
@@ -541,6 +580,8 @@ const Alert = {
 	 *   <Alert.Content>
 	 *     <Alert.Title>Alert Title</Alert.Title>
 	 *     <Alert.Description>Alert description text.</Alert.Description>
+	 *     <Alert.DismissIconButton />
+	 *     <Alert.ExpandButton count={2} expanded={false} />
 	 *   </Alert.Content>
 	 * </Alert.Root>
 	 * ```
@@ -562,6 +603,7 @@ const Alert = {
 	 *     <Alert.Title>Alert Title</Alert.Title>
 	 *     <Alert.DismissIconButton />
 	 *     <Alert.Description>Alert description text.</Alert.Description>
+	 *     <Alert.ExpandButton count={2} expanded={false} />
 	 *   </Alert.Content>
 	 * </Alert.Root>
 	 * ```
@@ -579,6 +621,8 @@ const Alert = {
 	 *   <Alert.Content>
 	 *     <Alert.Title>Alert Title</Alert.Title>
 	 *     <Alert.Description>Alert description text.</Alert.Description>
+	 *     <Alert.DismissIconButton />
+	 *     <Alert.ExpandButton count={2} expanded={false} />
 	 *   </Alert.Content>
 	 * </Alert.Root>
 	 * ```
@@ -596,6 +640,8 @@ const Alert = {
 	 *   <Alert.Content>
 	 *     <Alert.Title>Alert Title</Alert.Title>
 	 *     <Alert.Description>Alert description text.</Alert.Description>
+	 *     <Alert.DismissIconButton />
+	 *     <Alert.ExpandButton count={2} expanded={false} />
 	 *   </Alert.Content>
 	 * </Alert.Root>
 	 * ```

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -401,7 +401,10 @@ const DismissIconButton = ({
 
 type AlertExpandButtonProps = Omit<
 	ButtonProps,
-	"appearance" | "children" | "icon" | "iconPlacement" | "intent" | "size"
+	// `asChild` is omitted: ExpandButton always renders multiple children (count,
+	// label, caret), which would trip Button's single-child `Children.only`
+	// invariant at runtime — so the invalid configuration is unrepresentable.
+	"appearance" | "asChild" | "children" | "icon" | "iconPlacement" | "intent" | "size"
 > & {
 	/** The number of alerts hidden by a collapsed alert center. */
 	count: number;
@@ -455,7 +458,7 @@ const ExpandButton = ({ count, expanded, className, ...props }: AlertExpandButto
 			)}
 			{...props}
 		>
-			<span className="w-[2ch] text-center tabular-nums">+{count}</span>
+			<span className="min-w-[2ch] text-center tabular-nums">+{count}</span>
 			<span className="hidden md:inline">more</span>
 			<CaretDownIcon
 				weight="bold"

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -1,4 +1,5 @@
 import { CheckCircleIcon } from "@phosphor-icons/react/CheckCircle";
+import { CaretDownIcon } from "@phosphor-icons/react/CaretDown";
 import { InfoIcon } from "@phosphor-icons/react/Info";
 import { MegaphoneIcon } from "@phosphor-icons/react/Megaphone";
 import { WarningIcon } from "@phosphor-icons/react/Warning";
@@ -10,6 +11,7 @@ import { createContext, useContext, useMemo } from "react";
 import invariant from "tiny-invariant";
 import { $cssProperties, type WithAsChild } from "../../types/index.js";
 import { cx } from "../../utils/cx/cx.js";
+import { Button, type ButtonProps } from "../button/button.js";
 import {
 	IconButton,
 	type IconButtonAppearance,
@@ -57,15 +59,15 @@ const alertVariants = cva(
 			 */
 			intent: {
 				danger:
-					"border-danger-500/50 bg-danger-500/10 text-danger-700 [&_code]:bg-danger-500/10 [&_code]:border-danger-500/20 [&_code]:text-danger-900 [&_a]:text-danger-700 [&_a]:underline",
+					"border-danger-500/50 bg-danger-500/10 text-danger-700 [&_code]:bg-danger-500/10 [&_code]:border-danger-500/20 [&_code]:text-danger-900 [&_a:not([data-slot=button])]:text-danger-700 [&_a:not([data-slot=button])]:underline",
 				important:
-					"border-important-500/50 bg-important-500/10 text-important-700 [&_code]:bg-important-500/10 [&_code]:border-important-500/20 [&_code]:text-important-900 [&_a]:text-important-700 [&_a]:underline",
-				info: "border-info-500/50 bg-info-500/10 text-info-700 [&_code]:bg-info-500/10 [&_code]:border-info-500/20 [&_code]:text-info-900 [&_a]:text-info-700 [&_a]:underline",
+					"border-important-500/50 bg-important-500/10 text-important-700 [&_code]:bg-important-500/10 [&_code]:border-important-500/20 [&_code]:text-important-900 [&_a:not([data-slot=button])]:text-important-700 [&_a:not([data-slot=button])]:underline",
+				info: "border-info-500/50 bg-info-500/10 text-info-700 [&_code]:bg-info-500/10 [&_code]:border-info-500/20 [&_code]:text-info-900 [&_a:not([data-slot=button])]:text-info-700 [&_a:not([data-slot=button])]:underline",
 				// neutral: "border-neutral-500/50 bg-neutral-500/10 text-neutral-700",
 				success:
-					"border-success-500/50 bg-success-500/10 text-success-700 [&_code]:bg-success-500/10 [&_code]:border-success-500/20 [&_code]:text-success-900 [&_a]:text-success-700 [&_a]:underline",
+					"border-success-500/50 bg-success-500/10 text-success-700 [&_code]:bg-success-500/10 [&_code]:border-success-500/20 [&_code]:text-success-900 [&_a:not([data-slot=button])]:text-success-700 [&_a:not([data-slot=button])]:underline",
 				warning:
-					"border-warning-500/50 bg-warning-500/10 text-warning-700 [&_code]:bg-warning-500/10 [&_code]:border-warning-500/20 [&_code]:text-warning-900 [&_a]:text-warning-700 [&_a]:underline",
+					"border-warning-500/50 bg-warning-500/10 text-warning-700 [&_code]:bg-warning-500/10 [&_code]:border-warning-500/20 [&_code]:text-warning-900 [&_a:not([data-slot=button])]:text-warning-700 [&_a:not([data-slot=button])]:underline",
 			} as const satisfies Record<AlertIntent, string>,
 			/**
 			 * Controls the visual style of the Alert.
@@ -118,7 +120,7 @@ type AlertProps = ComponentProps<"div"> & {
  * </Alert>
  *```
  */
-const Root = ({ appearance = "default", className, intent, ref, ...props }: AlertProps) => {
+const Root = ({ appearance = "default", className, intent, ref, style, ...props }: AlertProps) => {
 	const context: AlertContextValue = useMemo(() => ({ intent }), [intent]);
 
 	return (
@@ -126,7 +128,24 @@ const Root = ({ appearance = "default", className, intent, ref, ...props }: Aler
 			<div
 				ref={ref}
 				data-slot="alert"
-				className={cx(alertVariants({ appearance, intent }), className)}
+				className={cx(
+					alertVariants({ appearance, intent }),
+					// Each trailing control reserves its own space: the root's right
+					// padding makes room for dismiss, and the content's padding makes
+					// room for expand. Together they compose without extra consumer work.
+					"has-data-alert-dismiss:pr-10",
+					"has-data-alert-expand:[&_[data-slot=alert-dismiss-icon-button]]:right-16",
+					"md:has-data-alert-expand:[&_[data-slot=alert-dismiss-icon-button]]:right-24",
+					"has-data-alert-expand:[&_[data-slot=alert-content]]:pr-12",
+					"md:has-data-alert-expand:[&_[data-slot=alert-content]]:pr-[5.5rem]",
+					className,
+				)}
+				style={$cssProperties({
+					"--alert-control-color": alertControlTextColor(intent),
+					"--alert-control-hover-color": alertControlHoverColor(intent),
+					"--alert-control-hover-bg": alertControlHoverBgColor(intent),
+					...style,
+				})}
 				{...props}
 			/>
 		</AlertContext.Provider>
@@ -189,7 +208,8 @@ const Icon = ({ className, ref, svg, ...props }: AlertIconProps) => {
 };
 
 /**
- * The container for the content slot of an alert. Place the title and description as direct children.
+ * The container for the content slot of an alert. Place the title, description,
+ * and trailing controls as direct children.
  *
  * @see https://mantle.ngrok.com/components/feedback/alert#alertcontent
  *
@@ -286,11 +306,11 @@ const Description = ({ asChild = false, className, ref, ...props }: AlertDescrip
 	);
 };
 
-const dismissTextColor = (intent: AlertIntent) => `var(--color-${intent}-700)`;
+const alertControlTextColor = (intent: AlertIntent) => `var(--color-${intent}-700)`;
 
-const dismissHoverColor = (intent: AlertIntent) => `var(--color-${intent}-800)`;
+const alertControlHoverColor = (intent: AlertIntent) => `var(--color-${intent}-800)`;
 
-const dismissHoverBgColor = (intent: AlertIntent) =>
+const alertControlHoverBgColor = (intent: AlertIntent) =>
 	`color-mix(in oklab, var(--color-${intent}-500) 10%, transparent)`;
 
 type AlertDismissIconButtonProps = Partial<
@@ -310,6 +330,15 @@ type AlertDismissIconButtonProps = Partial<
 	icon?: ReactNode;
 };
 
+/**
+ * A compact, trailing control for dismissing an alert.
+ *
+ * It inherits `--alert-control-color`, `--alert-control-hover-color`, and
+ * `--alert-control-hover-bg` from `Alert.Root`, shared with
+ * `Alert.ExpandButton` when both controls are composed together.
+ *
+ * @see https://mantle.ngrok.com/components/feedback/alert#alertdismissiconbutton
+ */
 const DismissIconButton = ({
 	size = "sm",
 	type = "button",
@@ -317,10 +346,8 @@ const DismissIconButton = ({
 	appearance = "ghost",
 	className,
 	icon = defaultDismissIcon,
-	style,
 	...props
 }: AlertDismissIconButtonProps) => {
-	const ctx = useAlertContext();
 	return (
 		<IconButton
 			appearance={appearance}
@@ -336,19 +363,82 @@ const DismissIconButton = ({
 			data-alert-dismiss
 			className={cx(
 				"right-1.5 top-1.5 absolute",
-				"text-(--alert-dismiss-icon-color)",
-				"not-disabled:hover:bg-(--alert-dismiss-hover-bg) not-disabled:hover:text-(--alert-dismiss-icon-hover-color)",
+				"text-(--alert-control-color)",
+				"not-disabled:hover:bg-(--alert-control-hover-bg) not-disabled:hover:text-(--alert-control-hover-color)",
 				className,
 			)}
 			type={type}
-			style={$cssProperties({
-				...style,
-				"--alert-dismiss-icon-color": dismissTextColor(ctx.intent),
-				"--alert-dismiss-icon-hover-color": dismissHoverColor(ctx.intent),
-				"--alert-dismiss-hover-bg": dismissHoverBgColor(ctx.intent),
-			})}
 			{...props}
 		/>
+	);
+};
+
+type AlertExpandButtonProps = Omit<
+	ButtonProps,
+	"appearance" | "children" | "icon" | "iconPlacement" | "intent" | "size"
+> & {
+	/** The number of alerts hidden by a collapsed alert center. */
+	count: number;
+	/** Whether the alerts controlled by this button are currently visible. */
+	expanded: boolean;
+};
+
+/**
+ * A compact, trailing control for expanding or collapsing related alerts.
+ *
+ * It occupies the trailing control area alongside `Alert.DismissIconButton`
+ * when both are present, and marks the alert so `Alert.Content` reserves room
+ * for its plus-prefixed count and caret on narrow viewports. It shares the
+ * `--alert-control-*` color variables from `Alert.Root` with the dismiss
+ * control.
+ *
+ * @see https://mantle.ngrok.com/components/feedback/alert#alertexpandbutton
+ *
+ * @example
+ * ```tsx
+ * <Alert.Content>
+ *   <Alert.Title>Usage limit approaching</Alert.Title>
+ *   <Alert.ExpandButton
+ *     count={2}
+ *     expanded={isExpanded}
+ *     onClick={() => setExpanded(!isExpanded)}
+ *   />
+ * </Alert.Content>
+ * ```
+ */
+const ExpandButton = ({ count, expanded, className, ...props }: AlertExpandButtonProps) => {
+	return (
+		<Button
+			type="button"
+			appearance="ghost"
+			intent="neutral"
+			size="sm"
+			aria-expanded={expanded}
+			aria-label={
+				expanded
+					? "Collapse additional alerts"
+					: `Show ${count} more ${count === 1 ? "alert" : "alerts"}`
+			}
+			data-slot="alert-expand-button"
+			data-alert-expand
+			className={cx(
+				"right-1.5 top-1.5 absolute gap-1 px-1.5",
+				"text-(--alert-control-color)",
+				"not-disabled:hover:bg-(--alert-control-hover-bg) not-disabled:hover:text-(--alert-control-hover-color)",
+				className,
+			)}
+			{...props}
+		>
+			<span className="w-[2ch] text-center tabular-nums">+{count}</span>
+			<span className="hidden md:inline">more</span>
+			<CaretDownIcon
+				weight="bold"
+				className={cx(
+					"size-4 transition-transform ease-out duration-150",
+					expanded && "-rotate-180",
+				)}
+			/>
+		</Button>
 	);
 };
 
@@ -362,10 +452,11 @@ const DismissIconButton = ({
  * ```
  * Alert.Root
  * ├── Alert.Icon
- * └── Alert.Content
+ * ├── Alert.Content
  *     ├── Alert.Title
  *     ├── Alert.Description
- *     └── Alert.DismissIconButton
+ *     ├── Alert.DismissIconButton
+ *     └── Alert.ExpandButton
  * ```
  *
  * @example
@@ -418,6 +509,27 @@ const Alert = {
 	 */
 	Content,
 	/**
+	 * A compact trailing control for expanding or collapsing related alerts.
+	 * It inherits the `--alert-control-color`, `--alert-control-hover-color`, and
+	 * `--alert-control-hover-bg` variables from `Alert.Root`, shared with the
+	 * dismiss control.
+	 *
+	 * @see https://mantle.ngrok.com/components/feedback/alert#alertexpandbutton
+	 *
+	 * @example
+	 * ```tsx
+	 * <Alert.Content>
+	 *   <Alert.Title>Usage limit approaching</Alert.Title>
+	 *   <Alert.ExpandButton
+	 *     count={2}
+	 *     expanded={isExpanded}
+	 *     onClick={() => setExpanded(!isExpanded)}
+	 *   />
+	 * </Alert.Content>
+	 * ```
+	 */
+	ExpandButton,
+	/**
 	 * The optional description of an alert.
 	 *
 	 * @see https://mantle.ngrok.com/components/feedback/alert#alertdescription
@@ -436,6 +548,9 @@ const Alert = {
 	Description,
 	/**
 	 * An optional dismiss button that can be used to close the alert.
+	 * It inherits the `--alert-control-color`, `--alert-control-hover-color`, and
+	 * `--alert-control-hover-bg` variables from `Alert.Root`, shared with the
+	 * expand control.
 	 *
 	 * @see https://mantle.ngrok.com/components/feedback/alert#alertdismissiconbutton
 	 *


### PR DESCRIPTION
## Summary

- add `Alert.ExpandButton` with responsive count labels and shared alert intent styling
- allow dismiss and expand controls to compose inside `Alert.Content` with reserved trailing space
- document the shared root CSS variables and composed-control usage

## Validation

- `pnpm -w run lint`
- `pnpm -w run fmt:check`
- `pnpm -w run typecheck`
- `pnpm -w run test`