### PR TITLE
fix(charts): never render fractional axis ticks for integer-valued data

### DIFF
--- a/.changeset/chart-integer-ticks.md
+++ b/.changeset/chart-integer-ticks.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+Charts no longer render fractional axis ticks for integer-valued data (MNTL-56).
+
+When every value backing an axis is an integer — request counts, error totals — the tick step is clamped to whole numbers, so a small domain like `[0, 3]` ticks at `0, 1, 2, 3` instead of `0, 0.5, 1, …`. The clamp follows the data, not the axis part: it covers the value axis in both bar orientations (including the value ticks painted along the bottom of horizontal bars) and linear x axes on line, area, and scatter charts. Any fractional value in the data restores sub-integer stepping, and `tickCount` remains an approximate hint.

--- a/apps/www/app/docs/components/charts/area-chart.mdx
+++ b/apps/www/app/docs/components/charts/area-chart.mdx
@@ -858,16 +858,16 @@ Tick labels along the bottom of the plot. Renderless — painted on canvas. Labe
 | Prop         | Type                                          | Default         | Description                                                                                                                                  |
 | ------------ | --------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tickFormat` | `(value: string \| number \| Date) => string` |                 | Format a tick label. Receives the row's x value: the category value on point scales, a `Date` on time scales, and a number on linear scales. |
-| `tickCount`  | `number`                                      | density-derived | Target tick count (continuous scales only).                                                                                                  |
+| `tickCount`  | `number`                                      | density-derived | Target tick count (continuous scales only). Approximate: a linear axis over integer-only x values never renders fractional ticks.            |
 
 ### AreaChart.YAxis
 
 Value tick labels along the left of the plot. Renderless — painted on canvas. Ticks land on clean thousands-separated numbers.
 
-| Prop         | Type                        | Default             | Description          |
-| ------------ | --------------------------- | ------------------- | -------------------- |
-| `tickFormat` | `(value: number) => string` | thousands-separated | Format a tick label. |
-| `tickCount`  | `number`                    | density-derived     | Target tick count.   |
+| Prop         | Type                        | Default             | Description                                                                                             |
+| ------------ | --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `tickFormat` | `(value: number) => string` | thousands-separated | Format a tick label.                                                                                    |
+| `tickCount`  | `number`                    | density-derived     | Target tick count. Approximate: integer-valued data never renders fractional ticks, whatever the count. |
 
 ### AreaChart.ReferenceLine
 

--- a/apps/www/app/docs/components/charts/bar-chart.mdx
+++ b/apps/www/app/docs/components/charts/bar-chart.mdx
@@ -161,6 +161,26 @@ export function SingleSeriesBarChartExample() {
 	);
 }
 
+export const failedDeploys = [
+	{ weekday: "Monday", failures: 1 },
+	{ weekday: "Tuesday", failures: 0 },
+	{ weekday: "Wednesday", failures: 3 },
+	{ weekday: "Thursday", failures: 2 },
+	{ weekday: "Friday", failures: 1 },
+];
+
+export function IntegerCountsBarChartExample() {
+	return (
+		<BarChart.Root data={failedDeploys} xKey="weekday" aria-label="Failed deploys by weekday">
+			<BarChart.Grid />
+			<BarChart.XAxis tickFormat={(weekday) => String(weekday).slice(0, 3)} />
+			<BarChart.YAxis />
+			<BarChart.Bar dataKey="failures" label="Failures" />
+			<BarChart.Tooltip />
+		</BarChart.Root>
+	);
+}
+
 export function ReferenceLineBarChartExample() {
 	return (
 		<BarChart.Root data={monthlyVisitors} xKey="month" aria-label="Visitors by month">
@@ -574,6 +594,38 @@ function SingleSeriesBarChartExample() {
 				<BarChart.Bar dataKey="requests" label="Requests" />
 			</BarChart.Root>
 		</div>
+	);
+}
+```
+
+## Integer counts
+
+Counts are integers, and the value axis knows it: when every series value is a whole number, ticks step by whole numbers — this chart's `[0, 3]` domain ticks at 0, 1, 2, 3 rather than inventing a meaningless "1.5 failures" gridline. Nothing to configure; the behavior follows the data, so a single fractional value (an average, a rate) restores sub-integer ticks. The same guarantee covers the value axis of horizontal bars and linear x axes on the other chart families.
+
+<Example>
+	<IntegerCountsBarChartExample />
+</Example>
+
+```tsx
+import { BarChart } from "@ngrok/mantle/bar-chart";
+
+const failedDeploys = [
+	{ weekday: "Monday", failures: 1 },
+	{ weekday: "Tuesday", failures: 0 },
+	{ weekday: "Wednesday", failures: 3 },
+	{ weekday: "Thursday", failures: 2 },
+	{ weekday: "Friday", failures: 1 },
+];
+
+function IntegerCountsBarChartExample() {
+	return (
+		<BarChart.Root data={failedDeploys} xKey="weekday" aria-label="Failed deploys by weekday">
+			<BarChart.Grid />
+			<BarChart.XAxis tickFormat={(weekday) => String(weekday).slice(0, 3)} />
+			<BarChart.YAxis />
+			<BarChart.Bar dataKey="failures" label="Failures" />
+			<BarChart.Tooltip />
+		</BarChart.Root>
 	);
 }
 ```
@@ -1015,10 +1067,10 @@ Category labels along the bottom of the plot (renderless; painted on canvas). La
 
 Value tick labels along the left of the plot (renderless; painted on canvas). Ticks land on clean thousands-separated numbers. Accepts no `className` or DOM props.
 
-| Prop          | Type                        | Default                     | Description          |
-| ------------- | --------------------------- | --------------------------- | -------------------- |
-| `tickFormat?` | `(value: number) => string` | thousands-separated numbers | Format a tick label. |
-| `tickCount?`  | `number`                    |                             | Target tick count.   |
+| Prop          | Type                        | Default                     | Description                                                                                             |
+| ------------- | --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `tickFormat?` | `(value: number) => string` | thousands-separated numbers | Format a tick label.                                                                                    |
+| `tickCount?`  | `number`                    |                             | Target tick count. Approximate: integer-valued data never renders fractional ticks, whatever the count. |
 
 ### BarChart.ReferenceLine
 

--- a/apps/www/app/docs/components/charts/line-chart.mdx
+++ b/apps/www/app/docs/components/charts/line-chart.mdx
@@ -757,16 +757,16 @@ Tick labels along the bottom of the plot. Renderless — painted on canvas. Labe
 | Prop          | Type                                          | Default         | Description                                                                                                                                                                                                                                          |
 | ------------- | --------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tickFormat?` | `(value: string \| number \| Date) => string` | scale-dependent | Format a tick label. Receives the row's x value — a `Date` on time scales, a number on linear scales, and the category value on point scales. Defaults to calendar-aware formatting on time scales and thousands-separated numbers on linear scales. |
-| `tickCount?`  | `number`                                      | density-derived | Target tick count (continuous scales only).                                                                                                                                                                                                          |
+| `tickCount?`  | `number`                                      | density-derived | Target tick count (continuous scales only). Approximate: a linear axis over integer-only x values never renders fractional ticks.                                                                                                                    |
 
 ### LineChart.YAxis
 
 Value tick labels along the left of the plot. Renderless — painted on canvas. Ticks land on clean thousands-separated numbers.
 
-| Prop          | Type                        | Default             | Description          |
-| ------------- | --------------------------- | ------------------- | -------------------- |
-| `tickFormat?` | `(value: number) => string` | thousands-separated | Format a tick label. |
-| `tickCount?`  | `number`                    | `5`                 | Target tick count.   |
+| Prop          | Type                        | Default             | Description                                                                                             |
+| ------------- | --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `tickFormat?` | `(value: number) => string` | thousands-separated | Format a tick label.                                                                                    |
+| `tickCount?`  | `number`                    | `5`                 | Target tick count. Approximate: integer-valued data never renders fractional ticks, whatever the count. |
 
 ### LineChart.ReferenceLine
 

--- a/apps/www/app/docs/components/charts/scatter-plot.mdx
+++ b/apps/www/app/docs/components/charts/scatter-plot.mdx
@@ -838,16 +838,16 @@ Value labels along the bottom of the plot. Renderless — painted on canvas; 2D 
 | Prop          | Type                                          | Default         | Description                                                                                                                                                                   |
 | ------------- | --------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tickFormat?` | `(value: string \| number \| Date) => string` | scale-dependent | Format a tick label. Receives the row's x value — a number on linear scales, a `Date` on time scales. Defaults to thousands-separated numbers and calendar-aware time labels. |
-| `tickCount?`  | `number`                                      | density-derived | Target tick count.                                                                                                                                                            |
+| `tickCount?`  | `number`                                      | density-derived | Target tick count. Approximate: a linear axis over integer-only x values never renders fractional ticks.                                                                      |
 
 ### ScatterPlot.YAxis
 
 Value tick labels along the left of the plot. Renderless — painted on canvas; 2D only. Ticks land on clean thousands-separated numbers.
 
-| Prop          | Type                        | Default             | Description          |
-| ------------- | --------------------------- | ------------------- | -------------------- |
-| `tickFormat?` | `(value: number) => string` | thousands-separated | Format a tick label. |
-| `tickCount?`  | `number`                    | `5`                 | Target tick count.   |
+| Prop          | Type                        | Default             | Description                                                                                             |
+| ------------- | --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `tickFormat?` | `(value: number) => string` | thousands-separated | Format a tick label.                                                                                    |
+| `tickCount?`  | `number`                    | `5`                 | Target tick count. Approximate: integer-valued data never renders fractional ticks, whatever the count. |
 
 ### ScatterPlot.ReferenceLine
 

--- a/packages/mantle/src/components/chart/engine.ts
+++ b/packages/mantle/src/components/chart/engine.ts
@@ -211,6 +211,15 @@ class ChartEngine {
 	#columns = new Map<string, Float64Array>();
 	#valueMin = 0;
 	#valueMax = 0;
+	/**
+	 * Every finite series value is an integer. Integer-count data (requests,
+	 * errors) never renders fractional value ticks — a "1.5" label on a count
+	 * axis is meaningless — so value tick generation clamps its step to whole
+	 * numbers while this holds (MNTL-56).
+	 */
+	#valuesAllIntegers = true;
+	/** Every x position is an integer; linear x scales get the same whole-step tick clamp. */
+	#xsAllIntegers = true;
 	#stack: StackBoundaries | null = null;
 
 	// Domains chase their targets (liveline-style exponential glide) so regular
@@ -742,6 +751,10 @@ class ChartEngine {
 			this.#rowCount = count;
 			this.#xs = xs;
 			this.#xValues = xValues;
+			// Band/point positions are indices — vacuously integral (and unread:
+			// category axes never linear-tick). Reset so a scale change to linear
+			// on the same engine never reads a stale flag.
+			this.#xsAllIntegers = true;
 		} else {
 			const entries: Array<{ source: number; x: number }> = [];
 			// `undefined` = key absent (an all-rows absence is a typo, below);
@@ -791,6 +804,7 @@ class ChartEngine {
 			const xs = new Float64Array(count);
 			const xValues: XValue[] = Array.from({ length: count }, () => "");
 			let identityOrder = count === rows.length;
+			let xsAllIntegers = true;
 			const order = new Int32Array(count);
 			for (let index = 0; index < count; index++) {
 				const entry = ordered[index];
@@ -798,6 +812,9 @@ class ChartEngine {
 					continue;
 				}
 				xs[index] = entry.x;
+				if (!Number.isInteger(entry.x)) {
+					xsAllIntegers = false;
+				}
 				if (xScale === "time") {
 					xValues[index] = new Date(entry.x);
 				} else {
@@ -827,6 +844,7 @@ class ChartEngine {
 			this.#rowCount = count;
 			this.#xs = xs;
 			this.#xValues = xValues;
+			this.#xsAllIntegers = xsAllIntegers;
 		}
 		// Date label granularity is a dataset property, not a sample property:
 		// the midnight point inside an hourly series must keep its time of day.
@@ -882,6 +900,9 @@ class ChartEngine {
 		this.#columns = new Map();
 		let min = Number.POSITIVE_INFINITY;
 		let max = Number.NEGATIVE_INFINITY;
+		// Stacked sums of integers are integers, so scanning the raw per-series
+		// values covers stacked domains too.
+		let valuesAllIntegers = true;
 		for (const spec of specs) {
 			const values = new Float64Array(count);
 			let found = false;
@@ -906,6 +927,9 @@ class ChartEngine {
 					if (value > max) {
 						max = value;
 					}
+					if (!Number.isInteger(value)) {
+						valuesAllIntegers = false;
+					}
 				}
 			}
 			invariant(
@@ -916,6 +940,7 @@ class ChartEngine {
 		}
 		this.#valueMin = min === Number.POSITIVE_INFINITY ? 0 : min;
 		this.#valueMax = max === Number.NEGATIVE_INFINITY ? 0 : max;
+		this.#valuesAllIntegers = valuesAllIntegers;
 
 		// 3D scatter: the depth column, sorted-aligned like every series column.
 		const zKey = this.#options.zKey;
@@ -1442,9 +1467,14 @@ class ChartEngine {
 	#yTicks(): Array<{ value: number; text: string }> {
 		const snapshot = this.#store.getSnapshot();
 		const domain = this.#yTween.values();
+		// Integer data keeps integer ticks even mid-glide (tweened fractional
+		// domain bounds) and under a fractional yDomain override — integrality is
+		// a fact about the data, not the domain. `tickCount` stays a hint: the
+		// integer clamp wins when the domain span is smaller than the request.
 		const ticks = linearTicks(
 			[domain[0] ?? 0, domain[1] ?? 1],
 			snapshot.yAxis?.tickCount ?? Y_TICK_COUNT,
+			{ integer: this.#valuesAllIntegers },
 		);
 		const format = snapshot.yAxis?.tickFormat;
 		// Precision follows the tick step, so small-magnitude domains (error
@@ -1503,7 +1533,9 @@ class ChartEngine {
 				text: format == null ? defaultFormat(epoch) : format(new Date(epoch)),
 			}));
 		}
-		const ticks = linearTicks(range, count);
+		// Same whole-step clamp as the value axis: a linear x over integer data
+		// (attempt number, batch index) never grows fractional ticks.
+		const ticks = linearTicks(range, count, { integer: this.#xsAllIntegers });
 		const digits =
 			ticks.length > 1
 				? tickFractionDigits(Math.abs((ticks[1] ?? 0) - (ticks[0] ?? 0)))

--- a/packages/mantle/src/components/chart/integer-ticks.browser.test.tsx
+++ b/packages/mantle/src/components/chart/integer-ticks.browser.test.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { render, waitFor } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { BarChart } from "../bar-chart/index.js";
+import { LineChart } from "../line-chart/index.js";
+
+/**
+ * Real-browser regression tests for MNTL-56: axes backed by integer-only data
+ * must never paint fractional tick labels ("0.5" on a request-count axis).
+ * Tick labels are canvas ink, so happy-dom (null 2d context) never reaches the
+ * paint path — these spy on `fillText` in Chromium instead and assert on the
+ * painted strings.
+ */
+const STYLE = `
+:root {
+	--color-chart-1: #3e6ff4;
+	--color-chart-other: #737373;
+	--border-color-card-muted: #e5e5e5;
+	--border-color-card: #d4d4d4;
+	--text-color-muted: #717171;
+	--color-neutral-500: #737373;
+	--background-color-card: #ffffff;
+}
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+}
+/* Browser tests load no Tailwind build; mirror the chart's structural layout so
+   the plot geometry is realistic. */
+[data-slot="bar-chart"],
+[data-slot="line-chart"] {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 100%;
+}
+[data-slot$="-plot"] {
+	position: relative;
+	flex: 1;
+	min-height: 0;
+	width: 100%;
+}
+[data-slot$="-plot"] > canvas,
+[data-slot$="-plot"] > [tabindex] {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+}
+`;
+
+let styleElement: HTMLStyleElement;
+let fillTextSpy: MockInstance;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+	// Calls through to the real implementation, so painting is unchanged — the
+	// spy only records which strings hit the canvas.
+	fillTextSpy = vi.spyOn(CanvasRenderingContext2D.prototype, "fillText");
+});
+
+afterEach(() => {
+	fillTextSpy.mockClear();
+});
+
+afterAll(() => {
+	fillTextSpy.mockRestore();
+	styleElement.remove();
+});
+
+const paintedLabels = (): string[] => fillTextSpy.mock.calls.map((call) => String(call[0]));
+
+/**
+ * A tick label with a decimal fraction, in either decimal-separator locale.
+ * The datasets here stay below 1,000 so grouping separators never match.
+ */
+const isFractionalLabel = (label: string): boolean => /^\d+[.,]\d+$/.test(label);
+
+describe("integer-valued data never paints fractional axis ticks (MNTL-56)", () => {
+	test("vertical bars: a small count domain ticks by whole numbers", async () => {
+		render(
+			<div style={{ width: 600, height: 300 }}>
+				<BarChart.Root
+					data={[
+						{ cat: "A", count: 1 },
+						{ cat: "B", count: 3 },
+					]}
+					xKey="cat"
+					animate={false}
+					aria-label="Request counts"
+				>
+					<BarChart.XAxis />
+					<BarChart.YAxis />
+					<BarChart.Bar dataKey="count" label="Count" color="chart-1" />
+				</BarChart.Root>
+			</div>,
+		);
+		await waitFor(() => {
+			// The [0, 3] domain's top tick proves the value axis painted.
+			expect(paintedLabels()).toContain("3");
+		});
+		expect(paintedLabels().filter(isFractionalLabel)).toEqual([]);
+	});
+
+	test("horizontal bars: the value axis along the bottom keeps whole-number ticks", async () => {
+		render(
+			<div style={{ width: 600, height: 300 }}>
+				<BarChart.Root
+					data={[
+						{ cat: "A", count: 1 },
+						{ cat: "B", count: 3 },
+					]}
+					xKey="cat"
+					orientation="horizontal"
+					animate={false}
+					aria-label="Request counts, horizontal"
+				>
+					<BarChart.XAxis />
+					<BarChart.YAxis />
+					<BarChart.Bar dataKey="count" label="Count" color="chart-1" />
+				</BarChart.Root>
+			</div>,
+		);
+		await waitFor(() => {
+			expect(paintedLabels()).toContain("3");
+		});
+		expect(paintedLabels().filter(isFractionalLabel)).toEqual([]);
+	});
+
+	test("a linear x axis over integer positions ticks by whole numbers", async () => {
+		// y values are large integers (whole-step ticks regardless), so any
+		// fractional label could only come from the [0, 3] linear x domain.
+		render(
+			<div style={{ width: 600, height: 300 }}>
+				<LineChart.Root
+					data={[
+						{ attempt: 0, latency: 100 },
+						{ attempt: 1, latency: 240 },
+						{ attempt: 2, latency: 180 },
+						{ attempt: 3, latency: 300 },
+					]}
+					xKey="attempt"
+					animate={false}
+					aria-label="Latency by attempt"
+				>
+					<LineChart.XAxis />
+					<LineChart.YAxis />
+					<LineChart.Line dataKey="latency" label="Latency" color="chart-1" />
+				</LineChart.Root>
+			</div>,
+		);
+		await waitFor(() => {
+			// An interior x tick proves the linear x axis painted.
+			expect(paintedLabels()).toContain("2");
+		});
+		expect(paintedLabels().filter(isFractionalLabel)).toEqual([]);
+	});
+
+	test("fractional data keeps sub-integer ticks (the clamp is data-driven, not global)", async () => {
+		render(
+			<div style={{ width: 600, height: 300 }}>
+				<LineChart.Root
+					data={[
+						{ cat: "A", rate: 0.2 },
+						{ cat: "B", rate: 0.8 },
+					]}
+					xKey="cat"
+					animate={false}
+					aria-label="Error rate"
+				>
+					<LineChart.XAxis />
+					<LineChart.YAxis />
+					<LineChart.Line dataKey="rate" label="Rate" color="chart-1" />
+				</LineChart.Root>
+			</div>,
+		);
+		await waitFor(() => {
+			expect(paintedLabels().some(isFractionalLabel)).toBe(true);
+		});
+	});
+});

--- a/packages/mantle/src/components/chart/primitive.tsx
+++ b/packages/mantle/src/components/chart/primitive.tsx
@@ -681,7 +681,12 @@ type XAxisPrimitiveProps = {
 	 * band/point scales, a `Date` on time scales, and a number on linear scales.
 	 */
 	tickFormat?: (value: XValue) => string;
-	/** Target tick count (continuous scales only; a density-derived default otherwise). */
+	/**
+	 * Target tick count (continuous scales only; a density-derived default
+	 * otherwise). Approximate: ticks land on human-friendly steps, and a linear
+	 * axis whose x values are all integers never renders fractional ticks —
+	 * the integer step wins over the requested count.
+	 */
 	tickCount?: number;
 };
 
@@ -698,7 +703,11 @@ const useXAxisPrimitive = (partName: string, props: XAxisPrimitiveProps): null =
 type YAxisPrimitiveProps = {
 	/** Format a tick label. Defaults to thousands-separated numbers. */
 	tickFormat?: (value: number) => string;
-	/** Target tick count. */
+	/**
+	 * Target tick count. Approximate: ticks land on human-friendly steps, and
+	 * when every series value is an integer (counts) the axis never renders
+	 * fractional ticks — the integer step wins over the requested count.
+	 */
 	tickCount?: number;
 };
 

--- a/packages/mantle/src/components/chart/scales.test.ts
+++ b/packages/mantle/src/components/chart/scales.test.ts
@@ -139,6 +139,47 @@ describe("linearTicks", () => {
 	});
 });
 
+describe("linearTicks with the integer option", () => {
+	// Regression: MNTL-56 — a small integer-count domain used to grow fractional
+	// ticks ("0.5 requests") because the 1/2/5 solver steps below 1.
+	test("a small integer domain steps by whole numbers instead of fractions", () => {
+		expect(linearTicks([0, 3], 5, { integer: true })).toEqual([0, 1, 2, 3]);
+		expect(linearTicks([0, 1], 5, { integer: true })).toEqual([0, 1]);
+	});
+
+	test("the integer step wins over a larger requested count", () => {
+		expect(linearTicks([0, 3], 10, { integer: true })).toEqual([0, 1, 2, 3]);
+	});
+
+	test("domains wide enough for whole steps are unchanged", () => {
+		expect(linearTicks([0, 10], 5, { integer: true })).toEqual([0, 2, 4, 6, 8, 10]);
+		expect(linearTicks([0, 1000], 5, { integer: true })).toEqual([0, 200, 400, 600, 800, 1000]);
+	});
+
+	test("fractional bounds keep only the integers inside them", () => {
+		// The padded domain a constant integer series produces (flat 3 → [1.5, 4.5]).
+		expect(linearTicks([1.5, 4.5], 5, { integer: true })).toEqual([2, 3, 4]);
+		expect(linearTicks([0, 0.5], 5, { integer: true })).toEqual([0]);
+	});
+
+	test("a fractional domain containing no integer yields no ticks", () => {
+		expect(linearTicks([0.2, 0.8], 5, { integer: true })).toEqual([]);
+		expect(linearTicks([2.5, 2.5], 5, { integer: true })).toEqual([]);
+	});
+
+	test("a reversed domain counts down by whole steps", () => {
+		expect(linearTicks([3, 0], 5, { integer: true })).toEqual([3, 2, 1, 0]);
+	});
+
+	test("a flat integer domain yields the single value", () => {
+		expect(linearTicks([5, 5], 5, { integer: true })).toEqual([5]);
+	});
+
+	test("omitting the option preserves sub-integer stepping", () => {
+		expect(linearTicks([0, 3], 5)).toEqual([0, 0.5, 1, 1.5, 2, 2.5, 3]);
+	});
+});
+
 describe("timeTicks", () => {
 	test("produces calendar-aligned ticks inside the domain", () => {
 		const start = new Date(2026, 6, 18, 10, 0, 0).getTime();

--- a/packages/mantle/src/components/chart/scales.ts
+++ b/packages/mantle/src/components/chart/scales.ts
@@ -9,13 +9,34 @@ const e5 = Math.sqrt(10);
 const e2 = Math.sqrt(2);
 
 /**
+ * Options for tick generation.
+ */
+type TickOptions = {
+	/**
+	 * Clamp the tick step to whole numbers so every tick is an integer — the
+	 * shape for axes whose backing data is entirely integer-valued (counts),
+	 * where a "1.5" gridline label is meaningless. May yield fewer ticks than
+	 * `count`; a domain containing no integer yields no ticks.
+	 */
+	integer?: boolean;
+};
+
+/**
  * Solve for the tick range as scaled integers: returns `[i1, i2, inc]` where the
  * ticks are `i1..i2` multiplied by `inc`. A negative `inc` encodes a sub-integer
  * step: divide by `-inc` instead of multiplying, which keeps sub-integer ticks
  * free of floating-point drift.
  */
-const tickSpec = (start: number, stop: number, count: number): [number, number, number] => {
-	const step = (stop - start) / Math.max(0, count);
+const tickSpec = (
+	start: number,
+	stop: number,
+	count: number,
+	options?: TickOptions,
+): [number, number, number] => {
+	const rawStep = (stop - start) / Math.max(0, count);
+	// Integer mode: a step below 1 would place fractional ticks; clamping to 1
+	// keeps the 1/2/5 progression (whose steps at or above 1 are all whole).
+	const step = options?.integer ? Math.max(1, rawStep) : rawStep;
 	const power = Math.floor(Math.log10(step));
 	const error = step / Math.pow(10, power);
 	const factor = error >= e10 ? 10 : error >= e5 ? 5 : error >= e2 ? 2 : 1;
@@ -45,30 +66,38 @@ const tickSpec = (start: number, stop: number, count: number): [number, number, 
 		}
 	}
 	if (i2 < i1 && 0.5 <= count && count < 2) {
-		return tickSpec(start, stop, count * 2);
+		return tickSpec(start, stop, count * 2, options);
 	}
 	return [i1, i2, inc];
 };
 
 /**
  * Human-friendly tick values (1/2/5 stepping) spanning `[start, stop]` for the
- * requested approximate `count`. Returns `[start]` for a flat domain and `[]`
- * for a non-positive count.
+ * requested approximate `count`. Returns `[start]` for a flat domain (unless
+ * integer mode excludes a fractional one) and `[]` for a non-positive count.
  *
  * @example
  * ```ts
  * ticks(0, 1000, 5); // [0, 200, 400, 600, 800, 1000]
+ * ticks(0, 3, 5, { integer: true }); // [0, 1, 2, 3]
  * ```
  */
-const ticks = (start: number, stop: number, count: number): number[] => {
+const ticks = (start: number, stop: number, count: number, options?: TickOptions): number[] => {
 	if (!(count > 0)) {
 		return [];
 	}
 	if (start === stop) {
+		// A flat fractional domain (an explicitly flat fractional override) has
+		// no integer to tick — the no-fractional-ticks contract is absolute.
+		if (options?.integer && !Number.isInteger(start)) {
+			return [];
+		}
 		return [start];
 	}
 	const reverse = stop < start;
-	const [i1, i2, inc] = reverse ? tickSpec(stop, start, count) : tickSpec(start, stop, count);
+	const [i1, i2, inc] = reverse
+		? tickSpec(stop, start, count, options)
+		: tickSpec(start, stop, count, options);
 	if (!(i2 >= i1)) {
 		return [];
 	}
@@ -227,15 +256,21 @@ const invertBand = (layout: BandLayout, pixel: number): number | null => {
 };
 
 /**
- * Human-friendly ticks (1/2/5 stepping) for a linear domain.
+ * Human-friendly ticks (1/2/5 stepping) for a linear domain. With
+ * `{ integer: true }` the step is clamped to whole numbers, so an axis backed
+ * by integer-only data (counts) never grows fractional ticks like `1.5`.
  *
  * @example
  * ```ts
  * linearTicks([0, 1000], 5); // [0, 200, 400, 600, 800, 1000]
+ * linearTicks([0, 3], 5, { integer: true }); // [0, 1, 2, 3]
  * ```
  */
-const linearTicks = (domain: readonly [number, number], count: number): number[] =>
-	ticks(domain[0], domain[1], count);
+const linearTicks = (
+	domain: readonly [number, number],
+	count: number,
+	options?: TickOptions,
+): number[] => ticks(domain[0], domain[1], count, options);
 
 /**
  * Calendar-aware ticks (epoch milliseconds) for a time domain — the reason


### PR DESCRIPTION
Resolves MNTL-56 — https://linear.app/ngrok/issue/MNTL-56/charts-yaxis-renders-fractional-ticks-for-small-integer-count-series

## Problem

A chart of small integer counts (e.g. a `[0, 3]` domain) rendered y ticks at `0, 0.5, 1, 1.5, 2, 2.5, 3` — a meaningless "0.5 requests" gridline. The 1/2/5 tick solver happily steps below 1 whenever the domain span is smaller than the requested tick count.

## Design

No new public API — this ships as a smarter default, consistent with the chart family's correct-by-default behaviors (step-derived label precision, marker density hiding, label thinning): **when every value backing an axis is an integer, the tick step is clamped to whole numbers.**

The clamp is keyed on the *data feeding a scale*, not on the axis part:

- **Value axis** — integrality is scanned during the existing ingestion min/max pass over all series columns (stacked sums of integers are integers, so per-column scanning suffices). Because the engine keeps `YAxis` = value domain under `orientation="horizontal"` and only flips the pixel edge it paints on, horizontal bars' bottom value ticks are covered by the same path.
- **Linear x axis** — the same clamp applies to `#xTicks` when `xScale="linear"` and every x position is an integer (attempt number, batch index). Time, band, and point scales are untouched.

Contract details:
- `tickCount` stays an approximate hint — the integer step wins when the domain span is smaller than the request.
- A fractional `yDomain` override doesn't disable the clamp (integrality is a fact about the data); the fractional bound just doesn't receive a tick.
- One fractional value anywhere on the axis restores today's sub-integer stepping exactly.

## Changes

- `scales.ts`: `linearTicks`/`ticks`/`tickSpec` accept an internal `{ integer?: boolean }` option that clamps the solver's step to ≥ 1 (steps ≥ 1 in the 1/2/5 progression are all whole numbers).
- `engine.ts`: `#valuesAllIntegers` / `#xsAllIntegers` flags tracked in the existing ingestion scans, passed to both tick call sites.
- `primitive.tsx`: `tickCount` JSDoc documents the guarantee on both axis parts.
- Docs: a runtime **Integer counts** example on the Bar Chart page, plus updated `tickCount` API rows on all four chart pages.
- Changeset: patch.

## Tests

- `scales.test.ts`: unit coverage of the integer option — small domains, count overrides, fractional/padded/reversed/flat domains, no-integer domains.
- `integer-ticks.browser.test.tsx` (Chromium; tick labels are canvas ink, unreachable in happy-dom): spies on `fillText` and asserts no fractional label paints for vertical bars, horizontal bars, and a linear x axis — plus a control asserting fractional data still gets sub-integer ticks. **All 3 regression tests verified failing before the fix** (stash-checked) and passing after.
- Full suite green: lint, fmt:check, typecheck, unit (1500), browser (221).