### PR TITLE
fix(sidebar): stop Sidebar.Tooltip popping a label when the rail collapses

### DIFF
--- a/.changeset/fix-sidebar-tooltip-rail-latch.md
+++ b/.changeset/fix-sidebar-tooltip-rail-latch.md
@@ -1,0 +1,31 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix `Sidebar.Tooltip` popping a label when the panel collapses, with no pointer anywhere near the row.
+
+The part gated its `Tooltip.Content` on the collapsed rail state but left `Tooltip.Root` to manage its own
+open state — and Radix's pointer close path lives *inside* the content, which tracks the pointer leaving the
+trigger. With the content withheld, nothing could close it: the pointer crossing an expanded row on its way
+to the collapse trigger latched that row's label open, invisibly, and collapsing the panel then mounted every
+latched label at once. The app shell demos put the account switcher row right beside the `Sidebar.Trigger`, so
+a tooltip appeared on nearly every collapse. The same stale open state pointed the row's `aria-describedby` at
+an id that was not in the document and left `data-state="instant-open"` on rows in the expanded panel.
+
+A row wrapped in a menu or dialog trigger latched the same way without any hover: closing the overlay restores
+focus to the row, and Radix opens a tooltip on focus. In the shell demos that is the account switcher, which
+is why collapsing right after using its menu showed the account's name in the rail.
+
+The rail state is now a veto on a controlled open state rather than a gate on the content, and a rail toggle
+resets it, so:
+
+- the expanded panel and the mobile sheet keep every row at `data-state="closed"` with no `aria-describedby`;
+- collapsing or expanding dismisses the label instead of replaying a stale one — including the reverse case,
+  where a label shown in the rail survived an expand and reappeared on the next collapse;
+- the label closes when the pointer leaves the row. `disableHoverableContent` moves that close onto the
+  trigger, which is mounted at every rail state, and a rail label has nothing to hover into — per the
+  WAI-ARIA tooltip pattern it holds no interactive content.
+
+Opening is unchanged otherwise: the pointer entering a row in the collapsed rail, or focus reaching it, still
+shows the label. `Tooltip.Root` still stays mounted at every rail state, so toggling the rail never drops
+focus off the row the user was on.

--- a/.changeset/tailwind-v4-class-syntax.md
+++ b/.changeset/tailwind-v4-class-syntax.md
@@ -1,0 +1,20 @@
+---
+"@ngrok/mantle": patch
+---
+
+Modernize the `Sidebar` and `AppLayout` class strings to Tailwind v4 syntax. The compiled CSS is unchanged —
+these are the shorthands v4 added for what the bracket forms already expressed:
+
+| Before                                        | After                                     |
+| --------------------------------------------- | ----------------------------------------- |
+| `w-[var(--sidebar-width,16rem)]`              | `w-(--sidebar-width,16rem)`               |
+| `m-[var(--app-layout-card-gutter,0.5rem)]`    | `m-(--app-layout-card-gutter,0.5rem)`     |
+| `group-data-[hydrated]/sidebar-nav:`          | `group-data-hydrated/sidebar-nav:`        |
+| `group-has-[[data-slot~=sidebar-header]]/…`   | `group-has-data-[slot~=sidebar-header]/…` |
+| `[border-radius:0.625rem]`                    | `rounded-[0.625rem]`                      |
+| `[&>:first-child]:size-7`                     | `*:first:size-7`                          |
+
+The CSS variables, their fallbacks, and the selectors they compile to are identical — the variable shorthand
+carries its fallback (`w-(--sidebar-width,16rem)` still emits `width: var(--sidebar-width,16rem)`), and both
+`:has()` forms match the same `data-slot` token. Only the class strings on the elements changed, so update any
+test or stylesheet that matches them literally.

--- a/apps/www/app/docs/components/navigation/sidebar.mdx
+++ b/apps/www/app/docs/components/navigation/sidebar.mdx
@@ -855,7 +855,7 @@ export function PendingAwareRow() {
 ## Width
 
 The panel's width is a CSS variable, not a prop: `Sidebar.Nav` reads each of the three widths with the
-default as its fallback (`w-[var(--sidebar-width,16rem)]`), so there is nothing to thread through your shell
+default as its fallback (`w-(--sidebar-width,16rem)`), so there is nothing to thread through your shell
 and one place to change it.
 
 | CSS Variable             | Default          | What it sizes                                           |
@@ -1025,13 +1025,17 @@ export function LabeledRail() {
 }
 ```
 
-The tooltip only mounts while the desktop panel is collapsed — expanded rows already read their own text and
-the mobile sheet shows full labels, so there is nothing to duplicate. It gates its _content_, not the whole
-`Tooltip.Root`, which keeps the row mounted across a collapse so toggling the rail never drops focus off the
-row the user was on.
+The label shows only while the desktop panel is collapsed — expanded rows already read their own text and the
+mobile sheet shows full labels, so there is nothing to duplicate. The rail state _vetoes_ the tooltip's open
+state rather than withholding its content: the expanded panel and the mobile sheet keep the row at
+`data-state="closed"` with no `aria-describedby`, and toggling the rail dismisses whatever was showing, so
+collapsing the panel cannot pop a label under a pointer that has already moved on. `Tooltip.Root` itself stays
+mounted at every rail state, which keeps the row — and its focus — through a collapse.
 
 It needs a `TooltipProvider` ancestor, like any `Tooltip.Root` — mount one at your app root. The part
-deliberately does not provide its own, so your app-wide tooltip delay and hover settings still apply.
+deliberately does not provide its own, so your app-wide tooltip delay still applies. The one provider setting
+it does override is hoverable content: a rail label holds nothing to hover into, so the label closes when the
+pointer leaves the row instead of waiting for the pointer to leave the label too.
 
 For a row that also opens a menu — the **Help** row above — keep `DropdownMenu.Root` **outside** the tooltip:
 it is renderless, and `Tooltip.Trigger asChild` needs a real element to clone. The menu itself takes the
@@ -1518,12 +1522,12 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 
 **Data attributes**
 
-| Data Attribute  | Value                         | Description                                                                                                                                                                                                                                        |
-| --------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data-state`    | `"expanded"` \| `"collapsed"` | On the desktop panel surface. Mirrors the root's expanded state and drives the width collapse to the icon rail; descendant parts style off it with `group-data-[state=collapsed]/sidebar-nav:`.                                                    |
-| `data-hydrated` | present after hydration       | Presence-only, desktop panel surface. The CSS-side twin of the `isHydrated` gate: descendant collapse transitions are enabled only under `group-data-[hydrated]/sidebar-nav:`, so an SSR state correction snaps instead of animating on page load. |
-| `data-mobile`   | present in the mobile sheet   | Presence-only. Marks the `Sheet.Content` presentation used below the root's `mobileBreakpoint`.                                                                                                                                                    |
-| `data-state`    | `"open"` \| `"closed"`        | In the mobile sheet only, where the panel _is_ the `Sheet`'s Radix dialog content element and Radix owns the attribute — the sheet's open/close animation state, not the desktop expanded state. Consumers style against it too.                   |
+| Data Attribute  | Value                         | Description                                                                                                                                                                                                                                      |
+| --------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `data-state`    | `"expanded"` \| `"collapsed"` | On the desktop panel surface. Mirrors the root's expanded state and drives the width collapse to the icon rail; descendant parts style off it with `group-data-[state=collapsed]/sidebar-nav:`.                                                  |
+| `data-hydrated` | present after hydration       | Presence-only, desktop panel surface. The CSS-side twin of the `isHydrated` gate: descendant collapse transitions are enabled only under `group-data-hydrated/sidebar-nav:`, so an SSR state correction snaps instead of animating on page load. |
+| `data-mobile`   | present in the mobile sheet   | Presence-only. Marks the `Sheet.Content` presentation used below the root's `mobileBreakpoint`.                                                                                                                                                  |
+| `data-state`    | `"open"` \| `"closed"`        | In the mobile sheet only, where the panel _is_ the `Sheet`'s Radix dialog content element and Radix owns the attribute — the sheet's open/close animation state, not the desktop expanded state. Consumers style against it too.                 |
 
 `Sidebar.Header` reads one more public token, [`--sidebar-header-height`](#sidebarheader), which belongs on a
 common ancestor of the sidebar and the app-layout header rather than on the panel.
@@ -1702,6 +1706,11 @@ Labels a row while — and only while — the desktop panel is collapsed to the 
 [Labeling the rail for pointer users](#labeling-the-rail-for-pointer-users). Requires a
 [`TooltipProvider`](/components/overlays/tooltip#tooltipprovider) ancestor and must be inside a
 `Sidebar.Root` (it throws otherwise).
+
+It opens on hover or focus like any tooltip and closes when the pointer leaves the row — the label itself is
+not hoverable. The rail state vetoes it: the expanded panel and the mobile sheet never show it, and toggling
+the rail dismisses whatever was showing, so collapsing the panel cannot pop a label under a pointer that has
+already moved on.
 
 Its props are [`Tooltip.Content`](/components/overlays/tooltip#tooltipcontent)'s, minus the two this row
 owns, plus:

--- a/apps/www/app/docs/layouts/app-layout.mdx
+++ b/apps/www/app/docs/layouts/app-layout.mdx
@@ -681,7 +681,7 @@ AppLayout.Root
   rail, on either side) beside the `Content` card. The `min-h-0` is what lets `Body` scroll instead of the
   page. It owns **no gutter**, deliberately — so a rail stays flush against the window edge and a collapsed
   icon rail keeps its flush geometry.
-- **`Content`** is the card surface: `bg-card border-card-muted relative m-[var(--app-layout-card-gutter,0.5rem)] flex min-w-0 flex-1 flex-col
+- **`Content`** is the card surface: `bg-card border-card-muted relative m-(--app-layout-card-gutter,0.5rem) flex min-w-0 flex-1 flex-col
 overflow-clip rounded-xl border shadow-sm`. It insets **itself** with its own margin
   (`--app-layout-card-gutter`), because the gutter has to belong to the card rather than to a wrapper — the
   only other element that could hold it also contains the rail. It does **not** scroll.
@@ -2014,7 +2014,7 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 ### AppLayout.Content
 
 The card surface beside the sidebar:
-`bg-card border-card-muted relative m-[var(--app-layout-card-gutter,0.5rem)] flex min-w-0 flex-1 flex-col overflow-clip rounded-xl border shadow-sm`.
+`bg-card border-card-muted relative m-(--app-layout-card-gutter,0.5rem) flex min-w-0 flex-1 flex-col overflow-clip rounded-xl border shadow-sm`.
 Holds `AppLayout.Header` and `AppLayout.Body`.
 
 The card **does not scroll** — [`AppLayout.Body`](#applayoutbody) does. It insets itself from the window edge

--- a/packages/mantle/src/components/app-layout/app-layout.test.tsx
+++ b/packages/mantle/src/components/app-layout/app-layout.test.tsx
@@ -327,7 +327,7 @@ describe("AppLayout.Header", () => {
 		const { className } = screen.getByTestId("header");
 		expect(className).toContain("h-14");
 		expect(className).toContain(
-			"group-has-[[data-slot~=sidebar-header]]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
+			"group-has-data-[slot~=sidebar-header]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
 		);
 	});
 
@@ -355,7 +355,7 @@ describe("AppLayout.Header", () => {
 		expect([...root.classList]).toContain("group/app-layout");
 		expect(root.querySelector('[data-slot~="sidebar-header"]')).not.toBeNull();
 		expect(screen.getByTestId("header").className).toContain(
-			"group-has-[[data-slot~=sidebar-header]]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
+			"group-has-data-[slot~=sidebar-header]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
 		);
 	});
 });
@@ -393,7 +393,7 @@ describe("AppLayout.Content", () => {
 	test("owns the card gutter as its own margin, driven by a public variable", () => {
 		render(<AppLayout.Content data-testid="content">page</AppLayout.Content>);
 		expect(screen.getByTestId("content").className).toContain(
-			"m-[var(--app-layout-card-gutter,0.5rem)]",
+			"m-(--app-layout-card-gutter,0.5rem)",
 		);
 	});
 

--- a/packages/mantle/src/components/app-layout/app-layout.tsx
+++ b/packages/mantle/src/components/app-layout/app-layout.tsx
@@ -274,7 +274,7 @@ const Content = ({
 				// the only element that could hold padding is Workspace, which also
 				// contains the rail, so padding there would inset the sidebar off the
 				// window edge and break the flush collapsed icon rail.
-				"m-[var(--app-layout-card-gutter,0.5rem)]",
+				"m-(--app-layout-card-gutter,0.5rem)",
 				// clip, not hidden: `hidden` is a scroll container that paints no
 				// scrollbar, so a long toolbar lets focus scroll the card sideways —
 				// translating the header and the page off-screen with no way back.
@@ -367,7 +367,7 @@ const Header = ({
 				// needs its height to be the sidebar header's minus twice each.
 				// Overriding --sidebar-header-height at a common ancestor (e.g.
 				// AppLayout.Root) moves both rows together.
-				"group-has-[[data-slot~=sidebar-header]]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
+				"group-has-data-[slot~=sidebar-header]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
 				className,
 			)}
 			{...props}

--- a/packages/mantle/src/components/sidebar/sidebar.test.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { createRef, type ReactElement } from "react";
 import { renderToString } from "react-dom/server";
@@ -525,7 +525,7 @@ describe("Sidebar.Nav first paint", () => {
 		);
 		// The label's own transition is gated in CSS rather than in JS, so it ships
 		// in the server markup but only fires once the nav stamps data-hydrated.
-		expect(html).toContain("group-data-[hydrated]/sidebar-nav:transition-opacity");
+		expect(html).toContain("group-data-hydrated/sidebar-nav:transition-opacity");
 		expect(html).not.toContain("data-hydrated=");
 	});
 });
@@ -552,8 +552,8 @@ describe("Sidebar reduced motion", () => {
 			</Sidebar.Group>,
 		);
 		expect(screen.getByTestId("label")).toHaveClass(
-			"group-data-[hydrated]/sidebar-nav:transition-opacity",
-			"group-data-[hydrated]/sidebar-nav:motion-reduce:transition-none",
+			"group-data-hydrated/sidebar-nav:transition-opacity",
+			"group-data-hydrated/sidebar-nav:motion-reduce:transition-none",
 		);
 	});
 });
@@ -968,15 +968,19 @@ describe("Sidebar.Tooltip", () => {
 							</Sidebar.Group>
 						</Sidebar.Body>
 					</Sidebar.Nav>
+					{/* The rail state is what gates the label, so these tests toggle it
+					    the way a user does rather than by re-rendering `defaultOpen` —
+					    which seeds the uncontrolled state once and never collapses it. */}
+					<Sidebar.Trigger />
 				</Sidebar.Root>
 			</TooltipProvider>
 		);
 	}
 
 	/**
-	 * Renders one `Sidebar.Tooltip` in the collapsed desktop rail — the only state
-	 * where its `Tooltip.Content` mounts — hovers the row, and answers with the
-	 * tooltip surface, so a test can assert what reached `Tooltip.Content`.
+	 * Renders one `Sidebar.Tooltip` in the collapsed desktop rail — the only rail
+	 * state that shows a label — hovers the row, and answers with the tooltip
+	 * surface, so a test can assert what reached `Tooltip.Content`.
 	 */
 	async function hoverRailTooltip(tooltip: ReactElement): Promise<HTMLElement> {
 		const user = userEvent.setup();
@@ -1029,7 +1033,134 @@ describe("Sidebar.Tooltip", () => {
 			</TooltipProvider>,
 		);
 
+		const row = screen.getByRole("button", { name: "Endpoints" });
+		await user.hover(row);
+
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		// The mobile arm of the veto, held to the same bar as the expanded panel
+		// below: silent means Radix's own state is closed, not just that the
+		// surface was withheld.
+		expect(row).not.toHaveAttribute("aria-describedby");
+		expect(row).toHaveAttribute("data-state", "closed");
+	});
+
+	test("closes the label when the pointer leaves the row", async () => {
+		const user = userEvent.setup();
+		render(<RailRow defaultOpen={false} />);
+		const row = screen.getByRole("button", { name: "Endpoints" });
+
+		await user.hover(row);
+		expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+		await user.unhover(row);
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+	});
+
+	test("leaves an expanded row undescribed after the pointer sweeps across it", async () => {
+		// The label may not open while the panel is expanded, and "not open" has to
+		// mean Radix's own open state, not just a withheld surface: an open state
+		// with no mounted surface points aria-describedby at an id that is not in
+		// the document.
+		const user = userEvent.setup();
+		render(<RailRow defaultOpen />);
+		const row = screen.getByRole("button", { name: "Endpoints" });
+
+		await user.hover(row);
+
+		expect(row).not.toHaveAttribute("aria-describedby");
+		expect(row).toHaveAttribute("data-state", "closed");
+	});
+
+	test("stays closed when the rail collapses after the pointer swept an expanded row", async () => {
+		// Regression: the pointer crossing an expanded row on its way to the
+		// collapse trigger used to latch the label open — the panel withheld the
+		// surface, so nothing was mounted to close it again — and collapsing then
+		// popped a tooltip nobody was hovering.
+		const user = userEvent.setup();
+		render(<RailRow defaultOpen />);
+		const row = screen.getByRole("button", { name: "Endpoints" });
+
+		await user.hover(row);
+		await user.unhover(row);
+		await user.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+
+		expect(screen.getByTestId("nav")).toHaveAttribute("data-state", "collapsed");
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	test("stays closed when the rail collapses while the row holds focus", async () => {
+		// Focus opens a tooltip per the ARIA pattern, so a row focused while the
+		// panel was expanded must not have that pending state cashed in the moment
+		// the rail collapses under it.
+		const user = userEvent.setup();
+		render(<RailRow defaultOpen />);
+		const row = screen.getByRole("button", { name: "Endpoints" });
+		row.focus();
+
+		await user.keyboard(platformChord);
+
+		expect(screen.getByTestId("nav")).toHaveAttribute("data-state", "collapsed");
+		expect(row).toHaveFocus();
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	test("stays closed when a label shown in the rail survives an expand and a re-collapse", async () => {
+		// The pointer never leaves the row here: it is the rail toggling out from
+		// under it, twice. Neither flip may leave an open state behind to replay.
+		const user = userEvent.setup();
+		render(<RailRow defaultOpen={false} />);
+
 		await user.hover(screen.getByRole("button", { name: "Endpoints" }));
+		expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+		await user.keyboard(platformChord);
+		await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+
+		await user.keyboard(platformChord);
+
+		expect(screen.getByTestId("nav")).toHaveAttribute("data-state", "collapsed");
+		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+	});
+
+	test("stays closed when the rail collapses after a menu on the row hands focus back", async () => {
+		// The overlay path into the same bug. Closing a menu restores focus to its
+		// trigger, which here is also the tooltip trigger, so Radix asks for a label
+		// the expanded panel has no use for — a request that must not outlive the
+		// collapse either. The hover first is what makes it a *repeat* request, the
+		// shape a mirror of Radix's state can silently keep queued.
+		const user = userEvent.setup();
+		render(
+			<TooltipProvider>
+				<Sidebar.Root defaultOpen>
+					<Sidebar.Nav data-testid="nav">
+						<Sidebar.Footer>
+							<DropdownMenu.Root>
+								<Sidebar.Tooltip label="Help">
+									<DropdownMenu.Trigger asChild>
+										<Sidebar.ItemButton>Help</Sidebar.ItemButton>
+									</DropdownMenu.Trigger>
+								</Sidebar.Tooltip>
+								<DropdownMenu.Content>
+									<DropdownMenu.Item>Docs</DropdownMenu.Item>
+								</DropdownMenu.Content>
+							</DropdownMenu.Root>
+						</Sidebar.Footer>
+					</Sidebar.Nav>
+					<Sidebar.Trigger />
+				</Sidebar.Root>
+			</TooltipProvider>,
+		);
+		const row = screen.getByRole("button", { name: "Help" });
+
+		await user.hover(row);
+		await user.click(row);
+		await user.click(await screen.findByRole("menuitem", { name: "Docs" }));
+		await waitFor(() =>
+			expect(screen.queryByRole("menuitem", { name: "Docs" })).not.toBeInTheDocument(),
+		);
+		await user.keyboard(platformChord);
+
+		expect(screen.getByTestId("nav")).toHaveAttribute("data-state", "collapsed");
 		expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 	});
 
@@ -1076,15 +1207,19 @@ describe("Sidebar.Tooltip", () => {
 		expect(tooltip).toHaveAttribute("data-side", "top");
 	});
 
-	test("keeps the trigger mounted across a collapse so focus is not dropped", () => {
-		// Regression guard on gating the Content rather than the Root: unmounting
-		// Tooltip.Root would take the Trigger — and the focused row — with it.
-		const { rerender } = render(<RailRow defaultOpen />);
+	test("keeps the trigger mounted across a collapse so focus is not dropped", async () => {
+		// Regression guard on keeping Tooltip.Root mounted across the rail states:
+		// unmounting it would take the Trigger — and the focused row — with it. The
+		// rail collapses by keyboard so focus stays on the row under test.
+		const user = userEvent.setup();
+		render(<RailRow defaultOpen />);
 		const row = screen.getByRole("button", { name: "Endpoints" });
 		row.focus();
 		expect(row).toHaveFocus();
 
-		rerender(<RailRow defaultOpen={false} />);
+		await user.keyboard(platformChord);
+
+		expect(screen.getByTestId("nav")).toHaveAttribute("data-state", "collapsed");
 		expect(screen.getByRole("button", { name: "Endpoints" })).toBe(row);
 		expect(row).toHaveFocus();
 	});

--- a/packages/mantle/src/components/sidebar/sidebar.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.tsx
@@ -515,7 +515,7 @@ type SidebarNavProps = ComponentProps<"div"> & WithDataSlot;
  * | Data Attribute | Value | Description |
  * | --- | --- | --- |
  * | `data-state` | `"expanded"` \| `"collapsed"` | On the desktop panel surface. Mirrors the root's expanded state and drives the width collapse to the icon rail; descendant parts style off it with `group-data-[state=collapsed]/sidebar-nav:`. |
- * | `data-hydrated` | present after hydration | Presence-only, desktop panel surface. The CSS-side twin of the `isHydrated` gate: descendant collapse transitions are enabled only under `group-data-[hydrated]/sidebar-nav:`, so an SSR state correction snaps instead of animating on page load. |
+ * | `data-hydrated` | present after hydration | Presence-only, desktop panel surface. The CSS-side twin of the `isHydrated` gate: descendant collapse transitions are enabled only under `group-data-hydrated/sidebar-nav:`, so an SSR state correction snaps instead of animating on page load. |
  * | `data-mobile` | present in the mobile sheet | Presence-only. Marks the `Sheet.Content` presentation used below the root's `mobileBreakpoint`. |
  * | `data-state` | `"open"` \| `"closed"` | In the mobile sheet only, where the panel *is* the `Sheet`'s Radix dialog content element and Radix owns the attribute — the sheet's open/close animation state, not the desktop expanded state. Consumers style against it too. |
  *
@@ -588,7 +588,7 @@ const Nav = ({
 			<Sheet.Root open={openMobile} onOpenChange={setOpenMobile}>
 				<Sheet.Content
 					side="left"
-					preferredWidth="sm:max-w-[var(--sidebar-width-mobile,18rem)]"
+					preferredWidth="sm:max-w-(--sidebar-width-mobile,18rem)"
 					data-slot={joinDataSlot(dataSlot, "sidebar-nav")}
 					data-mobile=""
 					// A consumer aria-labelledby names the dialog too, keeping the
@@ -596,7 +596,7 @@ const Nav = ({
 					// an explicit undefined would override the Sheet's internal
 					// Title wiring and leave the dialog unnamed.
 					{...(ariaLabelledBy == null ? null : { "aria-labelledby": ariaLabelledBy })}
-					className={cx("bg-base w-[var(--sidebar-width-mobile,18rem)] max-w-full p-0", className)}
+					className={cx("bg-base w-(--sidebar-width-mobile,18rem) max-w-full p-0", className)}
 					{...props}
 				>
 					{/* The dialog's accessible name follows the nav's, so overriding
@@ -628,10 +628,10 @@ const Nav = ({
 			className={cx(
 				// bg lives on this surface (not the inner nav) so consumer
 				// className overrides like `bg-card` take effect on desktop too.
-				"group/sidebar-nav bg-base relative h-full w-[var(--sidebar-width,16rem)] shrink-0 overflow-hidden",
+				"group/sidebar-nav bg-base relative h-full w-(--sidebar-width,16rem) shrink-0 overflow-hidden",
 				// collapsing animates the width down to the skinny icon rail; the
 				// panel content stays interactive and in the accessibility tree.
-				"data-[state=collapsed]:w-[var(--sidebar-width-icon,3.25rem)]",
+				"data-[state=collapsed]:w-(--sidebar-width-icon,3.25rem)",
 				// Pre-hydration only: the server cannot know the viewport, so hide the
 				// desktop panel below the breakpoint in CSS to avoid a flash of the
 				// wrong presentation on a narrow screen. After hydration `isMobile`
@@ -918,7 +918,7 @@ const Header = ({
 				// The height token centers the switcher row on the same line as an
 				// AppLayout.Header toolbar, which derives its height from this same
 				// variable when a sidebar header is present (see AppLayout.Header).
-				"flex h-[var(--sidebar-header-height,4.5rem)] shrink-0 flex-col justify-center gap-2 px-3",
+				"flex h-(--sidebar-header-height,4.5rem) shrink-0 flex-col justify-center gap-2 px-3",
 				// When expanded, the adjacent AppLayout.Content contributes the
 				// trailing card gutter with its own margin, so trim the sidebar's
 				// own trailing inset to keep dividers and rows optically centered
@@ -1327,7 +1327,7 @@ const GroupLabel = ({
 				// motion-reduce must carry the same group gate: the gated
 				// transition rule's selector outranks a bare motion-reduce
 				// override (0,2,0 vs 0,1,0), so an ungated one would lose.
-				"group-data-[hydrated]/sidebar-nav:transition-opacity group-data-[hydrated]/sidebar-nav:duration-200 group-data-[hydrated]/sidebar-nav:ease-linear group-data-[hydrated]/sidebar-nav:motion-reduce:transition-none",
+				"group-data-hydrated/sidebar-nav:transition-opacity group-data-hydrated/sidebar-nav:duration-200 group-data-hydrated/sidebar-nav:ease-linear group-data-hydrated/sidebar-nav:motion-reduce:transition-none",
 				className,
 			)}
 			{...props}
@@ -1751,7 +1751,7 @@ const SwitcherTrigger = ({
 			data-slot={joinDataSlot(dataSlot, "sidebar-switcher-trigger")}
 			type={asChild ? type : (type ?? "button")}
 			className={cx(
-				"text-body hover:text-strong hover:bg-neutral-500/10 flex w-full min-w-0 items-center gap-2 [border-radius:0.625rem] py-1 pr-1.5 pl-1 text-left font-medium transition-none",
+				"text-body hover:text-strong hover:bg-neutral-500/10 flex w-full min-w-0 items-center gap-2 rounded-[0.625rem] py-1 pr-1.5 pl-1 text-left font-medium transition-none",
 				"data-state-open:bg-neutral-500/15 data-state-open:text-strong",
 				"ring-focus-accent focus:outline-hidden focus-visible:ring-4",
 				// The leading account/product tile uses rounded-md (6px) and
@@ -1760,7 +1760,7 @@ const SwitcherTrigger = ({
 				// source components by default; the tighter padding keeps the
 				// switcher row at the same net 36px height while preserving
 				// prototype spacing on the trailing action icon.
-				"[&>:first-child]:size-7",
+				"*:first:size-7",
 				// In the collapsed icon rail only the leading visual (product
 				// icon, account avatar) stays visible; the rest goes sr-only —
 				// visually gone but still part of the button's accessible name.
@@ -1821,12 +1821,20 @@ type SidebarTooltipProps = Omit<ComponentProps<typeof Tooltip.Content>, "childre
  * not removed), which serves screen-reader users but leaves a sighted pointer
  * user with an unlabeled icon column. This restores the label for them without
  * duplicating it for anyone else: expanded rows already read their own text, and
- * the mobile sheet shows full labels, so the tooltip content only mounts in the
- * collapsed desktop rail.
+ * the mobile sheet shows full labels, so the collapsed desktop rail is the only
+ * state that shows a label at all.
+ *
+ * It opens the way any tooltip does — the pointer entering the row, or focus
+ * reaching it — and the rail state vetoes it: the expanded panel and the mobile
+ * sheet keep the row at `data-state="closed"` with no `aria-describedby`, and
+ * toggling the rail dismisses whatever was showing, so collapsing the panel
+ * cannot pop a label under a pointer that has already moved on.
  *
  * **Requires a `TooltipProvider` ancestor**, like any `Tooltip.Root` — mount one
- * at your app root. This part deliberately does not provide its own, so tooltip
- * delay and hover settings stay app-wide rather than being overridden per row.
+ * at your app root. This part deliberately does not provide its own, so the
+ * app-wide tooltip delay stays app-wide rather than being overridden per row.
+ * The one provider setting it does override is hoverable content: a rail label
+ * holds nothing to hover into, so the pointer leaving the row closes it.
  *
  * It composes with a menu trigger: nest `DropdownMenu.Root >
  * Sidebar.Tooltip > DropdownMenu.Trigger asChild > Sidebar.ItemButton` for a
@@ -1892,28 +1900,66 @@ const SidebarTooltip = ({
 }: SidebarTooltipProps) => {
 	const { isMobile, open } = useSidebarContext("Tooltip");
 	const isCollapsedRail = !isMobile && !open;
+	const [labelOpen, setLabelOpen] = useState(false);
+	const [previousCollapsedRail, setPreviousCollapsedRail] = useState(isCollapsedRail);
+
+	// A rail flip drops the label. Radix opens on the pointer entering the trigger
+	// and on focus reaching it, both of which can happen in a rail state that has
+	// no business showing a label; without this, the next flip cashes that pending
+	// state in and a tooltip appears under a pointer that is somewhere else
+	// entirely. Reset during render (React's sanctioned "adjust state when a prop
+	// changes" pattern) so Radix never sees the stale value.
+	if (previousCollapsedRail !== isCollapsedRail) {
+		setPreviousCollapsedRail(isCollapsedRail);
+		setLabelOpen(false);
+	}
+
+	/**
+	 * Mirrors Radix's open state, clamped so it can only ever hold `true` in the
+	 * one rail state that shows a label.
+	 *
+	 * The clamp is load-bearing, not belt-and-braces. Radix reports every open it
+	 * wants, including ones the veto below discards, so an unclamped mirror holds
+	 * `true` through the whole expanded panel — and a repeat `open` (a menu on the
+	 * row closing and restoring focus to it, say) then sets the mirror to a value
+	 * it already has. React keeps that no-op update queued, and replays it after
+	 * the rail-flip reset commits, which lands `true` in the collapsed rail with
+	 * nothing hovering the row: the original bug, one path over.
+	 */
+	const setLabelOpenWhenRailShowsLabels = (nextOpen: boolean) => {
+		setLabelOpen(nextOpen && isCollapsedRail);
+	};
 
 	return (
-		<Tooltip.Root>
+		/*
+		 * The rail state vetoes the open state rather than withholding the Content:
+		 * Radix's own pointer close path lives inside `Tooltip.Content`, so a Root
+		 * left to its own devices while the Content is unmounted latches open with
+		 * nothing to close it — and meanwhile points the row's `aria-describedby` at
+		 * an id that is not in the document. Owning `open` keeps the expanded panel
+		 * and the mobile sheet at `data-state="closed"`, which is the truth.
+		 *
+		 * The Root itself stays mounted at every rail state: unmounting it would
+		 * unmount the Trigger with it, dropping focus off the row the user was on.
+		 *
+		 * `disableHoverableContent` moves the close path onto the Trigger, which is
+		 * always mounted. A rail label has nothing to hover into — per the WAI-ARIA
+		 * tooltip pattern it holds no interactive content — so trading the grace
+		 * area for a close that cannot depend on what is mounted is free.
+		 *
+		 * `className` is not destructured on purpose: it rides `props` into
+		 * `Tooltip.Content`, which already merges it last with `cx`, and this row
+		 * adds no classes of its own to compose ahead of it.
+		 */
+		<Tooltip.Root
+			disableHoverableContent
+			onOpenChange={setLabelOpenWhenRailShowsLabels}
+			open={isCollapsedRail && labelOpen}
+		>
 			<Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
-			{/*
-			 * Gate the Content, never the Root: unmounting the Root would unmount the
-			 * Trigger with it, so toggling the rail would drop focus off the row the
-			 * user was just on.
-			 *
-			 * `className` is not destructured on purpose: it rides `props` into
-			 * `Tooltip.Content`, which already merges it last with `cx`, and this row
-			 * adds no classes of its own to compose ahead of it.
-			 */}
-			{isCollapsedRail && (
-				<Tooltip.Content
-					data-slot={joinDataSlot(dataSlot, "sidebar-tooltip")}
-					side={side}
-					{...props}
-				>
-					{label}
-				</Tooltip.Content>
-			)}
+			<Tooltip.Content data-slot={joinDataSlot(dataSlot, "sidebar-tooltip")} side={side} {...props}>
+				{label}
+			</Tooltip.Content>
 		</Tooltip.Root>
 	);
 };
@@ -2526,7 +2572,7 @@ const Sidebar = {
 	 * | Data Attribute | Value | Description |
 	 * | --- | --- | --- |
 	 * | `data-state` | `"expanded"` \| `"collapsed"` | On the desktop panel surface. Mirrors the root's expanded state and drives the width collapse to the icon rail; descendant parts style off it with `group-data-[state=collapsed]/sidebar-nav:`. |
-	 * | `data-hydrated` | present after hydration | Presence-only, desktop panel surface. The CSS-side twin of the `isHydrated` gate: descendant collapse transitions are enabled only under `group-data-[hydrated]/sidebar-nav:`, so an SSR state correction snaps instead of animating on page load. |
+	 * | `data-hydrated` | present after hydration | Presence-only, desktop panel surface. The CSS-side twin of the `isHydrated` gate: descendant collapse transitions are enabled only under `group-data-hydrated/sidebar-nav:`, so an SSR state correction snaps instead of animating on page load. |
 	 * | `data-mobile` | present in the mobile sheet | Presence-only. Marks the `Sheet.Content` presentation used below the root's `mobileBreakpoint`. |
 	 * | `data-state` | `"open"` \| `"closed"` | In the mobile sheet only, where the panel *is* the `Sheet`'s Radix dialog content element and Radix owns the attribute — the sheet's open/close animation state, not the desktop expanded state. Consumers style against it too. |
 	 *


### PR DESCRIPTION
Collapsing the sidebar in the app-shell / app-layout examples made rail tooltips appear on their own, with no
pointer anywhere near the row.

## What was wrong

`Sidebar.Tooltip` rendered `Tooltip.Root` + `Tooltip.Trigger` at every rail state but gated `Tooltip.Content`
behind `isCollapsedRail`. Radix's pointer **close** path lives *inside* the content —
[`TooltipContentHoverable`](https://github.com/radix-ui/primitives/blob/main/packages/react/tooltip/src/tooltip.tsx)
is what tracks the pointer leaving the trigger, while the Root's `onTriggerLeave` only clears the open timer
unless `disableHoverableContent` is set. With the content withheld, an open state had **no close path at all**.

So dwelling on a row while the panel was expanded flipped Radix's open state to `true` invisibly (mantle's
`TooltipProvider` uses `delayDuration: 0`, so a frame of dwell is enough), and collapsing the panel mounted
every latched label at once.

Measured in Chromium against `main`: **13 of 13** rows in `/preview/app-shell` can be showing at once, with the
pointer 750px away, and they never close on their own. Two more symptoms shared the cause:

- a latched row advertised `aria-describedby="radix-…"` pointing at an id **not in the document**, and sat at
  `data-state="instant-open"` while expanded;
- a row wrapped in a menu trigger latched with **no hover at all** — closing the menu restores focus to the
  row and Radix opens a tooltip on focus. That is the account switcher in the shell demos, and it is what the
  screenshot above is.

## The fix

The rail state is now a **veto on a controlled open state** instead of a gate on the content, and every rail
flip resets it during render, so nothing can be replayed across a collapse.

Two details are load-bearing:

- **The setter is clamped to the rail state.** An unclamped mirror holds `true` through the whole expanded
  panel, and a *repeat* open request (the menu-hands-focus-back path) then sets it to the value it already
  has — React keeps that no-op update queued and replays it after the reset commits, landing `true` in the
  collapsed rail. Clamping means the only value that can be replayed is `false`, which can only close.
- **`disableHoverableContent`** moves the close onto the trigger, which is mounted at every rail state. A rail
  label holds nothing to hover into (per the WAI-ARIA tooltip pattern it holds nothing interactive), so the
  grace area buys nothing — and this is what makes the close deterministic instead of dependent on what is
  mounted.

`Tooltip.Root` still stays mounted at every rail state, so a collapse never drops focus off the row the user
was on — that constraint is why the veto replaced the gate rather than unmounting the Root.

## Tests

Six new regression tests in `sidebar.test.tsx`, each verified to fail before the fix and pass after: the
pointer sweep, the dangling `aria-describedby`, focus held across a collapse, a label shown in the rail
surviving an expand and a re-collapse, the menu-hands-focus-back path, and close-on-leave. happy-dom is enough
now precisely *because* of `disableHoverableContent` — the old close path needed real `getBoundingClientRect`
geometry for its grace-area hull.

The existing `keeps the trigger mounted across a collapse so focus is not dropped` guard also now collapses
for real: it re-rendered `defaultOpen`, which only seeds the uncontrolled state, so the panel never collapsed
and the assertions were vacuous.

## Also in this PR

A separate commit modernizes the `Sidebar` / `AppLayout` class strings to Tailwind v4 syntax
(`m-[var(--x,y)]` → `m-(--x,y)`, `group-has-[[data-slot~=…]]` → `group-has-data-[slot~=…]`, and friends).
Each pair was compiled through Tailwind 4.3.3 and the emitted rules diffed — the CSS is unchanged, only the
class strings on the elements are. Its own `patch` changeset flags that, since a consumer could be matching
them literally.

## Known, not fixed here

- **Focus still opens a rail label**, including focus restored by a closing menu *while collapsed*. That is
  the ARIA tooltip contract, so it stays.
- **A pointer resting on a row when the rail collapses** gets no label until it leaves and returns
  (`hasPointerMoveOpenedRef` only resets on `pointerleave`). Pre-fix that case showed a label via the latch.
- **A row that is both a tooltip trigger and a `DropdownMenu.Trigger` never gets `data-state="open"`** — the
  menu sets it and then the wrapping tooltip trigger's value wins, so the documented "row stays highlighted
  while its menu is open" is false for every tooltip-wrapped row. Pre-existing and unrelated to the latch;
  worth its own issue.

## Verification

`pnpm -w run lint` · `fmt:check` · `typecheck` · `test` (1821 mantle + 169 www, all passing) ·
`build -F @ngrok/mantle --force`

