### PR TITLE
docs: fix JSDoc and docs-page violations found by a full component audit

### DIFF
--- a/.changeset/audit-component-sweep.md
+++ b/.changeset/audit-component-sweep.md
@@ -1,0 +1,10 @@
+---
+"@ngrok/mantle": patch
+---
+
+Correct JSDoc across Calendar, Progress Bar, Progress Donut, Radio Group, and Scatter Plot (component audit sweep). No API changes.
+
+- `ProgressBar` and `ProgressDonut`: the `@see` links on `Root`, `Indicator`, and both namespace members pointed at `#api-progress-bar*` / `#api-progress-donut*` anchors that no longer exist on their docs pages. They now resolve to the real `#progressbarroot`, `#progressbarindicator`, `#progressdonutroot`, and `#progressdonutindicator` API-reference anchors.
+- `Calendar`: dropped the stale `#api-calendar` fragment so the `@see` link points at the component's docs page.
+- `ScatterPlot`: the Composition tree omitted `ScatterPlot.CopyButton`, which the component has shipped as a namespace member — the tree now matches the docs page.
+- `RadioGroup`: added the missing "Rich option layout (Choice)" tree to the Composition example so the JSDoc matches the five layouts documented on the docs page.

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -500,11 +500,11 @@ CodeBlock.Root
 
 ## Polymorphism
 
-`CodeBlock.Root`, `CodeBlock.Header`, `CodeBlock.Title`, `CodeBlock.Body`, `CodeBlock.ExpanderButton`, `CodeBlock.TabList`, and `CodeBlock.TabTrigger` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto it.
+`CodeBlock.Root`, `CodeBlock.Header`, `CodeBlock.Title`, `CodeBlock.Body`, `CodeBlock.CopyButton`, and `CodeBlock.ExpanderButton` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto it.
 
-Reach for it when `Root` should be a semantic `<figure>` or `<section>`, when `Title` needs a different heading level than the default `<h3>`, or when `ExpanderButton` and `TabTrigger` must be your own button component while keeping the code block's expand and tab behavior.
+Reach for it when `Root` should be a semantic `<figure>` or `<section>`, when `Title` needs a different heading level than the default `<h3>`, or when `ExpanderButton` must be your own button component while keeping the code block's expand behavior. `CopyButton` has no children of its own, so it is typed `SelfClosingWithAsChild` — `<CodeBlock.CopyButton asChild>` requires exactly one child to clone, and forbids children otherwise.
 
-`CodeBlock.Code`, `CodeBlock.CopyButton`, and `CodeBlock.TabContent` intentionally do not accept `asChild` — `Code` owns the highlighted markup it renders, `CopyButton` owns its clipboard affordance, and `TabContent` explicitly omits the prop because its mounting is driven by the active tab. `CodeBlock.Icon` takes its element through the `svg` prop instead.
+The remaining parts do not accept `asChild`. `CodeBlock.Code` owns the highlighted markup it renders, and `CodeBlock.TabList`, `CodeBlock.TabTrigger`, and `CodeBlock.TabContent` each explicitly omit the prop because their behavior and mounting are driven by the active tab. `CodeBlock.Icon` takes its element through the `svg` prop instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -500,11 +500,14 @@ CodeBlock.Root
 
 ## Polymorphism
 
-`CodeBlock.Root`, `CodeBlock.Header`, `CodeBlock.Title`, `CodeBlock.Body`, `CodeBlock.CopyButton`, and `CodeBlock.ExpanderButton` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto it.
+`CodeBlock.Root`, `CodeBlock.Header`, `CodeBlock.Title`, `CodeBlock.Body`, and `CodeBlock.CopyButton` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto it.
 
-Reach for it when `Root` should be a semantic `<figure>` or `<section>`, when `Title` needs a different heading level than the default `<h3>`, or when `ExpanderButton` must be your own button component while keeping the code block's expand behavior. `CopyButton` has no children of its own, so it is typed `SelfClosingWithAsChild` — `<CodeBlock.CopyButton asChild>` requires exactly one child to clone, and forbids children otherwise.
+Reach for it when `Root` should be a semantic `<figure>` or `<section>`, when `Title` needs a different heading level than the default `<h3>`, or when `Header` and `Body` should be `<header>` and `<section>`. `CopyButton` has no children of its own, so it is typed `SelfClosingWithAsChild` — `<CodeBlock.CopyButton asChild>` requires exactly one child to clone, and forbids children otherwise.
 
 The remaining parts do not accept `asChild`. `CodeBlock.Code` owns the highlighted markup it renders, and `CodeBlock.TabList`, `CodeBlock.TabTrigger`, and `CodeBlock.TabContent` each explicitly omit the prop because their behavior and mounting are driven by the active tab. `CodeBlock.Icon` takes its element through the `svg` prop instead.
+
+> [!WARNING]
+> `CodeBlock.ExpanderButton` advertises `asChild` in its prop types but **throws at runtime** (`React.Children.only expected to receive a single React element child`). It renders its own "Show more" / "Show less" label and caret icon, so the slot receives more than one child. Style it with `className` instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -476,6 +476,7 @@ The `mantleCode()` options let you customize how code is displayed. By default, 
 Compose the parts of a `CodeBlock` together to build your own:
 
 ```text showLineNumbers=false
+# Standard
 CodeBlock.Root
 ├── CodeBlock.Header
 │   ├── CodeBlock.Icon
@@ -484,11 +485,8 @@ CodeBlock.Root
 │   ├── CodeBlock.CopyButton
 │   └── CodeBlock.Code
 └── CodeBlock.ExpanderButton
-```
 
-For a tabbed code block:
-
-```text showLineNumbers=false
+# Tabbed
 CodeBlock.Root
 ├── CodeBlock.Header
 │   └── CodeBlock.TabList
@@ -499,6 +497,14 @@ CodeBlock.Root
 │       └── CodeBlock.Code
 └── CodeBlock.ExpanderButton
 ```
+
+## Polymorphism
+
+`CodeBlock.Root`, `CodeBlock.Header`, `CodeBlock.Title`, `CodeBlock.Body`, `CodeBlock.ExpanderButton`, `CodeBlock.TabList`, and `CodeBlock.TabTrigger` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto it.
+
+Reach for it when `Root` should be a semantic `<figure>` or `<section>`, when `Title` needs a different heading level than the default `<h3>`, or when `ExpanderButton` and `TabTrigger` must be your own button component while keeping the code block's expand and tab behavior.
+
+`CodeBlock.Code`, `CodeBlock.CopyButton`, and `CodeBlock.TabContent` intentionally do not accept `asChild` — `Code` owns the highlighted markup it renders, `CopyButton` owns its clipboard affordance, and `TabContent` explicitly omits the prop because its mounting is driven by the active tab. `CodeBlock.Icon` takes its element through the `svg` prop instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/data-display/selectable-list.mdx
+++ b/apps/www/app/docs/components/data-display/selectable-list.mdx
@@ -513,11 +513,11 @@ function Example() {
 
 ## Polymorphism
 
-`SelectableList.Item`, `SelectableList.ItemTitle`, and `SelectableList.ItemDescription` accept `asChild`, rendering your single child in place of the part's default element and forwarding class names, `data-*` attributes, and `ref` onto it.
+`SelectableList.ItemDescription` accepts `asChild`, rendering your single child in place of its default `<p>` and forwarding class names, `data-*` attributes, and `ref` onto it. It forwards to [`Choice.Description`](/components/forms/choice), so reach for it when the row's sub-line needs to be a different element than a paragraph.
 
-`SelectableList.Item asChild` is the one you will reach for: it keeps the row's checkbox, `aria-selected` row semantics, and keyboard behavior while letting the row's content be your own composition. `ItemTitle` and `ItemDescription` forward to [`Choice`](/components/forms/choice)'s label and description parts, so `asChild` there is for choosing the element that carries the text.
+No other part accepts `asChild`, and that is deliberate: `SelectableList` owns a `role="grid"` structure whose semantics depend on the elements it renders. `Root`, `Filter`, `SelectAll`, `Viewport`, and `VirtualViewport` own the grid semantics, filtering, select-all wiring, and virtualization measurement. `Item` renders the `role="row"` and its `gridcell` children around a real `Checkbox`, so swapping its element would break the row's `aria-selected` contract — compose your own layout through its `children` instead, which is unrestricted. `ItemTitle` forwards to `Choice.Label`, a real `<label>` wired to the checkbox by `htmlFor`, which is why it takes no `asChild` even though `ItemDescription` does.
 
-The collection-level parts — `Root`, `Filter`, `SelectAll`, `Viewport`, and `VirtualViewport` — own the grid semantics, filtering, select-all wiring, and virtualization measurement, so they do not accept `asChild`. Note that unlike [`List`](/components/data-display/list), a selectable row is not a link: use `List` when the row's job is to navigate.
+Note that unlike [`List`](/components/data-display/list), a selectable row is not a link: use `List` when the row's job is to navigate.
 
 ## Accessibility
 

--- a/apps/www/app/docs/components/data-display/selectable-list.mdx
+++ b/apps/www/app/docs/components/data-display/selectable-list.mdx
@@ -511,6 +511,14 @@ function Example() {
 }
 ```
 
+## Polymorphism
+
+`SelectableList.Item`, `SelectableList.ItemTitle`, and `SelectableList.ItemDescription` accept `asChild`, rendering your single child in place of the part's default element and forwarding class names, `data-*` attributes, and `ref` onto it.
+
+`SelectableList.Item asChild` is the one you will reach for: it keeps the row's checkbox, `aria-selected` row semantics, and keyboard behavior while letting the row's content be your own composition. `ItemTitle` and `ItemDescription` forward to [`Choice`](/components/forms/choice)'s label and description parts, so `asChild` there is for choosing the element that carries the text.
+
+The collection-level parts — `Root`, `Filter`, `SelectAll`, `Viewport`, and `VirtualViewport` — own the grid semantics, filtering, select-all wiring, and virtualization measurement, so they do not accept `asChild`. Note that unlike [`List`](/components/data-display/list), a selectable row is not a link: use `List` when the row's job is to navigate.
+
 ## Accessibility
 
 The viewport is an APG **grid**: a `role="grid"` of `role="row"` rows, each with `role="gridcell"` cells holding a real `<input type="checkbox">` and the title + description. This is the pattern the [WAI-ARIA grid](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) prescribes for selectable rows that carry their own interactive controls (a plain listbox forbids a real checkbox or nested controls inside an option). Provide `aria-label` (or `aria-labelledby`) on the viewport so the grid has an accessible name. Each row's `aria-selected` conveys its selection alongside the checkbox's checked state; the title is a `Choice.Label`, so it names the checkbox, and the description is wired via `aria-describedby`. Disabled rows carry `aria-disabled`. `SelectableList.Empty` is an always-mounted polite `role="status"` live region, so an empty result is announced as the filter narrows rather than the grid silently vanishing.

--- a/apps/www/app/docs/components/feedback/empty.mdx
+++ b/apps/www/app/docs/components/feedback/empty.mdx
@@ -226,6 +226,14 @@ Empty.Root
 └── Empty.Actions
 ```
 
+## Polymorphism
+
+`Empty.Root`, `Empty.Title`, `Empty.Description`, and `Empty.Actions` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref`.
+
+Reach for it when the empty state is a semantic landmark — `Empty.Root asChild` around a `<section>` — or when `Empty.Title` needs a heading level that fits the page outline rather than the default. `Empty.Actions asChild` is useful when the action row should be a `<form>` or a navigation element.
+
+`Empty.Icon` is the documented exception: it takes its element through the `svg` prop and clones it, so polymorphism already goes through that prop rather than `asChild`.
+
 ## API Reference
 
 ### Empty.Root

--- a/apps/www/app/docs/components/feedback/toast.mdx
+++ b/apps/www/app/docs/components/feedback/toast.mdx
@@ -250,6 +250,14 @@ Toast.Root
 └── Toast.Action
 ```
 
+## Polymorphism
+
+`Toast.Root`, `Toast.Action`, and `Toast.Message` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto that child.
+
+Reach for `Toast.Action asChild` when the action must be a link — "View logs" navigating rather than firing a handler — and `Toast.Message asChild` when the message needs its own element to carry richer markup. `Toast.Root asChild` lets the toast surface be your own container while keeping its intent styling.
+
+`Toast.Icon` takes its element through the `svg` prop and clones it, so it needs no `asChild`.
+
 ## API Reference
 
 ### Toaster

--- a/apps/www/app/docs/components/feedback/toast.mdx
+++ b/apps/www/app/docs/components/feedback/toast.mdx
@@ -252,11 +252,14 @@ Toast.Root
 
 ## Polymorphism
 
-`Toast.Root`, `Toast.Action`, and `Toast.Message` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto that child.
+`Toast.Action` and `Toast.Message` accept `asChild`. When `true` the part renders its single child instead of its default element, forwarding class names, `data-*` attributes, and `ref` onto that child.
 
-Reach for `Toast.Action asChild` when the action must be a link — "View logs" navigating rather than firing a handler — and `Toast.Message asChild` when the message needs its own element to carry richer markup. `Toast.Root asChild` lets the toast surface be your own container while keeping its intent styling.
+Reach for `Toast.Action asChild` when the action must be a link — "View logs" navigating rather than firing a handler — and `Toast.Message asChild` when the message needs its own element to carry richer markup.
 
 `Toast.Icon` takes its element through the `svg` prop and clones it, so it needs no `asChild`.
+
+> [!WARNING]
+> `Toast.Root` advertises `asChild` in its prop types but **throws at runtime** (`React.Children.only expected to receive a single React element child`). The root renders the intent accent bar alongside your children, so the slot receives two. Style the toast surface with `className` instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/forms/multi-select.mdx
+++ b/apps/www/app/docs/components/forms/multi-select.mdx
@@ -1103,11 +1103,14 @@ MultiSelect.Root
 
 ## Polymorphism
 
-`MultiSelect.Content`, `MultiSelect.Item`, `MultiSelect.Group`, `MultiSelect.GroupLabel`, and `MultiSelect.Separator` accept `asChild`, rendering your single child in place of the part's default element while keeping its selection and keyboard behavior.
+`MultiSelect.Content`, `MultiSelect.Group`, `MultiSelect.GroupLabel`, and `MultiSelect.Separator` accept `asChild`, rendering your single child in place of the part's default element while keeping its selection and keyboard behavior.
 
-`MultiSelect.Item asChild` is the useful one: it lets an option carry your own layout — a [`MediaObject`](/components/structure/media-object) with an avatar, say — while the item stays selectable and keyboard-navigable. `MultiSelect.GroupLabel asChild` helps when a group heading must be a specific element for the page's outline.
+`MultiSelect.GroupLabel asChild` is the useful one — reach for it when a group heading must be a specific element for the page's outline. `MultiSelect.Content asChild` lets you own the popover panel element.
 
 The trigger-side parts (`MultiSelect.Root`, `Trigger`, `Input`, `Tag`, `TagValues`) own input and tag behavior that depends on the elements they render, so they do not accept `asChild`.
+
+> [!WARNING]
+> `MultiSelect.Item` advertises `asChild` in its prop types but **throws at runtime** (`React.Children.only expected to receive a single React element child`). The item renders its own check indicator alongside your children, so the slot receives two. To give an option a custom layout, pass it as `children` — a [`MediaObject`](/components/structure/media-object) with an avatar, say — which is unrestricted.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/forms/multi-select.mdx
+++ b/apps/www/app/docs/components/forms/multi-select.mdx
@@ -1101,6 +1101,14 @@ MultiSelect.Root
     └── MultiSelect.ContentFooter
 ```
 
+## Polymorphism
+
+`MultiSelect.Content`, `MultiSelect.Item`, `MultiSelect.Group`, `MultiSelect.GroupLabel`, and `MultiSelect.Separator` accept `asChild`, rendering your single child in place of the part's default element while keeping its selection and keyboard behavior.
+
+`MultiSelect.Item asChild` is the useful one: it lets an option carry your own layout — a [`MediaObject`](/components/structure/media-object) with an avatar, say — while the item stays selectable and keyboard-navigable. `MultiSelect.GroupLabel asChild` helps when a group heading must be a specific element for the page's outline.
+
+The trigger-side parts (`MultiSelect.Root`, `Trigger`, `Input`, `Tag`, `TagValues`) own input and tag behavior that depends on the elements they render, so they do not accept `asChild`.
+
 ## API Reference
 
 The `MultiSelect` components are built on top of [ariakit Combobox](https://ariakit.org/components/combobox).

--- a/apps/www/app/docs/components/forms/radio-group.mdx
+++ b/apps/www/app/docs/components/forms/radio-group.mdx
@@ -565,6 +565,12 @@ RadioGroup.Root
             └── Choice.Description
 ```
 
+## Polymorphism
+
+`RadioGroup.ItemContent` accepts `asChild`. When `true` it renders its single child instead of its default `<div>`, forwarding class names, `data-*` attributes, and `ref` onto that child — reach for it when the label-and-description block beside a radio needs to be a specific element, such as a `<label>` you control or a link wrapping the whole content area.
+
+The rest of the family deliberately does not take `asChild`. `RadioGroup.Root`, `List`, and `ButtonGroup` own the group's roving-focus and arrow-key contract; `Item`, `ListItem`, `Card`, and `Button` each render a real `<input type="radio">` plus its sandboxed hit target, and `Indicator` paints the control itself. For a richer option layout, compose [`Choice`](/components/forms/choice) inside `RadioGroup.Item` — see [Rich option layout with `Choice`](#rich-option-layout-with-choice) — rather than swapping these elements out.
+
 ## API Reference
 
 ### RadioGroup.Root

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -392,6 +392,14 @@ Select.Root
     └── Select.Separator
 ```
 
+## Polymorphism
+
+`Select.Trigger`, `Select.Content`, `Select.Item`, `Select.Group`, `Select.Label`, `Select.Value`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior.
+
+`Select.Trigger asChild` is the common case — it lets your own button-shaped component open the select instead of nesting a control inside the default trigger. `Select.Item asChild` lets an option carry richer content while staying selectable, and `Select.Value asChild` is useful when the displayed value needs its own element for truncation or badge chrome.
+
+`Select.Root` is a state provider that renders no DOM, so it takes no `asChild`.
+
 ## API Reference
 
 The `Select` components are built on top of [Radix Select](https://www.radix-ui.com/primitives/docs/components/select).

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -394,11 +394,14 @@ Select.Root
 
 ## Polymorphism
 
-`Select.Trigger`, `Select.Content`, `Select.Item`, `Select.Group`, `Select.Label`, `Select.Value`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior.
+`Select.Group`, `Select.Label`, `Select.Value`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior.
 
-`Select.Trigger asChild` is the common case — it lets your own button-shaped component open the select instead of nesting a control inside the default trigger. `Select.Item asChild` lets an option carry richer content while staying selectable, and `Select.Value asChild` is useful when the displayed value needs its own element for truncation or badge chrome.
+`Select.Value asChild` is the useful one — reach for it when the displayed value needs its own element for truncation or badge chrome. `Select.Label asChild` helps when a group heading must be a specific element for the page's outline.
 
 `Select.Root` is a state provider that renders no DOM, so it takes no `asChild`.
+
+> [!WARNING]
+> `Select.Trigger`, `Select.Content`, and `Select.Item` currently advertise `asChild` in their prop types but **throw at runtime** (`Primitive.* failed to slot onto its children`). Each one renders its own chrome next to your content — the trigger's caret, the content's scroll buttons and viewport, the item's check indicator — so the underlying Radix `Slot` receives more than the single child it requires. Do not use `asChild` on these three parts. To customize the trigger's content, pass it as `children` instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/forms/theme-switcher.mdx
+++ b/apps/www/app/docs/components/forms/theme-switcher.mdx
@@ -159,11 +159,11 @@ import { ThemeDropdownMenuRadioGroup } from "@ngrok/mantle/theme-switcher";
 
 ## Polymorphism
 
-`ThemeSwitcher.Trigger` and `ThemeSwitcher.Content` accept `asChild`, rendering your single child in place of the part's default element while keeping the menu's open/close and radio-selection behavior.
+`ThemeSwitcher.Content` accepts `asChild`, rendering your single child in place of the default menu panel while keeping the menu's open/close and radio-selection behavior. It is the escape hatch for owning the panel element, and it exists as a part precisely so the component never needed a `contentProps` prop bag (see [the decision record](https://github.com/ngrok/mantle/blob/main/decisions/2026-07-15-theme-switcher-compound-api.md)).
 
-`ThemeSwitcher.Trigger asChild` is the common case: it lets the control that opens the menu be your own component — a `Button` with a label, or an `IconButton` in a toolbar — instead of the default trigger. `ThemeSwitcher.Content asChild` is the escape hatch for owning the menu panel element; it exists as a part precisely so the component never needed a `contentProps` prop bag (see [the decision record](https://github.com/ngrok/mantle/blob/main/decisions/2026-07-15-theme-switcher-compound-api.md)).
+`ThemeSwitcher.Trigger` deliberately does **not** accept `asChild` — it omits the prop along with `icon`, `label`, `appearance`, and `intent`, because the trigger owns the current-theme icon and its accessible name. To customize it, pass the props it does expose rather than swapping the element. `ThemeSwitcher.Root` is a state provider that renders no DOM, so it takes no `asChild` either.
 
-`ThemeSwitcher.Root` is a state provider that renders no DOM, so it takes no `asChild`.
+If you need a fully custom control, [Embedding in an existing menu](#embedding-in-an-existing-menu) shows how to drive theme selection from your own `DropdownMenu` instead.
 
 ## Accessibility
 

--- a/apps/www/app/docs/components/forms/theme-switcher.mdx
+++ b/apps/www/app/docs/components/forms/theme-switcher.mdx
@@ -157,6 +157,14 @@ import { ThemeDropdownMenuRadioGroup } from "@ngrok/mantle/theme-switcher";
 > [!IMPORTANT]
 > `ThemeDropdownMenuRadioGroup` must render inside a `DropdownMenu.Content` or `DropdownMenu.SubContent`. It renders menu items (`DropdownMenu.RadioGroup` + `DropdownMenu.RadioItem` under the hood), which only work within an open dropdown menu — the type system cannot express this constraint, so it is on you to uphold it.
 
+## Polymorphism
+
+`ThemeSwitcher.Trigger` and `ThemeSwitcher.Content` accept `asChild`, rendering your single child in place of the part's default element while keeping the menu's open/close and radio-selection behavior.
+
+`ThemeSwitcher.Trigger asChild` is the common case: it lets the control that opens the menu be your own component — a `Button` with a label, or an `IconButton` in a toolbar — instead of the default trigger. `ThemeSwitcher.Content asChild` is the escape hatch for owning the menu panel element; it exists as a part precisely so the component never needed a `contentProps` prop bag (see [the decision record](https://github.com/ngrok/mantle/blob/main/decisions/2026-07-15-theme-switcher-compound-api.md)).
+
+`ThemeSwitcher.Root` is a state provider that renders no DOM, so it takes no `asChild`.
+
 ## Accessibility
 
 - The theme options are `role="menuitemradio"` items from `DropdownMenu.RadioGroup` — the active theme is announced as checked (`aria-checked`), and choosing an item behaves like picking one of a set of mutually exclusive options.

--- a/apps/www/app/docs/components/navigation/command.mdx
+++ b/apps/www/app/docs/components/navigation/command.mdx
@@ -226,11 +226,11 @@ Command.DialogRoot
 
 ## Polymorphism
 
-`Command.Root`, `Command.List`, `Command.Group`, `Command.Item`, `Command.Separator`, and `Command.Empty` accept `asChild`, forwarded to the underlying [cmdk](https://cmdk.paco.me/) primitive. `Command.DialogTrigger` accepts it too, forwarded to its Radix dialog trigger.
+`Command.Root`, `Command.Input`, `Command.List`, `Command.Group`, `Command.Item`, `Command.Separator`, and `Command.Empty` accept `asChild`, forwarded to the underlying [cmdk](https://cmdk.paco.me/) primitive. `Command.DialogTrigger` accepts it too, forwarded to its Radix dialog trigger.
 
 The common case is `Command.Item asChild` with an `<a>` or a router `Link`, so selecting a result navigates while the item keeps its filtering, keyboard selection, and highlight behavior. `Command.DialogTrigger asChild` is the other frequent one — it lets any element, usually a `Button`, open the command dialog.
 
-`Command.Input` does **not** accept `asChild`: cmdk removes the prop from its input primitive, because the search input's value and change handling are owned by the command state.
+`Command.DialogRoot` and `Command.DialogContent` own the dialog's state and panel, and `Command.Shortcut` is a plain `<span>` for key hints, so none of those take `asChild`.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/navigation/command.mdx
+++ b/apps/www/app/docs/components/navigation/command.mdx
@@ -226,11 +226,14 @@ Command.DialogRoot
 
 ## Polymorphism
 
-`Command.Root`, `Command.Input`, `Command.List`, `Command.Group`, `Command.Item`, `Command.Separator`, and `Command.Empty` accept `asChild`, forwarded to the underlying [cmdk](https://cmdk.paco.me/) primitive. `Command.DialogTrigger` accepts it too, forwarded to its Radix dialog trigger.
+`Command.Input`, `Command.Item`, `Command.Separator`, and `Command.Empty` accept `asChild`, forwarded to the underlying [cmdk](https://cmdk.paco.me/) primitive. `Command.DialogTrigger` accepts it too, forwarded to its Radix dialog trigger.
 
 The common case is `Command.Item asChild` with an `<a>` or a router `Link`, so selecting a result navigates while the item keeps its filtering, keyboard selection, and highlight behavior. `Command.DialogTrigger asChild` is the other frequent one — it lets any element, usually a `Button`, open the command dialog.
 
 `Command.DialogRoot` and `Command.DialogContent` own the dialog's state and panel, and `Command.Shortcut` is a plain `<span>` for key hints, so none of those take `asChild`.
+
+> [!WARNING]
+> `Command.Root`, `Command.List`, and `Command.Group` advertise `asChild` through their cmdk props but **throw at runtime** (`Cannot use 'in' operator to search for 'render' in div`) — cmdk's own slot handling does not accept a plain element child for these three. Style them with `className` instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/navigation/command.mdx
+++ b/apps/www/app/docs/components/navigation/command.mdx
@@ -224,6 +224,14 @@ Command.DialogRoot
         └── Command.Separator
 ```
 
+## Polymorphism
+
+`Command.Root`, `Command.List`, `Command.Group`, `Command.Item`, `Command.Separator`, and `Command.Empty` accept `asChild`, forwarded to the underlying [cmdk](https://cmdk.paco.me/) primitive. `Command.DialogTrigger` accepts it too, forwarded to its Radix dialog trigger.
+
+The common case is `Command.Item asChild` with an `<a>` or a router `Link`, so selecting a result navigates while the item keeps its filtering, keyboard selection, and highlight behavior. `Command.DialogTrigger asChild` is the other frequent one — it lets any element, usually a `Button`, open the command dialog.
+
+`Command.Input` does **not** accept `asChild`: cmdk removes the prop from its input primitive, because the search input's value and change handling are owned by the command state.
+
 ## API Reference
 
 The `Command` component is built on top of [cmdk](https://cmdk.paco.me/) and provides a complete set of sub-components for building command palettes.

--- a/apps/www/app/docs/components/overlays/alert-dialog.mdx
+++ b/apps/www/app/docs/components/overlays/alert-dialog.mdx
@@ -221,6 +221,21 @@ function Example() {
 }
 ```
 
+## Polymorphism
+
+Every part of `AlertDialog` that renders DOM accepts `asChild`, which swaps the part's default element for your single child while keeping its styling, `data-slot`, and behavior. `AlertDialog.Root` is a state provider and renders no DOM, so it takes no `asChild`; `AlertDialog.Icon` already takes its element through the `svg` prop and clones it.
+
+| Part                                                           | Reach for `asChild` when                                                                                  |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `AlertDialog.Trigger`                                          | The control that opens the dialog is your own component — most often a `Button` or `IconButton`.          |
+| `AlertDialog.Action`                                           | The confirming action must be a link or a form submit button rather than the default `Button`.            |
+| `AlertDialog.Cancel`                                           | The dismissing control needs to be a link, or a button wired to your own handler.                         |
+| `AlertDialog.Close`                                            | Some other element inside the dialog should dismiss it.                                                   |
+| `AlertDialog.Title`                                            | The heading level must change to fit the page's outline.                                                  |
+| `AlertDialog.Description`                                      | The body copy needs a different element than the default paragraph.                                       |
+| `AlertDialog.Header`, `AlertDialog.Body`, `AlertDialog.Footer` | The region should be a semantic element such as `<header>`, `<section>`, or `<footer>`.                   |
+| `AlertDialog.Content`                                          | You need to own the dialog panel element itself — rare, since `Content` already carries the panel chrome. |
+
 ## API Reference
 
 ### AlertDialog.Root

--- a/apps/www/app/docs/components/overlays/dialog.mdx
+++ b/apps/www/app/docs/components/overlays/dialog.mdx
@@ -476,6 +476,14 @@ function Example() {
 }
 ```
 
+## Polymorphism
+
+`Dialog.Trigger`, `Dialog.Close`, `Dialog.Overlay`, `Dialog.Content`, `Dialog.Title`, `Dialog.Description`, and `Dialog.CloseIconButton` accept `asChild`, which renders your single child in place of the part's default element while keeping its styling and behavior.
+
+`Dialog.Trigger asChild` is by far the most common — it makes your own `Button` open the dialog instead of nesting a button inside one. Use `Dialog.Close asChild` to let any element dismiss the dialog, and `Dialog.Title asChild` when the heading level must fit the surrounding page outline.
+
+`Dialog.Root` and `Dialog.Portal` render no DOM of their own — `Root` is a state provider and `Portal` only relocates its children — so neither takes `asChild`. `Dialog.Header`, `Dialog.Body`, and `Dialog.Footer` are plain layout `<div>`s that do not currently accept it.
+
 ## API Reference
 
 ### Dialog.Root

--- a/apps/www/app/docs/components/overlays/hover-card.mdx
+++ b/apps/www/app/docs/components/overlays/hover-card.mdx
@@ -139,3 +139,12 @@ Renders at Tailwind `z-50`, Mantle's shared floating z-index.
 | `collisionPadding`  | `number \| Partial<Record<Side, number>>`      | `0`         | The distance in pixels from the boundary edges where collision detection should occur.                                                  |
 | `sticky`            | `"partial"` \| `"always"`                      | `"partial"` | The sticky behavior on the align axis.                                                                                                  |
 | `hideWhenDetached`  | `boolean`                                      | `false`     | Whether to hide the content when the trigger becomes fully occluded.                                                                    |
+
+### HoverCard.Portal
+
+The portal container that renders hover card content outside the normal DOM tree. `HoverCard.Content` already renders inside this portal internally, so you rarely need this part directly — reach for it only to customize portal placement with `container`, or to wrap multiple `HoverCard.Content` instances in one shared portal.
+
+| Prop         | Type                  | Default         | Description                                                                                               |
+| ------------ | --------------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
+| `container`  | `HTMLElement \| null` | `document.body` | The container element to portal the content into.                                                         |
+| `forceMount` | `boolean`             |                 | Force mounting when more control is needed, such as animating the content with a React animation library. |

--- a/apps/www/app/docs/components/overlays/hover-card.mdx
+++ b/apps/www/app/docs/components/overlays/hover-card.mdx
@@ -144,7 +144,7 @@ Renders at Tailwind `z-50`, Mantle's shared floating z-index.
 
 The portal container that renders hover card content outside the normal DOM tree. `HoverCard.Content` already renders inside this portal internally, so you rarely need this part directly — reach for it only to customize portal placement with `container`, or to wrap multiple `HoverCard.Content` instances in one shared portal.
 
-| Prop         | Type                  | Default         | Description                                                                                               |
-| ------------ | --------------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
-| `container`  | `HTMLElement \| null` | `document.body` | The container element to portal the content into.                                                         |
-| `forceMount` | `boolean`             |                 | Force mounting when more control is needed, such as animating the content with a React animation library. |
+| Prop         | Type                                  | Default         | Description                                                                                               |
+| ------------ | ------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
+| `container`  | `Element \| DocumentFragment \| null` | `document.body` | The container element to portal the content into.                                                         |
+| `forceMount` | `true`                                |                 | Force mounting when more control is needed, such as animating the content with a React animation library. |

--- a/apps/www/app/docs/components/overlays/sheet.mdx
+++ b/apps/www/app/docs/components/overlays/sheet.mdx
@@ -508,6 +508,14 @@ Sheet.Root
         └── Sheet.Close
 ```
 
+## Polymorphism
+
+`Sheet.Trigger`, `Sheet.Close`, `Sheet.Content`, `Sheet.Title`, `Sheet.Description`, and `Sheet.CloseIconButton` accept `asChild`, which renders your single child instead of the part's default element while keeping its styling and behavior.
+
+`Sheet.Trigger asChild` is the most common — it makes your own `Button` open the sheet rather than nesting a button inside one. `Sheet.Close asChild` lets any element dismiss the sheet, which is handy for a "Cancel" button in `Sheet.Footer`, and `Sheet.Title asChild` adjusts the heading level to fit the page outline.
+
+`Sheet.Root` renders no DOM of its own, so it takes no `asChild`. `Sheet.Header`, `Sheet.Body`, `Sheet.Footer`, `Sheet.TitleGroup`, and `Sheet.Actions` are layout containers that do not currently accept it.
+
 ## API Reference
 
 The `Sheet` components are built on top of [Radix Dialog](https://www.radix-ui.com/primitives/docs/components/dialog).

--- a/apps/www/app/docs/components/overlays/tooltip.mdx
+++ b/apps/www/app/docs/components/overlays/tooltip.mdx
@@ -70,11 +70,14 @@ Tooltip.Root
 
 ## Polymorphism
 
-`Tooltip.Trigger` and `Tooltip.Content` accept `asChild`, which renders your single child in place of the part's default element while keeping the tooltip's hover, focus, and dismissal behavior.
+`Tooltip.Trigger` accepts `asChild`, which renders your single child in place of the default trigger element while keeping the tooltip's hover, focus, and dismissal behavior.
 
 `Tooltip.Trigger asChild` is the standard way to use this component: wrap the element that should show the tooltip — a `Button`, an `IconButton`, a link, or any focusable control — so the trigger behavior attaches to it instead of nesting it inside an extra element. Remember that the trigger must be focusable for the tooltip to be reachable by keyboard.
 
-`Tooltip.Content asChild` is the rarer case, for owning the floating panel element itself. `Tooltip.Root` is a state provider and renders no DOM, so it takes no `asChild`.
+`Tooltip.Root` is a state provider and renders no DOM, so it takes no `asChild`.
+
+> [!WARNING]
+> `Tooltip.Content` advertises `asChild` in its prop types but **throws at runtime** (`Primitive.div failed to slot onto its Slottable`). The content renders its own arrow alongside your children, so the slot receives more than the single element it requires. Style `Tooltip.Content` with `className` instead.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/overlays/tooltip.mdx
+++ b/apps/www/app/docs/components/overlays/tooltip.mdx
@@ -68,6 +68,14 @@ Tooltip.Root
 └── Tooltip.Content
 ```
 
+## Polymorphism
+
+`Tooltip.Trigger` and `Tooltip.Content` accept `asChild`, which renders your single child in place of the part's default element while keeping the tooltip's hover, focus, and dismissal behavior.
+
+`Tooltip.Trigger asChild` is the standard way to use this component: wrap the element that should show the tooltip — a `Button`, an `IconButton`, a link, or any focusable control — so the trigger behavior attaches to it instead of nesting it inside an extra element. Remember that the trigger must be focusable for the tooltip to be reachable by keyboard.
+
+`Tooltip.Content asChild` is the rarer case, for owning the floating panel element itself. `Tooltip.Root` is a state provider and renders no DOM, so it takes no `asChild`.
+
 ## API Reference
 
 > [!NOTE]

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -621,7 +621,7 @@
     "summary": "A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.",
     "jsdoc": "A group of radio items.",
     "examples": [
-      "Composition:\n```\n# Default radios\nRadioGroup.Root\n└── RadioGroup.Item\n    ├── RadioGroup.Indicator\n    └── RadioGroup.ItemContent\n\n# List layout with descriptions\nRadioGroup.List\n└── RadioGroup.ListItem\n    ├── RadioGroup.Indicator\n    └── RadioGroup.ItemContent\n\n# Segmented button group\nRadioGroup.ButtonGroup\n└── RadioGroup.Button\n\n# Card-style radios\nRadioGroup.Root\n└── RadioGroup.Card\n    └── RadioGroup.Indicator\n```",
+      "Composition:\n```\n# Default radios\nRadioGroup.Root\n└── RadioGroup.Item\n    ├── RadioGroup.Indicator\n    └── RadioGroup.ItemContent\n\n# List layout with descriptions\nRadioGroup.List\n└── RadioGroup.ListItem\n    ├── RadioGroup.Indicator\n    └── RadioGroup.ItemContent\n\n# Segmented button group\nRadioGroup.ButtonGroup\n└── RadioGroup.Button\n\n# Card-style radios\nRadioGroup.Root\n└── RadioGroup.Card\n    └── RadioGroup.Indicator\n\n# Rich option layout (Choice)\nRadioGroup.Root\n└── RadioGroup.Item\n    └── Choice.Root\n        ├── Choice.Indicator\n        │   └── RadioGroup.Indicator\n        └── Choice.Content\n            ├── Choice.Title\n            └── Choice.Description\n```",
       "```tsx\n<RadioGroup.Root value={value} onChange={setValue}>\n  <RadioGroup.Item value=\"option1\">\n    <RadioGroup.Indicator />\n    <span>Option 1</span>\n  </RadioGroup.Item>\n  <RadioGroup.Item value=\"option2\">\n    <RadioGroup.Indicator />\n    <span>Option 2</span>\n  </RadioGroup.Item>\n</RadioGroup.Root>\n```"
     ]
   },
@@ -648,7 +648,7 @@
     "summary": "A canvas-rendered scatter plot for correlating two continuous measures — three with the rotatable 3D projection.",
     "jsdoc": "A canvas-rendered scatter plot for correlating two measures — three with the 3D projection (`zKey`), which renders a rotatable, depth-sorted point cloud (drag to orbit).",
     "examples": [
-      "Composition:\n```\nScatterPlot.Root\n├── ScatterPlot.Grid\n├── ScatterPlot.XAxis\n├── ScatterPlot.YAxis\n├── ScatterPlot.Point (one per series)\n├── ScatterPlot.ReferenceLine\n├── ScatterPlot.Tooltip\n└── ScatterPlot.Legend\n```",
+      "Composition:\n```\nScatterPlot.Root\n├── ScatterPlot.Grid\n├── ScatterPlot.XAxis\n├── ScatterPlot.YAxis\n├── ScatterPlot.Point (one per series)\n├── ScatterPlot.ReferenceLine\n├── ScatterPlot.Tooltip\n├── ScatterPlot.Legend\n└── ScatterPlot.CopyButton\n```",
       "```tsx\nconst data = [\n  { latency: 12, throughputA: 840, throughputB: 720 },\n  { latency: 28, throughputA: 610, throughputB: 590 },\n  { latency: 45, throughputA: 340, throughputB: 410 },\n];\n\n<ScatterPlot.Root data={data} xKey=\"latency\" aria-label=\"Latency vs throughput\">\n  <ScatterPlot.Grid />\n  <ScatterPlot.XAxis />\n  <ScatterPlot.YAxis />\n  <ScatterPlot.Point dataKey=\"throughputA\" label=\"Region A\" />\n  <ScatterPlot.Point dataKey=\"throughputB\" label=\"Region B\" />\n  <ScatterPlot.Tooltip />\n  <ScatterPlot.Legend />\n</ScatterPlot.Root>\n```"
     ]
   },

--- a/packages/mantle/src/components/calendar/calendar.tsx
+++ b/packages/mantle/src/components/calendar/calendar.tsx
@@ -26,7 +26,7 @@ const calendarNavButtonClasses = iconButtonVariants({
  * @preview This component is in `preview` mode which means the API is not stable and may change.
  * There may also be bugs! Please file an issue if you find any! <3
  *
- * @see https://mantle.ngrok.com/components/preview/calendar#api-calendar
+ * @see https://mantle.ngrok.com/components/preview/calendar
  *
  * @example
  * ```tsx

--- a/packages/mantle/src/components/progress/progress-bar.tsx
+++ b/packages/mantle/src/components/progress/progress-bar.tsx
@@ -50,7 +50,7 @@ type RootProps = ComponentProps<"div"> & {
  * A horizontal progress bar that shows the completion progress of a task.
  * Use this component for linear progress indication.
  *
- * @see https://mantle.ngrok.com/components/feedback/progress-bar#api-progress-bar
+ * @see https://mantle.ngrok.com/components/feedback/progress-bar#progressbarroot
  *
  * @example
  * ```tsx
@@ -109,7 +109,7 @@ type IndicatorProps = ComponentProps<typeof ProgressPrimitive.Indicator>;
  * The visual indicator that shows the actual progress within the progress bar.
  * This component should be used inside a ProgressBar.Root component.
  *
- * @see https://mantle.ngrok.com/components/feedback/progress-bar#api-progress-bar-indicator
+ * @see https://mantle.ngrok.com/components/feedback/progress-bar#progressbarindicator
  *
  * @example
  * ```tsx
@@ -176,7 +176,7 @@ const ProgressBar = {
 	 * A horizontal progress bar that shows the completion progress of a task.
 	 * Use this component for linear progress indication.
 	 *
-	 * @see https://mantle.ngrok.com/components/feedback/progress-bar#api-progress-bar
+	 * @see https://mantle.ngrok.com/components/feedback/progress-bar#progressbarroot
 	 *
 	 * @example
 	 * ```tsx
@@ -201,7 +201,7 @@ const ProgressBar = {
 	 * The visual indicator that shows the actual progress within the progress bar.
 	 * This component should be used inside a ProgressBar.Root component.
 	 *
-	 * @see https://mantle.ngrok.com/components/feedback/progress-bar#api-progress-bar-indicator
+	 * @see https://mantle.ngrok.com/components/feedback/progress-bar#progressbarindicator
 	 *
 	 * @example
 	 * ```tsx

--- a/packages/mantle/src/components/progress/progress-donut.tsx
+++ b/packages/mantle/src/components/progress/progress-donut.tsx
@@ -76,7 +76,7 @@ type Props = SvgAttributes & {
  * The indicator color is inherited via `currentColor`. Override the default
  * (`accent-600`) by setting the `ProgressDonut.Indicator`'s text color.
  *
- * @see https://mantle.ngrok.com/components/feedback/progress-donut#api-progress-donut
+ * @see https://mantle.ngrok.com/components/feedback/progress-donut#progressdonutroot
  *
  * @example
  * ```tsx
@@ -168,7 +168,7 @@ type ProgressDonutIndicatorProps = Omit<ComponentProps<"g">, "children">;
 /**
  * The indicator for the circular progress bar.
  *
- * @see https://mantle.ngrok.com/components/feedback/progress-donut#api-progress-donut-indicator
+ * @see https://mantle.ngrok.com/components/feedback/progress-donut#progressdonutindicator
  *
  * @example
  * ```tsx
@@ -253,7 +253,7 @@ const ProgressDonut = {
 	 * The indicator color is inherited via `currentColor`. Override the default
 	 * (`accent-600`) by setting the `ProgressDonut.Indicator`'s text color.
 	 *
-	 * @see https://mantle.ngrok.com/components/feedback/progress-donut#api-progress-donut-root
+	 * @see https://mantle.ngrok.com/components/feedback/progress-donut#progressdonutroot
 	 *
 	 * @example
 	 * ```tsx
@@ -270,7 +270,7 @@ const ProgressDonut = {
 	/**
 	 * The indicator for the circular progress bar.
 	 *
-	 * @see https://mantle.ngrok.com/components/feedback/progress-donut#api-progress-donut-indicator
+	 * @see https://mantle.ngrok.com/components/feedback/progress-donut#progressdonutindicator
 	 *
 	 * @example
 	 * ```tsx

--- a/packages/mantle/src/components/radio-group/radio-group.tsx
+++ b/packages/mantle/src/components/radio-group/radio-group.tsx
@@ -571,6 +571,16 @@ const InputSandbox = ({ children, onClick, onKeyDown, ...props }: RadioInputSand
  * RadioGroup.Root
  * └── RadioGroup.Card
  *     └── RadioGroup.Indicator
+ *
+ * # Rich option layout (Choice)
+ * RadioGroup.Root
+ * └── RadioGroup.Item
+ *     └── Choice.Root
+ *         ├── Choice.Indicator
+ *         │   └── RadioGroup.Indicator
+ *         └── Choice.Content
+ *             ├── Choice.Title
+ *             └── Choice.Description
  * ```
  *
  * @example

--- a/packages/mantle/src/components/scatter-plot/scatter-plot.tsx
+++ b/packages/mantle/src/components/scatter-plot/scatter-plot.tsx
@@ -363,7 +363,8 @@ const CopyButton = (props: ScatterPlotCopyButtonProps) => (
  * ├── ScatterPlot.Point (one per series)
  * ├── ScatterPlot.ReferenceLine
  * ├── ScatterPlot.Tooltip
- * └── ScatterPlot.Legend
+ * ├── ScatterPlot.Legend
+ * └── ScatterPlot.CopyButton
  * ```
  *
  * @example


### PR DESCRIPTION
Ran `/audit-component` across every in-scope component and applied the auto-fixable findings. **Documentation only — no API, behavior, or markup changes.**

## Scope

63 in-scope export directories (`chart` correctly excluded as the export-less internal engine) — 65 stable components, 1 preview (Calendar), 1 layout.

Worth recording: **the library is in better shape than COMPONENT_SPEC.md's "Scope and status" implies.** These passed clean library-wide with zero findings — no `displayName`, `forwardRef`, `React.FC`, prop-bag, nested-namespace, or `interface` violations; no non-null assertions; all 39 compound components have `## Composition` and no simple component wrongly has one; every `@see` route resolves. The `any` / `=== undefined` hits were all in out-of-scope `chart/` and `*/primitive.tsx`.

## What this fixes — 27 items across 20 files

| § | Fix |
| --- | --- |
| §4.1 | **9 broken `@see` anchors** pointing at a retired `#api-*` heading scheme — `progress-bar.tsx` ×4, `progress-donut.tsx` ×4, `calendar.tsx` ×1. Anchors are `rehype-slug`-generated, so each target was derived from the page's real heading rather than guessed. |
| §7.2 | **`### HoverCard.Portal` API-reference subsection.** `Portal` is an exported namespace member that had no subsection, which also left the two `@see #hovercardportal` anchors in `hover-card.tsx:69,237` dangling. |
| §4.2 | **3 mismatched Composition trees** — `ScatterPlot.CopyButton` was missing from the JSDoc tree (it has shipped as a namespace member); RadioGroup's "Rich option layout (Choice)" tree was missing from the JSDoc; CodeBlock's docs page split its two trees across unlabeled fences instead of one `# Standard` / `# Tabbed` fence. |
| §7.2.6 | **13 missing `## Polymorphism` sections** — alert-dialog, code-block, command, dialog, empty, multi-select, radio-group, select, selectable-list, sheet, theme-switcher, toast, tooltip. |

`asChild` support was verified **per part**, not per component, which caught three things worth knowing: `CodeBlock.TabContent` explicitly `Omit`s the prop, cmdk strips it from `Command.Input` but keeps it on every other part, and Radix `Root`/`Portal` parts render no DOM so they legitimately take none. The new sections are prose-only — §7.2 item 6 requires listing the parts and when to reach for them; an example is optional. Adding live examples would be a good follow-up.

## Runtime verification (round 3)

Copilot correctly flagged the Select section: `Trigger`, `Content`, and `Item` render their own chrome, so forwarding `asChild` hands the slot more than one child. That exposed a gap in round 2 — a type-level check proves `asChild` is *in* a part's props, not that it *works*.

So all 57 parts documented as accepting `asChild` were re-probed by **actually rendering** each with `asChild` and a single element child. **Ten throw at runtime:**

| Part | Runtime error | Why |
| --- | --- | --- |
| `Select.Trigger`, `.Content`, `.Item` | `Primitive.* failed to slot onto its children` | caret / scroll buttons + viewport / check indicator |
| `Tooltip.Content` | `failed to slot onto its \`Slottable\`` | renders `Arrow` beside children |
| `CodeBlock.ExpanderButton` | `React.Children.only` | renders its own label text + caret |
| `MultiSelect.Item` | `React.Children.only` | renders check indicator beside children |
| `Toast.Root` | `React.Children.only` | renders intent accent bar beside children |
| `Command.Root`, `.List`, `.Group` | `Cannot use 'in' operator to search for 'render' in div` | cmdk slot handling rejects a plain element child |

Each affected section now documents only the parts that work, plus a warning naming the broken part, its real error, why, and the alternative (`children` or `className`).

**New author-judgment finding — the underlying defect.** These ten parts advertise `asChild` in their prop types but cannot honor it. That is a §1.6 "make invalid states unrepresentable" violation: the type permits something that throws. Two possible fixes, both API-affecting, so reported rather than applied:

1. Wrap the part's own chrome in Radix `Slottable` so the slot can find the consumer's child (keeps `asChild` working), or
2. `Omit<…, "asChild">` from those props types so the compiler rejects it (matches what `CodeBlock.TabList`/`TabTrigger` and `ThemeSwitcher.Trigger` already do deliberately).

Option 1 is the better outcome where the chrome is decorative (`Tooltip.Content`'s arrow, `Toast.Root`'s accent bar). Option 2 is more honest for `Select.Item` and `MultiSelect.Item`, whose indicators are part of the selection contract. `Command`'s three are upstream cmdk behavior and may only be fixable by option 2.

## Verification

All five COMPONENT_SPEC.md §9 commands pass: `lint` (0), `fmt:check` (clean), `typecheck` (0), **unscoped** `test` (135/135), `build -F @ngrok/mantle`. `components-surface.json` regenerated with `pnpm -F @app/www test -u` and committed. `mantle-component-name.ts` unchanged (no new components); nothing touched that affects `INTERNAL_CHUNKS_BY_COMPONENT` or the four theme stylesheets.

Changeset: `patch` — the `packages/mantle` diff is JSDoc-comment-only, and `apps/www/**` needs none per §2.5.

## Reported, not fixed — needs a maintainer decision

Per §10.3 an audit reports anything touching public API, runtime behavior, or accessibility semantics rather than fixing it. Eight clusters:

1. **21 directories ship no test file** — badge, browser-only, calendar, card, code, combobox, dialog, dropdown-menu, flag, hover-card, icons, kbd, main, media-object, popover, sandboxed-on-click, separator, sheet, skeleton, table, tooltip — plus family-dir `button-group`, `progress-bar`, `cursor-pagination`. Matches the spec's own stated count exactly.
2. **9 props types based on `HTMLAttributes<…>`, which drops `ref`** (§3.1) — `Tabs.Badge`, `Empty.Title`, `HorizontalSeparatorGroup`, `RadioGroup.Indicator` / `.ItemContent` / `.InputSandbox`, and `Sheet.Body` / `.Header` / `.Footer`. Verified against the compiler (`"ref" extends keyof Props<…>`), with `Sheet.Title`, `Empty.Root`, and `Separator` as passing controls. Fixing adds `ref` to public API, so it wants a `minor`.
3. **`--slider-thumb-size`** (`slider.tsx:153,194,206`) — named like public API and set by `Root`, but read bare at :206 with no fallback. Either publish it (fallback + both doc tables) or privatize to `--_slider-thumb-size`.
4. **`--icon-button-border-radius` §5.3 gap** — `icon-button.mdx` documents it and already notes ButtonGroup's override, so the owner side is covered. The gap is the *reader*: `code-block.tsx:586` reads it via `rounded-[var(--icon-button-border-radius,0.375rem)]` and CodeBlock's page carries no CSS-variable table, so §5.3's "read, not owned" entry is missing.
5. **`Field.LabelRow` borrows the reserved word `Row`** (§1.4) — it renders a plain flex `<div>` with no `role="row"` and no grid keyboard contract. A rename is breaking and must go all the way through. Deliberately **not** resolved by adding the role, per §10.3's hard rule.
6. **No docs page carries a data-attribute table** (§6 — the spec states this is explicitly not an audit auto-fix).
7. **15 placeholder/fragment code fences** (§7.3) — code-block (2), selectable-list (4), radio-group (2), text-area (3), skeleton, field, theme-switcher, breadcrumb. §10.3 calls these auto-fixable, but several `…` deliberately stand in for "your code here", so a blind rewrite risks making the docs worse.
8. **3 docs titles disagree with their nav label** — `BrowserOnly` / `SkipToMainLink` / `TextArea` vs "Browser Only" / "Skip to Main Link" / "Text Area". Each page's frontmatter matches its own H1, so this isn't a typo, and `SandboxedOnClick` sets a one-word precedent. Fixable in either direction; both directions change the published manifest.

## Adversarial re-check

After an incorrect finding slipped into the first revision, every claim in this PR was re-verified against the **type system** rather than source-reading — asserting `"asChild" extends keyof Props<typeof Part>` for all 113 parts across the 13 components and reading which assertions failed. That found **7 factual errors in the Polymorphism sections this PR itself added**, all fixed in `3e66be47`:

| Part | Was documented as | Actually |
| --- | --- | --- |
| `CodeBlock.TabList`, `CodeBlock.TabTrigger` | accepts `asChild` | explicitly `Omit`s it |
| `CodeBlock.CopyButton` | does *not* accept it | accepts it via `SelfClosingWithAsChild` |
| `SelectableList.Item` (named as the headline case), `SelectableList.ItemTitle` | accepts `asChild` | neither does; only `ItemDescription` |
| `ThemeSwitcher.Trigger` (named as the common case) | accepts `asChild` | omits it with `icon`/`label`/`appearance`/`intent` |
| `Command.Input` | cmdk strips `asChild` | accepts it |

All 108 corrected claims now pass the same check. The `HoverCard.Portal` props table was corrected too (`container` is `Element | DocumentFragment | null`; `forceMount` is the literal `true`).

**One finding was retracted entirely.** An earlier revision flagged `data-table.tsx:35` (`createContext<DataTableContextShape<any> | null>`) as a §3.1 no-`any` violation. False positive: the `any` is load-bearing, since `TData` sits in contravariant positions inside TanStack's `TableInstance<TData>`. Swapping in `unknown` fails with `TS2322` at the provider (`data-table.tsx:104`), and the only way to compile it is a forbidden `as` assertion — strictly worse. This is §3.1's documented "framework/runtime boundaries" exception, and line 34 already carries an `oxlint-disable` saying exactly that. `DataTableContext` is module-internal, so no consumer surface is involved.

A §3.3 observation falls out of the table above: `CodeBlock.TabList`/`TabTrigger`/`TabContent`, `SelectableList.Item`/`ItemTitle`, and `ThemeSwitcher.Trigger` all render DOM but deliberately omit `asChild`. Each omission looks intentional and reasoned, but §3.3 wants a comment at the declaration recording the reason — currently only the type says so. Adding `asChild` to a part that lacks it is author-judgment per §10.3, so it is reported, not changed.

## Verification

Full **Vibe Check** re-run locally after every round — all six jobs green: static-checks (`fmt:check` + `lint`), mise lockfile, **full** `pnpm run build` (not just `-F @ngrok/mantle`), `typecheck`, unit tests, and **browser tests (23 files / 221 tests)**.

**Reviewed and cleared:** the chart `Grid` parts and the `SelectableListOption` *type* hit reserved pattern words but are fine (gridlines; and a data type rather than a part). `Row`/`Cell` in `table`/`data-table` are earned via native `<tr>`/`<td>`, and the Radix/Ariakit/cmdk-wrapped `Menu`/`Tab`/`Dialog`/`Combobox` names all emit their role along with its keyboard contract.




