### PR TITLE
feat(avatar): add Avatar, no dependency, and remove the sidebar-scoped avatars

### DIFF
--- a/.changeset/add-avatar.md
+++ b/.changeset/add-avatar.md
@@ -32,7 +32,9 @@ import { Avatar } from "@ngrok/mantle/avatar";
 - **`Avatar.Image`** renders only once the image has actually loaded, so a slow or dead URL degrades to the
   fallback instead of flashing a broken-image icon. That is knowable only in a browser, so server-rendered
   markup always carries the fallback; the docs page shows the plain-`<img>` escape hatch for an above-the-fold
-  avatar whose URL is known good.
+  avatar whose URL is known good. Its **`alt` is required** — stricter than both the `<img>` element and Radix,
+  because an avatar is the one image everyone forgets and an `<img>` with no `alt` announces its URL. Pass
+  `alt=""` when adjacent text already names the subject, which is the common case.
 - **`Avatar.Fallback`** takes either `children` (an icon, a monogram) or `name`, which renders at most two
   uppercase initials — punctuation stripped, code points kept whole so an emoji-leading name survives, casing
   locale-invariant so SSR and the client agree. The two are mutually exclusive in the type. Derived initials

--- a/.changeset/add-avatar.md
+++ b/.changeset/add-avatar.md
@@ -29,20 +29,22 @@ import { Avatar } from "@ngrok/mantle/avatar";
   `text-static-white`, so a subject keeps its color across renders, sessions, devices and the server with
   nothing stored. Seed it with an **id, not a display name** — a rename would otherwise recolor the avatar.
   Omit it for a neutral surface.
-- **`Avatar.Image`** renders only once the image has actually loaded, so a slow or dead URL degrades to the
-  fallback instead of flashing a broken-image icon. That is knowable only in a browser, so server-rendered
-  markup always carries the fallback; the docs page shows the plain-`<img>` escape hatch for an above-the-fold
-  avatar whose URL is known good. Its **`alt` is required** — stricter than both the `<img>` element and Radix,
-  because an avatar is the one image everyone forgets and an `<img>` with no `alt` announces its URL. Pass
-  `alt=""` when adjacent text already names the subject, which is the common case.
+- **`Avatar.Image`** is a plain `<img>` layered over the fallback — no wrapper library, no loading state. The
+  server renders it, the browser fetches while it parses HTML, and a cached image is on screen in the first
+  frame; a loading one shows initials through it, and a failed one unmounts itself and reveals them again.
+  `onError` runs first and can `preventDefault()` to keep the image mounted, and changing `src` is always a
+  fresh attempt. Its **`alt` is required** — stricter than the `<img>` element, because an avatar is the one
+  image everyone forgets and an `<img>` with no `alt` announces its URL. Pass `alt=""` when adjacent text
+  already names the subject, which is the common case.
 - **`Avatar.Fallback`** takes either `children` (an icon, a monogram) or `name`, which renders at most two
   uppercase initials — punctuation stripped, code points kept whole so an emoji-leading name survives, casing
   locale-invariant so SSR and the client agree. The two are mutually exclusive in the type. Derived initials
   are `aria-hidden`, because they abbreviate a name the page already carries beside the avatar; announcing them
   would read it twice ("A C Acme Corp"). Name the root (`role="img"` + `aria-label`) when the avatar is the only
   thing identifying its subject.
-- Every part takes `asChild`, forwarded to Radix's own composition, and stamps `data-slot` (`avatar`,
-  `avatar-image`, `avatar-fallback`), joining an ancestor-forwarded chain rather than replacing it.
+- Every part takes `asChild` and stamps `data-slot` (`avatar`, `avatar-image`, `avatar-fallback`), joining an
+  ancestor-forwarded chain rather than replacing it. `Avatar.Root` renders a `<span>`, so it stays valid inside
+  the `<button>` of a switcher row.
 
 **`Sidebar.AccountAvatar` and `Sidebar.UserAvatar` are removed.** They were the same component twice, scoped to
 a place an avatar has no reason to be scoped to — the sidebar — which is why the ngrok dashboard had already

--- a/.changeset/add-avatar.md
+++ b/.changeset/add-avatar.md
@@ -1,0 +1,80 @@
+---
+"@ngrok/mantle": minor
+---
+
+Add **`Avatar`** — a small image representing a person or an account, with a text or icon fallback for when
+there is no picture, or before one loads. Import from `@ngrok/mantle/avatar`.
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+
+// an account: a rounded square whose color is derived from its id
+<Avatar.Root appearance="square" colorSeed={account.id}>
+	<Avatar.Fallback name={account.name} />
+</Avatar.Root>
+
+// a person: a circle, with the fallback covering the load and any failure
+<Avatar.Root>
+	<Avatar.Image src={user.avatarUrl} alt="Jane Doe" />
+	<Avatar.Fallback name="Jane Doe" />
+</Avatar.Root>
+```
+
+- **`Avatar.Root`** owns the shape, size and surface. `appearance="circle"` (default) is a person;
+  `appearance="square"` is a rounded square for the things people belong to — an account, workspace, or team.
+  Keeping the two shapes distinct is what lets a row showing both stay legible without labels. It is `size-7`
+  and `shrink-0`, so the flex rows an avatar usually sits in cannot squeeze it; `className` merges last, so
+  `className="size-10"` wins.
+- **`colorSeed`** hashes a stable id into one of 17 swatches and switches the foreground to
+  `text-static-white`, so a subject keeps its color across renders, sessions, devices and the server with
+  nothing stored. Seed it with an **id, not a display name** — a rename would otherwise recolor the avatar.
+  Omit it for a neutral surface.
+- **`Avatar.Image`** renders only once the image has actually loaded, so a slow or dead URL degrades to the
+  fallback instead of flashing a broken-image icon. That is knowable only in a browser, so server-rendered
+  markup always carries the fallback; the docs page shows the plain-`<img>` escape hatch for an above-the-fold
+  avatar whose URL is known good.
+- **`Avatar.Fallback`** takes either `children` (an icon, a monogram) or `name`, which renders at most two
+  uppercase initials — punctuation stripped, code points kept whole so an emoji-leading name survives, casing
+  locale-invariant so SSR and the client agree. The two are mutually exclusive in the type. Derived initials
+  are `aria-hidden`, because they abbreviate a name the page already carries beside the avatar; announcing them
+  would read it twice ("A C Acme Corp"). Name the root (`role="img"` + `aria-label`) when the avatar is the only
+  thing identifying its subject.
+- Every part takes `asChild`, forwarded to Radix's own composition, and stamps `data-slot` (`avatar`,
+  `avatar-image`, `avatar-fallback`), joining an ancestor-forwarded chain rather than replacing it.
+
+**`Sidebar.AccountAvatar` and `Sidebar.UserAvatar` are removed.** They were the same component twice, scoped to
+a place an avatar has no reason to be scoped to — the sidebar — which is why the ngrok dashboard had already
+hand-rolled its own copy of the initials and swatch logic beside them. Migration:
+
+```tsx
+// before
+<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+// after
+<Avatar.Root appearance="square" colorSeed={account.id}>
+	<Avatar.Fallback name={account.name} />
+</Avatar.Root>
+
+// before
+<Sidebar.UserAvatar alt="Jane Doe" />
+// after
+<Avatar.Root aria-label="Jane Doe" className="text-muted" role="img">
+	<Avatar.Fallback>
+		<UserIcon className="size-4" />
+	</Avatar.Fallback>
+</Avatar.Root>
+
+// before — with a photo
+<Sidebar.UserAvatar src={user.avatarUrl} alt="Jane Doe" />
+// after
+<Avatar.Root>
+	<Avatar.Image src={user.avatarUrl} alt="Jane Doe" />
+	<Avatar.Fallback name="Jane Doe" />
+</Avatar.Root>
+```
+
+The swatch palette and its hash are unchanged, so accounts keep the colors they already have. Two behavior
+notes: the person silhouette is gone in favor of any icon you compose (the docs use Phosphor's `UserIcon`), and
+`data-slot="sidebar-account-avatar"` / `"sidebar-user-avatar"` become `"avatar"` — update any selector or test
+matching them.
+
+Docs: https://mantle.ngrok.com/components/data-display/avatar

--- a/.changeset/vite-plugins-know-avatar.md
+++ b/.changeset/vite-plugins-know-avatar.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle-vite-plugins": patch
+---
+
+Teach `mantleTwSourcePlugin` about the new `avatar` subpath, so a consumer importing `@ngrok/mantle/avatar`
+gets its classes scanned by Tailwind instead of an unstyled avatar. Generated from `@ngrok/mantle`'s export
+map — no behavior change for any other component.

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -53,6 +53,7 @@ export const componentsByCategory = {
 	Charts: ["Area Chart", "Bar Chart", "Line Chart", "Scatter Plot"],
 	"Data Display": [
 		"Accordion",
+		"Avatar",
 		"Badge",
 		"Code",
 		"Code Block",
@@ -139,6 +140,7 @@ export const prodReadyComponentRouteLookup = {
 	"Alert Dialog": "/components/overlays/alert-dialog",
 	Anchor: "/components/navigation/anchor",
 	"Area Chart": "/components/charts/area-chart",
+	Avatar: "/components/data-display/avatar",
 	Badge: "/components/data-display/badge",
 	"Bar Chart": "/components/charts/bar-chart",
 	Breadcrumb: "/components/navigation/breadcrumb",

--- a/apps/www/app/docs/components/data-display/avatar.mdx
+++ b/apps/www/app/docs/components/data-display/avatar.mdx
@@ -104,14 +104,6 @@ export function AvatarMediaObjectExample() {
 	);
 }
 
-export function AvatarServerRenderedExample() {
-	return (
-		<Avatar.Root>
-			<img alt="Jane Doe" className="size-full object-cover" src="/example-avatar.svg" />
-		</Avatar.Root>
-	);
-}
-
 export function AvatarLinkExample() {
 	return (
 		<Avatar.Root asChild appearance="square" colorSeed="acc_acme">
@@ -173,14 +165,16 @@ Avatar.Root
 └── Avatar.Fallback
 ```
 
-`Avatar.Image` and `Avatar.Fallback` are siblings, not alternatives you branch on: Radix shows exactly one of
-them, swapping to the image only once it has actually loaded. Render both and there is no loading state to
-handle.
+`Avatar.Image` and `Avatar.Fallback` are siblings, not alternatives you branch on. The fallback renders in flow;
+the image is positioned over it. A loading image shows initials through it, a loaded one covers them, and a
+failed one unmounts itself and reveals them again — no loading state for anyone to handle, and nothing waiting
+on hydration, because the `<img>` is in the server-rendered markup. (A _transparent_ image is the one case where
+initials show through a loaded picture; give it its own backdrop if that matters.)
 
 ## Polymorphism
 
-`Avatar.Root`, `Avatar.Image`, and `Avatar.Fallback` each accept `asChild`, forwarded to Radix's own
-composition. Reach for it on `Root` when the avatar is itself a link or a button, and on `Fallback` when the
+`Avatar.Root`, `Avatar.Image`, and `Avatar.Fallback` each accept `asChild`. Reach for it on `Image` to swap in a
+framework image component, on `Root` when the avatar is itself a link or a button, and on `Fallback` when the
 initials want a more specific element — an `<abbr title="…">`, say.
 
 <Example className="p-4 md:p-8">
@@ -349,37 +343,12 @@ export function MemberRow() {
 }
 ```
 
-## The first paint is the fallback
-
-`Avatar.Image` renders **only once the image has loaded**, which is knowable only in a browser — so
-server-rendered markup always carries the fallback, including for an image already in cache. That is the trade
-for never flashing a broken-image icon at anyone: a slow or dead URL degrades to initials instead.
-
-When an avatar is above the fold and its URL is known good, skip `Avatar.Image` and put a plain `<img>` inside
-`Avatar.Root` instead. The server markup then carries the image, and you own the error case:
-
-<Example className="p-4 md:p-8">
-	<AvatarServerRenderedExample />
-</Example>
-
-```tsx
-import { Avatar } from "@ngrok/mantle/avatar";
-
-export function ServerRenderedAvatar() {
-	return (
-		<Avatar.Root>
-			<img alt="Jane Doe" className="size-full object-cover" src="/example-avatar.svg" />
-		</Avatar.Root>
-	);
-}
-```
-
 ## API Reference
 
 ### Avatar.Root
 
-The sizing, shape, and surface. Renders a `<span>`. Accepts all Radix `Avatar.Root` props (`asChild`,
-`className`, `style`, `ref`, `data-*`, `aria-*`, `role`), plus:
+The sizing, shape, and surface. Renders a `<span>`, so it stays valid inside a switcher row's `<button>`.
+Accepts all `<span>` props (`asChild`, `className`, `style`, `ref`, `data-*`, `aria-*`, `role`), plus:
 
 | Prop          | Type                     | Default    | Description                                                                                                                                                                 |
 | ------------- | ------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -395,14 +364,16 @@ The sizing, shape, and surface. Renders a `<span>`. Accepts all Radix `Avatar.Ro
 
 ### Avatar.Image
 
-The picture. Renders an `<img>`, and only once the image has loaded — never during SSR. Accepts all Radix
-`Avatar.Image` props, which are an `<img>`'s (`src`, `referrerPolicy`, `crossOrigin`, `asChild`,
-`onLoadingStatusChange`), plus:
+The picture, layered over the fallback. A plain `<img>`, so the server renders it and a cached image needs no
+hydration to appear. A failed load unmounts it, revealing the fallback. Accepts all `<img>` props (`srcSet`,
+`sizes`, `loading`, `referrerPolicy`, `crossOrigin`, `asChild`, …), plus:
 
-| Prop         | Type     | Default | Description                                                                                                                                                                                                                        |
-| ------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `alt`        | `string` | —       | **Required**, unlike the `<img>` element and unlike Radix — an image with no `alt` announces its URL. Pass `""` when adjacent text already names the subject. It cannot name the avatar in the states where no `<img>` is mounted. |
-| `data-slot?` | `string` | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-image`.                                                                                                                                           |
+| Prop         | Type                              | Default | Description                                                                                                                                                                                                              |
+| ------------ | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `alt`        | `string`                          | —       | **Required**, stricter than the `<img>` element — an image with no `alt` announces its URL. Pass `""` when adjacent text already names the subject. It cannot name the avatar in the states where no `<img>` is mounted. |
+| `src?`       | `string`                          | —       | The picture's URL. Nullish or empty renders nothing and the fallback stands alone, so an optional URL passes straight through without branching.                                                                         |
+| `onError?`   | `(event: SyntheticEvent) => void` | —       | Runs **before** the image unmounts itself; `preventDefault()` keeps it mounted, for a consumer who would rather retry than fall back. Changing `src` is always a fresh attempt.                                          |
+| `data-slot?` | `string`                          | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-image`.                                                                                                                                 |
 
 **Data attributes**
 
@@ -413,14 +384,13 @@ The picture. Renders an `<img>`, and only once the image has loaded — never du
 ### Avatar.Fallback
 
 What shows when there is no image — while one loads, when it fails, or when there was never one. Renders a
-`<span>`. Accepts all Radix `Avatar.Fallback` props (`delayMs`, `asChild`, `className`, `ref`), plus exactly
-one source of content:
+`<span>` that is always present, behind `Avatar.Image`. Accepts all `<span>` props (`asChild`, `className`,
+`ref`, `aria-*`), plus exactly one source of content:
 
 | Prop         | Type        | Default | Description                                                                                                                                                                                           |
 | ------------ | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `children`   | `ReactNode` | —       | What to show: an icon, a monogram, initials you derived yourself. Announced normally. Mutually exclusive with `name` — the type forbids passing both.                                                 |
 | `name`       | `string`    | —       | A display name, rendered as at most two uppercase initials (`"Acme Corp"` → `"AC"`, an unusable name → `"?"`). `aria-hidden`, since it abbreviates text already beside the avatar. Not for `asChild`. |
-| `delayMs?`   | `number`    | —       | Wait this long before showing the fallback, so a fast image never flashes initials first.                                                                                                             |
 | `data-slot?` | `string`    | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-fallback`.                                                                                                           |
 
 **Data attributes**

--- a/apps/www/app/docs/components/data-display/avatar.mdx
+++ b/apps/www/app/docs/components/data-display/avatar.mdx
@@ -23,10 +23,7 @@ export function AvatarExample() {
 				<Avatar.Fallback name="Acme Corp" />
 			</Avatar.Root>
 			<Avatar.Root>
-				<Avatar.Image
-					alt="Jane Doe"
-					src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=64&h=64&fit=crop"
-				/>
+				<Avatar.Image alt="Jane Doe" src="/example-avatar.svg" />
 				<Avatar.Fallback name="Jane Doe" />
 			</Avatar.Root>
 			<Avatar.Root aria-label="Your account" className="text-muted" role="img">
@@ -145,10 +142,7 @@ export function AccountAndUserAvatars() {
 
 			{/* a person with a photo: the fallback covers the load and any failure */}
 			<Avatar.Root>
-				<Avatar.Image
-					alt="Jane Doe"
-					src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=64&h=64&fit=crop"
-				/>
+				<Avatar.Image alt="Jane Doe" src="/example-avatar.svg" />
 				<Avatar.Fallback name="Jane Doe" />
 			</Avatar.Root>
 

--- a/apps/www/app/docs/components/data-display/avatar.mdx
+++ b/apps/www/app/docs/components/data-display/avatar.mdx
@@ -1,0 +1,421 @@
+---
+title: Avatar
+description: A small image representing a person or an account, with a text or icon fallback.
+---
+
+import { Avatar } from "@ngrok/mantle/avatar";
+import { MediaObject } from "@ngrok/mantle/media-object";
+import { UserIcon } from "@phosphor-icons/react/User";
+import { Example } from "~/components/example";
+
+export const accounts = [
+	{ id: "acc_acme", name: "Acme Corp" },
+	{ id: "acc_atlas", name: "Atlas Industries" },
+	{ id: "acc_globex", name: "Globex" },
+	{ id: "acc_initech", name: "Initech" },
+	{ id: "acc_umbrella", name: "Umbrella Group" },
+];
+
+export function AvatarExample() {
+	return (
+		<div className="flex items-center gap-4">
+			<Avatar.Root appearance="square" colorSeed="acc_acme">
+				<Avatar.Fallback name="Acme Corp" />
+			</Avatar.Root>
+			<Avatar.Root>
+				<Avatar.Image
+					alt="Jane Doe"
+					src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=64&h=64&fit=crop"
+				/>
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root aria-label="Your account" className="text-muted" role="img">
+				<Avatar.Fallback>
+					<UserIcon className="size-4" />
+				</Avatar.Fallback>
+			</Avatar.Root>
+		</div>
+	);
+}
+
+export function AvatarAppearanceExample() {
+	return (
+		<div className="flex items-center gap-6">
+			<div className="flex items-center gap-2">
+				<Avatar.Root appearance="circle" colorSeed="usr_jane">
+					<Avatar.Fallback name="Jane Doe" />
+				</Avatar.Root>
+				<span className="text-sm">Jane Doe</span>
+			</div>
+			<div className="flex items-center gap-2">
+				<Avatar.Root appearance="square" colorSeed="acc_acme">
+					<Avatar.Fallback name="Acme Corp" />
+				</Avatar.Root>
+				<span className="text-sm">Acme Corp</span>
+			</div>
+		</div>
+	);
+}
+
+export function AvatarSeedExample() {
+	return (
+		<div className="flex flex-wrap items-center gap-4">
+			{accounts.map((account) => (
+				<div key={account.id} className="flex items-center gap-2">
+					<Avatar.Root appearance="square" colorSeed={account.id}>
+						<Avatar.Fallback name={account.name} />
+					</Avatar.Root>
+					<span className="text-sm">{account.name}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+export function AvatarSizeExample() {
+	return (
+		<div className="flex items-end gap-4">
+			<Avatar.Root className="size-5 text-[0.625rem]" colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root className="size-10 text-sm" colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root className="size-16 text-lg" colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+		</div>
+	);
+}
+
+export function AvatarMediaObjectExample() {
+	return (
+		<MediaObject.Root className="max-w-sm">
+			<MediaObject.Media>
+				<Avatar.Root className="size-9" colorSeed="usr_jane">
+					<Avatar.Fallback name="Jane Doe" />
+				</Avatar.Root>
+			</MediaObject.Media>
+			<MediaObject.Content>
+				<p className="text-strong text-sm font-medium">Jane Doe</p>
+				<p className="text-muted text-sm">jane@acme.com</p>
+			</MediaObject.Content>
+		</MediaObject.Root>
+	);
+}
+
+export function AvatarLinkExample() {
+	return (
+		<Avatar.Root asChild appearance="square" colorSeed="acc_acme">
+			<a href="/components/data-display/avatar" title="Acme Corp">
+				<Avatar.Fallback name="Acme Corp" />
+			</a>
+		</Avatar.Root>
+	);
+}
+
+# Avatar
+
+A small image representing a person or an account, with a text or icon fallback for when there is no picture —
+or before one loads.
+
+The shape carries the meaning. `appearance="circle"` is a person; `appearance="square"` — a rounded square —
+is one of the things people belong to: an account, workspace, team, or organization. A row that shows both, an
+account switcher with the signed-in user's photo beside it, stays readable without labels because the two never
+look alike.
+
+<Example className="p-4 md:p-8">
+	<AvatarExample />
+</Example>
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+import { UserIcon } from "@phosphor-icons/react/User";
+
+export function AccountAndUserAvatars() {
+	return (
+		<div className="flex items-center gap-4">
+			{/* an account: rounded square, color derived from its id */}
+			<Avatar.Root appearance="square" colorSeed="acc_acme">
+				<Avatar.Fallback name="Acme Corp" />
+			</Avatar.Root>
+
+			{/* a person with a photo: the fallback covers the load and any failure */}
+			<Avatar.Root>
+				<Avatar.Image
+					alt="Jane Doe"
+					src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=64&h=64&fit=crop"
+				/>
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+
+			{/* a person with no photo and no name to abbreviate: the avatar names itself */}
+			<Avatar.Root aria-label="Your account" className="text-muted" role="img">
+				<Avatar.Fallback>
+					<UserIcon className="size-4" />
+				</Avatar.Fallback>
+			</Avatar.Root>
+		</div>
+	);
+}
+```
+
+## Composition
+
+```text showLineNumbers=false
+Avatar.Root
+├── Avatar.Image
+└── Avatar.Fallback
+```
+
+`Avatar.Image` and `Avatar.Fallback` are siblings, not alternatives you branch on: Radix shows exactly one of
+them, swapping to the image only once it has actually loaded. Render both and there is no loading state to
+handle.
+
+## Polymorphism
+
+`Avatar.Root`, `Avatar.Image`, and `Avatar.Fallback` each accept `asChild`, forwarded to Radix's own
+composition. Reach for it on `Root` when the avatar is itself a link or a button, and on `Fallback` when the
+initials want a more specific element — an `<abbr title="…">`, say.
+
+<Example className="p-4 md:p-8">
+	<AvatarLinkExample />
+</Example>
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+
+export function LinkedAvatar() {
+	return (
+		<Avatar.Root asChild appearance="square" colorSeed="acc_acme">
+			<a href="/accounts/acme" title="Acme Corp">
+				<Avatar.Fallback name="Acme Corp" />
+			</a>
+		</Avatar.Root>
+	);
+}
+```
+
+## Appearance
+
+Circles are people, rounded squares are accounts. Nothing enforces it — but keeping the two distinct is what
+lets a dense row of both stay legible, so pick per subject rather than per screen.
+
+<Example className="p-4 md:p-8">
+	<AvatarAppearanceExample />
+</Example>
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+
+export function Appearances() {
+	return (
+		<div className="flex items-center gap-6">
+			<div className="flex items-center gap-2">
+				<Avatar.Root appearance="circle" colorSeed="usr_jane">
+					<Avatar.Fallback name="Jane Doe" />
+				</Avatar.Root>
+				<span className="text-sm">Jane Doe</span>
+			</div>
+			<div className="flex items-center gap-2">
+				<Avatar.Root appearance="square" colorSeed="acc_acme">
+					<Avatar.Fallback name="Acme Corp" />
+				</Avatar.Root>
+				<span className="text-sm">Acme Corp</span>
+			</div>
+		</div>
+	);
+}
+```
+
+## Deterministic color
+
+`colorSeed` hashes a stable identifier into one of a fixed set of swatches, so an account is the same color on
+every device and every session with nothing stored and nothing fetched. Seed it with an **id, not a display
+name** — names get edited, and a rename would silently recolor the avatar.
+
+Omit `colorSeed` for a neutral surface, or set your own `bg-*` through `className` to opt out entirely.
+
+<Example className="p-4 md:p-8">
+	<AvatarSeedExample />
+</Example>
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+
+const accounts = [
+	{ id: "acc_acme", name: "Acme Corp" },
+	{ id: "acc_atlas", name: "Atlas Industries" },
+	{ id: "acc_globex", name: "Globex" },
+	{ id: "acc_initech", name: "Initech" },
+	{ id: "acc_umbrella", name: "Umbrella Group" },
+];
+
+export function SeededAvatars() {
+	return (
+		<div className="flex flex-wrap items-center gap-4">
+			{accounts.map((account) => (
+				<div key={account.id} className="flex items-center gap-2">
+					<Avatar.Root appearance="square" colorSeed={account.id}>
+						<Avatar.Fallback name={account.name} />
+					</Avatar.Root>
+					<span className="text-sm">{account.name}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+```
+
+## Sizing
+
+An avatar is `size-7` and `shrink-0`: a fixed-size visual that the flex rows it usually sits in — a switcher
+row, a table cell, a comment header — must not be able to squeeze. Override the size with `className`, which
+merges last and wins, and scale the text with it so initials stay proportional.
+
+<Example className="p-4 md:p-8">
+	<AvatarSizeExample />
+</Example>
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+
+export function Sizes() {
+	return (
+		<div className="flex items-end gap-4">
+			<Avatar.Root className="size-5 text-[0.625rem]" colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root className="size-10 text-sm" colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+			<Avatar.Root className="size-16 text-lg" colorSeed="usr_jane">
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>
+		</div>
+	);
+}
+```
+
+## Accessibility
+
+An avatar is almost always redundant with text beside it, and mantle defaults to that reading:
+
+- **Initials derived from `name` are `aria-hidden`.** They abbreviate a name the page already carries, so
+  announcing them would read it twice — "A C Acme Corp". Children are not hidden; you own their semantics.
+- **When the avatar is the only thing naming its subject** — a collapsed rail, a bare stack of members — name
+  the root: `role="img"` plus `aria-label="Acme Corp"`. A bare `<span>` is `role="generic"`, where accessible
+  names are prohibited, so the role is what makes the label count.
+- **`alt` on `Avatar.Image` is the image's own contract.** Pass the subject's name when the avatar is the only
+  thing naming them, and `alt=""` when adjacent text already does.
+
+## Composing with MediaObject
+
+For a name and a secondary line beside the avatar, compose
+[MediaObject](/components/data-display/media-object) rather than hand-rolling the row.
+
+<Example className="p-4 md:p-8">
+	<AvatarMediaObjectExample />
+</Example>
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+import { MediaObject } from "@ngrok/mantle/media-object";
+
+export function MemberRow() {
+	return (
+		<MediaObject.Root className="max-w-sm">
+			<MediaObject.Media>
+				<Avatar.Root className="size-9" colorSeed="usr_jane">
+					<Avatar.Fallback name="Jane Doe" />
+				</Avatar.Root>
+			</MediaObject.Media>
+			<MediaObject.Content>
+				<p className="text-strong text-sm font-medium">Jane Doe</p>
+				<p className="text-muted text-sm">jane@acme.com</p>
+			</MediaObject.Content>
+		</MediaObject.Root>
+	);
+}
+```
+
+## The first paint is the fallback
+
+`Avatar.Image` renders **only once the image has loaded**, which is knowable only in a browser — so
+server-rendered markup always carries the fallback, including for an image already in cache. That is the trade
+for never flashing a broken-image icon at anyone: a slow or dead URL degrades to initials instead.
+
+When an avatar is above the fold and its URL is known good, skip `Avatar.Image` and put a plain `<img>` inside
+`Avatar.Root` instead. The server markup then carries the image, and you own the error case:
+
+```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
+
+export function ServerRenderedAvatar() {
+	return (
+		<Avatar.Root>
+			<img alt="Jane Doe" className="size-full object-cover" src="/avatars/jane.png" />
+		</Avatar.Root>
+	);
+}
+```
+
+## API Reference
+
+### Avatar.Root
+
+The sizing, shape, and surface. Renders a `<span>`. Accepts all Radix `Avatar.Root` props (`asChild`,
+`className`, `style`, `ref`, `data-*`, `aria-*`, `role`), plus:
+
+| Prop          | Type                     | Default    | Description                                                                                                                                                                 |
+| ------------- | ------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appearance?` | `"circle"` \| `"square"` | `"circle"` | The shape. `"circle"` for a person, `"square"` (a rounded square) for an account, workspace, or team.                                                                       |
+| `colorSeed?`  | `string`                 | —          | A stable id that deterministically selects a background swatch and switches the foreground to `text-static-white`. Omit for a neutral surface. Seed with an id, not a name. |
+| `data-slot?`  | `string`                 | —          | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar` rather than replacing it.                                                                 |
+
+**Data attributes**
+
+| Data Attribute | Value      | Description                                                                     |
+| -------------- | ---------- | ------------------------------------------------------------------------------- |
+| `data-slot`    | `"avatar"` | On the avatar surface, with any forwarded chain ahead of it. Styling/test hook. |
+
+### Avatar.Image
+
+The picture. Renders an `<img>`, and only once the image has loaded — never during SSR. Accepts all Radix
+`Avatar.Image` props, which are an `<img>`'s (`src`, `alt`, `referrerPolicy`, `crossOrigin`, `asChild`,
+`onLoadingStatusChange`), plus:
+
+| Prop         | Type     | Default | Description                                                                              |
+| ------------ | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| `data-slot?` | `string` | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-image`. |
+
+**Data attributes**
+
+| Data Attribute | Value            | Description                                                              |
+| -------------- | ---------------- | ------------------------------------------------------------------------ |
+| `data-slot`    | `"avatar-image"` | On the `<img>`, with any forwarded chain ahead of it. Styling/test hook. |
+
+### Avatar.Fallback
+
+What shows when there is no image — while one loads, when it fails, or when there was never one. Renders a
+`<span>`. Accepts all Radix `Avatar.Fallback` props (`delayMs`, `asChild`, `className`, `ref`), plus exactly
+one source of content:
+
+| Prop         | Type        | Default | Description                                                                                                                                                                                           |
+| ------------ | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`   | `ReactNode` | —       | What to show: an icon, a monogram, initials you derived yourself. Announced normally. Mutually exclusive with `name` — the type forbids passing both.                                                 |
+| `name`       | `string`    | —       | A display name, rendered as at most two uppercase initials (`"Acme Corp"` → `"AC"`, an unusable name → `"?"`). `aria-hidden`, since it abbreviates text already beside the avatar. Not for `asChild`. |
+| `delayMs?`   | `number`    | —       | Wait this long before showing the fallback, so a fast image never flashes initials first.                                                                                                             |
+| `data-slot?` | `string`    | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-fallback`.                                                                                                           |
+
+**Data attributes**
+
+| Data Attribute | Value               | Description                                                               |
+| -------------- | ------------------- | ------------------------------------------------------------------------- |
+| `data-slot`    | `"avatar-fallback"` | On the fallback, with any forwarded chain ahead of it. Styling/test hook. |

--- a/apps/www/app/docs/components/data-display/avatar.mdx
+++ b/apps/www/app/docs/components/data-display/avatar.mdx
@@ -104,6 +104,14 @@ export function AvatarMediaObjectExample() {
 	);
 }
 
+export function AvatarServerRenderedExample() {
+	return (
+		<Avatar.Root>
+			<img alt="Jane Doe" className="size-full object-cover" src="/example-avatar.svg" />
+		</Avatar.Root>
+	);
+}
+
 export function AvatarLinkExample() {
 	return (
 		<Avatar.Root asChild appearance="square" colorSeed="acc_acme">
@@ -306,13 +314,15 @@ An avatar is almost always redundant with text beside it, and mantle defaults to
 - **When the avatar is the only thing naming its subject** — a collapsed rail, a bare stack of members — name
   the root: `role="img"` plus `aria-label="Acme Corp"`. A bare `<span>` is `role="generic"`, where accessible
   names are prohibited, so the role is what makes the label count.
-- **`alt` on `Avatar.Image` is the image's own contract.** Pass the subject's name when the avatar is the only
-  thing naming them, and `alt=""` when adjacent text already does.
+- **`alt` on `Avatar.Image` is required**, and mantle makes it required deliberately — an `<img>` with no `alt`
+  announces its URL. Pass `""` when adjacent text already names the subject. What `alt` cannot do is name the
+  avatar in every state: that `<img>` is absent whenever there is no `src`, the load fails, or the page is
+  server-rendered, so an avatar that must always be named needs the `role="img"` + `aria-label` above as well.
 
 ## Composing with MediaObject
 
 For a name and a secondary line beside the avatar, compose
-[MediaObject](/components/data-display/media-object) rather than hand-rolling the row.
+[MediaObject](/components/structure/media-object) rather than hand-rolling the row.
 
 <Example className="p-4 md:p-8">
 	<AvatarMediaObjectExample />
@@ -348,13 +358,17 @@ for never flashing a broken-image icon at anyone: a slow or dead URL degrades to
 When an avatar is above the fold and its URL is known good, skip `Avatar.Image` and put a plain `<img>` inside
 `Avatar.Root` instead. The server markup then carries the image, and you own the error case:
 
+<Example className="p-4 md:p-8">
+	<AvatarServerRenderedExample />
+</Example>
+
 ```tsx
 import { Avatar } from "@ngrok/mantle/avatar";
 
 export function ServerRenderedAvatar() {
 	return (
 		<Avatar.Root>
-			<img alt="Jane Doe" className="size-full object-cover" src="/avatars/jane.png" />
+			<img alt="Jane Doe" className="size-full object-cover" src="/example-avatar.svg" />
 		</Avatar.Root>
 	);
 }
@@ -382,12 +396,13 @@ The sizing, shape, and surface. Renders a `<span>`. Accepts all Radix `Avatar.Ro
 ### Avatar.Image
 
 The picture. Renders an `<img>`, and only once the image has loaded — never during SSR. Accepts all Radix
-`Avatar.Image` props, which are an `<img>`'s (`src`, `alt`, `referrerPolicy`, `crossOrigin`, `asChild`,
+`Avatar.Image` props, which are an `<img>`'s (`src`, `referrerPolicy`, `crossOrigin`, `asChild`,
 `onLoadingStatusChange`), plus:
 
-| Prop         | Type     | Default | Description                                                                              |
-| ------------ | -------- | ------- | ---------------------------------------------------------------------------------------- |
-| `data-slot?` | `string` | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-image`. |
+| Prop         | Type     | Default | Description                                                                                                                                                                                                                        |
+| ------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `alt`        | `string` | —       | **Required**, unlike the `<img>` element and unlike Radix — an image with no `alt` announces its URL. Pass `""` when adjacent text already names the subject. It cannot name the avatar in the states where no `<img>` is mounted. |
+| `data-slot?` | `string` | —       | An ancestor-forwarded `data-slot` chain, joined ahead of this part's own `avatar-image`.                                                                                                                                           |
 
 **Data attributes**
 

--- a/apps/www/app/docs/components/navigation/sidebar.mdx
+++ b/apps/www/app/docs/components/navigation/sidebar.mdx
@@ -55,6 +55,7 @@ preview's desktop and tablet widths; ngrok's dashboards keep the `lg` default.
 
 ```tsx
 import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Avatar } from "@ngrok/mantle/avatar";
 import { Breadcrumb } from "@ngrok/mantle/breadcrumb";
 import { Button } from "@ngrok/mantle/button";
 import { cx } from "@ngrok/mantle/cx";
@@ -82,6 +83,7 @@ import { ShrimpIcon } from "@phosphor-icons/react/Shrimp";
 import { SignOutIcon } from "@phosphor-icons/react/SignOut";
 import { SpeedometerIcon } from "@phosphor-icons/react/Speedometer";
 import { TerminalWindowIcon } from "@phosphor-icons/react/TerminalWindow";
+import { UserIcon } from "@phosphor-icons/react/User";
 import { UserCircleIcon } from "@phosphor-icons/react/UserCircle";
 import { UsersThreeIcon } from "@phosphor-icons/react/UsersThree";
 import { WarningCircleIcon } from "@phosphor-icons/react/WarningCircle";
@@ -466,11 +468,20 @@ function AccountSwitcher({
 		<DropdownMenu.Root>
 			<DropdownMenu.Trigger asChild>
 				<Sidebar.SwitcherTrigger>
-					<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+					<Avatar.Root appearance="square" colorSeed={account.id}>
+						<Avatar.Fallback name={account.name} />
+					</Avatar.Root>
 					<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 						{account.name}
 					</span>
-					<Sidebar.UserAvatar alt="Jane Doe" />
+					{/* the user has no picture here, so the avatar is a silhouette that
+					    names the signed-in user itself — a bare span is role=generic,
+					    where an accessible name is prohibited, hence role="img" */}
+					<Avatar.Root aria-label="Jane Doe" className="text-muted" role="img">
+						<Avatar.Fallback>
+							<UserIcon className="size-4" />
+						</Avatar.Fallback>
+					</Avatar.Root>
 				</Sidebar.SwitcherTrigger>
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content
@@ -496,7 +507,9 @@ function AccountSwitcher({
 							<DropdownMenu.RadioGroup value={account.id} onValueChange={onAccountChange}>
 								{accounts.map((candidate) => (
 									<DropdownMenu.RadioItem key={candidate.id} value={candidate.id}>
-										<Sidebar.AccountAvatar accountId={candidate.id} accountName={candidate.name} />
+										<Avatar.Root appearance="square" colorSeed={candidate.id}>
+											<Avatar.Fallback name={candidate.name} />
+										</Avatar.Root>
 										<span className="min-w-0 flex-1 truncate">{candidate.name}</span>
 									</DropdownMenu.RadioItem>
 								))}
@@ -678,8 +691,6 @@ Sidebar.Root
 │       ├── Sidebar.ItemButton
 │       ├── Sidebar.Separator
 │       └── Sidebar.SwitcherTrigger
-│           ├── Sidebar.AccountAvatar
-│           └── Sidebar.UserAvatar
 └── Sidebar.Trigger
 ```
 
@@ -687,29 +698,22 @@ Sidebar.Root
 including inside layout components that know nothing about the sidebar. Render exactly one `Sidebar.Nav` per
 `Sidebar.Root`; nested roots shadow the outer sidebar for everything below them.
 There is deliberately no account-switcher part: a "Switch accounts" submenu is a composition of
-[DropdownMenu](/components/overlays/dropdown-menu)'s `RadioGroup`/`RadioItem` with `Sidebar.AccountAvatar`,
-exactly as the shell demo above shows — the account model (what a row contains, badges, ordering) belongs to
-the app, not the design system.
+[DropdownMenu](/components/overlays/dropdown-menu)'s `RadioGroup`/`RadioItem` with
+[Avatar](/components/data-display/avatar), exactly as the shell demo above shows — the account model (what a
+row contains, badges, ordering) belongs to the app, not the design system.
 
 ## Polymorphism
 
 `Sidebar.Header`, `Sidebar.Body`, `Sidebar.Footer`, `Sidebar.Group`, `Sidebar.GroupLabel`, `Sidebar.List`,
-`Sidebar.Item`, `Sidebar.ItemButton`, `Sidebar.SwitcherTrigger`, `Sidebar.Separator`,
-`Sidebar.AccountAvatar`, `Sidebar.UserAvatar`, and `Sidebar.Tooltip` accept an `asChild` prop. When `true`,
-the part renders its single child instead of its default element, forwarding all class names, `data-*`
-attributes, and the ref onto that child. The most common uses are router links on `Sidebar.ItemButton`
-(shown throughout this page) and composing `Sidebar.SwitcherTrigger` with `DropdownMenu.Trigger asChild` or
-`Dialog.Trigger asChild`. `Sidebar.Separator` inherits it from the
+`Sidebar.Item`, `Sidebar.ItemButton`, `Sidebar.SwitcherTrigger`, `Sidebar.Separator`, and `Sidebar.Tooltip`
+accept an `asChild` prop. When `true`, the part renders its single child instead of its default element,
+forwarding all class names, `data-*` attributes, and the ref onto that child. The most common uses are router
+links on `Sidebar.ItemButton` (shown throughout this page) and composing `Sidebar.SwitcherTrigger` with
+`DropdownMenu.Trigger asChild` or `Dialog.Trigger asChild`. `Sidebar.Separator` inherits it from the
 [Separator](/components/structure/separator) it composes, and `Sidebar.Tooltip` forwards it to the
 [`Tooltip.Content`](/components/overlays/tooltip#tooltipcontent) whose props it takes — Radix implements that
 swap itself, so it replaces the **tooltip surface**, not the row you wrap. The row's own polymorphism goes
 through the `Sidebar.ItemButton` or `Sidebar.SwitcherTrigger` inside it.
-
-The two avatars are a special case: `Sidebar.AccountAvatar` derives its initials from `accountName` and
-`Sidebar.UserAvatar` derives its visual from `src`, neither of which a consumer can compute, so `asChild`
-swaps the element while the content stays the part's — pass a single **empty** element, such as a `<span />`
-when the avatar sits inside a `<button>`, which may not contain a `<div>`. The type requires that child when
-`asChild` is `true` and forbids it otherwise, so there is no way to ask for a swap with nothing to swap.
 
 `Sidebar.Root`, `Sidebar.Nav`, and `Sidebar.Trigger` are the exceptions. `Sidebar.Root` renders no DOM at
 all, so there is nothing to swap; the nav renders a fixed two-element collapse structure (and a `Sheet` on
@@ -1064,11 +1068,13 @@ expand the panel with the trigger, and open it again — the menu is the same wi
 </Example>
 
 ```tsx
+import { Avatar } from "@ngrok/mantle/avatar";
 import { DropdownMenu } from "@ngrok/mantle/dropdown-menu";
 import { Sidebar } from "@ngrok/mantle/sidebar";
 import { GearIcon } from "@phosphor-icons/react/Gear";
 import { GraphIcon } from "@phosphor-icons/react/Graph";
 import { SignOutIcon } from "@phosphor-icons/react/SignOut";
+import { UserIcon } from "@phosphor-icons/react/User";
 
 export function AccountRowMenu() {
 	return (
@@ -1092,11 +1098,17 @@ export function AccountRowMenu() {
 						<DropdownMenu.Root>
 							<DropdownMenu.Trigger asChild>
 								<Sidebar.SwitcherTrigger>
-									<Sidebar.AccountAvatar accountId="acc_acme" accountName="Acme Corp" />
+									<Avatar.Root appearance="square" colorSeed="acc_acme">
+										<Avatar.Fallback name="Acme Corp" />
+									</Avatar.Root>
 									<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 										Acme Corp
 									</span>
-									<Sidebar.UserAvatar alt="Jane Doe" />
+									<Avatar.Root aria-label="Jane Doe" className="text-muted" role="img">
+										<Avatar.Fallback>
+											<UserIcon className="size-4" />
+										</Avatar.Fallback>
+									</Avatar.Root>
 								</Sidebar.SwitcherTrigger>
 							</DropdownMenu.Trigger>
 							<DropdownMenu.Content
@@ -1671,10 +1683,11 @@ All props from `button` plus:
 ### Sidebar.SwitcherTrigger
 
 The styled switcher row for the header (app switcher) and footer (account/user row). Its leading visual is
-size-7 to match selected rail icons while the row keeps a compact 36px footprint. The control uses a custom
-10px radius on all corners so product and account switchers share the same shape around their rounded tiles.
-A styled button only — compose it with `DropdownMenu.Trigger asChild` or `Dialog.Trigger asChild`, which
-provide the open state (`data-state="open"` styling responds automatically).
+size-7 to match selected rail icons while the row keeps a compact 36px footprint —
+[Avatar](/components/data-display/avatar) is that size by default, which is what an account or user row puts
+there. The control uses a custom 10px radius on all corners so product and account switchers share the same
+shape around their rounded tiles. A styled button only — compose it with `DropdownMenu.Trigger asChild` or
+`Dialog.Trigger asChild`, which provide the open state (`data-state="open"` styling responds automatically).
 
 Match the trailing affordance to the surface the trigger actually opens. A `CaretDown` promises a menu
 dropping from the row, so keep it for `DropdownMenu`-backed switchers; a `Dialog`-backed switcher reads
@@ -1749,29 +1762,6 @@ All props from [Separator](/components/structure/separator), including:
 | `asChild?`     | `boolean`                      | `false`        | Use the `asChild` prop to compose the `Sidebar.Separator` styling onto alternative element types or your own components.       |
 | `orientation?` | `"horizontal"` \| `"vertical"` | `"horizontal"` | The separator's axis. Sidebar regions stack vertically, so the horizontal default is almost always what you want.              |
 | `semantic?`    | `boolean`                      | `false`        | When `true`, renders `role="separator"` and is announced. Leave it `false` for a decorative divider between navigation groups. |
-
-### Sidebar.AccountAvatar
-
-A `size-7` rounded-square account avatar. The swatch color derives deterministically from `accountId` (stable
-across sessions and devices) using the prototype account switcher palette.
-
-| Prop          | Type                  | Default | Description                                                                                                                                                                                                     |
-| ------------- | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accountId`   | `string \| undefined` | —       | Stable id; seeds the deterministic swatch color.                                                                                                                                                                |
-| `accountName` | `string \| undefined` | —       | Display name; its first 1–2 letters become the initials.                                                                                                                                                        |
-| `asChild?`    | `boolean`             | `false` | Render `children` instead of the avatar's own `<div>` — a `<span />` when the avatar sits inside a `<button>`, or a link.                                                                                       |
-| `children?`   | `ReactElement`        | —       | The single empty element `asChild` swaps in. Required with `asChild` and rejected without it: the initials are derived from `accountName`, so they render _inside_ this element, replacing anything it carried. |
-
-### Sidebar.UserAvatar
-
-A `size-7` circular user avatar with a silhouette fallback.
-
-| Prop        | Type           | Default          | Description                                                                                                                                                                                        |
-| ----------- | -------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src?`      | `string`       | —                | Profile picture URL; falls back to a silhouette when omitted.                                                                                                                                      |
-| `alt?`      | `string`       | `"Your account"` | Accessible label for the avatar.                                                                                                                                                                   |
-| `asChild?`  | `boolean`      | `false`          | Render `children` instead of the avatar's own `<div>` — a `<span />` when the avatar sits inside a `<button>`, or a link.                                                                          |
-| `children?` | `ReactElement` | —                | The single empty element `asChild` swaps in. Required with `asChild` and rejected without it: the image (or the silhouette fallback) renders _inside_ this element, replacing anything it carried. |
 
 ### useSidebar
 

--- a/apps/www/app/docs/layouts/app-layout.mdx
+++ b/apps/www/app/docs/layouts/app-layout.mdx
@@ -59,6 +59,7 @@ default.
 import { Alert } from "@ngrok/mantle/alert";
 import { AlertCenter } from "@ngrok/mantle/alert-center";
 import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Avatar } from "@ngrok/mantle/avatar";
 import { Breadcrumb } from "@ngrok/mantle/breadcrumb";
 import { IconButton } from "@ngrok/mantle/button";
 import { Dialog } from "@ngrok/mantle/dialog";
@@ -85,6 +86,7 @@ import { SignOutIcon } from "@phosphor-icons/react/SignOut";
 import { SlidersHorizontalIcon } from "@phosphor-icons/react/SlidersHorizontal";
 import { SparkleIcon } from "@phosphor-icons/react/Sparkle";
 import { SpeedometerIcon } from "@phosphor-icons/react/Speedometer";
+import { UserIcon } from "@phosphor-icons/react/User";
 import { UserCircleIcon } from "@phosphor-icons/react/UserCircle";
 import { UsersThreeIcon } from "@phosphor-icons/react/UsersThree";
 import { WarningIcon } from "@phosphor-icons/react/Warning";
@@ -358,11 +360,20 @@ function AccountSwitcher({
 			<Sidebar.Tooltip label={account.name}>
 				<DropdownMenu.Trigger asChild>
 					<Sidebar.SwitcherTrigger>
-						<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+						<Avatar.Root appearance="square" colorSeed={account.id}>
+							<Avatar.Fallback name={account.name} />
+						</Avatar.Root>
 						<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 							{account.name}
 						</span>
-						<Sidebar.UserAvatar alt="Jane Doe" />
+						{/* the user has no picture here, so the avatar is a silhouette that
+						    names the signed-in user itself — a bare span is role=generic,
+						    where an accessible name is prohibited, hence role="img" */}
+						<Avatar.Root aria-label="Jane Doe" className="text-muted" role="img">
+							<Avatar.Fallback>
+								<UserIcon className="size-4" />
+							</Avatar.Fallback>
+						</Avatar.Root>
 					</Sidebar.SwitcherTrigger>
 				</DropdownMenu.Trigger>
 			</Sidebar.Tooltip>
@@ -393,7 +404,9 @@ function AccountSwitcher({
 							<DropdownMenu.RadioGroup value={account.id} onValueChange={onAccountChange}>
 								{accounts.map((candidate) => (
 									<DropdownMenu.RadioItem key={candidate.id} value={candidate.id}>
-										<Sidebar.AccountAvatar accountId={candidate.id} accountName={candidate.name} />
+										<Avatar.Root appearance="square" colorSeed={candidate.id}>
+											<Avatar.Fallback name={candidate.name} />
+										</Avatar.Root>
 										<span className="min-w-0 flex-1 truncate">{candidate.name}</span>
 									</DropdownMenu.RadioItem>
 								))}
@@ -780,6 +793,7 @@ row at the top of `Sidebar.Body` instead.
 
 ```tsx
 import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Avatar } from "@ngrok/mantle/avatar";
 import { Breadcrumb } from "@ngrok/mantle/breadcrumb";
 import { DropdownMenu } from "@ngrok/mantle/dropdown-menu";
 import { Main } from "@ngrok/mantle/main";
@@ -878,7 +892,9 @@ function AccountSwitcher({
 			<Sidebar.Tooltip label={account.name}>
 				<DropdownMenu.Trigger asChild>
 					<Sidebar.SwitcherTrigger>
-						<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+						<Avatar.Root appearance="square" colorSeed={account.id}>
+							<Avatar.Fallback name={account.name} />
+						</Avatar.Root>
 						<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 							{account.name}
 						</span>
@@ -896,7 +912,9 @@ function AccountSwitcher({
 						<DropdownMenu.RadioGroup value={accountId} onValueChange={onAccountChange}>
 							{accounts.map((candidate) => (
 								<DropdownMenu.RadioItem key={candidate.id} value={candidate.id}>
-									<Sidebar.AccountAvatar accountId={candidate.id} accountName={candidate.name} />
+									<Avatar.Root appearance="square" colorSeed={candidate.id}>
+										<Avatar.Fallback name={candidate.name} />
+									</Avatar.Root>
 									<span className="min-w-0 flex-1 truncate">{candidate.name}</span>
 								</DropdownMenu.RadioItem>
 							))}

--- a/apps/www/app/features/app-shell-demo.tsx
+++ b/apps/www/app/features/app-shell-demo.tsx
@@ -1,6 +1,7 @@
 import { Alert } from "@ngrok/mantle/alert";
 import { AlertCenter } from "@ngrok/mantle/alert-center";
 import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Avatar } from "@ngrok/mantle/avatar";
 import { Breadcrumb } from "@ngrok/mantle/breadcrumb";
 import { IconButton } from "@ngrok/mantle/button";
 import { cx } from "@ngrok/mantle/cx";
@@ -42,6 +43,7 @@ import { SlidersHorizontalIcon } from "@phosphor-icons/react/SlidersHorizontal";
 import { SparkleIcon } from "@phosphor-icons/react/Sparkle";
 import { SpeedometerIcon } from "@phosphor-icons/react/Speedometer";
 import { TerminalWindowIcon } from "@phosphor-icons/react/TerminalWindow";
+import { UserIcon } from "@phosphor-icons/react/User";
 import { UserCircleIcon } from "@phosphor-icons/react/UserCircle";
 import { UsersIcon } from "@phosphor-icons/react/Users";
 import { UsersThreeIcon } from "@phosphor-icons/react/UsersThree";
@@ -673,11 +675,20 @@ function AppShellAccountSwitcher({
 			<Sidebar.Tooltip label={account.name}>
 				<DropdownMenu.Trigger asChild>
 					<Sidebar.SwitcherTrigger>
-						<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+						<Avatar.Root appearance="square" colorSeed={account.id}>
+							<Avatar.Fallback name={account.name} />
+						</Avatar.Root>
 						<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 							{account.name}
 						</span>
-						<Sidebar.UserAvatar alt="Jane Doe" />
+						{/* the user has no picture here, so the avatar is a silhouette that
+						    names the signed-in user itself — a bare span is role=generic,
+						    where an accessible name is prohibited, hence role="img" */}
+						<Avatar.Root aria-label="Jane Doe" className="text-muted" role="img">
+							<Avatar.Fallback>
+								<UserIcon className="size-4" />
+							</Avatar.Fallback>
+						</Avatar.Root>
 					</Sidebar.SwitcherTrigger>
 				</DropdownMenu.Trigger>
 			</Sidebar.Tooltip>
@@ -708,10 +719,9 @@ function AppShellAccountSwitcher({
 							<DropdownMenu.RadioGroup value={account.id} onValueChange={onAccountChange}>
 								{demoAccounts.map((demoAccount) => (
 									<DropdownMenu.RadioItem key={demoAccount.id} value={demoAccount.id}>
-										<Sidebar.AccountAvatar
-											accountId={demoAccount.id}
-											accountName={demoAccount.name}
-										/>
+										<Avatar.Root appearance="square" colorSeed={demoAccount.id}>
+											<Avatar.Fallback name={demoAccount.name} />
+										</Avatar.Root>
 										<span className="min-w-0 flex-1 truncate">{demoAccount.name}</span>
 									</DropdownMenu.RadioItem>
 								))}
@@ -997,7 +1007,9 @@ function BridgeAccountSwitcher({
 			<Sidebar.Tooltip label={account.name}>
 				<DropdownMenu.Trigger asChild>
 					<Sidebar.SwitcherTrigger>
-						<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+						<Avatar.Root appearance="square" colorSeed={account.id}>
+							<Avatar.Fallback name={account.name} />
+						</Avatar.Root>
 						<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 							{account.name}
 						</span>
@@ -1019,10 +1031,9 @@ function BridgeAccountSwitcher({
 							<DropdownMenu.RadioGroup value={accountId} onValueChange={onAccountChange}>
 								{demoAccounts.map((demoAccount) => (
 									<DropdownMenu.RadioItem key={demoAccount.id} value={demoAccount.id}>
-										<Sidebar.AccountAvatar
-											accountId={demoAccount.id}
-											accountName={demoAccount.name}
-										/>
+										<Avatar.Root appearance="square" colorSeed={demoAccount.id}>
+											<Avatar.Fallback name={demoAccount.name} />
+										</Avatar.Root>
 										<span className="min-w-0 flex-1 truncate">{demoAccount.name}</span>
 									</DropdownMenu.RadioItem>
 								))}

--- a/apps/www/app/features/sidebar-demos.tsx
+++ b/apps/www/app/features/sidebar-demos.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Avatar } from "@ngrok/mantle/avatar";
 import { DropdownMenu } from "@ngrok/mantle/dropdown-menu";
 import { useLocalStorage } from "@ngrok/mantle/hooks";
 import { Main } from "@ngrok/mantle/main";
@@ -12,6 +13,7 @@ import { GraphIcon } from "@phosphor-icons/react/Graph";
 import { HashIcon } from "@phosphor-icons/react/Hash";
 import { QuestionIcon } from "@phosphor-icons/react/Question";
 import { SignOutIcon } from "@phosphor-icons/react/SignOut";
+import { UserIcon } from "@phosphor-icons/react/User";
 import { useState } from "react";
 
 /**
@@ -247,11 +249,17 @@ export function SidebarRowWidthMenuExample() {
 						<DropdownMenu.Root>
 							<DropdownMenu.Trigger asChild>
 								<Sidebar.SwitcherTrigger>
-									<Sidebar.AccountAvatar accountId="acc_acme" accountName="Acme Corp" />
+									<Avatar.Root appearance="square" colorSeed="acc_acme">
+										<Avatar.Fallback name="Acme Corp" />
+									</Avatar.Root>
 									<span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">
 										Acme Corp
 									</span>
-									<Sidebar.UserAvatar alt="Jane Doe" />
+									<Avatar.Root aria-label="Jane Doe" className="text-muted" role="img">
+										<Avatar.Fallback>
+											<UserIcon className="size-4" />
+										</Avatar.Fallback>
+									</Avatar.Root>
 								</Sidebar.SwitcherTrigger>
 							</DropdownMenu.Trigger>
 							<DropdownMenu.Content

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -81,6 +81,7 @@ export default [
 		...docRoute("components/charts/scatter-plot"),
 		// data display
 		...docRoute("components/data-display/accordion"),
+		...docRoute("components/data-display/avatar"),
 		...docRoute("components/data-display/badge"),
 		...docRoute("components/data-display/code"),
 		...docRoute("components/data-display/code-block"),

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -96,6 +96,20 @@
     ]
   },
   {
+    "name": "Avatar",
+    "slug": "components/data-display/avatar",
+    "kind": "component",
+    "category": "Data Display",
+    "status": "stable",
+    "importPath": "@ngrok/mantle/avatar",
+    "summary": "A small image representing a person or an account, with a text or icon fallback.",
+    "jsdoc": "A small image representing a person or an account, with a text or icon fallback for when there is no picture — or before one loads. `appearance` carries the meaning: `\"circle\"` for a person, `\"square\"` (a rounded square) for an account, workspace, team, or organization.",
+    "examples": [
+      "Composition:\n```\nAvatar.Root\n├── Avatar.Image\n└── Avatar.Fallback\n```",
+      "```tsx\n<Avatar.Root appearance=\"square\" colorSeed=\"acc_123\">\n  <Avatar.Image src=\"https://example.com/acme.png\" alt=\"\" />\n  <Avatar.Fallback name=\"Acme Corp\" />\n</Avatar.Root>\n```"
+    ]
+  },
+  {
     "name": "Badge",
     "slug": "components/data-display/badge",
     "kind": "component",
@@ -746,8 +760,8 @@
     "summary": "A composable, collapsible app-navigation sidebar with a mobile sheet presentation and a trigger that mounts anywhere in your app shell.",
     "jsdoc": "A composable, collapsible app-navigation sidebar. `Sidebar.Root` owns the state (no DOM); `Sidebar.Nav` renders the panel — inline on desktop, collapsing to a skinny icon rail, and a left-side `Sheet` below the root's `mobileBreakpoint`; and `Sidebar.Trigger` toggles it from anywhere under the root (typically an `AppLayout.Header`).",
     "examples": [
-      "Composition:\n```\nSidebar.Root\n├── Sidebar.Nav\n│   ├── Sidebar.Header\n│   │   └── Sidebar.SwitcherTrigger\n│   ├── Sidebar.Body\n│   │   └── Sidebar.Group\n│   │       ├── Sidebar.GroupLabel\n│   │       └── Sidebar.List\n│   │           └── Sidebar.Item\n│   │               └── Sidebar.Tooltip\n│   │                   └── Sidebar.ItemButton\n│   └── Sidebar.Footer\n│       ├── Sidebar.ItemButton\n│       ├── Sidebar.Separator\n│       └── Sidebar.SwitcherTrigger\n│           ├── Sidebar.AccountAvatar\n│           └── Sidebar.UserAvatar\n└── Sidebar.Trigger\n```",
-      "```tsx\n<Sidebar.Root>\n  <Sidebar.Nav aria-label=\"Main\">\n    <Sidebar.Header>\n      <DropdownMenu.Root>\n        <DropdownMenu.Trigger asChild>\n          <Sidebar.SwitcherTrigger>\n            <GlobeIcon />\n            <span className=\"text-strong min-w-0 flex-1 truncate text-base\">Universal Gateway</span>\n            <CaretDownIcon className=\"text-muted size-4 shrink-0\" />\n          </Sidebar.SwitcherTrigger>\n        </DropdownMenu.Trigger>\n        <DropdownMenu.Content width=\"trigger\" className=\"min-w-(--sidebar-row-width)\">…</DropdownMenu.Content>\n      </DropdownMenu.Root>\n    </Sidebar.Header>\n    <Sidebar.Body>\n      <Sidebar.Group>\n        <Sidebar.GroupLabel>Traffic</Sidebar.GroupLabel>\n        <Sidebar.List>\n          <Sidebar.Item>\n            <Sidebar.ItemButton asChild current>\n              <a href=\"/endpoints\">\n                <GraphIcon />\n                Endpoints\n              </a>\n            </Sidebar.ItemButton>\n          </Sidebar.Item>\n        </Sidebar.List>\n      </Sidebar.Group>\n    </Sidebar.Body>\n    <Sidebar.Footer>\n      <Sidebar.Separator />\n      <DropdownMenu.Root>\n        <DropdownMenu.Trigger asChild>\n          <Sidebar.SwitcherTrigger>\n            <Sidebar.AccountAvatar accountId=\"acc_123\" accountName=\"Acme Corp\" />\n            <span className=\"text-strong min-w-0 flex-1 truncate text-sm font-medium\">Acme Corp</span>\n            <Sidebar.UserAvatar alt=\"Jane Doe\" />\n          </Sidebar.SwitcherTrigger>\n        </DropdownMenu.Trigger>\n        <DropdownMenu.Content width=\"trigger\" className=\"min-w-(--sidebar-row-width)\">…</DropdownMenu.Content>\n      </DropdownMenu.Root>\n    </Sidebar.Footer>\n  </Sidebar.Nav>\n  <Sidebar.Trigger />\n</Sidebar.Root>\n```"
+      "Composition:\n```\nSidebar.Root\n├── Sidebar.Nav\n│   ├── Sidebar.Header\n│   │   └── Sidebar.SwitcherTrigger\n│   ├── Sidebar.Body\n│   │   └── Sidebar.Group\n│   │       ├── Sidebar.GroupLabel\n│   │       └── Sidebar.List\n│   │           └── Sidebar.Item\n│   │               └── Sidebar.Tooltip\n│   │                   └── Sidebar.ItemButton\n│   └── Sidebar.Footer\n│       ├── Sidebar.ItemButton\n│       ├── Sidebar.Separator\n│       └── Sidebar.SwitcherTrigger\n└── Sidebar.Trigger\n```",
+      "```tsx\n<Sidebar.Root>\n  <Sidebar.Nav aria-label=\"Main\">\n    <Sidebar.Header>\n      <DropdownMenu.Root>\n        <DropdownMenu.Trigger asChild>\n          <Sidebar.SwitcherTrigger>\n            <GlobeIcon />\n            <span className=\"text-strong min-w-0 flex-1 truncate text-base\">Universal Gateway</span>\n            <CaretDownIcon className=\"text-muted size-4 shrink-0\" />\n          </Sidebar.SwitcherTrigger>\n        </DropdownMenu.Trigger>\n        <DropdownMenu.Content width=\"trigger\" className=\"min-w-(--sidebar-row-width)\">…</DropdownMenu.Content>\n      </DropdownMenu.Root>\n    </Sidebar.Header>\n    <Sidebar.Body>\n      <Sidebar.Group>\n        <Sidebar.GroupLabel>Traffic</Sidebar.GroupLabel>\n        <Sidebar.List>\n          <Sidebar.Item>\n            <Sidebar.ItemButton asChild current>\n              <a href=\"/endpoints\">\n                <GraphIcon />\n                Endpoints\n              </a>\n            </Sidebar.ItemButton>\n          </Sidebar.Item>\n        </Sidebar.List>\n      </Sidebar.Group>\n    </Sidebar.Body>\n    <Sidebar.Footer>\n      <Sidebar.Separator />\n      <DropdownMenu.Root>\n        <DropdownMenu.Trigger asChild>\n          <Sidebar.SwitcherTrigger>\n            <Avatar.Root appearance=\"square\" colorSeed=\"acc_123\">\n              <Avatar.Fallback name=\"Acme Corp\" />\n            </Avatar.Root>\n            <span className=\"text-strong min-w-0 flex-1 truncate text-sm font-medium\">Acme Corp</span>\n          </Sidebar.SwitcherTrigger>\n        </DropdownMenu.Trigger>\n        <DropdownMenu.Content width=\"trigger\" className=\"min-w-(--sidebar-row-width)\">…</DropdownMenu.Content>\n      </DropdownMenu.Root>\n    </Sidebar.Footer>\n  </Sidebar.Nav>\n  <Sidebar.Trigger />\n</Sidebar.Root>\n```"
     ]
   },
   {

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -543,7 +543,7 @@
     "jsdoc": "A small, reusable layout primitive for \"image/icon on one side, descriptive content on the other\" — the foundational \"media object\" pattern.",
     "examples": [
       "Composition:\n```\nMediaObject.Root\n├── MediaObject.Media\n└── MediaObject.Content\n```",
-      "```tsx\nimport { MediaObject } from \"@ngrok/mantle/media-object\";\n\n<MediaObject.Root>\n  <MediaObject.Media>\n    <Avatar src={user.avatarUrl} alt=\"\" />\n  </MediaObject.Media>\n  <MediaObject.Content>\n    <p className=\"font-medium\">{user.name}</p>\n    <p className=\"text-muted text-sm\">{comment}</p>\n  </MediaObject.Content>\n</MediaObject.Root>\n```"
+      "```tsx\nimport { Avatar } from \"@ngrok/mantle/avatar\";\nimport { MediaObject } from \"@ngrok/mantle/media-object\";\n\n<MediaObject.Root>\n  <MediaObject.Media>\n    <Avatar.Root>\n      <Avatar.Image src={user.avatarUrl} alt=\"\" />\n      <Avatar.Fallback name={user.name} />\n    </Avatar.Root>\n  </MediaObject.Media>\n  <MediaObject.Content>\n    <p className=\"font-medium\">{user.name}</p>\n    <p className=\"text-muted text-sm\">{comment}</p>\n  </MediaObject.Content>\n</MediaObject.Root>\n```"
     ]
   },
   {

--- a/apps/www/public/example-avatar.svg
+++ b/apps/www/public/example-avatar.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="presentation">
+	<!-- A stand-in profile picture for the Avatar docs examples. Local on purpose:
+	     the docs site depends on no third-party image CDN, and an example whose
+	     image silently 404s would demonstrate the fallback instead of the image. -->
+	<defs>
+		<linearGradient id="example-avatar-backdrop" x1="0" y1="0" x2="1" y2="1">
+			<stop offset="0" stop-color="#5b8def" />
+			<stop offset="1" stop-color="#8b5cf6" />
+		</linearGradient>
+	</defs>
+	<rect width="128" height="128" fill="url(#example-avatar-backdrop)" />
+	<circle cx="64" cy="50" r="22" fill="#ffffff" fill-opacity="0.92" />
+	<path
+		d="M64 78c-22 0-40 13.5-44 32.5A64 64 0 0 0 64 128a64 64 0 0 0 44-17.5C104 91.5 86 78 64 78Z"
+		fill="#ffffff"
+		fill-opacity="0.92"
+	/>
+</svg>

--- a/packages/mantle-vite-plugins/src/mantle-component-name.ts
+++ b/packages/mantle-vite-plugins/src/mantle-component-name.ts
@@ -22,6 +22,7 @@ export const MANTLE_COMPONENT_NAMES = [
 	"anchor",
 	"app-layout",
 	"area-chart",
+	"avatar",
 	"badge",
 	"bar-chart",
 	"breadcrumb",

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -429,7 +429,6 @@
 	"dependencies": {
 		"@ariakit/react": "0.4.35",
 		"@headlessui/react": "2.2.10",
-		"@radix-ui/react-avatar": "1.2.6",
 		"@radix-ui/react-dialog": "1.1.23",
 		"@radix-ui/react-dropdown-menu": "2.1.24",
 		"@radix-ui/react-hover-card": "1.1.23",

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -85,6 +85,11 @@
 			"types": "./dist/area-chart.d.ts",
 			"import": "./dist/area-chart.js"
 		},
+		"./avatar": {
+			"@ngrok/src-live-types": "./src/components/avatar/index.ts",
+			"types": "./dist/avatar.d.ts",
+			"import": "./dist/avatar.js"
+		},
 		"./badge": {
 			"@ngrok/src-live-types": "./src/components/badge/index.ts",
 			"types": "./dist/badge.d.ts",
@@ -424,6 +429,7 @@
 	"dependencies": {
 		"@ariakit/react": "0.4.35",
 		"@headlessui/react": "2.2.10",
+		"@radix-ui/react-avatar": "1.2.6",
 		"@radix-ui/react-dialog": "1.1.23",
 		"@radix-ui/react-dropdown-menu": "2.1.24",
 		"@radix-ui/react-hover-card": "1.1.23",

--- a/packages/mantle/src/components/avatar/avatar.test.tsx
+++ b/packages/mantle/src/components/avatar/avatar.test.tsx
@@ -1,51 +1,43 @@
-import { act, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { type ComponentProps, createRef } from "react";
 import { renderToString } from "react-dom/server";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { Avatar } from "./avatar.js";
 
-/**
- * Radix decides whether `Avatar.Image` may render by preloading the `src`
- * through `new window.Image()` and reading `complete` / `naturalWidth`. happy-dom
- * ships with `enableImageFileLoading` off, so it answers every image with
- * `complete: true, naturalWidth: 0` — which Radix reads as `"error"`, making the
- * loaded path unreachable. This stubs that one constructor with a probe that
- * reports the outcome under test, synchronously.
- */
-function stubImageLoading(outcome: "loaded" | "error") {
-	class ProbeImage {
-		complete = true;
-		naturalWidth = outcome === "loaded" ? 128 : 0;
-		crossOrigin: string | null = null;
-		referrerPolicy = "";
-		src = "";
-		addEventListener() {}
-		removeEventListener() {}
-	}
-	vi.stubGlobal("Image", ProbeImage);
-}
-
-afterEach(() => {
-	vi.unstubAllGlobals();
-});
-
 describe("Avatar.Root", () => {
-	test("renders the documented composition, showing the fallback until an image loads", () => {
+	test("renders the documented composition, with the image over the fallback", () => {
 		render(
 			<Avatar.Root appearance="square" colorSeed="acc_123">
-				<Avatar.Image src="https://example.com/acme.png" alt="" />
+				<Avatar.Image alt="" src="https://example.com/acme.png" />
 				<Avatar.Fallback name="Acme Corp" />
 			</Avatar.Root>,
 		);
+		// Both, together: the fallback is what a loading image shows through, not an
+		// alternative branch the consumer picks between.
+		expect(screen.getByRole("presentation")).toHaveAttribute("src", "https://example.com/acme.png");
 		expect(screen.getByText("AC")).toBeInTheDocument();
-		expect(screen.queryByRole("img")).not.toBeInTheDocument();
 	});
 
 	test("is a fixed-size, unsqueezable circle by default", () => {
-		// shrink-0 is load-bearing: an avatar is a fixed-size visual and the flex
-		// rows it sits in must not be able to compress it.
+		// shrink-0 is load-bearing: an avatar is a fixed-size visual and the flex rows
+		// it sits in must not be able to compress it. `relative` is what the image
+		// positions against — the pair is asserted together in the Image tests below.
 		render(<Avatar.Root data-testid="avatar" />);
-		expect(screen.getByTestId("avatar")).toHaveClass("size-7", "shrink-0", "rounded-full");
+		expect(screen.getByTestId("avatar")).toHaveClass(
+			"size-7",
+			"shrink-0",
+			"relative",
+			"rounded-full",
+		);
+	});
+
+	test("renders a span, so it stays valid inside a switcher row's button", () => {
+		render(
+			<button type="button">
+				<Avatar.Root data-testid="avatar" />
+			</button>,
+		);
+		expect(screen.getByTestId("avatar").tagName).toBe("SPAN");
 	});
 
 	test("appearance=square renders a rounded square", () => {
@@ -57,10 +49,9 @@ describe("Avatar.Root", () => {
 
 	test("colorSeed paints a swatch and the static foreground that stays legible on it", () => {
 		render(<Avatar.Root colorSeed="acc_123" data-testid="avatar" />);
-		const avatar = screen.getByTestId("avatar");
-		// Pinned on purpose: the palette order is what makes a seed's color stable,
-		// so reordering it — which would recolor every account on screen — fails here.
-		expect(avatar).toHaveClass("bg-orange-500", "text-static-white");
+		// Pinned on purpose: the palette order is what makes a seed's color stable, so
+		// reordering it — which would recolor every account on screen — fails here.
+		expect(screen.getByTestId("avatar")).toHaveClass("bg-orange-500", "text-static-white");
 	});
 
 	test("the same seed always resolves to the same swatch, and different seeds spread", () => {
@@ -77,10 +68,9 @@ describe("Avatar.Root", () => {
 	});
 
 	test("a seeded swatch survives server rendering unchanged", () => {
-		// The hash has to agree across the SSR boundary or the avatar changes color
-		// on hydration.
-		const html = renderToString(<Avatar.Root colorSeed="acc_atlas" />);
-		expect(html).toContain("bg-purple-500");
+		// The hash has to agree across the SSR boundary or the avatar changes color on
+		// hydration.
+		expect(renderToString(<Avatar.Root colorSeed="acc_atlas" />)).toContain("bg-purple-500");
 	});
 
 	test("without a seed it stays neutral and keeps the surrounding foreground", () => {
@@ -96,6 +86,7 @@ describe("Avatar.Root", () => {
 			<Avatar.Root className="size-10" data-flavor="primary" data-testid="avatar" ref={ref} />,
 		);
 		const avatar = screen.getByTestId("avatar");
+		// A tailwind-merge override contract: the consumer's size beats the default.
 		expect(avatar).toHaveClass("size-10");
 		expect(avatar).not.toHaveClass("size-7");
 		expect(avatar).toHaveAttribute("data-flavor", "primary");
@@ -141,8 +132,8 @@ describe("Avatar.Fallback", () => {
 		{ expected: "ÉC", name: "école centrale" },
 		{ expected: "山太", name: "山田 太郎" },
 		{ expected: "مع", name: "محمد علي" },
-		// Uppercasing happens per word, before the code point is taken: "ß" → "SS"
-		// and "ﬄ" → "FFL", so uppercasing the joined result would overrun two.
+		// Uppercasing happens per word, before the code point is taken: "ß" → "SS" and
+		// "ﬄ" → "FFL", so uppercasing the joined result would overrun two.
 		{ expected: "SH", name: "straße hof" },
 		{ expected: "FF", name: "ﬄuent ﬂow" },
 		// Unicode punctuation reaches the "?" floor too, not just ASCII.
@@ -150,33 +141,30 @@ describe("Avatar.Fallback", () => {
 		{ expected: "?", name: "— —" },
 		{ expected: "A", name: "«Acme»" },
 	])("name=$name renders the initials $expected", ({ expected, name }) => {
-		render(
-			<Avatar.Root>
-				<Avatar.Fallback name={name} />
-			</Avatar.Root>,
-		);
+		render(<Avatar.Fallback name={name} />);
 		expect(screen.getByText(expected)).toBeInTheDocument();
 	});
 
 	test("derived initials are decorative, so a row's accessible name is not doubled", () => {
 		// The name they abbreviate is already in the DOM beside the avatar; without
-		// this a menu row reads "A C Acme Corp".
+		// this the row reads "A C Acme Corp".
 		render(
-			<Avatar.Root>
-				<Avatar.Fallback data-testid="fallback" name="Acme Corp" />
-			</Avatar.Root>,
+			<button type="button">
+				<Avatar.Root>
+					<Avatar.Fallback name="Acme Corp" />
+				</Avatar.Root>
+				Acme Corp
+			</button>,
 		);
-		expect(screen.getByTestId("fallback")).toHaveAttribute("aria-hidden", "true");
+		expect(screen.getByRole("button")).toHaveAccessibleName("Acme Corp");
 	});
 
 	test("children are announced, and an explicit aria-hidden still wins", () => {
 		render(
-			<Avatar.Root>
+			<>
 				<Avatar.Fallback data-testid="children">AC</Avatar.Fallback>
-				<Avatar.Root>
-					<Avatar.Fallback aria-hidden={false} data-testid="override" name="Acme Corp" />
-				</Avatar.Root>
-			</Avatar.Root>,
+				<Avatar.Fallback aria-hidden={false} data-testid="override" name="Acme Corp" />
+			</>,
 		);
 		expect(screen.getByTestId("children")).not.toHaveAttribute("aria-hidden");
 		expect(screen.getByTestId("override")).toHaveAttribute("aria-hidden", "false");
@@ -184,36 +172,34 @@ describe("Avatar.Fallback", () => {
 
 	test("children render instead of derived initials", () => {
 		render(
-			<Avatar.Root>
-				<Avatar.Fallback>
-					<svg aria-hidden="true" data-testid="silhouette" />
-				</Avatar.Fallback>
-			</Avatar.Root>,
+			<Avatar.Fallback>
+				<svg aria-hidden="true" data-testid="silhouette" />
+			</Avatar.Fallback>,
 		);
 		expect(screen.getByTestId("silhouette")).toBeInTheDocument();
 	});
 
-	test("throws when rendered outside Avatar.Root", () => {
-		// Radix owns the context that decides whether a fallback may render, so it
-		// fails loudly rather than rendering an avatar that can never show anything.
-		expect(() => render(<Avatar.Fallback name="Acme Corp" />)).toThrow(
-			/must be used within `Avatar`/,
-		);
+	test("a child that resolves to nothing renders nothing, not a stray question mark", () => {
+		// `{isAdmin && <ShieldIcon />}` is the caller saying "nothing here" for
+		// everyone else. Coalescing that into derived initials would answer with a bare
+		// "?" — and an announced one, since only name-derived initials are hidden.
+		render(<Avatar.Fallback data-testid="fallback">{null}</Avatar.Fallback>);
+		const fallback = screen.getByTestId("fallback");
+		expect(fallback).toBeEmptyDOMElement();
+		expect(fallback).not.toHaveAttribute("aria-hidden");
 	});
 
 	test("forwards className, data-*, and the ref, and joins the data-slot chain", () => {
 		const ref = createRef<HTMLSpanElement>();
 		render(
-			<Avatar.Root>
-				<Avatar.Fallback
-					className="custom-class"
-					data-flavor="primary"
-					data-slot="outer"
-					data-testid="fallback"
-					name="Acme Corp"
-					ref={ref}
-				/>
-			</Avatar.Root>,
+			<Avatar.Fallback
+				className="custom-class"
+				data-flavor="primary"
+				data-slot="outer"
+				data-testid="fallback"
+				name="Acme Corp"
+				ref={ref}
+			/>,
 		);
 		const fallback = screen.getByTestId("fallback");
 		expect(fallback).toHaveClass("custom-class", "size-full");
@@ -225,13 +211,11 @@ describe("Avatar.Fallback", () => {
 	test("asChild renders the consumer element with the fallback styles and ref", () => {
 		const ref = createRef<HTMLSpanElement>();
 		render(
-			<Avatar.Root>
-				<Avatar.Fallback asChild ref={ref}>
-					<abbr className="custom-class" data-flavor="primary" title="Acme Corp">
-						AC
-					</abbr>
-				</Avatar.Fallback>
-			</Avatar.Root>,
+			<Avatar.Fallback asChild ref={ref}>
+				<abbr className="custom-class" data-flavor="primary" title="Acme Corp">
+					AC
+				</abbr>
+			</Avatar.Fallback>,
 		);
 		const abbreviation = screen.getByTitle("Acme Corp");
 		expect(abbreviation).toHaveClass("custom-class", "items-center");
@@ -239,66 +223,111 @@ describe("Avatar.Fallback", () => {
 		expect(abbreviation).toHaveAttribute("data-slot", "avatar-fallback");
 		expect(ref.current).toBe(abbreviation);
 	});
-
-	test("a child that resolves to nothing renders nothing, not a stray question mark", () => {
-		// `{isAdmin && <ShieldIcon />}` is the caller saying "nothing here" for
-		// everyone else. Coalescing that into derived initials would answer with a
-		// bare "?" — and an announced one, since only name-derived initials are
-		// hidden.
-		render(
-			<Avatar.Root>
-				<Avatar.Fallback data-testid="fallback">{null}</Avatar.Fallback>
-			</Avatar.Root>,
-		);
-		const fallback = screen.getByTestId("fallback");
-		expect(fallback).toBeEmptyDOMElement();
-		expect(fallback).not.toHaveAttribute("aria-hidden");
-	});
-
-	test("requires exactly one source of content at the type level", () => {
-		// Two sources would leave the winner to precedence, and no source would
-		// render an empty avatar; both are compile errors rather than surprises.
-		// `asChild` needs a real element to clone, so it belongs to the children arm
-		// only — otherwise it typechecks and then throws inside Radix's slot.
-		const withBoth = (
-			// @ts-expect-error -- name and children are mutually exclusive
-			<Avatar.Fallback name="Acme Corp">AC</Avatar.Fallback>
-		);
-		const withNeither = (
-			// @ts-expect-error -- one of name or children is required
-			<Avatar.Fallback />
-		);
-		const withAsChildAndName = (
-			// @ts-expect-error -- asChild has nothing to clone beside name
-			<Avatar.Fallback asChild name="Acme Corp" />
-		);
-		expect(withBoth).toBeTruthy();
-		expect(withNeither).toBeTruthy();
-		expect(withAsChildAndName).toBeTruthy();
-	});
 });
 
 describe("Avatar.Image", () => {
-	test("renders the picture once it has loaded, and drops the fallback", () => {
-		stubImageLoading("loaded");
-		render(
+	test("is in the server-rendered markup, alongside the fallback behind it", () => {
+		// The reason this part is a plain <img>: the server emits it, so the browser
+		// fetches while it parses HTML and a cached image is on screen in the first
+		// frame — no hydration, no swap, no flash of initials.
+		const html = renderToString(
 			<Avatar.Root>
 				<Avatar.Image alt="Jane Doe" src="https://example.com/jane.png" />
 				<Avatar.Fallback name="Jane Doe" />
 			</Avatar.Root>,
 		);
-		const image = screen.getByRole("img", { name: "Jane Doe" });
-		expect(image).toHaveAttribute("src", "https://example.com/jane.png");
-		expect(image).toHaveClass("size-full", "object-cover");
-		expect(image).toHaveAttribute("data-slot", "avatar-image");
-		expect(screen.queryByText("JD")).not.toBeInTheDocument();
+		expect(html).toContain('src="https://example.com/jane.png"');
+		expect(html).toContain('alt="Jane Doe"');
+		expect(html).toContain("JD");
 	});
 
-	test("a failed image shows the fallback rather than a broken-image icon", () => {
-		stubImageLoading("error");
+	test("covers the fallback rather than replacing it", () => {
+		render(
+			<Avatar.Root data-testid="avatar">
+				<Avatar.Image alt="Jane Doe" src="https://example.com/jane.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		// Both sides of the pair in one test: the image is positioned against the
+		// root's own `relative`, which is what lets the fallback sit behind it with no
+		// loading state anywhere.
+		expect(screen.getByTestId("avatar")).toHaveClass("relative");
+		expect(screen.getByRole("img", { name: "Jane Doe" })).toHaveClass(
+			"absolute",
+			"inset-0",
+			"size-full",
+			"object-cover",
+		);
+		expect(screen.getByText("JD")).toBeInTheDocument();
+	});
+
+	test("a failed load unmounts the image, leaving the fallback showing", () => {
 		render(
 			<Avatar.Root>
 				<Avatar.Image alt="Jane Doe" src="https://example.com/missing.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+
+		fireEvent.error(screen.getByRole("img", { name: "Jane Doe" }));
+
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+		expect(screen.getByText("JD")).toBeInTheDocument();
+	});
+
+	test("onError runs first and can preventDefault to keep the image mounted", () => {
+		// The house convention for a wrapped handler: the consumer's callback runs
+		// first and `preventDefault()` bails out of the default behavior — here, for
+		// someone who would rather retry a URL than fall back.
+		const onError = vi.fn<(event: { preventDefault: () => void }) => void>((event) => {
+			event.preventDefault();
+		});
+		render(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" onError={onError} src="https://example.com/flaky.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+
+		fireEvent.error(screen.getByRole("img", { name: "Jane Doe" }));
+
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("img", { name: "Jane Doe" })).toBeInTheDocument();
+	});
+
+	test("a new src is a fresh attempt, so a good URL recovers from a bad one", () => {
+		// Only the exact URL that failed stays unmounted — a boolean would strand an
+		// avatar whose src changed after one failure.
+		const { rerender } = render(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" src="https://example.com/missing.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		fireEvent.error(screen.getByRole("img", { name: "Jane Doe" }));
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+
+		rerender(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" src="https://example.com/jane.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+
+		expect(screen.getByRole("img", { name: "Jane Doe" })).toHaveAttribute(
+			"src",
+			"https://example.com/jane.png",
+		);
+	});
+
+	test.for([
+		{ label: "undefined", src: undefined },
+		{ label: "an empty string", src: "" },
+	])("renders nothing when src is $label, so the fallback stands alone", ({ src }) => {
+		// An empty src would otherwise re-request the current page URL.
+		render(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" src={src} />
 				<Avatar.Fallback name="Jane Doe" />
 			</Avatar.Root>,
 		);
@@ -307,7 +336,6 @@ describe("Avatar.Image", () => {
 	});
 
 	test("forwards className, data-*, and the ref, and joins the data-slot chain", () => {
-		stubImageLoading("loaded");
 		const ref = createRef<HTMLImageElement>();
 		render(
 			<Avatar.Root>
@@ -319,7 +347,6 @@ describe("Avatar.Image", () => {
 					ref={ref}
 					src="https://example.com/jane.png"
 				/>
-				<Avatar.Fallback name="Jane Doe" />
 			</Avatar.Root>,
 		);
 		const image = screen.getByRole("img", { name: "Jane Doe" });
@@ -329,70 +356,16 @@ describe("Avatar.Image", () => {
 		expect(ref.current).toBe(image);
 	});
 
-	test("shows the fallback while the image is still loading, then swaps to it", async () => {
-		// The middle state the synchronous stubs skip: Radix holds "loading" until the
-		// preloaded image fires `load`, so the fallback covers the wait and the image
-		// replaces it without the consumer branching on anything.
-		const loadListeners: Array<() => void> = [];
-		class PendingImage {
-			complete = false;
-			naturalWidth = 0;
-			crossOrigin: string | null = null;
-			referrerPolicy = "";
-			src = "";
-			// Radix reads the outcome off `event.currentTarget`, so the fake event has
-			// to carry the image that just "finished".
-			addEventListener(type: string, listener: (event: { currentTarget: unknown }) => void) {
-				if (type === "load") {
-					loadListeners.push(() => {
-						this.complete = true;
-						this.naturalWidth = 128;
-						listener({ currentTarget: this });
-					});
-				}
-			}
-			removeEventListener() {}
-		}
-		vi.stubGlobal("Image", PendingImage);
-		const onLoadingStatusChange = vi.fn<(status: string) => void>();
-		render(
-			<Avatar.Root>
-				<Avatar.Image
-					alt="Jane Doe"
-					onLoadingStatusChange={onLoadingStatusChange}
-					src="https://example.com/jane.png"
-				/>
-				<Avatar.Fallback name="Jane Doe" />
-			</Avatar.Root>,
-		);
-
-		expect(screen.getByText("JD")).toBeInTheDocument();
-		expect(screen.queryByRole("img")).not.toBeInTheDocument();
-		expect(onLoadingStatusChange).toHaveBeenCalledWith("loading");
-
-		await act(async () => {
-			for (const fireLoad of loadListeners) {
-				fireLoad();
-			}
-		});
-
-		expect(await screen.findByRole("img", { name: "Jane Doe" })).toBeInTheDocument();
-		expect(screen.queryByText("JD")).not.toBeInTheDocument();
-		expect(onLoadingStatusChange).toHaveBeenCalledWith("loaded");
-	});
-
 	test("asChild renders the consumer element with the image styles, data-slot, and ref", () => {
-		stubImageLoading("loaded");
 		const ref = createRef<HTMLImageElement>();
-		// The real reason to swap this part is a framework image component; the
-		// wrapper stands in for one, and receives the `alt`/`src` the part supplies.
+		// The real reason to swap this part is a framework image component; the wrapper
+		// stands in for one, and receives the src/alt the part supplies.
 		const FrameworkImage = (props: ComponentProps<"img">) => <img alt={props.alt} {...props} />;
 		render(
 			<Avatar.Root>
 				<Avatar.Image asChild alt="Jane Doe" ref={ref} src="https://example.com/jane.png">
 					<FrameworkImage className="custom-class" data-flavor="primary" />
 				</Avatar.Image>
-				<Avatar.Fallback name="Jane Doe" />
 			</Avatar.Root>,
 		);
 		const image = screen.getByRole("img", { name: "Jane Doe" });
@@ -402,27 +375,30 @@ describe("Avatar.Image", () => {
 		expect(image).toHaveAttribute("src", "https://example.com/jane.png");
 		expect(ref.current).toBe(image);
 	});
-
-	test("requires alt, more strictly than the img element does", () => {
-		// An avatar is the image a developer forgets, and an <img> with no alt
-		// announces its URL.
-		const withoutAlt = (
-			// @ts-expect-error -- alt is required
-			<Avatar.Image src="https://example.com/jane.png" />
-		);
-		expect(withoutAlt).toBeTruthy();
-	});
-
-	test("does not render during server rendering, so the fallback is the first paint", () => {
-		// Loading status is only knowable in a browser, so SSR markup can only carry
-		// the fallback — documented on the part, and asserted here so it stays true.
-		const html = renderToString(
-			<Avatar.Root>
-				<Avatar.Image alt="Jane Doe" src="https://example.com/jane.png" />
-				<Avatar.Fallback name="Jane Doe" />
-			</Avatar.Root>,
-		);
-		expect(html).not.toContain("<img");
-		expect(html).toContain("JD");
-	});
 });
+
+/**
+ * Type-level contracts, owned by `pnpm typecheck` rather than by a `test()`: a
+ * `@ts-expect-error` that compiles is the assertion, and pairing it with a runtime
+ * `expect` would read as coverage the vitest run does not have.
+ *
+ * `Avatar.Fallback` takes exactly one source of content — two would leave the winner
+ * to precedence, none would render an empty avatar — and `asChild` needs a real
+ * element to clone, so it belongs to the `children` arm only; beside `name` it would
+ * otherwise typecheck and then render a string into `Slot`. `Avatar.Image` requires
+ * `alt`, because an `<img>` without one announces its URL.
+ */
+export function typeLevelContracts() {
+	return (
+		<>
+			{/* @ts-expect-error -- name and children are mutually exclusive */}
+			<Avatar.Fallback name="Acme Corp">AC</Avatar.Fallback>
+			{/* @ts-expect-error -- one of name or children is required */}
+			<Avatar.Fallback />
+			{/* @ts-expect-error -- asChild has nothing to clone beside name */}
+			<Avatar.Fallback asChild name="Acme Corp" />
+			{/* @ts-expect-error -- alt is required */}
+			<Avatar.Image src="https://example.com/jane.png" />
+		</>
+	);
+}

--- a/packages/mantle/src/components/avatar/avatar.test.tsx
+++ b/packages/mantle/src/components/avatar/avatar.test.tsx
@@ -1,0 +1,311 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Avatar } from "./avatar.js";
+
+/**
+ * Radix decides whether `Avatar.Image` may render by preloading the `src`
+ * through `new window.Image()` and reading `complete` / `naturalWidth` — happy-dom
+ * fetches nothing, so without a stand-in every image stays `"loading"` forever
+ * and only the fallback is ever reachable. This stubs that one constructor with a
+ * probe that reports the outcome under test, synchronously.
+ */
+function stubImageLoading(outcome: "loaded" | "error") {
+	class ProbeImage {
+		complete = true;
+		naturalWidth = outcome === "loaded" ? 128 : 0;
+		crossOrigin: string | null = null;
+		referrerPolicy = "";
+		src = "";
+		addEventListener() {}
+		removeEventListener() {}
+	}
+	vi.stubGlobal("Image", ProbeImage);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("Avatar.Root", () => {
+	test("renders the documented composition, showing the fallback until an image loads", () => {
+		render(
+			<Avatar.Root appearance="square" colorSeed="acc_123">
+				<Avatar.Image src="https://example.com/acme.png" alt="" />
+				<Avatar.Fallback name="Acme Corp" />
+			</Avatar.Root>,
+		);
+		expect(screen.getByText("AC")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
+
+	test("is a fixed-size, unsqueezable circle by default", () => {
+		// shrink-0 is load-bearing: an avatar is a fixed-size visual and the flex
+		// rows it sits in must not be able to compress it.
+		render(<Avatar.Root data-testid="avatar" />);
+		expect(screen.getByTestId("avatar")).toHaveClass("size-7", "shrink-0", "rounded-full");
+	});
+
+	test("appearance=square renders a rounded square", () => {
+		render(<Avatar.Root appearance="square" data-testid="avatar" />);
+		const avatar = screen.getByTestId("avatar");
+		expect(avatar).toHaveClass("rounded-md");
+		expect(avatar).not.toHaveClass("rounded-full");
+	});
+
+	test("colorSeed paints a swatch and the static foreground that stays legible on it", () => {
+		render(<Avatar.Root colorSeed="acc_123" data-testid="avatar" />);
+		const avatar = screen.getByTestId("avatar");
+		// Pinned on purpose: the palette order is what makes a seed's color stable,
+		// so reordering it — which would recolor every account on screen — fails here.
+		expect(avatar).toHaveClass("bg-orange-500", "text-static-white");
+	});
+
+	test("the same seed always resolves to the same swatch, and different seeds spread", () => {
+		render(
+			<>
+				<Avatar.Root colorSeed="acc_acme" data-testid="first" />
+				<Avatar.Root colorSeed="acc_acme" data-testid="second" />
+				<Avatar.Root colorSeed="acc_atlas" data-testid="third" />
+			</>,
+		);
+		expect(screen.getByTestId("first")).toHaveClass("bg-emerald-500");
+		expect(screen.getByTestId("second")).toHaveClass("bg-emerald-500");
+		expect(screen.getByTestId("third")).toHaveClass("bg-purple-500");
+	});
+
+	test("a seeded swatch survives server rendering unchanged", () => {
+		// The hash has to agree across the SSR boundary or the avatar changes color
+		// on hydration.
+		const html = renderToString(<Avatar.Root colorSeed="acc_atlas" />);
+		expect(html).toContain("bg-purple-500");
+	});
+
+	test("without a seed it stays neutral and keeps the surrounding foreground", () => {
+		render(<Avatar.Root data-testid="avatar" />);
+		const avatar = screen.getByTestId("avatar");
+		expect(avatar).toHaveClass("bg-neutral-500/15", "text-body");
+		expect(avatar).not.toHaveClass("text-static-white");
+	});
+
+	test("forwards className, data-*, and the ref, and the consumer's size wins", () => {
+		const ref = createRef<HTMLSpanElement>();
+		render(
+			<Avatar.Root className="size-10" data-flavor="primary" data-testid="avatar" ref={ref} />,
+		);
+		const avatar = screen.getByTestId("avatar");
+		expect(avatar).toHaveClass("size-10");
+		expect(avatar).not.toHaveClass("size-7");
+		expect(avatar).toHaveAttribute("data-flavor", "primary");
+		expect(avatar).toHaveAttribute("data-slot", "avatar");
+		expect(ref.current).toBe(avatar);
+	});
+
+	test("joins an ancestor-forwarded data-slot chain ahead of its own", () => {
+		render(<Avatar.Root data-slot="outer" data-testid="avatar" />);
+		expect(screen.getByTestId("avatar")).toHaveAttribute("data-slot", "outer avatar");
+	});
+
+	test("asChild renders the consumer element with the avatar styles, data-slot, and ref", () => {
+		const ref = createRef<HTMLAnchorElement>();
+		render(
+			<Avatar.Root asChild appearance="square" colorSeed="acc_acme" ref={ref}>
+				<a className="custom-class" data-flavor="primary" href="/accounts/acme">
+					<Avatar.Fallback name="Acme Corp" />
+				</a>
+			</Avatar.Root>,
+		);
+		const link = screen.getByRole("link");
+		expect(link).toHaveClass("custom-class", "shrink-0", "rounded-md", "bg-emerald-500");
+		expect(link).toHaveAttribute("data-slot", "avatar");
+		expect(link).toHaveAttribute("data-flavor", "primary");
+		expect(ref.current).toBe(link);
+	});
+});
+
+describe("Avatar.Fallback", () => {
+	test.for([
+		{ expected: "AC", name: "Acme Corp" },
+		{ expected: "J", name: "jane" },
+		// the first two words, not first-and-last: a middle initial takes the second slot
+		{ expected: "JQ", name: "Jane Q. Doe" },
+		{ expected: "AC", name: "  acme   corp  " },
+		{ expected: "AI", name: "Atlas Industries, Inc." },
+		{ expected: "?", name: "" },
+		{ expected: "?", name: "   " },
+		{ expected: "?", name: "!@#$%" },
+		{ expected: "I", name: "ipek" },
+		{ expected: "🚀A", name: "🚀 Acme" },
+		{ expected: "ÉC", name: "école centrale" },
+	])("name=$name renders the initials $expected", ({ expected, name }) => {
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback name={name} />
+			</Avatar.Root>,
+		);
+		expect(screen.getByText(expected)).toBeInTheDocument();
+	});
+
+	test("derived initials are decorative, so a row's accessible name is not doubled", () => {
+		// The name they abbreviate is already in the DOM beside the avatar; without
+		// this a menu row reads "A C Acme Corp".
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback data-testid="fallback" name="Acme Corp" />
+			</Avatar.Root>,
+		);
+		expect(screen.getByTestId("fallback")).toHaveAttribute("aria-hidden", "true");
+	});
+
+	test("children are announced, and an explicit aria-hidden still wins", () => {
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback data-testid="children">AC</Avatar.Fallback>
+				<Avatar.Root>
+					<Avatar.Fallback aria-hidden={false} data-testid="override" name="Acme Corp" />
+				</Avatar.Root>
+			</Avatar.Root>,
+		);
+		expect(screen.getByTestId("children")).not.toHaveAttribute("aria-hidden");
+		expect(screen.getByTestId("override")).toHaveAttribute("aria-hidden", "false");
+	});
+
+	test("children render instead of derived initials", () => {
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback>
+					<svg aria-hidden="true" data-testid="silhouette" />
+				</Avatar.Fallback>
+			</Avatar.Root>,
+		);
+		expect(screen.getByTestId("silhouette")).toBeInTheDocument();
+	});
+
+	test("throws when rendered outside Avatar.Root", () => {
+		// Radix owns the context that decides whether a fallback may render, so it
+		// fails loudly rather than rendering an avatar that can never show anything.
+		expect(() => render(<Avatar.Fallback name="Acme Corp" />)).toThrow(
+			/must be used within `Avatar`/,
+		);
+	});
+
+	test("forwards className, data-*, and the ref, and joins the data-slot chain", () => {
+		const ref = createRef<HTMLSpanElement>();
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback
+					className="custom-class"
+					data-flavor="primary"
+					data-slot="outer"
+					data-testid="fallback"
+					name="Acme Corp"
+					ref={ref}
+				/>
+			</Avatar.Root>,
+		);
+		const fallback = screen.getByTestId("fallback");
+		expect(fallback).toHaveClass("custom-class", "size-full");
+		expect(fallback).toHaveAttribute("data-flavor", "primary");
+		expect(fallback).toHaveAttribute("data-slot", "outer avatar-fallback");
+		expect(ref.current).toBe(fallback);
+	});
+
+	test("asChild renders the consumer element with the fallback styles and ref", () => {
+		const ref = createRef<HTMLSpanElement>();
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback asChild ref={ref}>
+					<abbr className="custom-class" data-flavor="primary" title="Acme Corp">
+						AC
+					</abbr>
+				</Avatar.Fallback>
+			</Avatar.Root>,
+		);
+		const abbreviation = screen.getByTitle("Acme Corp");
+		expect(abbreviation).toHaveClass("custom-class", "items-center");
+		expect(abbreviation).toHaveAttribute("data-flavor", "primary");
+		expect(abbreviation).toHaveAttribute("data-slot", "avatar-fallback");
+		expect(ref.current).toBe(abbreviation);
+	});
+
+	test("requires exactly one source of content at the type level", () => {
+		// Two sources would leave the winner to precedence, and no source would
+		// render an empty avatar; both are compile errors rather than surprises.
+		const withBoth = (
+			// @ts-expect-error -- name and children are mutually exclusive
+			<Avatar.Fallback name="Acme Corp">AC</Avatar.Fallback>
+		);
+		const withNeither = (
+			// @ts-expect-error -- one of name or children is required
+			<Avatar.Fallback />
+		);
+		expect(withBoth).toBeTruthy();
+		expect(withNeither).toBeTruthy();
+	});
+});
+
+describe("Avatar.Image", () => {
+	test("renders the picture once it has loaded, and drops the fallback", () => {
+		stubImageLoading("loaded");
+		render(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" src="https://example.com/jane.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		const image = screen.getByRole("img", { name: "Jane Doe" });
+		expect(image).toHaveAttribute("src", "https://example.com/jane.png");
+		expect(image).toHaveClass("size-full", "object-cover");
+		expect(image).toHaveAttribute("data-slot", "avatar-image");
+		expect(screen.queryByText("JD")).not.toBeInTheDocument();
+	});
+
+	test("a failed image shows the fallback rather than a broken-image icon", () => {
+		stubImageLoading("error");
+		render(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" src="https://example.com/missing.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+		expect(screen.getByText("JD")).toBeInTheDocument();
+	});
+
+	test("forwards className, data-*, and the ref, and joins the data-slot chain", () => {
+		stubImageLoading("loaded");
+		const ref = createRef<HTMLImageElement>();
+		render(
+			<Avatar.Root>
+				<Avatar.Image
+					alt="Jane Doe"
+					className="custom-class"
+					data-flavor="primary"
+					data-slot="outer"
+					ref={ref}
+					src="https://example.com/jane.png"
+				/>
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		const image = screen.getByRole("img", { name: "Jane Doe" });
+		expect(image).toHaveClass("custom-class", "object-cover");
+		expect(image).toHaveAttribute("data-flavor", "primary");
+		expect(image).toHaveAttribute("data-slot", "outer avatar-image");
+		expect(ref.current).toBe(image);
+	});
+
+	test("does not render during server rendering, so the fallback is the first paint", () => {
+		// Loading status is only knowable in a browser, so SSR markup can only carry
+		// the fallback — documented on the part, and asserted here so it stays true.
+		const html = renderToString(
+			<Avatar.Root>
+				<Avatar.Image alt="Jane Doe" src="https://example.com/jane.png" />
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		expect(html).not.toContain("<img");
+		expect(html).toContain("JD");
+	});
+});

--- a/packages/mantle/src/components/avatar/avatar.test.tsx
+++ b/packages/mantle/src/components/avatar/avatar.test.tsx
@@ -1,15 +1,16 @@
-import { render, screen } from "@testing-library/react";
-import { createRef } from "react";
+import { act, render, screen } from "@testing-library/react";
+import { type ComponentProps, createRef } from "react";
 import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { Avatar } from "./avatar.js";
 
 /**
  * Radix decides whether `Avatar.Image` may render by preloading the `src`
- * through `new window.Image()` and reading `complete` / `naturalWidth` — happy-dom
- * fetches nothing, so without a stand-in every image stays `"loading"` forever
- * and only the fallback is ever reachable. This stubs that one constructor with a
- * probe that reports the outcome under test, synchronously.
+ * through `new window.Image()` and reading `complete` / `naturalWidth`. happy-dom
+ * ships with `enableImageFileLoading` off, so it answers every image with
+ * `complete: true, naturalWidth: 0` — which Radix reads as `"error"`, making the
+ * loaded path unreachable. This stubs that one constructor with a probe that
+ * reports the outcome under test, synchronously.
  */
 function stubImageLoading(outcome: "loaded" | "error") {
 	class ProbeImage {
@@ -138,6 +139,16 @@ describe("Avatar.Fallback", () => {
 		{ expected: "I", name: "ipek" },
 		{ expected: "🚀A", name: "🚀 Acme" },
 		{ expected: "ÉC", name: "école centrale" },
+		{ expected: "山太", name: "山田 太郎" },
+		{ expected: "مع", name: "محمد علي" },
+		// Uppercasing happens per word, before the code point is taken: "ß" → "SS"
+		// and "ﬄ" → "FFL", so uppercasing the joined result would overrun two.
+		{ expected: "SH", name: "straße hof" },
+		{ expected: "FF", name: "ﬄuent ﬂow" },
+		// Unicode punctuation reaches the "?" floor too, not just ASCII.
+		{ expected: "?", name: "…" },
+		{ expected: "?", name: "— —" },
+		{ expected: "A", name: "«Acme»" },
 	])("name=$name renders the initials $expected", ({ expected, name }) => {
 		render(
 			<Avatar.Root>
@@ -229,9 +240,26 @@ describe("Avatar.Fallback", () => {
 		expect(ref.current).toBe(abbreviation);
 	});
 
+	test("a child that resolves to nothing renders nothing, not a stray question mark", () => {
+		// `{isAdmin && <ShieldIcon />}` is the caller saying "nothing here" for
+		// everyone else. Coalescing that into derived initials would answer with a
+		// bare "?" — and an announced one, since only name-derived initials are
+		// hidden.
+		render(
+			<Avatar.Root>
+				<Avatar.Fallback data-testid="fallback">{null}</Avatar.Fallback>
+			</Avatar.Root>,
+		);
+		const fallback = screen.getByTestId("fallback");
+		expect(fallback).toBeEmptyDOMElement();
+		expect(fallback).not.toHaveAttribute("aria-hidden");
+	});
+
 	test("requires exactly one source of content at the type level", () => {
 		// Two sources would leave the winner to precedence, and no source would
 		// render an empty avatar; both are compile errors rather than surprises.
+		// `asChild` needs a real element to clone, so it belongs to the children arm
+		// only — otherwise it typechecks and then throws inside Radix's slot.
 		const withBoth = (
 			// @ts-expect-error -- name and children are mutually exclusive
 			<Avatar.Fallback name="Acme Corp">AC</Avatar.Fallback>
@@ -240,8 +268,13 @@ describe("Avatar.Fallback", () => {
 			// @ts-expect-error -- one of name or children is required
 			<Avatar.Fallback />
 		);
+		const withAsChildAndName = (
+			// @ts-expect-error -- asChild has nothing to clone beside name
+			<Avatar.Fallback asChild name="Acme Corp" />
+		);
 		expect(withBoth).toBeTruthy();
 		expect(withNeither).toBeTruthy();
+		expect(withAsChildAndName).toBeTruthy();
 	});
 });
 
@@ -294,6 +327,90 @@ describe("Avatar.Image", () => {
 		expect(image).toHaveAttribute("data-flavor", "primary");
 		expect(image).toHaveAttribute("data-slot", "outer avatar-image");
 		expect(ref.current).toBe(image);
+	});
+
+	test("shows the fallback while the image is still loading, then swaps to it", async () => {
+		// The middle state the synchronous stubs skip: Radix holds "loading" until the
+		// preloaded image fires `load`, so the fallback covers the wait and the image
+		// replaces it without the consumer branching on anything.
+		const loadListeners: Array<() => void> = [];
+		class PendingImage {
+			complete = false;
+			naturalWidth = 0;
+			crossOrigin: string | null = null;
+			referrerPolicy = "";
+			src = "";
+			// Radix reads the outcome off `event.currentTarget`, so the fake event has
+			// to carry the image that just "finished".
+			addEventListener(type: string, listener: (event: { currentTarget: unknown }) => void) {
+				if (type === "load") {
+					loadListeners.push(() => {
+						this.complete = true;
+						this.naturalWidth = 128;
+						listener({ currentTarget: this });
+					});
+				}
+			}
+			removeEventListener() {}
+		}
+		vi.stubGlobal("Image", PendingImage);
+		const onLoadingStatusChange = vi.fn<(status: string) => void>();
+		render(
+			<Avatar.Root>
+				<Avatar.Image
+					alt="Jane Doe"
+					onLoadingStatusChange={onLoadingStatusChange}
+					src="https://example.com/jane.png"
+				/>
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+
+		expect(screen.getByText("JD")).toBeInTheDocument();
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+		expect(onLoadingStatusChange).toHaveBeenCalledWith("loading");
+
+		await act(async () => {
+			for (const fireLoad of loadListeners) {
+				fireLoad();
+			}
+		});
+
+		expect(await screen.findByRole("img", { name: "Jane Doe" })).toBeInTheDocument();
+		expect(screen.queryByText("JD")).not.toBeInTheDocument();
+		expect(onLoadingStatusChange).toHaveBeenCalledWith("loaded");
+	});
+
+	test("asChild renders the consumer element with the image styles, data-slot, and ref", () => {
+		stubImageLoading("loaded");
+		const ref = createRef<HTMLImageElement>();
+		// The real reason to swap this part is a framework image component; the
+		// wrapper stands in for one, and receives the `alt`/`src` the part supplies.
+		const FrameworkImage = (props: ComponentProps<"img">) => <img alt={props.alt} {...props} />;
+		render(
+			<Avatar.Root>
+				<Avatar.Image asChild alt="Jane Doe" ref={ref} src="https://example.com/jane.png">
+					<FrameworkImage className="custom-class" data-flavor="primary" />
+				</Avatar.Image>
+				<Avatar.Fallback name="Jane Doe" />
+			</Avatar.Root>,
+		);
+		const image = screen.getByRole("img", { name: "Jane Doe" });
+		expect(image).toHaveClass("custom-class", "size-full", "object-cover");
+		expect(image).toHaveAttribute("data-slot", "avatar-image");
+		expect(image).toHaveAttribute("data-flavor", "primary");
+		expect(image).toHaveAttribute("src", "https://example.com/jane.png");
+		expect(ref.current).toBe(image);
+	});
+
+	test("requires alt, more strictly than the img element does", () => {
+		// An avatar is the image a developer forgets, and an <img> with no alt
+		// announces its URL.
+		const withoutAlt = (
+			// @ts-expect-error -- alt is required
+			<Avatar.Image src="https://example.com/jane.png" />
+		);
+		expect(withoutAlt).toBeTruthy();
 	});
 
 	test("does not render during server rendering, so the fallback is the first paint", () => {

--- a/packages/mantle/src/components/avatar/avatar.tsx
+++ b/packages/mantle/src/components/avatar/avatar.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import type { ComponentProps, ReactNode } from "react";
+import { cx } from "../../utils/cx/cx.js";
+import type { WithDataSlot } from "../../utils/data-slot.js";
+import { joinDataSlot } from "../../utils/data-slot.js";
+
+/**
+ * The shape an `Avatar.Root` renders as. Circles read as people, rounded
+ * squares as the things people belong to — accounts, workspaces, teams,
+ * organizations. Keeping the two shapes visually distinct is the point: a
+ * switcher row showing both at once stays legible without labels.
+ *
+ * @see https://mantle.ngrok.com/components/data-display/avatar
+ *
+ * @example
+ * ```tsx
+ * <Avatar.Root appearance="square" colorSeed="acc_123">
+ *   <Avatar.Fallback name="Acme Corp" />
+ * </Avatar.Root>
+ * ```
+ */
+type AvatarAppearance = "circle" | "square";
+
+/**
+ * The border radius each {@link AvatarAppearance} paints. A complete `Record`
+ * (not cva) so adding an appearance without its classes is a compile error.
+ */
+const appearanceClassName: Record<AvatarAppearance, string> = {
+	circle: "rounded-full",
+	square: "rounded-md",
+};
+
+/**
+ * The swatch palette a `colorSeed` selects from. Every entry is a Tailwind
+ * background color. Keep the hue order stable: {@link swatchClassName} indexes
+ * into this tuple by seed hash, so reordering it changes the color of every
+ * account already on screen.
+ */
+const swatchClassNames = [
+	"bg-emerald-500",
+	"bg-gray-500",
+	"bg-red-500",
+	"bg-violet-500",
+	"bg-cyan-500",
+	"bg-rose-500",
+	"bg-purple-500",
+	"bg-fuchsia-500",
+	"bg-green-500",
+	"bg-orange-500",
+	"bg-indigo-500",
+	"bg-teal-500",
+	"bg-yellow-500",
+	"bg-sky-500",
+	"bg-pink-500",
+	"bg-blue-500",
+	"bg-amber-500",
+] as const;
+
+/**
+ * djb2 is a stable, fast string hashing function. It is what makes a seed's
+ * swatch reproducible across renders, sessions, devices, and the server — an
+ * account keeps its color everywhere, with nothing stored.
+ */
+function djb2Hash(value: string): number {
+	let hash = 5381;
+	for (let index = 0; index < value.length; index += 1) {
+		hash = (hash * 33) ^ value.charCodeAt(index);
+	}
+	// Convert to unsigned 32-bit so the modulo below stays positive.
+	return hash >>> 0;
+}
+
+/**
+ * The swatch class a seed maps to — the same seed always yields the same
+ * swatch.
+ *
+ * @example
+ * ```ts
+ * swatchClassName("acc_123"); // e.g. "bg-violet-500"
+ * ```
+ */
+function swatchClassName(seed: string): string {
+	const index = djb2Hash(seed) % swatchClassNames.length;
+	// `swatchClassNames` is a non-empty `as const` tuple; the fallback satisfies
+	// the strict-mode index-access type without a non-null assertion.
+	return swatchClassNames[index] ?? "bg-neutral-500";
+}
+
+/**
+ * At most two uppercase initials for a name: punctuation is stripped, the first
+ * code point of each of the first two words is kept (so an emoji-leading name is
+ * not split mid-surrogate), casing is locale-invariant so SSR and client agree,
+ * and a name with no usable characters renders `"?"`.
+ *
+ * @example
+ * ```ts
+ * initialsFromName("Acme Corp"); // "AC"
+ * initialsFromName("jane"); // "J"
+ * initialsFromName("…"); // "?"
+ * ```
+ */
+function initialsFromName(name: string): string {
+	const initials = name
+		.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/g, "")
+		.trim()
+		.split(/\s+/)
+		.slice(0, 2)
+		// `Array.from` iterates code points, so a leading emoji or astral
+		// character survives instead of being cut in half.
+		.map((part) => Array.from(part)[0] ?? "")
+		.join("")
+		// locale-invariant casing: toLocaleUpperCase() follows the *host* locale,
+		// so an SSR server and a Turkish-locale client would disagree (i → İ) and
+		// mismatch on hydration.
+		.toUpperCase();
+	return initials || "?";
+}
+
+/**
+ * The props for `Avatar.Root`. Radix's `Avatar.Root` props — so `className`,
+ * `style`, `ref`, `asChild`, and any `data-*` reach the rendered `<span>` —
+ * plus the shape and swatch this root owns.
+ */
+type AvatarRootProps = ComponentProps<typeof AvatarPrimitive.Root> &
+	WithDataSlot & {
+		/**
+		 * The shape to render. `"circle"` for a person, `"square"` for a rounded
+		 * square representing an account, workspace, or team.
+		 *
+		 * @default "circle"
+		 */
+		appearance?: AvatarAppearance;
+		/**
+		 * A stable identifier — an account id, a user id — that deterministically
+		 * selects a background swatch, so the same subject always gets the same
+		 * color with nothing persisted. Omit it for a neutral surface, or set your
+		 * own `bg-*` class through `className` to opt out entirely.
+		 *
+		 * Seed it with an **id, not a display name**: names get edited, and a
+		 * rename would silently recolor the avatar.
+		 */
+		colorSeed?: string;
+	};
+
+/**
+ * A small image representing a person or an account, with a text or icon
+ * fallback for when there is no picture — or before one loads.
+ *
+ * The root sizes and shapes the avatar and paints the surface behind it. It is
+ * `size-7` and `shrink-0` by default: an avatar is a fixed-size visual, and the
+ * flex rows it usually sits in (a switcher row, a table cell, a comment header)
+ * must not be able to squeeze it. Override the size with `className`, which
+ * merges last and wins.
+ *
+ * @see https://mantle.ngrok.com/components/data-display/avatar#avatarroot
+ *
+ * **Data attributes:**
+ *
+ * | Data Attribute | Value      | Description                                             |
+ * | -------------- | ---------- | ------------------------------------------------------- |
+ * | `data-slot`    | `"avatar"` | Styling and test-targeting hook, with any forwarded chain ahead of it. |
+ *
+ * @example
+ * ```tsx
+ * <Avatar.Root appearance="square" colorSeed="acc_123">
+ *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+ *   <Avatar.Fallback name="Acme Corp" />
+ * </Avatar.Root>
+ * ```
+ */
+const Root = ({
+	appearance = "circle",
+	className,
+	colorSeed,
+	"data-slot": dataSlot,
+	...props
+}: AvatarRootProps) => (
+	<AvatarPrimitive.Root
+		className={cx(
+			"text-body bg-neutral-500/15 relative flex size-7 shrink-0 items-center justify-center overflow-hidden text-xs font-medium select-none",
+			appearanceClassName[appearance],
+			// A seeded swatch is a colored surface, so its content switches to the
+			// static white that stays legible on every hue in both themes.
+			colorSeed != null && ["text-static-white", swatchClassName(colorSeed)],
+			className,
+		)}
+		data-slot={joinDataSlot(dataSlot, "avatar")}
+		{...props}
+	/>
+);
+
+/**
+ * The props for `Avatar.Image`. Radix's `Avatar.Image` props, which are an
+ * `<img>`'s — including `src`, `alt`, `referrerPolicy`, `crossOrigin`, and
+ * `onLoadingStatusChange`.
+ */
+type AvatarImageProps = ComponentProps<typeof AvatarPrimitive.Image> & WithDataSlot;
+
+/**
+ * The avatar's picture. It renders **only once the image has loaded**, so a
+ * broken or slow URL shows `Avatar.Fallback` instead of a broken-image icon —
+ * and it never renders during SSR, because loading status is only knowable in a
+ * browser. The first paint is therefore always the fallback, including for a
+ * cached image; that is the trade for never flashing a broken image. When an
+ * avatar is above the fold and its URL is known good, render a plain
+ * `<img className="size-full object-cover">` inside `Avatar.Root` instead and
+ * the server markup will carry it.
+ *
+ * `alt` is the image's own contract: pass a person's or account's name when the
+ * avatar is the only thing naming them, and `alt=""` when adjacent text already
+ * does, so a screen reader does not read the name twice.
+ *
+ * @see https://mantle.ngrok.com/components/data-display/avatar#avatarimage
+ *
+ * **Data attributes:**
+ *
+ * | Data Attribute | Value            | Description                                             |
+ * | -------------- | ---------------- | ------------------------------------------------------- |
+ * | `data-slot`    | `"avatar-image"` | Styling and test-targeting hook, with any forwarded chain ahead of it. |
+ *
+ * @example
+ * ```tsx
+ * <Avatar.Root appearance="square" colorSeed="acc_123">
+ *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+ *   <Avatar.Fallback name="Acme Corp" />
+ * </Avatar.Root>
+ * ```
+ */
+const Image = ({ className, "data-slot": dataSlot, ...props }: AvatarImageProps) => (
+	<AvatarPrimitive.Image
+		className={cx("size-full object-cover", className)}
+		data-slot={joinDataSlot(dataSlot, "avatar-image")}
+		{...props}
+	/>
+);
+
+/**
+ * The props for `Avatar.Fallback`. Radix's `Avatar.Fallback` props — including
+ * `delayMs` and `asChild` — with the content stated exactly one way: either
+ * `children` you render yourself, or a `name` this part derives initials from.
+ * Passing both would leave the winner to precedence, so the type forbids it.
+ */
+type AvatarFallbackProps = Omit<ComponentProps<typeof AvatarPrimitive.Fallback>, "children"> &
+	WithDataSlot &
+	(
+		| {
+				/**
+				 * What to show when there is no image: initials, an icon, anything. Use
+				 * `name` instead when the content is just the subject's initials.
+				 */
+				children: ReactNode;
+				name?: never;
+		  }
+		| {
+				children?: never;
+				/**
+				 * The subject's display name, rendered as at most two uppercase
+				 * initials — `"Acme Corp"` becomes `"AC"`, a name with no usable
+				 * characters becomes `"?"`. Deriving it here keeps one implementation
+				 * of a surprisingly fiddly rule (punctuation, code points, and casing
+				 * that has to match between server and client).
+				 *
+				 * Initials derived this way are `aria-hidden`: they abbreviate a name
+				 * the page already carries in text beside the avatar. When the avatar
+				 * is the only thing naming its subject, name it — `role="img"` plus
+				 * `aria-label` on `Avatar.Root` — rather than announcing `"AC"`.
+				 *
+				 * Incompatible with `asChild`, which needs a real element to clone.
+				 */
+				name: string;
+		  }
+	);
+
+/**
+ * What the avatar shows when there is no picture — initials, an icon, a
+ * monogram. Radix renders it whenever `Avatar.Image` is absent, still loading,
+ * or failed, which makes it the first paint in every server-rendered page.
+ *
+ * Pass `name` to render the subject's initials, or `children` for anything else.
+ * A fallback is decorative when adjacent text already names the subject, so give
+ * an icon child `aria-hidden` unless the avatar is the only label.
+ *
+ * @see https://mantle.ngrok.com/components/data-display/avatar#avatarfallback
+ *
+ * **Data attributes:**
+ *
+ * | Data Attribute | Value               | Description                                             |
+ * | -------------- | ------------------- | ------------------------------------------------------- |
+ * | `data-slot`    | `"avatar-fallback"` | Styling and test-targeting hook, with any forwarded chain ahead of it. |
+ *
+ * @example
+ * ```tsx
+ * <Avatar.Root appearance="square" colorSeed="acc_123">
+ *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+ *   <Avatar.Fallback name="Acme Corp" />
+ * </Avatar.Root>
+ * ```
+ */
+const Fallback = ({
+	children,
+	className,
+	"data-slot": dataSlot,
+	name,
+	...props
+}: AvatarFallbackProps) => (
+	<AvatarPrimitive.Fallback
+		// Derived initials are a visual shorthand for a name the page already
+		// carries — the row, cell, or card next to the avatar — so announcing them
+		// would read it twice ("A C Acme Corp"). They are decorative by default;
+		// `children` are not, and an explicit `aria-hidden` overrides either way.
+		aria-hidden={name == null ? undefined : true}
+		className={cx("flex size-full items-center justify-center", className)}
+		data-slot={joinDataSlot(dataSlot, "avatar-fallback")}
+		{...props}
+	>
+		{/*
+		 * The type guarantees exactly one of `children` / `name`. An untyped call
+		 * site can still send neither, which lands on the same `"?"` that a name
+		 * with no usable characters renders — an avatar, not a blank.
+		 */}
+		{children ?? initialsFromName(name ?? "")}
+	</AvatarPrimitive.Fallback>
+);
+
+/**
+ * A small image representing a person or an account, with a text or icon
+ * fallback for when there is no picture — or before one loads.
+ *
+ * `appearance` carries the meaning: `"circle"` for a person, `"square"` (a
+ * rounded square) for an account, workspace, team, or organization. A row that
+ * shows both — an account switcher with the signed-in user's photo beside it —
+ * stays readable without labels because the shapes differ.
+ *
+ * `colorSeed` gives a subject a stable color derived from its id, so the same
+ * account is the same color on every device with nothing stored. Omit it for a
+ * neutral surface.
+ *
+ * For a person's name and title beside their avatar, compose it with
+ * [MediaObject](https://mantle.ngrok.com/components/data-display/media-object).
+ * For the leading visual of a sidebar switcher row, put it inside
+ * [Sidebar.SwitcherTrigger](https://mantle.ngrok.com/components/navigation/sidebar#sidebarswitchertrigger).
+ *
+ * @see https://mantle.ngrok.com/components/data-display/avatar
+ *
+ * @example
+ * Composition:
+ * ```
+ * Avatar.Root
+ * ├── Avatar.Image
+ * └── Avatar.Fallback
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <Avatar.Root appearance="square" colorSeed="acc_123">
+ *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+ *   <Avatar.Fallback name="Acme Corp" />
+ * </Avatar.Root>
+ * ```
+ */
+const Avatar: {
+	Root: typeof Root;
+	Image: typeof Image;
+	Fallback: typeof Fallback;
+} = {
+	/**
+	 * A small image representing a person or an account, with a text or icon
+	 * fallback for when there is no picture — or before one loads.
+	 *
+	 * The root sizes and shapes the avatar and paints the surface behind it. It is
+	 * `size-7` and `shrink-0` by default: an avatar is a fixed-size visual, and the
+	 * flex rows it usually sits in must not be able to squeeze it. Override the
+	 * size with `className`, which merges last and wins.
+	 *
+	 * @see https://mantle.ngrok.com/components/data-display/avatar#avatarroot
+	 *
+	 * **Data attributes:**
+	 *
+	 * | Data Attribute | Value      | Description                                             |
+	 * | -------------- | ---------- | ------------------------------------------------------- |
+	 * | `data-slot`    | `"avatar"` | Styling and test-targeting hook, with any forwarded chain ahead of it. |
+	 *
+	 * @example
+	 * ```tsx
+	 * <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+	 *   <Avatar.Fallback name="Acme Corp" />
+	 * </Avatar.Root>
+	 * ```
+	 */
+	Root,
+	/**
+	 * The avatar's picture. It renders only once the image has loaded, so a broken
+	 * or slow URL shows `Avatar.Fallback` instead of a broken-image icon — and it
+	 * never renders during SSR, so the fallback is always the first paint.
+	 *
+	 * @see https://mantle.ngrok.com/components/data-display/avatar#avatarimage
+	 *
+	 * **Data attributes:**
+	 *
+	 * | Data Attribute | Value            | Description                                             |
+	 * | -------------- | ---------------- | ------------------------------------------------------- |
+	 * | `data-slot`    | `"avatar-image"` | Styling and test-targeting hook, with any forwarded chain ahead of it. |
+	 *
+	 * @example
+	 * ```tsx
+	 * <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+	 *   <Avatar.Fallback name="Acme Corp" />
+	 * </Avatar.Root>
+	 * ```
+	 */
+	Image,
+	/**
+	 * What the avatar shows when there is no picture — initials, an icon, a
+	 * monogram. Pass `name` to render the subject's initials, or `children` for
+	 * anything else.
+	 *
+	 * @see https://mantle.ngrok.com/components/data-display/avatar#avatarfallback
+	 *
+	 * **Data attributes:**
+	 *
+	 * | Data Attribute | Value               | Description                                             |
+	 * | -------------- | ------------------- | ------------------------------------------------------- |
+	 * | `data-slot`    | `"avatar-fallback"` | Styling and test-targeting hook, with any forwarded chain ahead of it. |
+	 *
+	 * @example
+	 * ```tsx
+	 * <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *   <Avatar.Image src="https://example.com/acme.png" alt="" />
+	 *   <Avatar.Fallback name="Acme Corp" />
+	 * </Avatar.Root>
+	 * ```
+	 */
+	Fallback,
+} as const;
+
+export {
+	//,
+	Avatar,
+};
+
+export type {
+	//,
+	AvatarAppearance,
+	AvatarFallbackProps,
+	AvatarImageProps,
+	AvatarRootProps,
+};

--- a/packages/mantle/src/components/avatar/avatar.tsx
+++ b/packages/mantle/src/components/avatar/avatar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import * as AvatarPrimitive from "@radix-ui/react-avatar";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ReactEventHandler, ReactNode } from "react";
+import { useState } from "react";
+import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
+import { Slot } from "../slot/index.js";
 
 /**
  * The shape an `Avatar.Root` renders as. Circles read as people, rounded
@@ -129,11 +131,12 @@ function initialsFromName(name: string): string {
 }
 
 /**
- * The props for `Avatar.Root`. Radix's `Avatar.Root` props — so `className`,
- * `style`, `ref`, `asChild`, and any `data-*` reach the rendered `<span>` —
+ * The props for `Avatar.Root`. A `<span>`'s props — so `className`, `style`,
+ * `ref`, `asChild`, and any `data-*` or `aria-*` reach the rendered element —
  * plus the shape and swatch this root owns.
  */
-type AvatarRootProps = ComponentProps<typeof AvatarPrimitive.Root> &
+type AvatarRootProps = ComponentProps<"span"> &
+	WithAsChild &
 	WithDataSlot & {
 		/**
 		 * The shape to render. `"circle"` for a person, `"square"` for a rounded
@@ -164,6 +167,9 @@ type AvatarRootProps = ComponentProps<typeof AvatarPrimitive.Root> &
  * must not be able to squeeze it. Override the size with `className`, which
  * merges last and wins.
  *
+ * It renders a `<span>`, not a `<div>`, so it stays valid inside the `<button>`
+ * of a switcher row.
+ *
  * @see https://mantle.ngrok.com/components/data-display/avatar#avatarroot
  *
  * **Data attributes:**
@@ -182,62 +188,80 @@ type AvatarRootProps = ComponentProps<typeof AvatarPrimitive.Root> &
  */
 const Root = ({
 	appearance = "circle",
+	asChild,
 	className,
 	colorSeed,
 	"data-slot": dataSlot,
 	...props
-}: AvatarRootProps) => (
-	<AvatarPrimitive.Root
-		className={cx(
-			"text-body bg-neutral-500/15 relative flex size-7 shrink-0 items-center justify-center overflow-hidden text-xs font-medium select-none",
-			appearanceClassName[appearance],
-			// A seeded swatch is a colored surface, so its content switches to the
-			// static white that stays legible on every hue in both themes.
-			colorSeed != null && ["text-static-white", swatchClassName(colorSeed)],
-			className,
-		)}
-		data-slot={joinDataSlot(dataSlot, "avatar")}
-		{...props}
-	/>
-);
+}: AvatarRootProps) => {
+	const Comp = asChild ? Slot : "span";
+
+	return (
+		<Comp
+			className={cx(
+				// `relative` is load-bearing: `Avatar.Image` positions itself against
+				// this box so it covers the fallback rather than displacing it.
+				"text-body bg-neutral-500/15 relative flex size-7 shrink-0 items-center justify-center overflow-hidden text-xs font-medium select-none",
+				appearanceClassName[appearance],
+				// A seeded swatch is a colored surface, so its content switches to the
+				// static white that stays legible on every hue in both themes.
+				colorSeed != null && ["text-static-white", swatchClassName(colorSeed)],
+				className,
+			)}
+			data-slot={joinDataSlot(dataSlot, "avatar")}
+			{...props}
+		/>
+	);
+};
 
 /**
- * The props for `Avatar.Image`. Radix's `Avatar.Image` props, which are an
- * `<img>`'s — including `src`, `referrerPolicy`, `crossOrigin`, and
- * `onLoadingStatusChange` — with `alt` promoted to required.
+ * The props for `Avatar.Image`. An `<img>`'s props — so `srcSet`, `sizes`,
+ * `loading`, `referrerPolicy`, `crossOrigin`, `className`, `style`, `ref`,
+ * `asChild`, and any `data-*` reach the element — with `alt` promoted to
+ * required.
  */
-type AvatarImageProps = Omit<ComponentProps<typeof AvatarPrimitive.Image>, "alt"> &
+type AvatarImageProps = Omit<ComponentProps<"img">, "alt" | "onError"> &
+	WithAsChild &
 	WithDataSlot & {
 		/**
-		 * The image's alternative text. **Required**, deliberately more strict than
-		 * the `<img>` element and than Radix: an avatar is the one image a developer
-		 * reliably forgets, and an `<img>` with no `alt` falls back to announcing its
-		 * URL.
+		 * The image's alternative text. **Required**, deliberately stricter than the
+		 * `<img>` element: an avatar is the one image a developer reliably forgets,
+		 * and an `<img>` with no `alt` announces its URL.
 		 *
 		 * Pass `alt=""` when adjacent text already names the subject — the common
 		 * case, and the reason this is not just "always pass the name". Pass the name
-		 * when the avatar stands alone, and name `Avatar.Root` as well
-		 * (`role="img"` + `aria-label`) so the label survives the states where the
-		 * image is not mounted.
+		 * when the avatar stands alone, and name `Avatar.Root` as well (`role="img"`
+		 * + `aria-label`) so the label survives the states where the image is gone.
 		 */
 		alt: string;
+		/**
+		 * Called when the image fails to load, **before** it unmounts itself.
+		 * `preventDefault()` keeps it mounted, for a consumer who would rather retry
+		 * a URL than fall back.
+		 *
+		 * Typed against `HTMLElement` rather than `HTMLImageElement`, because
+		 * `asChild` means the element that failed may be a consumer's own.
+		 */
+		onError?: ReactEventHandler<HTMLElement>;
 	};
 
 /**
- * The avatar's picture. It renders **only once the image has loaded**, so a
- * broken or slow URL shows `Avatar.Fallback` instead of a broken-image icon —
- * and it never renders during SSR, because loading status is only knowable in a
- * browser. The first paint is therefore always the fallback, including for a
- * cached image; that is the trade for never flashing a broken image. When an
- * avatar is above the fold and its URL is known good, render a plain
- * `<img className="size-full object-cover">` inside `Avatar.Root` instead and
- * the server markup will carry it.
+ * The avatar's picture, layered over `Avatar.Fallback` so the fallback shows
+ * through until the image paints. It is a plain `<img>` in the markup, which is
+ * the whole point: the server renders it, the browser starts fetching while it
+ * parses the HTML, and a cached image is simply *there* on the first frame — no
+ * hydration, no swap, no flash of initials.
  *
- * `alt` is required — pass `""` when adjacent text already names the subject,
- * which is the common case. Note what `alt` alone cannot do: this `<img>` is
- * absent in exactly the states where a name is most needed (no `src`, a failed
- * load, SSR), so an avatar that must be named in every state names its **root**
- * (`role="img"` + `aria-label`), and `alt` describes the picture within it.
+ * A failed load unmounts the image and leaves the fallback showing. That covers
+ * every failure the client can observe; one it cannot is a load that fails
+ * *before* hydration, where the error event has already come and gone. There the
+ * browser's own rendering stands, which for `alt=""` is nothing at all — the
+ * fallback simply shows through — and is one more reason to prefer `alt=""`
+ * whenever adjacent text names the subject.
+ *
+ * `onError` runs first and can `preventDefault()` to keep the image mounted, for
+ * a consumer who would rather retry a URL than fall back. Changing `src` is
+ * always a fresh attempt: only the exact URL that failed stays unmounted.
  *
  * @see https://mantle.ngrok.com/components/data-display/avatar#avatarimage
  *
@@ -255,31 +279,54 @@ type AvatarImageProps = Omit<ComponentProps<typeof AvatarPrimitive.Image>, "alt"
  * </Avatar.Root>
  * ```
  */
-const Image = ({ className, "data-slot": dataSlot, ...props }: AvatarImageProps) => (
-	<AvatarPrimitive.Image
-		className={cx("size-full object-cover", className)}
-		data-slot={joinDataSlot(dataSlot, "avatar-image")}
-		{...props}
-	/>
-);
+const Image = ({
+	asChild,
+	className,
+	"data-slot": dataSlot,
+	onError,
+	src,
+	...props
+}: AvatarImageProps) => {
+	// The failed URL, not a boolean: a new `src` is a new attempt, so this needs no
+	// reset when the prop changes and cannot strand an avatar that got a good URL
+	// after a bad one.
+	const [failedSrc, setFailedSrc] = useState<string>();
+	const Comp = asChild ? Slot : "img";
+
+	if (src == null || src === "" || src === failedSrc) {
+		return null;
+	}
+
+	return (
+		<Comp
+			className={cx("absolute inset-0 size-full object-cover", className)}
+			data-slot={joinDataSlot(dataSlot, "avatar-image")}
+			onError={(event) => {
+				onError?.(event);
+				if (!event.defaultPrevented) {
+					setFailedSrc(src);
+				}
+			}}
+			src={src}
+			{...props}
+		/>
+	);
+};
 
 /**
- * The props for `Avatar.Fallback`. Radix's `Avatar.Fallback` props — including
- * `delayMs` and `asChild` — with the content stated exactly one way: either
- * `children` you render yourself, or a `name` this part derives initials from.
- * Passing both would leave the winner to precedence, so the type forbids it.
+ * The props for `Avatar.Fallback`. A `<span>`'s props, with the content stated
+ * exactly one way: either `children` you render yourself, or a `name` this part
+ * derives initials from. Passing both would leave the winner to precedence, so
+ * the type forbids it — and `asChild`, which needs a real element to clone,
+ * belongs to the `children` side only.
  */
-type AvatarFallbackProps = Omit<
-	ComponentProps<typeof AvatarPrimitive.Fallback>,
-	"asChild" | "children"
-> &
+type AvatarFallbackProps = Omit<ComponentProps<"span">, "children"> &
 	WithDataSlot &
 	(
 		| {
 				/**
-				 * Render this element instead of the fallback's own `<span>`, forwarded
-				 * to Radix's own composition. Only available beside `children` — there
-				 * has to be an element to clone.
+				 * Render this element instead of the fallback's own `<span>`. Only
+				 * available beside `children` — there has to be an element to clone.
 				 */
 				asChild?: boolean;
 				/**
@@ -303,8 +350,6 @@ type AvatarFallbackProps = Omit<
 				 * the page already carries in text beside the avatar. When the avatar
 				 * is the only thing naming its subject, name it — `role="img"` plus
 				 * `aria-label` on `Avatar.Root` — rather than announcing `"AC"`.
-				 *
-				 * Incompatible with `asChild`, which needs a real element to clone.
 				 */
 				name: string;
 		  }
@@ -312,8 +357,10 @@ type AvatarFallbackProps = Omit<
 
 /**
  * What the avatar shows when there is no picture — initials, an icon, a
- * monogram. Radix renders it whenever `Avatar.Image` is absent, still loading,
- * or failed, which makes it the first paint in every server-rendered page.
+ * monogram. It always renders, sitting *behind* `Avatar.Image`: that is what
+ * makes a loading image show initials instead of an empty box, with no loading
+ * state for anyone to handle. A loaded image covers it, so give a transparent
+ * PNG its own backdrop if you would rather not see initials through it.
  *
  * Pass `name` to render the subject's initials, or `children` for anything else.
  * A fallback is decorative when adjacent text already names the subject, so give
@@ -336,32 +383,37 @@ type AvatarFallbackProps = Omit<
  * ```
  */
 const Fallback = ({
+	asChild,
 	children,
 	className,
 	"data-slot": dataSlot,
 	name,
 	...props
-}: AvatarFallbackProps) => (
-	<AvatarPrimitive.Fallback
-		// Derived initials are a visual shorthand for a name the page already
-		// carries — the row, cell, or card next to the avatar — so announcing them
-		// would read it twice ("A C Acme Corp"). They are decorative by default;
-		// `children` are not, and an explicit `aria-hidden` overrides either way.
-		aria-hidden={name == null ? undefined : true}
-		className={cx("flex size-full items-center justify-center", className)}
-		data-slot={joinDataSlot(dataSlot, "avatar-fallback")}
-		{...props}
-	>
-		{/*
-		 * Keyed on `name`, not on `children ?? initialsFromName(…)`: a conditional
-		 * child that resolves to `null` is still the caller saying "render nothing
-		 * here", and coalescing would answer `{isAdmin && <ShieldIcon />}` with a
-		 * bare `"?"` for everyone else. `name` wins only when it was actually
-		 * passed, which the type already makes exclusive with `children`.
-		 */}
-		{name == null ? children : initialsFromName(name)}
-	</AvatarPrimitive.Fallback>
-);
+}: AvatarFallbackProps) => {
+	const Comp = asChild ? Slot : "span";
+
+	return (
+		<Comp
+			// Derived initials are a visual shorthand for a name the page already
+			// carries — the row, cell, or card next to the avatar — so announcing them
+			// would read it twice ("A C Acme Corp"). They are decorative by default;
+			// `children` are not, and an explicit `aria-hidden` overrides either way.
+			aria-hidden={name == null ? undefined : true}
+			className={cx("flex size-full items-center justify-center", className)}
+			data-slot={joinDataSlot(dataSlot, "avatar-fallback")}
+			{...props}
+		>
+			{/*
+			 * Keyed on `name`, not on `children ?? initialsFromName(…)`: a conditional
+			 * child that resolves to `null` is still the caller saying "render nothing
+			 * here", and coalescing would answer `{isAdmin && <ShieldIcon />}` with a
+			 * bare `"?"` for everyone else. `name` wins only when it was actually
+			 * passed, which the type already makes exclusive with `children`.
+			 */}
+			{name == null ? children : initialsFromName(name)}
+		</Comp>
+	);
+};
 
 /**
  * A small image representing a person or an account, with a text or icon
@@ -375,6 +427,11 @@ const Fallback = ({
  * `colorSeed` gives a subject a stable color derived from its id, so the same
  * account is the same color on every device with nothing stored. Omit it for a
  * neutral surface.
+ *
+ * The picture is a plain `<img>` layered over the fallback, so the server
+ * renders it and a cached image is on screen in the first frame. There is no
+ * loading state to handle: the fallback is simply behind, and shows until the
+ * image paints.
  *
  * For a person's name and title beside their avatar, compose it with
  * [MediaObject](https://mantle.ngrok.com/components/structure/media-object).
@@ -399,11 +456,7 @@ const Fallback = ({
  * </Avatar.Root>
  * ```
  */
-const Avatar: {
-	Root: typeof Root;
-	Image: typeof Image;
-	Fallback: typeof Fallback;
-} = {
+const Avatar = {
 	/**
 	 * A small image representing a person or an account, with a text or icon
 	 * fallback for when there is no picture — or before one loads.
@@ -411,7 +464,8 @@ const Avatar: {
 	 * The root sizes and shapes the avatar and paints the surface behind it. It is
 	 * `size-7` and `shrink-0` by default: an avatar is a fixed-size visual, and the
 	 * flex rows it usually sits in must not be able to squeeze it. Override the
-	 * size with `className`, which merges last and wins.
+	 * size with `className`, which merges last and wins. It renders a `<span>`, so
+	 * it stays valid inside the `<button>` of a switcher row.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-display/avatar#avatarroot
 	 *
@@ -431,9 +485,10 @@ const Avatar: {
 	 */
 	Root,
 	/**
-	 * The avatar's picture. It renders only once the image has loaded, so a broken
-	 * or slow URL shows `Avatar.Fallback` instead of a broken-image icon — and it
-	 * never renders during SSR, so the fallback is always the first paint.
+	 * The avatar's picture, layered over `Avatar.Fallback` so the fallback shows
+	 * through until the image paints. A plain `<img>` in the markup: the server
+	 * renders it, and a cached image needs no hydration to appear. A failed load
+	 * unmounts it and leaves the fallback showing.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-display/avatar#avatarimage
 	 *
@@ -454,8 +509,9 @@ const Avatar: {
 	Image,
 	/**
 	 * What the avatar shows when there is no picture — initials, an icon, a
-	 * monogram. Pass `name` to render the subject's initials, or `children` for
-	 * anything else.
+	 * monogram. It always renders, behind `Avatar.Image`, which is what makes a
+	 * loading image show initials rather than an empty box. Pass `name` to render
+	 * the subject's initials, or `children` for anything else.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-display/avatar#avatarfallback
 	 *

--- a/packages/mantle/src/components/avatar/avatar.tsx
+++ b/packages/mantle/src/components/avatar/avatar.tsx
@@ -98,23 +98,33 @@ function swatchClassName(seed: string): string {
  * ```ts
  * initialsFromName("Acme Corp"); // "AC"
  * initialsFromName("jane"); // "J"
+ * initialsFromName("山田 太郎"); // "山太"
+ * initialsFromName("straße hof"); // "SH" — not "SSH"
  * initialsFromName("…"); // "?"
  * ```
  */
 function initialsFromName(name: string): string {
 	const initials = name
-		.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/g, "")
+		// `\p{P}` reaches the punctuation an ASCII class cannot — ellipses,
+		// guillemets, em dashes — while leaving `\p{S}` symbols alone so an
+		// emoji-leading name still resolves to the emoji rather than to `"?"`. The
+		// ASCII tail covers the symbols that read as punctuation in a name.
+		.replace(/[\p{P}`~!@#$%^&*+|=<>]/gu, "")
 		.trim()
 		.split(/\s+/)
 		.slice(0, 2)
-		// `Array.from` iterates code points, so a leading emoji or astral
-		// character survives instead of being cut in half.
-		.map((part) => Array.from(part)[0] ?? "")
-		.join("")
-		// locale-invariant casing: toLocaleUpperCase() follows the *host* locale,
-		// so an SSR server and a Turkish-locale client would disagree (i → İ) and
-		// mismatch on hydration.
-		.toUpperCase();
+		.map(
+			(part) =>
+				// Uppercase the word BEFORE taking its first code point, not the joined
+				// result: "ß".toUpperCase() is "SS" and "ﬄ" is "FFL", so uppercasing
+				// afterwards would blow past two characters. Locale-invariant on purpose
+				// — toLocaleUpperCase() follows the *host* locale, so an SSR server and a
+				// Turkish-locale client would disagree (i → İ) and mismatch on hydration.
+				// `Array.from` iterates code points, so an astral character or emoji
+				// survives instead of being cut in half.
+				Array.from(part.toUpperCase())[0] ?? "",
+		)
+		.join("");
 	return initials || "?";
 }
 
@@ -193,10 +203,25 @@ const Root = ({
 
 /**
  * The props for `Avatar.Image`. Radix's `Avatar.Image` props, which are an
- * `<img>`'s — including `src`, `alt`, `referrerPolicy`, `crossOrigin`, and
- * `onLoadingStatusChange`.
+ * `<img>`'s — including `src`, `referrerPolicy`, `crossOrigin`, and
+ * `onLoadingStatusChange` — with `alt` promoted to required.
  */
-type AvatarImageProps = ComponentProps<typeof AvatarPrimitive.Image> & WithDataSlot;
+type AvatarImageProps = Omit<ComponentProps<typeof AvatarPrimitive.Image>, "alt"> &
+	WithDataSlot & {
+		/**
+		 * The image's alternative text. **Required**, deliberately more strict than
+		 * the `<img>` element and than Radix: an avatar is the one image a developer
+		 * reliably forgets, and an `<img>` with no `alt` falls back to announcing its
+		 * URL.
+		 *
+		 * Pass `alt=""` when adjacent text already names the subject — the common
+		 * case, and the reason this is not just "always pass the name". Pass the name
+		 * when the avatar stands alone, and name `Avatar.Root` as well
+		 * (`role="img"` + `aria-label`) so the label survives the states where the
+		 * image is not mounted.
+		 */
+		alt: string;
+	};
 
 /**
  * The avatar's picture. It renders **only once the image has loaded**, so a
@@ -208,9 +233,11 @@ type AvatarImageProps = ComponentProps<typeof AvatarPrimitive.Image> & WithDataS
  * `<img className="size-full object-cover">` inside `Avatar.Root` instead and
  * the server markup will carry it.
  *
- * `alt` is the image's own contract: pass a person's or account's name when the
- * avatar is the only thing naming them, and `alt=""` when adjacent text already
- * does, so a screen reader does not read the name twice.
+ * `alt` is required — pass `""` when adjacent text already names the subject,
+ * which is the common case. Note what `alt` alone cannot do: this `<img>` is
+ * absent in exactly the states where a name is most needed (no `src`, a failed
+ * load, SSR), so an avatar that must be named in every state names its **root**
+ * (`role="img"` + `aria-label`), and `alt` describes the picture within it.
  *
  * @see https://mantle.ngrok.com/components/data-display/avatar#avatarimage
  *
@@ -242,10 +269,19 @@ const Image = ({ className, "data-slot": dataSlot, ...props }: AvatarImageProps)
  * `children` you render yourself, or a `name` this part derives initials from.
  * Passing both would leave the winner to precedence, so the type forbids it.
  */
-type AvatarFallbackProps = Omit<ComponentProps<typeof AvatarPrimitive.Fallback>, "children"> &
+type AvatarFallbackProps = Omit<
+	ComponentProps<typeof AvatarPrimitive.Fallback>,
+	"asChild" | "children"
+> &
 	WithDataSlot &
 	(
 		| {
+				/**
+				 * Render this element instead of the fallback's own `<span>`, forwarded
+				 * to Radix's own composition. Only available beside `children` — there
+				 * has to be an element to clone.
+				 */
+				asChild?: boolean;
 				/**
 				 * What to show when there is no image: initials, an icon, anything. Use
 				 * `name` instead when the content is just the subject's initials.
@@ -254,6 +290,7 @@ type AvatarFallbackProps = Omit<ComponentProps<typeof AvatarPrimitive.Fallback>,
 				name?: never;
 		  }
 		| {
+				asChild?: never;
 				children?: never;
 				/**
 				 * The subject's display name, rendered as at most two uppercase
@@ -316,11 +353,13 @@ const Fallback = ({
 		{...props}
 	>
 		{/*
-		 * The type guarantees exactly one of `children` / `name`. An untyped call
-		 * site can still send neither, which lands on the same `"?"` that a name
-		 * with no usable characters renders — an avatar, not a blank.
+		 * Keyed on `name`, not on `children ?? initialsFromName(…)`: a conditional
+		 * child that resolves to `null` is still the caller saying "render nothing
+		 * here", and coalescing would answer `{isAdmin && <ShieldIcon />}` with a
+		 * bare `"?"` for everyone else. `name` wins only when it was actually
+		 * passed, which the type already makes exclusive with `children`.
 		 */}
-		{children ?? initialsFromName(name ?? "")}
+		{name == null ? children : initialsFromName(name)}
 	</AvatarPrimitive.Fallback>
 );
 
@@ -338,7 +377,7 @@ const Fallback = ({
  * neutral surface.
  *
  * For a person's name and title beside their avatar, compose it with
- * [MediaObject](https://mantle.ngrok.com/components/data-display/media-object).
+ * [MediaObject](https://mantle.ngrok.com/components/structure/media-object).
  * For the leading visual of a sidebar switcher row, put it inside
  * [Sidebar.SwitcherTrigger](https://mantle.ngrok.com/components/navigation/sidebar#sidebarswitchertrigger).
  *

--- a/packages/mantle/src/components/avatar/index.ts
+++ b/packages/mantle/src/components/avatar/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Re-exports for the Avatar component.
+ *
+ * @see https://mantle.ngrok.com/components/data-display/avatar
+ */
+
+export {
+	//,
+	Avatar,
+} from "./avatar.js";
+
+export type {
+	AvatarAppearance,
+	AvatarFallbackProps,
+	AvatarImageProps,
+	AvatarRootProps,
+} from "./avatar.js";

--- a/packages/mantle/src/components/media-object/media-object.tsx
+++ b/packages/mantle/src/components/media-object/media-object.tsx
@@ -141,11 +141,15 @@ const Content = ({ asChild = false, className, children, style, ref }: Props) =>
  *
  * @example
  * ```tsx
+ * import { Avatar } from "@ngrok/mantle/avatar";
  * import { MediaObject } from "@ngrok/mantle/media-object";
  *
  * <MediaObject.Root>
  *   <MediaObject.Media>
- *     <Avatar src={user.avatarUrl} alt="" />
+ *     <Avatar.Root>
+ *       <Avatar.Image src={user.avatarUrl} alt="" />
+ *       <Avatar.Fallback name={user.name} />
+ *     </Avatar.Root>
  *   </MediaObject.Media>
  *   <MediaObject.Content>
  *     <p className="font-medium">{user.name}</p>

--- a/packages/mantle/src/components/sidebar/sidebar.test.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.test.tsx
@@ -5,6 +5,7 @@ import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, type MockInstance, test, vi } from "vitest";
 import mantleCss from "../../mantle.css?raw";
 import type * as UseBreakpointModule from "../../hooks/use-breakpoint.js";
+import { Avatar } from "../avatar/index.js";
 import { DropdownMenu } from "../dropdown-menu/index.js";
 import { TooltipProvider } from "../tooltip/index.js";
 import { Sidebar, useSidebar } from "./sidebar.js";
@@ -1302,8 +1303,8 @@ describe("Sidebar.Tooltip", () => {
 
 describe("switch-accounts recipe (composition)", () => {
 	// The account switcher is deliberately not a Sidebar part — it composes
-	// DropdownMenu.RadioGroup/RadioItem with Sidebar.AccountAvatar (see the
-	// docs recipe). This guards the composition the docs demonstrate.
+	// DropdownMenu.RadioGroup/RadioItem with an Avatar (see the docs recipe).
+	// This guards the composition the docs demonstrate.
 	test("radio items compose an avatar, name, and checked state", async () => {
 		const user = userEvent.setup();
 		const onValueChange = vi.fn<(value: string) => void>();
@@ -1317,7 +1318,9 @@ describe("switch-accounts recipe (composition)", () => {
 							{ id: "acc_atlas", name: "Atlas Industries" },
 						].map((account) => (
 							<DropdownMenu.RadioItem key={account.id} value={account.id}>
-								<Sidebar.AccountAvatar accountId={account.id} accountName={account.name} />
+								<Avatar.Root appearance="square" colorSeed={account.id}>
+									<Avatar.Fallback name={account.name} />
+								</Avatar.Root>
 								<span className="min-w-0 flex-1 truncate">{account.name}</span>
 							</DropdownMenu.RadioItem>
 						))}
@@ -1347,109 +1350,6 @@ describe("Sidebar.Separator", () => {
 		// inset: aligned with the px-3 content padding, never edge to edge
 		expect(separator.className).toContain("my-3");
 		expect(separator.className).not.toContain("-mx-3");
-	});
-});
-
-function renderedSwatchClass(accountId: string | undefined): string {
-	const { unmount } = render(
-		<Sidebar.AccountAvatar data-testid="avatar" accountId={accountId} accountName="Test" />,
-	);
-	const avatar = screen.getByTestId("avatar");
-	const swatch = Array.from(avatar.classList).find((name) => name.startsWith("bg-"));
-	unmount();
-	expect(swatch).toBeDefined();
-	return swatch ?? "";
-}
-
-describe("Sidebar.AccountAvatar", () => {
-	test("derives one uppercase initial from a single-word name", () => {
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName="ngrok" />);
-		expect(screen.getByText("N")).toBeInTheDocument();
-	});
-
-	test("derives two initials from a multi-word name and caps at two", () => {
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName="Acme Corp International" />);
-		expect(screen.getByText("AC")).toBeInTheDocument();
-	});
-
-	test("strips special characters before deriving initials", () => {
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName="!!!Banana***" />);
-		expect(screen.getByText("B")).toBeInTheDocument();
-	});
-
-	test("keeps a surrogate-pair first character whole instead of splitting it", () => {
-		// Regression: substring(0, 1) split an emoji-leading name into a lone
-		// surrogate that rendered as U+FFFD.
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName="🚀 Rocket" />);
-		expect(screen.getByText("🚀R")).toBeInTheDocument();
-	});
-
-	test("falls back to ? for empty names", () => {
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName="" />);
-		expect(screen.getByText("?")).toBeInTheDocument();
-	});
-
-	test("falls back to ? for an undefined name", () => {
-		// `accountName` is typed `string | undefined` — a name that has not loaded
-		// yet renders the placeholder rather than an empty avatar.
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName={undefined} />);
-		expect(screen.getByText("?")).toBeInTheDocument();
-	});
-
-	test("falls back to ? for a name with no usable characters", () => {
-		// The documented `getInitials` example: punctuation is stripped first, so
-		// there is nothing left to initial.
-		render(<Sidebar.AccountAvatar accountId="acc_1" accountName="  ~!@  " />);
-		expect(screen.getByText("?")).toBeInTheDocument();
-	});
-
-	test("uppercases locale-invariantly so SSR and a Turkish-locale client agree", () => {
-		// `toLocaleUpperCase()` follows the HOST locale, where Turkish maps "i" to
-		// "İ" (U+0130) — a server and a Turkish client would then disagree and
-		// mismatch on hydration. The suite's own locale cannot be switched at
-		// runtime, so the pin is that the locale-sensitive path is never taken.
-		const toLocaleUpperCase = vi.spyOn(String.prototype, "toLocaleUpperCase");
-		try {
-			render(<Sidebar.AccountAvatar accountId="acc_1" accountName="ilkay ergun" />);
-		} finally {
-			toLocaleUpperCase.mockRestore();
-		}
-		expect(toLocaleUpperCase).not.toHaveBeenCalled();
-		expect(screen.getByText("IE")).toBeInTheDocument();
-	});
-
-	test("the same accountId always renders the same swatch", () => {
-		const first = renderedSwatchClass("acc_stable");
-		const second = renderedSwatchClass("acc_stable");
-		expect(first).toBe(second);
-	});
-
-	test("a missing accountId resolves like the empty string", () => {
-		// Documented on `pickColorClass`: an id that has not loaded yet still picks
-		// a real swatch instead of leaving the avatar unpainted.
-		expect(renderedSwatchClass(undefined)).toBe(renderedSwatchClass(""));
-	});
-});
-
-describe("Sidebar.UserAvatar", () => {
-	test("renders the silhouette fallback and aria-label without a src", () => {
-		render(<Sidebar.UserAvatar data-testid="avatar" alt="Jane Doe" />);
-		const avatar = screen.getByTestId("avatar");
-		expect(avatar).toHaveAttribute("aria-label", "Jane Doe");
-		expect(avatar.querySelector("img")).not.toBeInTheDocument();
-		expect(avatar.querySelector("svg")).toBeInTheDocument();
-	});
-
-	test("renders the profile image and drops the container aria-label with a src", () => {
-		render(
-			<Sidebar.UserAvatar data-testid="avatar" src="https://example.com/me.png" alt="Jane Doe" />,
-		);
-		const avatar = screen.getByTestId("avatar");
-		expect(avatar).not.toHaveAttribute("aria-label");
-		expect(screen.getByRole("img", { name: "Jane Doe" })).toHaveAttribute(
-			"src",
-			"https://example.com/me.png",
-		);
 	});
 });
 
@@ -1643,22 +1543,6 @@ const defaultElementCases: Array<PartCase> = [
 		tagName: "DIV",
 		renderPart: (probe) => <Sidebar.Separator {...probe} />,
 	},
-	{
-		name: "AccountAvatar",
-		ownClass: "rounded-md",
-		slot: "sidebar-account-avatar",
-		tagName: "DIV",
-		renderPart: (probe) => (
-			<Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" {...probe} />
-		),
-	},
-	{
-		name: "UserAvatar",
-		ownClass: "rounded-full",
-		slot: "sidebar-user-avatar",
-		tagName: "DIV",
-		renderPart: (probe) => <Sidebar.UserAvatar alt="Jane Doe" {...probe} />,
-	},
 ];
 
 /**
@@ -1799,30 +1683,6 @@ const asChildCases: Array<PartCase> = [
 			<Sidebar.Separator asChild {...probe}>
 				<hr />
 			</Sidebar.Separator>
-		),
-	},
-	{
-		name: "AccountAvatar",
-		ownClass: "rounded-md",
-		slot: "sidebar-account-avatar",
-		tagName: "SPAN",
-		renderPart: (probe) => (
-			// The initials render INSIDE the swapped element, so it is passed empty —
-			// a <span> is what fits inside the <button> the switcher row renders.
-			<Sidebar.AccountAvatar asChild accountId="acc_123" accountName="Acme Corp" {...probe}>
-				<span />
-			</Sidebar.AccountAvatar>
-		),
-	},
-	{
-		name: "UserAvatar",
-		ownClass: "rounded-full",
-		slot: "sidebar-user-avatar",
-		tagName: "SPAN",
-		renderPart: (probe) => (
-			<Sidebar.UserAvatar asChild alt="Jane Doe" {...probe}>
-				<span />
-			</Sidebar.UserAvatar>
 		),
 	},
 ];

--- a/packages/mantle/src/components/sidebar/sidebar.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.tsx
@@ -3,9 +3,7 @@
 import { SidebarSimpleIcon } from "@phosphor-icons/react/SidebarSimple";
 import type { ComponentProps, ReactElement, ReactNode } from "react";
 import {
-	cloneElement,
 	createContext,
-	isValidElement,
 	useCallback,
 	useContext,
 	useEffect,
@@ -18,7 +16,7 @@ import invariant from "tiny-invariant";
 import { useCallbackRef } from "../../hooks/use-callback-ref.js";
 import { useIsBelowBreakpoint } from "../../hooks/use-breakpoint.js";
 import { useIsHydrated } from "../../hooks/use-is-hydrated.js";
-import type { SelfClosingWithAsChild, WithAsChild } from "../../types/as-child.js";
+import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
@@ -319,9 +317,10 @@ function claimKeyboardShortcut(): { isOwner: () => boolean; release: () => void 
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -557,9 +556,10 @@ type SidebarNavProps = ComponentProps<"div"> & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -765,9 +765,10 @@ const defaultTriggerIcon = <SidebarSimpleIcon />;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -889,9 +890,10 @@ type SidebarHeaderProps = ComponentProps<"div"> & WithAsChild & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -980,9 +982,10 @@ type SidebarBodyProps = ComponentProps<"div"> & WithAsChild & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1034,8 +1037,8 @@ type SidebarFooterProps = ComponentProps<"div"> & WithAsChild & WithDataSlot;
 /**
  * The bottom container of a `Sidebar.Nav`, pinned below the scrollable
  * `Sidebar.Body`. Typically holds cross-product items and the account/user
- * switcher row (`Sidebar.SwitcherTrigger` with `Sidebar.AccountAvatar` and
- * `Sidebar.UserAvatar`).
+ * switcher row (`Sidebar.SwitcherTrigger` with an
+ * [Avatar](https://mantle.ngrok.com/components/data-display/avatar)).
  *
  * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebarfooter
  *
@@ -1075,9 +1078,10 @@ type SidebarFooterProps = ComponentProps<"div"> & WithAsChild & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1177,9 +1181,10 @@ type SidebarGroupProps = ComponentProps<"div"> & WithAsChild & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1264,9 +1269,10 @@ type SidebarGroupLabelProps = ComponentProps<"div"> & WithAsChild & WithDataSlot
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1382,9 +1388,10 @@ type SidebarListProps = ComponentProps<"ul"> & WithAsChild & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1463,9 +1470,10 @@ type SidebarItemProps = ComponentProps<"li"> & WithAsChild & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1586,9 +1594,10 @@ type SidebarItemButtonProps = ComponentProps<"button"> &
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -1723,9 +1732,10 @@ type SidebarSwitcherTriggerProps = ComponentProps<"button"> & WithAsChild & With
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2012,9 +2022,10 @@ type SidebarSeparatorProps = ComponentProps<typeof Separator> & WithDataSlot;
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2036,385 +2047,6 @@ const SidebarSeparator = ({
 		{...props}
 	/>
 );
-
-/**
- * The avatar swatch palette. Every entry is a Tailwind background color whose
- * hue and order match the sidebar prototype account switcher. Keep the hue
- * order stable: `pickColorClass` indexes into this tuple by account-id hash,
- * so reordering changes every account's color.
- */
-const accountAvatarColors = [
-	"bg-emerald-500",
-	"bg-gray-500",
-	"bg-red-500",
-	"bg-violet-500",
-	"bg-cyan-500",
-	"bg-rose-500",
-	"bg-purple-500",
-	"bg-fuchsia-500",
-	"bg-green-500",
-	"bg-orange-500",
-	"bg-indigo-500",
-	"bg-teal-500",
-	"bg-yellow-500",
-	"bg-sky-500",
-	"bg-pink-500",
-	"bg-blue-500",
-	"bg-amber-500",
-] as const;
-
-/**
- * djb2 is a stable, fast string hashing function. We use it to deterministically
- * pick a background color from `accountAvatarColors` for a given account ID, so
- * the same account always gets the same swatch.
- */
-function djb2Hash(value: string): number {
-	let hash = 5381;
-	for (let index = 0; index < value.length; index += 1) {
-		hash = (hash * 33) ^ value.charCodeAt(index);
-	}
-	// Convert to unsigned 32-bit so the modulo below stays positive.
-	return hash >>> 0;
-}
-
-/**
- * The swatch class an account id maps to — the same id always yields the same
- * swatch, and a missing id resolves like the empty string.
- *
- * @example
- * ```ts
- * pickColorClass("acc_123"); // e.g. "bg-violet-500"
- * ```
- */
-function pickColorClass(accountId: string | undefined): string {
-	const hash = djb2Hash(accountId ?? "");
-	const index = hash % accountAvatarColors.length;
-	// `accountAvatarColors` is a non-empty `as const` tuple; the fallback
-	// satisfies the strict-mode index-access type without a non-null assertion.
-	return accountAvatarColors[index] ?? "bg-neutral-500";
-}
-
-/**
- * At most two uppercase initials for an account name: punctuation is stripped,
- * the first code point of each of the first two words is kept (so an
- * emoji-leading name is not split mid-surrogate), casing is locale-invariant so
- * SSR and client agree, and a name with no usable characters renders `"?"`.
- *
- * @example
- * ```ts
- * getInitials("Acme Corp"); // "AC"
- * getInitials("  ~!@  ");   // "?"
- * ```
- */
-function getInitials(accountName: string | undefined): string {
-	const stripped = (accountName ?? "")
-		.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/gi, "")
-		.trim();
-	const initials = stripped
-		.split(" ")
-		.map((part) => part.trim())
-		.filter((part) => part.length > 0)
-		.slice(0, 2)
-		// code-point-safe first character: substring(0, 1) would split a
-		// surrogate pair (e.g. an emoji-leading name) into a lone surrogate
-		// that renders as U+FFFD.
-		.map((part) => Array.from(part)[0] ?? "")
-		.join("")
-		// locale-invariant casing: toLocaleUpperCase() follows the *host*
-		// locale, so an SSR server and a Turkish-locale client would disagree
-		// (i → İ) and mismatch on hydration.
-		.toUpperCase();
-	return initials || "?";
-}
-
-/**
- * The props for `Sidebar.AccountAvatar`.
- *
- * `children` is valid only with `asChild`, where it is the element the avatar
- * renders as instead of its own `<div>` — pass an empty one, e.g. `<span />`
- * when the avatar sits inside a `<button>` (which may not contain a `<div>`).
- * The initials are derived from `accountName`, which a consumer cannot compute,
- * so they render *inside* that element in place of its own children.
- */
-type SidebarAccountAvatarProps = Omit<ComponentProps<"div">, "children"> &
-	SelfClosingWithAsChild &
-	WithDataSlot & {
-		/**
-		 * The account's stable identifier. Used to deterministically select a
-		 * background swatch from the design system's palette so the same account
-		 * always gets the same color.
-		 */
-		accountId: string | undefined;
-		/**
-		 * The account's display name. The first one or two letters become the
-		 * avatar's initials. Falls back to `?` when the name is empty.
-		 */
-		accountName: string | undefined;
-	};
-
-/**
- * A small rounded-square avatar that represents an account (workspace,
- * organization, etc.). The background color is derived deterministically from
- * the `accountId` so an account's swatch is stable across renders, sessions,
- * and devices.
- *
- * Accounts are rendered as squares to differentiate them visually from users,
- * which use a circular `Sidebar.UserAvatar`.
- *
- * Pass `asChild` with a single empty element to swap the `<div>` it renders —
- * a `<span />` inside a `<button>`, or a link. The initials are derived from
- * `accountName`, so they render inside the swapped element; anything that
- * element carried of its own is replaced.
- *
- * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebaraccountavatar
- *
- * @example
- * ```tsx
- * <Sidebar.Root>
- *   <Sidebar.Nav aria-label="Main">
- *     <Sidebar.Header>
- *       <DropdownMenu.Root>
- *         <DropdownMenu.Trigger asChild>
- *           <Sidebar.SwitcherTrigger>
- *             <GlobeIcon />
- *             <span className="text-strong min-w-0 flex-1 truncate text-base">Universal Gateway</span>
- *             <CaretDownIcon className="text-muted size-4 shrink-0" />
- *           </Sidebar.SwitcherTrigger>
- *         </DropdownMenu.Trigger>
- *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
- *       </DropdownMenu.Root>
- *     </Sidebar.Header>
- *     <Sidebar.Body>
- *       <Sidebar.Group>
- *         <Sidebar.GroupLabel>Traffic</Sidebar.GroupLabel>
- *         <Sidebar.List>
- *           <Sidebar.Item>
- *             <Sidebar.ItemButton asChild current>
- *               <a href="/endpoints">
- *                 <GraphIcon />
- *                 Endpoints
- *               </a>
- *             </Sidebar.ItemButton>
- *           </Sidebar.Item>
- *         </Sidebar.List>
- *       </Sidebar.Group>
- *     </Sidebar.Body>
- *     <Sidebar.Footer>
- *       <Sidebar.Separator />
- *       <DropdownMenu.Root>
- *         <DropdownMenu.Trigger asChild>
- *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
- *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
- *           </Sidebar.SwitcherTrigger>
- *         </DropdownMenu.Trigger>
- *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
- *       </DropdownMenu.Root>
- *     </Sidebar.Footer>
- *   </Sidebar.Nav>
- *   <Sidebar.Trigger />
- * </Sidebar.Root>
- * ```
- */
-const AccountAvatar = ({
-	accountId,
-	accountName,
-	asChild,
-	children,
-	className,
-	"data-slot": dataSlot,
-	...props
-}: SidebarAccountAvatarProps) => {
-	const Comp = asChild ? Slot : "div";
-	const initials = getInitials(accountName);
-
-	// The types already require a single element with `asChild`; this catches the
-	// untyped call site and fails with the reason instead of rendering an avatar
-	// with no initials in it.
-	if (asChild) {
-		invariant(
-			isValidElement(children),
-			"When using `asChild`, Sidebar.AccountAvatar must be passed a single child as a JSX tag.",
-		);
-	}
-
-	return (
-		<Comp
-			data-slot={joinDataSlot(dataSlot, "sidebar-account-avatar")}
-			className={cx(
-				"text-static-white flex size-7 shrink-0 items-center justify-center rounded-md text-xs font-medium",
-				pickColorClass(accountId),
-				className,
-			)}
-			aria-hidden="true"
-			{...props}
-		>
-			{/* `asChild` swaps the avatar's element, not its content: the initials go
-			    inside the swapped child, replacing whatever it carried. */}
-			{isValidElement(children) ? cloneElement(children, {}, initials) : initials}
-		</Comp>
-	);
-};
-
-/**
- * A neutral person silhouette rendered with `currentColor` so it picks up the
- * surrounding text color and adapts to any theme. Used as the default visual
- * when no `src` is provided to `Sidebar.UserAvatar`.
- */
-const UserSilhouetteIcon = ({ className, ...props }: ComponentProps<"svg">) => (
-	<svg
-		className={cx("block size-full", className)}
-		viewBox="0 0 24 24"
-		fill="currentColor"
-		aria-hidden="true"
-		{...props}
-	>
-		<circle cx="12" cy="12" r="12" opacity={0.15} />
-		<circle cx="12" cy="10" r="3.5" />
-		<path d="M5.25 19.5C6.6 16.7 9.1 15 12 15s5.4 1.7 6.75 4.5A12 12 0 0 1 12 22a12 12 0 0 1-6.75-2.5Z" />
-	</svg>
-);
-
-/**
- * The props for `Sidebar.UserAvatar`.
- *
- * `children` is valid only with `asChild`, where it is the element the avatar
- * renders as instead of its own `<div>` — pass an empty one, e.g. `<span />`
- * when the avatar sits inside a `<button>` (which may not contain a `<div>`).
- * The avatar's visual (the `src` image, or the silhouette fallback) renders
- * *inside* that element in place of its own children.
- */
-type SidebarUserAvatarProps = Omit<ComponentProps<"div">, "children"> &
-	SelfClosingWithAsChild &
-	WithDataSlot & {
-		/**
-		 * Optional URL of the user's profile picture. When provided, the image is
-		 * rendered to fill the avatar with `object-cover`. When omitted (or while
-		 * loading), a neutral person silhouette is shown.
-		 */
-		src?: string;
-		/**
-		 * Accessible label for the avatar. Used as the image's `alt` text and as
-		 * the container's `aria-label` when no image is rendered.
-		 *
-		 * @default "Your account"
-		 */
-		alt?: string;
-	};
-
-/**
- * A circular avatar that represents the currently signed-in user. Renders the
- * user's profile picture when `src` is provided, otherwise falls back to a
- * neutral, theme-aware person silhouette.
- *
- * Users are rendered as circles to differentiate them visually from accounts,
- * which use a square `Sidebar.AccountAvatar`.
- *
- * Pass `asChild` with a single empty element to swap the `<div>` it renders —
- * a `<span />` inside a `<button>`, or a link. The image (or the silhouette
- * fallback) renders inside the swapped element; anything that element carried of
- * its own is replaced.
- *
- * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebaruseravatar
- *
- * @example
- * ```tsx
- * <Sidebar.Root>
- *   <Sidebar.Nav aria-label="Main">
- *     <Sidebar.Header>
- *       <DropdownMenu.Root>
- *         <DropdownMenu.Trigger asChild>
- *           <Sidebar.SwitcherTrigger>
- *             <GlobeIcon />
- *             <span className="text-strong min-w-0 flex-1 truncate text-base">Universal Gateway</span>
- *             <CaretDownIcon className="text-muted size-4 shrink-0" />
- *           </Sidebar.SwitcherTrigger>
- *         </DropdownMenu.Trigger>
- *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
- *       </DropdownMenu.Root>
- *     </Sidebar.Header>
- *     <Sidebar.Body>
- *       <Sidebar.Group>
- *         <Sidebar.GroupLabel>Traffic</Sidebar.GroupLabel>
- *         <Sidebar.List>
- *           <Sidebar.Item>
- *             <Sidebar.ItemButton asChild current>
- *               <a href="/endpoints">
- *                 <GraphIcon />
- *                 Endpoints
- *               </a>
- *             </Sidebar.ItemButton>
- *           </Sidebar.Item>
- *         </Sidebar.List>
- *       </Sidebar.Group>
- *     </Sidebar.Body>
- *     <Sidebar.Footer>
- *       <Sidebar.Separator />
- *       <DropdownMenu.Root>
- *         <DropdownMenu.Trigger asChild>
- *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
- *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
- *           </Sidebar.SwitcherTrigger>
- *         </DropdownMenu.Trigger>
- *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
- *       </DropdownMenu.Root>
- *     </Sidebar.Footer>
- *   </Sidebar.Nav>
- *   <Sidebar.Trigger />
- * </Sidebar.Root>
- * ```
- */
-const UserAvatar = ({
-	alt = "Your account",
-	asChild,
-	children,
-	className,
-	"data-slot": dataSlot,
-	src,
-	...props
-}: SidebarUserAvatarProps) => {
-	const Comp = asChild ? Slot : "div";
-	const visual = src ? (
-		<img src={src} alt={alt} className="size-full object-cover" />
-	) : (
-		<UserSilhouetteIcon />
-	);
-
-	// The types already require a single element with `asChild`; this catches the
-	// untyped call site and fails with the reason instead of rendering an empty
-	// avatar.
-	if (asChild) {
-		invariant(
-			isValidElement(children),
-			"When using `asChild`, Sidebar.UserAvatar must be passed a single child as a JSX tag.",
-		);
-	}
-
-	return (
-		<Comp
-			data-slot={joinDataSlot(dataSlot, "sidebar-user-avatar")}
-			className={cx(
-				"text-muted bg-neutral-500/15 relative flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full",
-				className,
-			)}
-			// aria-label needs a role that permits naming — a bare div is
-			// role=generic, where accessible names are prohibited. A swapped child
-			// that already has a naming role (a `<button>`, an `<a>`) can drop both
-			// by passing `role={undefined}`.
-			role={src ? undefined : "img"}
-			aria-label={src ? undefined : alt}
-			{...props}
-		>
-			{/* `asChild` swaps the avatar's element, not its content: the image or
-			    silhouette goes inside the swapped child, replacing whatever it
-			    carried. */}
-			{isValidElement(children) ? cloneElement(children, {}, visual) : visual}
-		</Comp>
-	);
-};
 
 /**
  * A composable, collapsible app-navigation sidebar. `Sidebar.Root` owns the
@@ -2449,8 +2081,6 @@ const UserAvatar = ({
  * │       ├── Sidebar.ItemButton
  * │       ├── Sidebar.Separator
  * │       └── Sidebar.SwitcherTrigger
- * │           ├── Sidebar.AccountAvatar
- * │           └── Sidebar.UserAvatar
  * └── Sidebar.Trigger
  * ```
  *
@@ -2490,9 +2120,10 @@ const UserAvatar = ({
  *       <DropdownMenu.Root>
  *         <DropdownMenu.Trigger asChild>
  *           <Sidebar.SwitcherTrigger>
- *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+ *             <Avatar.Root appearance="square" colorSeed="acc_123">
+ *               <Avatar.Fallback name="Acme Corp" />
+ *             </Avatar.Root>
  *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
- *             <Sidebar.UserAvatar alt="Jane Doe" />
  *           </Sidebar.SwitcherTrigger>
  *         </DropdownMenu.Trigger>
  *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2547,9 +2178,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2614,9 +2246,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2679,9 +2312,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2736,9 +2370,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2791,9 +2426,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2847,9 +2483,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2903,9 +2540,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -2959,9 +2597,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -3014,9 +2653,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -3069,9 +2709,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -3133,9 +2774,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -3195,9 +2837,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -3257,9 +2900,10 @@ const Sidebar = {
 	 *           <Sidebar.Tooltip label="Acme Corp">
 	 *             <DropdownMenu.Trigger asChild>
 	 *               <Sidebar.SwitcherTrigger>
-	 *                 <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *                 <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *                   <Avatar.Fallback name="Acme Corp" />
+	 *                 </Avatar.Root>
 	 *                 <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *                 <Sidebar.UserAvatar alt="Jane Doe" />
 	 *               </Sidebar.SwitcherTrigger>
 	 *             </DropdownMenu.Trigger>
 	 *           </Sidebar.Tooltip>
@@ -3315,9 +2959,10 @@ const Sidebar = {
 	 *       <DropdownMenu.Root>
 	 *         <DropdownMenu.Trigger asChild>
 	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
+	 *             <Avatar.Root appearance="square" colorSeed="acc_123">
+	 *               <Avatar.Fallback name="Acme Corp" />
+	 *             </Avatar.Root>
 	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
 	 *           </Sidebar.SwitcherTrigger>
 	 *         </DropdownMenu.Trigger>
 	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
@@ -3329,119 +2974,6 @@ const Sidebar = {
 	 * ```
 	 */
 	Separator: SidebarSeparator,
-	/**
-	 * A rounded-square account avatar with deterministic, WCAG-compliant
-	 * swatch colors derived from the account id. `asChild` swaps its `<div>` for
-	 * a single empty element and renders the initials inside it.
-	 *
-	 * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebaraccountavatar
-	 *
-	 * @example
-	 * ```tsx
-	 * <Sidebar.Root>
-	 *   <Sidebar.Nav aria-label="Main">
-	 *     <Sidebar.Header>
-	 *       <DropdownMenu.Root>
-	 *         <DropdownMenu.Trigger asChild>
-	 *           <Sidebar.SwitcherTrigger>
-	 *             <GlobeIcon />
-	 *             <span className="text-strong min-w-0 flex-1 truncate text-base">Universal Gateway</span>
-	 *             <CaretDownIcon className="text-muted size-4 shrink-0" />
-	 *           </Sidebar.SwitcherTrigger>
-	 *         </DropdownMenu.Trigger>
-	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
-	 *       </DropdownMenu.Root>
-	 *     </Sidebar.Header>
-	 *     <Sidebar.Body>
-	 *       <Sidebar.Group>
-	 *         <Sidebar.GroupLabel>Traffic</Sidebar.GroupLabel>
-	 *         <Sidebar.List>
-	 *           <Sidebar.Item>
-	 *             <Sidebar.ItemButton asChild current>
-	 *               <a href="/endpoints">
-	 *                 <GraphIcon />
-	 *                 Endpoints
-	 *               </a>
-	 *             </Sidebar.ItemButton>
-	 *           </Sidebar.Item>
-	 *         </Sidebar.List>
-	 *       </Sidebar.Group>
-	 *     </Sidebar.Body>
-	 *     <Sidebar.Footer>
-	 *       <Sidebar.Separator />
-	 *       <DropdownMenu.Root>
-	 *         <DropdownMenu.Trigger asChild>
-	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
-	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
-	 *           </Sidebar.SwitcherTrigger>
-	 *         </DropdownMenu.Trigger>
-	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
-	 *       </DropdownMenu.Root>
-	 *     </Sidebar.Footer>
-	 *   </Sidebar.Nav>
-	 *   <Sidebar.Trigger />
-	 * </Sidebar.Root>
-	 * ```
-	 */
-	AccountAvatar,
-	/**
-	 * A circular user avatar with a silhouette fallback. `asChild` swaps its
-	 * `<div>` for a single empty element and renders the image inside it.
-	 *
-	 * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebaruseravatar
-	 *
-	 * @example
-	 * ```tsx
-	 * <Sidebar.Root>
-	 *   <Sidebar.Nav aria-label="Main">
-	 *     <Sidebar.Header>
-	 *       <DropdownMenu.Root>
-	 *         <DropdownMenu.Trigger asChild>
-	 *           <Sidebar.SwitcherTrigger>
-	 *             <GlobeIcon />
-	 *             <span className="text-strong min-w-0 flex-1 truncate text-base">Universal Gateway</span>
-	 *             <CaretDownIcon className="text-muted size-4 shrink-0" />
-	 *           </Sidebar.SwitcherTrigger>
-	 *         </DropdownMenu.Trigger>
-	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
-	 *       </DropdownMenu.Root>
-	 *     </Sidebar.Header>
-	 *     <Sidebar.Body>
-	 *       <Sidebar.Group>
-	 *         <Sidebar.GroupLabel>Traffic</Sidebar.GroupLabel>
-	 *         <Sidebar.List>
-	 *           <Sidebar.Item>
-	 *             <Sidebar.ItemButton asChild current>
-	 *               <a href="/endpoints">
-	 *                 <GraphIcon />
-	 *                 Endpoints
-	 *               </a>
-	 *             </Sidebar.ItemButton>
-	 *           </Sidebar.Item>
-	 *         </Sidebar.List>
-	 *       </Sidebar.Group>
-	 *     </Sidebar.Body>
-	 *     <Sidebar.Footer>
-	 *       <Sidebar.Separator />
-	 *       <DropdownMenu.Root>
-	 *         <DropdownMenu.Trigger asChild>
-	 *           <Sidebar.SwitcherTrigger>
-	 *             <Sidebar.AccountAvatar accountId="acc_123" accountName="Acme Corp" />
-	 *             <span className="text-strong min-w-0 flex-1 truncate text-sm font-medium">Acme Corp</span>
-	 *             <Sidebar.UserAvatar alt="Jane Doe" />
-	 *           </Sidebar.SwitcherTrigger>
-	 *         </DropdownMenu.Trigger>
-	 *         <DropdownMenu.Content width="trigger" className="min-w-(--sidebar-row-width)">…</DropdownMenu.Content>
-	 *       </DropdownMenu.Root>
-	 *     </Sidebar.Footer>
-	 *   </Sidebar.Nav>
-	 *   <Sidebar.Trigger />
-	 * </Sidebar.Root>
-	 * ```
-	 */
-	UserAvatar,
 } as const;
 
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,9 +269,6 @@ importers:
       '@headlessui/react':
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-avatar':
-        specifier: 1.2.6
-        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-dialog':
         specifier: 1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1393,19 +1390,6 @@ packages:
 
   '@radix-ui/react-arrow@1.1.15':
     resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-avatar@1.2.6':
-    resolution: {integrity: sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5898,20 +5882,6 @@ snapshots:
   '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@headlessui/react':
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-avatar':
+        specifier: 1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-dialog':
         specifier: 1.1.23
         version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1390,6 +1393,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.15':
     resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.2.6':
+    resolution: {integrity: sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4088,10 +4104,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
-    engines: {node: '>=12.20.0'}
-
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -5886,6 +5898,20 @@ snapshots:
   '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -8553,8 +8579,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obug@2.1.3: {}
-
   obug@2.1.4: {}
 
   on-finished@2.4.1:
@@ -9501,7 +9525,7 @@ snapshots:
       es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0


### PR DESCRIPTION
`Avatar.Root` / `Avatar.Image` / `Avatar.Fallback` at `@ngrok/mantle/avatar` — hand-rolled, no new dependency —
and `Sidebar.AccountAvatar` / `Sidebar.UserAvatar` deleted, because they were the same component twice, scoped
to a place an avatar has no reason to be scoped to.

The evidence that they were misplaced: `local/frontend` had already hand-rolled the same thing twice —
`apps/dashboard/app/components/layout/account-avatar.tsx` and
`apps/ai-dashboard/app/components/account-avatar.tsx`, each with its own copy of djb2, its own palette (18 and
16 entries, one with a duplicate `bg-red-500`), and its own initials rule. Three divergent copies of a
surprisingly fiddly function.

```tsx
import { Avatar } from "@ngrok/mantle/avatar";

// an account: a rounded square whose color comes from its id
<Avatar.Root appearance="square" colorSeed={account.id}>
	<Avatar.Fallback name={account.name} />
</Avatar.Root>

// a person: a picture over initials, no loading state to handle
<Avatar.Root>
	<Avatar.Image src={user.avatarUrl} alt="Jane Doe" />
	<Avatar.Fallback name="Jane Doe" />
</Avatar.Root>
```

## Layered, not switched — and no dependency

This started on `@radix-ui/react-avatar` and moved off it during review. Radix's Avatar buys one real trick:
it constructs `new window.Image()` in a layout effect, reads `complete && naturalWidth > 0`, and mounts the
`<img>` only once the load has succeeded — so a broken URL never paints a broken-image icon. It also offers
`delayMs` and `onLoadingStatusChange`, neither of which anything here or in either dashboard used, and `asChild`,
which mantle's own `Slot` already provides.

What it cost was the server render: loading status is only knowable in a browser, so the `<img>` could never
appear in SSR markup. Every server-rendered avatar painted initials and swapped after hydration, even for a
cached image, and the browser could not begin fetching until then. An earlier commit here has the receipt —
`expect(html).not.toContain("<img")` — and the docs page had a section rationalizing it that ended in an escape
hatch telling readers to skip `Avatar.Image` and hand-roll an `<img>` above the fold. When a page's advice for
the common case is "don't use this part", the part is wrong. §0.8: the first paint is part of the API.

The platform already does the job. The fallback renders in flow, the image is positioned over it:

- **loading** → the image is transparent, so initials show through;
- **loaded** → the image covers them;
- **failed** → the image unmounts itself and reveals them again.

No context, no loading state, no dependency, and the `<img>` sits in the server markup where the browser finds
it during parse. The only JS left is the one thing the platform doesn't cover — dropping a failed image so its
alt text doesn't land on top of the initials.

One failure the client cannot observe: a load that fails *before* hydration, where the error event has already
come and gone. There the browser's own rendering stands, which for `alt=""` is nothing at all — the fallback
shows through — and is one more reason to prefer `alt=""` whenever adjacent text names the subject. It is
documented on the part. A mount-time `complete && naturalWidth === 0` probe would catch it, but happy-dom
reports every rendered `<img>` exactly that way, so it would unmount every image in every consumer's happy-dom
tests.

## The other decisions

- **`appearance="circle" | "square"`** carries the meaning: circles are people, rounded squares are the things
  people belong to. A row showing both stays legible without labels because the shapes never look alike.
- **`shrink-0` and `size-7`** on the root. An avatar is a fixed-size visual and the flex rows it lives in — a
  switcher row, a table cell, a comment header — must not be able to squeeze it. `className` still merges last,
  so `size-10` wins. It renders a `<span>`, so it stays valid inside a switcher row's `<button>` — the reason
  the deleted `Sidebar.AccountAvatar` needed `asChild` to be usable there at all.
- **`colorSeed` keeps the derivation in mantle** rather than pushing it back to app code: one tested djb2 and
  one palette instead of three. The palette and hash are byte-identical to the deleted sidebar version, so
  every account keeps the color it already has. Seed with an **id, not a name** — a rename would otherwise
  recolor the avatar, which the prop docs say out loud.
- **`Avatar.Fallback` takes `children` XOR `name`**, mutually exclusive in the type, so there is no precedence
  to learn. `name` derives at most two uppercase initials: punctuation stripped (including Unicode
  punctuation), code points kept whole so an emoji-leading name survives, each word uppercased *before* its
  first code point is taken (`"ß"` → `"SS"`, so the naive order overruns two characters), casing
  locale-invariant so SSR and a Turkish-locale client agree.
- **Derived initials are `aria-hidden`.** They abbreviate a name the page already carries beside the avatar, so
  announcing them reads it twice — "A C Acme Corp". That was the deleted `Sidebar.AccountAvatar`'s behavior,
  and the sidebar suite is what caught its absence: a `DropdownMenu.RadioItem` row's accessible name broke the
  moment the avatar stopped hiding itself.
- **`alt` on `Avatar.Image` is required** — stricter than the `<img>` element. Pass `alt=""` when adjacent text
  names the subject. What `alt` cannot do is name the avatar in every state, since the image is absent whenever
  there is no `src` or the load failed, so an always-named avatar names its **root** (`role="img"` +
  `aria-label`). The docs page says so where a reader would otherwise get it wrong.
- **`onError` runs first and can `preventDefault()`** to keep the image mounted, for a consumer who would rather
  retry a URL than fall back. The failed *URL* is tracked rather than a boolean, so changing `src` is always a
  fresh attempt with no reset effect to keep in sync. A nullish or empty `src` renders nothing, so an optional
  URL passes straight through (empty would otherwise re-request the page URL).

## Migration

Every docs page, fence, and demo moves with it — the app-shell and bridge-shell previews, the sidebar and
app-layout pages, `sidebar-demos`, and the switch-accounts recipe. Two behavior notes for consumers: the person
silhouette gives way to any icon you compose (the docs use Phosphor's `UserIcon`), and
`data-slot="sidebar-account-avatar"` / `"sidebar-user-avatar"` become `"avatar"`.

## Review

The diff went through an adversarial review pass (4 dimensions, every finding independently refuted or
confirmed with a probe). 18 survived, all fixed in commit 3. The ones worth naming, because lint, typecheck,
test and build were all green with them in place:

- `asChild` + `name` typechecked and then threw inside a slot with a string child.
- `children ?? initialsFromName(…)` answered `{isAdmin && <ShieldIcon />}` with a bare, announced `"?"`.
- Initials could exceed two characters for code points whose uppercase mapping expands.
- Both "compose it with MediaObject" links pointed at `data-display/media-object`; MediaObject lives under
  `structure`, and the dead URL had already shipped into `dist/avatar.d.ts` and the agent manifest.
- `MediaObject`'s own JSDoc example rendered `<Avatar src alt="" />` — a placeholder that was harmless until
  `Avatar` became real.

## Tests

46 for the component, and the `window.Image` stub is gone — every state is now reachable with `fireEvent.error`
and `renderToString`. Coverage: both `asChild` merge triples, the initials rule across CJK, RTL,
uppercase-expanding code points and Unicode punctuation, swatch determinism across the SSR boundary, the
image-over-fallback layering asserted on both sides of the `relative`/`absolute` pair, recovery when `src`
changes after a failure, the `preventDefault` opt-out with call counts, nullish and empty `src`, and the
span-inside-a-button constraint. Type-level contracts live at module scope, since `@ts-expect-error` is owned by
`pnpm typecheck` and a placeholder runtime `expect` would read as coverage the vitest run does not have.

## Verification

`pnpm -w run lint` · `fmt:check` · `typecheck` · `test` (1849 mantle + 169 www) ·
`build -F @ngrok/mantle --force`. Both generated files are regenerated and committed
(`components-surface.json`, `mantle-component-name.ts`). `INTERNAL_CHUNKS_BY_COMPONENT` deliberately gets no
entry: Avatar renders no other mantle component and its classes land in its own `dist/avatar.js`, which the
plugin's per-component `@source` pair already covers — checked by grepping the built chunk. The built bundle
imports no Radix.

## Notes

- `pnpm -w add -E <pkg> -F @ngrok/mantle`, the command AGENTS.md documents, also writes a stray `dependencies`
  block into the **root** `package.json`. Hit while adding the Radix dep that is now gone again; the docs line
  may want fixing separately.
