### PR TITLE
fix(www): hide React Query devtools inside framed previews

### DIFF
--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -206,7 +206,9 @@ export function Layout({ children }: PropsWithChildren) {
 					<TooltipProvider>
 						<Toaster />
 						<QueryClientProvider client={queryClient}>
-							{showReactQueryDevtools && (
+							{/* Suppressed inside framed example previews: the floating devtools
+							    button would render on top of the demo in the docs page's iframe. */}
+							{showReactQueryDevtools && !isFramedPreview && (
 								<Suspense fallback={null}>
 									<ReactQueryDevtoolsLazy />
 								</Suspense>


### PR DESCRIPTION
## Summary

The floating React Query (TanStack) devtools button rendered on top of the demo inside the docs pages' framed-preview iframe, obscuring the example.

This gates the devtools on the existing `useIsFramedPreview()` so it only shows in the top-level app, never inside an example preview iframe.

```diff
 <QueryClientProvider client={queryClient}>
-  {showReactQueryDevtools && (
+  {/* Suppressed inside framed example previews: the floating devtools
+      button would render on top of the demo in the docs page's iframe. */}
+  {showReactQueryDevtools && !isFramedPreview && (
     <Suspense fallback={null}>
       <ReactQueryDevtoolsLazy />
     </Suspense>
   )}
```

## Notes

- Extracted as a standalone fix from the `sandbar` (PowerBar, #1341) branch, where it was discovered — the `root.tsx` here is byte-for-byte identical to that branch's version.
- `isFramedPreview` already exists on `main` (from `useIsFramedPreview()`), so this is a one-line gate.
- apps/www only — no `packages/mantle` change, so no changeset.

## Test plan

- Open any framed example preview in the docs (e.g. an app-layout or centered-layout demo) — the devtools button no longer overlays the demo.
- The devtools still appear in the top-level docs app (non-preview routes) when enabled.