### PR TITLE
fix(www): prevent browser default on the command palette mod+k hotkey

### DIFF
--- a/apps/www/app/components/command-palette.test.tsx
+++ b/apps/www/app/components/command-palette.test.tsx
@@ -162,6 +162,27 @@ describe("CommandPalette", () => {
 		});
 	});
 
+	// Regression: without preventDefault, mod+k also triggers the browser's own
+	// binding (Firefox focuses the search/address bar) alongside opening the
+	// palette. fireEvent returns false when the event's default was prevented.
+	// react-hotkeys-hook matches on event.code and resolves "mod" per platform
+	// userAgent, so the event carries code plus both modifiers.
+	it("opens on mod+k and prevents the browser's default shortcut", async () => {
+		renderPalette();
+
+		const notPrevented = fireEvent.keyDown(document.body, {
+			key: "k",
+			code: "KeyK",
+			metaKey: true,
+			ctrlKey: true,
+		});
+
+		expect(notPrevented).toBe(false);
+		await waitFor(() => {
+			expect(screen.getByPlaceholderText("Search Mantle...")).toBeTruthy();
+		});
+	});
+
 	it("clears the query when the palette closes so reopening starts fresh", async () => {
 		renderPalette();
 		const input = await openPalette();

--- a/apps/www/app/components/command-palette.tsx
+++ b/apps/www/app/components/command-palette.tsx
@@ -153,8 +153,6 @@ export function CommandPalette() {
 	const [query, setQuery] = useState("");
 	// preventDefault: browsers bind mod+k themselves (Firefox focuses the
 	// search bar), so the shortcut must claim the event to open only our palette
-	// preventDefault: browsers bind mod+k themselves (Firefox focuses the
-	// search bar), so the shortcut must claim the event to open only our palette
 	useHotkeys("mod+k", () => setOpen(true), { preventDefault: true }, [setOpen]);
 
 	const commands = useMemo(() => buildPaletteCommands(mantleVersion), [mantleVersion]);

--- a/apps/www/app/components/command-palette.tsx
+++ b/apps/www/app/components/command-palette.tsx
@@ -151,7 +151,11 @@ export function CommandPalette() {
 	const mantleVersion = useMantleVersion();
 	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState("");
-	useHotkeys("mod+k", () => setOpen(true), [setOpen]);
+	// preventDefault: browsers bind mod+k themselves (Firefox focuses the
+	// search bar), so the shortcut must claim the event to open only our palette
+	// preventDefault: browsers bind mod+k themselves (Firefox focuses the
+	// search bar), so the shortcut must claim the event to open only our palette
+	useHotkeys("mod+k", () => setOpen(true), { preventDefault: true }, [setOpen]);
 
 	const commands = useMemo(() => buildPaletteCommands(mantleVersion), [mantleVersion]);
 	const groups = useMemo(() => groupPaletteCommands(commands), [commands]);

--- a/apps/www/app/docs/components/navigation/command.mdx
+++ b/apps/www/app/docs/components/navigation/command.mdx
@@ -180,6 +180,33 @@ function CommandDialogDemo() {
 }
 ```
 
+## Common mistakes
+
+A global hotkey that opens the command dialog must call `event.preventDefault()`. Browsers reserve many of the same shortcuts apps reach for — Firefox binds `⌘K` to focus its search bar and `⌘J` to open downloads — so a handler that does not claim the event runs **both** actions. The classic symptom: pressing `⌘K` opens the palette, but focus (and your typing) lands in the browser's search or address bar.
+
+```tsx
+// ❌ Wrong — the browser's own binding also fires (Firefox ⌘K focuses its search bar)
+const keydown = (event: KeyboardEvent) => {
+	if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+		setOpen(true);
+	}
+};
+
+// ✅ Correct — claim the event before the browser acts on it
+const keydown = (event: KeyboardEvent) => {
+	if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+		event.preventDefault();
+		setOpen(true);
+	}
+};
+```
+
+Hotkey libraries typically leave this opt-in as well — for example, `react-hotkeys-hook` only claims the event when you pass `{ preventDefault: true }`:
+
+```tsx
+useHotkeys("mod+k", () => setOpen(true), { preventDefault: true });
+```
+
 ## Composition
 
 Compose the parts of a `Command` together to build your own:


### PR DESCRIPTION
## Summary

In Firefox, pressing <kbd>⌘K</kbd> on the docs site opened the command palette **and** focused the browser's search bar, because `react-hotkeys-hook` does not call `preventDefault` unless you opt in via its options.

- Pass `{ preventDefault: true }` to the `useHotkeys("mod+k", …)` binding in `CommandPalette` so the shortcut claims the event before the browser's own binding fires.
- Add a regression test that dispatches mod+K and asserts the keydown's default is prevented and the palette opens (verified to fail before the fix). Note: `react-hotkeys-hook` matches on `event.code` and resolves `mod` per platform userAgent, so the test event carries `code: "KeyK"` plus both modifiers.
- Add a **Common mistakes** section to the Command docs page documenting the gotcha (global palette hotkeys must claim the event with `preventDefault`, and hotkey libraries typically leave that opt-in), so both humans and LLMs can self-diagnose it quickly.

The `Command` component itself is intentionally unchanged — it's a controlled component with no global listener, so hotkey binding (and this preventDefault rule) stays an app concern. The Command docs demo already models the correct pattern.

## Verification

- `pnpm -w run lint` — 0 errors
- `pnpm -w run fmt:check` — clean
- `pnpm -w run typecheck` — 0 errors
- `pnpm -w run test -F @app/www` — 32/32 pass
- `pnpm -w run build -F @app/www` — MDX compiles

No `packages/mantle` changes, so no changeset.