### PR TITLE
test(mantle): close useSessionStorage test-coverage gap with useLocalStorage

### DIFF
--- a/packages/mantle/src/hooks/use-session-storage.test.tsx
+++ b/packages/mantle/src/hooks/use-session-storage.test.tsx
@@ -47,6 +47,21 @@ describe("useSessionStorage", () => {
 		expect(window.sessionStorage.getItem(key)).toBe(JSON.stringify("next-value"));
 	});
 
+	test("a storage event without a storageArea fails open and updates the value", () => {
+		const { result } = renderHook(() => useSessionStorage(key, defaultValue));
+
+		act(() => {
+			window.sessionStorage.setItem(key, JSON.stringify("untagged-dispatch"));
+			// dispatchers that omit storageArea must still notify the hook
+			window.dispatchEvent(
+				new StorageEvent("storage", { key, newValue: JSON.stringify("untagged-dispatch") }),
+			);
+		});
+
+		const [value] = result.current;
+		expect(value).toBe("untagged-dispatch");
+	});
+
 	test("ignores storage events for other keys and other storage areas", () => {
 		window.sessionStorage.setItem(key, JSON.stringify("initial"));
 		const { result } = renderHook(() => useSessionStorage(key, defaultValue));
@@ -99,6 +114,15 @@ describe("useSessionStorage", () => {
 
 	test("a corrupt (unparseable) entry resolves to the default instead of throwing", () => {
 		window.sessionStorage.setItem(key, "not-json{");
+
+		const { result } = renderHook(() => useSessionStorage(key, defaultValue));
+
+		const [value] = result.current;
+		expect(value).toBe(defaultValue);
+	});
+
+	test("a parseable non-string entry resolves to the default", () => {
+		window.sessionStorage.setItem(key, JSON.stringify({ nested: true }));
 
 		const { result } = renderHook(() => useSessionStorage(key, defaultValue));
 


### PR DESCRIPTION
## Summary

`useSessionStorage` shipped in #1305 as the per-tab sibling of `useLocalStorage` — same SSR-safe `useSyncExternalStore` contract, tests, and docs. Its test file, however, was missing two regression tests that the `useLocalStorage` suite has, both covering branches that already exist in the session hook's implementation:

- **fail-open on missing `storageArea`** — a `storage` event dispatched without a `storageArea` (some dispatchers omit it) must still notify the hook (`subscribeToSessionStorageKey`'s `event.storageArea == null` branch).
- **parseable non-string entry resolves to the default** — a stored entry that parses as JSON but isn't a string (e.g. `{"nested":true}`) resolves to `defaultValue` instead of leaking a non-string value (`parseStoredValue`'s `typeof parsed === "string"` guard).

Test-only change — no published behavior changes, so no changeset.

## Verification

- `pnpm -w run test -F @ngrok/mantle` — 120 files, 1502 tests passed
- `pnpm -w run lint` — 0 errors
- `pnpm -w run fmt:check` — 0 errors
- `pnpm -w run typecheck` — 0 errors