### PR TITLE
fix(breadcrumb): mute current page text

### DIFF
--- a/.changeset/mute-breadcrumb-page.md
+++ b/.changeset/mute-breadcrumb-page.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+Render `Breadcrumb.Page` with the same muted foreground color as the rest of the breadcrumb trail instead of emphasizing it with strong text.

--- a/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
@@ -254,7 +254,7 @@ const Page = ({
 		<Comp
 			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "breadcrumb-page")}
-			className={cx("text-strong", className)}
+			className={cx("text-muted", className)}
 			{...props}
 			aria-current="page"
 		>


### PR DESCRIPTION
## Summary
- render `Breadcrumb.Page` with the same muted foreground as the breadcrumb trail
- include a patch changeset for the visual adjustment

## Test plan
- [x] `pnpm -w run lint`
- [x] `pnpm -w run fmt:check`
- [x] `pnpm -w run typecheck`
- [x] `pnpm -w run test`
- [x] `pnpm -w run build -F @ngrok/mantle`

Made with [Cursor](https://cursor.com)