### PR TITLE
docs: adopt Simplified Technical English for comments, JSDoc, and PR prose

### DIFF
--- a/.claude/skills/simplified-technical-english/SKILL.md
+++ b/.claude/skills/simplified-technical-english/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: simplified-technical-english
+description: "Write concise, unambiguous technical prose with the ASD-STE100 Simplified Technical English rules in CONVENTIONS.md § Writing. Use WHENEVER you write or edit a code comment, JSDoc, a changeset, a decision doc, a docs-page paragraph, a commit message, or a pull request description. Also use when the user asks to tighten, shorten, de-fluff, or clean up any of those. Skip it for chat replies, product copy, and marketing text."
+---
+
+# Simplified Technical English
+
+[CONVENTIONS.md § Writing](../../../CONVENTIONS.md#writing) holds the rules. This file is only how they get applied.
+
+**The section is the standard; this file is a trigger.** Where the two appear to disagree, CONVENTIONS.md governs: report the mismatch, do not edit either file mid-task.
+
+## What to do
+
+1. Read [§ Writing](../../../CONVENTIONS.md#writing). Read it again rather than write from memory — the carve-outs are the part that gets misremembered.
+2. Classify the text. Procedural prose — a commit subject, a step, a `TODO` — takes the imperative and 20 words. Descriptive prose — JSDoc, a changeset, a decision doc, docs-page copy, a PR body — states the contract or the reason. Past 25 words is the smell.
+3. Apply the rules to the prose you write or edit in this task. Nothing else.
+4. Run the self-check below.
+
+## Before and after
+
+| Instead of                                                                                                                    | Write                                                             |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `It should be noted that the retry logic may potentially be triggered when the upstream service is experiencing degradation.` | `The client retries when upstream returns 5xx.`                   |
+| `The input component for the Command. It provides the input for the command palette.`                                         | `The palette's query field.`                                      |
+| `By default the selected item's text will be rendered.`                                                                       | `Renders the selected item's text by default.`                    |
+| `It should not be styled to ensure correct positioning.`                                                                      | `Do not style this part — the trigger positions it.`              |
+| `// This could be removed, or simplified`                                                                                     | Delete it. Investigation narration belongs in the PR description. |
+| `This PR essentially refactors the handler in order to facilitate improved testability.`                                      | `Split the handler so the parser runs without a server.`          |
+| `The configuration file parsing utility function`                                                                             | `The config parser`                                               |
+
+## Self-check
+
+- a banned word that no carve-out covers — and remember the carve-outs: `Provider`, `enabled`, `performance`, `not just`, `high-leverage`, a `seamless` tile
+- the passive voice where the actor is known, a compound tense, or an `-ing` form as the main verb
+- one idea per sentence, and the condition first
+- a noun stack over three words, or an abbreviation that is not on the exempt list
+- a comment or JSDoc summary that restates the identifier
+- a sentence past 25 words: it usually wants a list, not a trim
+- a changed JSDoc summary whose other copies and `components-surface.json` snapshot are still stale
+
+Fix what you find.
+
+## What not to do
+
+- Do not sweep unrelated prose into the same pull request. The rules cover the lines you touch.
+- Do not restyle a shipped `decisions/*.md`. Each one is a dated record.
+- Do not paraphrase quoted upstream text, such as MDN or a spec. Keep it verbatim, and keep its `@see` link.
+- Do not reflow an ASCII composition tree or the code inside an `@example` fence.
+- Do not narrate the check to the user. The `Conventions pass:` note [AGENTS.md](../../../AGENTS.md) requires is where it belongs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,3 +6,4 @@
 - Assume formatting/linting is already enforced by `pnpm run fmt` and `pnpm run lint`; do not duplicate those checks.
 - Focus feedback on correctness, security, performance, and missing tests.
 - Avoid suggesting changes to intentional patterns documented in CONVENTIONS.md.
+- Prose in comments, JSDoc, changesets, and PR descriptions follows [CONVENTIONS.md § Writing](../CONVENTIONS.md#writing) (ASD-STE100 Simplified Technical English); do not suggest longer, more formal, or more hedged phrasing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file follows the [AGENTS.md standard](https://agents.md) and is the canonic
 
 This file, [CONVENTIONS.md](./CONVENTIONS.md), and [COMPONENT_SPEC.md](./COMPONENT_SPEC.md) are active instructions, not background reading. Work is incomplete until the agent has verified its own changed files against them.
 
-The three divide as follows: **CONVENTIONS.md** governs code style everywhere in the monorepo, **COMPONENT_SPEC.md** is the self-contained standard for authoring a `@ngrok/mantle` component (principles, artifacts, API shape, JSDoc, CSS-variable and data-attribute documentation, docs page, tests, wiring, changeset, and the audit procedure), and this file governs how you work. On a component question where the spec and the conventions appear to disagree, COMPONENT_SPEC.md governs.
+The three divide as follows: **CONVENTIONS.md** governs code and prose style everywhere in the monorepo (including comments, JSDoc, changesets, commit messages, and PR descriptions), **COMPONENT_SPEC.md** is the self-contained standard for authoring a `@ngrok/mantle` component (principles, artifacts, API shape, JSDoc, CSS-variable and data-attribute documentation, docs page, tests, wiring, changeset, and the audit procedure), and this file governs how you work. On a component question where the spec and the conventions appear to disagree, COMPONENT_SPEC.md governs.
 
 The spec is the bar for new components and for the parts of a component you are changing; existing components are brought up to it over time, not in a sweep. See its [Scope and status](./COMPONENT_SPEC.md#scope-and-status).
 
@@ -34,6 +34,7 @@ Required diff-audit checklist:
 
 - **Components: work [COMPONENT_SPEC.md's review checklist](./COMPONENT_SPEC.md#11-review-checklist) against the diff.** It is the complete list for anything under `packages/mantle/src/components/` or its docs, tests, and wiring — artifacts, API shape, `data-slot` and `asChild`, JSDoc, CSS variables and data attributes documented in **both** the JSDoc and the docs-page API reference, and the wiring that no verification command catches.
 - JSDoc: exported functions, hooks, components, and prop types are documented; required `@example` blocks are present.
+- Prose: comments, JSDoc, changesets, decision docs, docs-page copy, the commit subject, and the PR description follow [CONVENTIONS.md § Writing](./CONVENTIONS.md#writing) — active voice, simple tenses, one idea per sentence, condition first, no comment that restates the code, and none of the banned filler (`utilize`, `facilitate`, `ensure`, `robust`, `comprehensive`, `simply`, and the six carve-out words).
 - Tests: bug fixes have regression tests; business logic has edge-case tests (transformations, validation, conditional rendering, state machines, parsing/formatting). For every test you added or changed, name the one-line implementation change it would catch — if you can't, it doesn't count. Anything interactive must be driven with a real event (`user.click` / `user.keyboard`) and assert the resulting DOM/ARIA state, not just initial markup. No Tailwind utility-string assertions, no arbitrary `setTimeout` waits, no `toBeDefined()`/`not.toThrow()` as a test's only assertion, no bare `toHaveBeenCalled()` where the count matters. See [CONVENTIONS.md § Testing](./CONVENTIONS.md#testing).
 - TypeScript: no `any`, no forbidden `as Type` assertions, no non-null assertions (`value!`), no `React.FC`; prefer `type` over `interface`.
 - Nullish checks: `== null` / `!= null`, not `=== undefined` / `!== undefined`.
@@ -77,7 +78,7 @@ packages/mantle/src/components/my-component/
 
 ## Commands
 
-All commands run from workspace root (leverages turbo caching):
+All commands run from workspace root, which reuses the turbo cache:
 
 - `pnpm -w run start` — Start docs site with hot reload
 - `pnpm -w run build` — Build everything
@@ -94,7 +95,7 @@ Use `-F` to scope: `pnpm -w run build -F @ngrok/mantle`, `pnpm -w run test -F @n
 
 ## Verification
 
-Run these from the workspace root once a coherent chunk of work is done and before the final response (see the Agent Contract's verification cadence) — not after every edit. Ensure they pass:
+Run these from the workspace root once a coherent chunk of work is done and before the final response (see the Agent Contract's verification cadence) — not after every edit. Make sure they pass:
 
 1. `pnpm -w run lint` — 0 errors
 2. `pnpm -w run fmt:check` — 0 errors (run `pnpm -w run fmt` to auto-fix)
@@ -123,7 +124,7 @@ Run these from the workspace root once a coherent chunk of work is done and befo
 ## Common Issues & Solutions
 
 - **Build failures**: Run `pnpm run clean` then `pnpm run build`
-- **Type errors**: Ensure all packages are built before typechecking
+- **Type errors**: Build all packages before typechecking
 - **Hot reload issues**: Restart dev server or clear `.react-router/` cache
 - **Toolchain drift**: Run `mise run doctor` to verify Node and pnpm match committed pins. Re-run `./scripts/setup` if they don't.
 - **Lockfile drift** (CI flags `mise.lock` out of sync with `.nvmrc` / `package.json#packageManager`): bump the source pin in `.nvmrc` or `package.json#packageManager`, then `mise run relock && mise install` and commit `mise.lock` alongside the pin change.

--- a/COMPONENT_SPEC.md
+++ b/COMPONENT_SPEC.md
@@ -33,10 +33,10 @@ is a bug in the rule.
 
 - **This file governs component questions** — artifacts, API shape, JSDoc, CSS variables, data attributes,
   docs page, tests, wiring.
-- [CONVENTIONS.md](./CONVENTIONS.md) governs general code style for the whole monorepo (formatting, imports,
-  package management, TypeScript rules that are not component-specific). Where a component requirement depends
-  on a style rule, this file restates it so the checklist is complete; CONVENTIONS.md remains authoritative for
-  the rule itself.
+- [CONVENTIONS.md](./CONVENTIONS.md) governs general code and prose style for the whole monorepo (formatting,
+  imports, package management, prose in comments/JSDoc/changesets, TypeScript rules that are not
+  component-specific). Where a component requirement depends on a style rule, this file restates it so the
+  checklist is complete; CONVENTIONS.md remains authoritative for the rule itself.
 - [AGENTS.md](./AGENTS.md) governs how you work (verification cadence, diff auditing).
 - The [Philosophy page](./apps/www/app/docs/philosophy.mdx) explains the _why_ at length. §0 below is its
   actionable distillation.
@@ -496,6 +496,9 @@ JSDoc is the API surface for IntelliSense, `llms.txt`, `/api/components.json`, a
 library. It is not optional and it is not a summary of the implementation. It is also snapshot-guarded: the
 summary and every `@example` feed `components-surface.json` ([§2.1](#21-artifacts)).
 
+This section owns _what_ the JSDoc must contain. [CONVENTIONS.md § Writing](./CONVENTIONS.md#writing) owns how
+its sentences read.
+
 ### 4.1. Every exported symbol
 
 Components, hooks, functions, and prop types each need:
@@ -694,6 +697,9 @@ multi-file example app. Keep the live example and its code block in sync; the li
 generated dataset. Icons come from `@phosphor-icons/react`.
 
 ### 7.4. Prose rules
+
+Sentence-level style — voice, tense, sentence length, noun stacks, banned filler — is
+[CONVENTIONS.md § Writing](./CONVENTIONS.md#writing). These bullets are what the docs prose must cover.
 
 - Explain the _why_ behind non-obvious API, especially anything a reader would otherwise "fix" — a fake router
   in a demo, a deliberate absence of a part, an intentional ARIA choice.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -102,7 +102,7 @@ These rules are [ASD-STE100](https://www.asd-ste100.org/) Simplified Technical E
   - `perform` — cut the vague verb, so `performs an action` becomes `runs an action`. The noun `performance` and the API `performance.now()` stay.
   - `enable` — use the verb for a real flag only (`Whether to enable filtering of command items.`). The adjective `enabled` is the antonym of `disabled`, not the verb. It always stays, and so does `oxlint-enable`.
   - `just` — where deleting it changes no meaning, cut it. Contrastive `not just`, comparative `just as` and `just like`, temporal `just` (`the index just past the closing quote`), and `justify-*` all stay.
-  - `seamless` — cut the quality adjective. It stays for a tile that repeats with no visible seam (`chart/texture.ts`).
+  - `seamless` — cut the quality adjective. It stays for a tile that repeats with no visible seam (`packages/mantle/src/components/chart/texture.ts`).
 - **Cap a noun stack at three words.** A backticked identifier counts as one word. `retry backoff config` passes. `user account credential rotation policy handler` fails — add a preposition: `handler for rotating user account credentials`.
 - **Spell out a new abbreviation on first use in the file.** Never invent one. Two lists decide it:
   - **Bare is fine** — `HTTP`, `API`, `SQL`, `TLS`, `URL`, `DOM`, `CSS`, `HTML`, `JSON`, `SVG`, `JSX`, `UI`, `ID`, `SSR`, `ARIA`, `a11y`, `WAI`, `APG`, `FOUC`, `CDN`, `POJO`, and the initialisms [Readability & Maintainability](#readability--maintainability) allows in identifiers.
@@ -137,7 +137,7 @@ These rules are [ASD-STE100](https://www.asd-ste100.org/) Simplified Technical E
 - **Restructure instead of explaining.** If a comment excuses confusing code, rename or split the code.
 - **`@example` prose follows these rules; the code in the fence does not.** Never paraphrase example code. Never de-duplicate the repeated full-tree examples [COMPONENT_SPEC.md §4.2](./COMPONENT_SPEC.md#42-compound-components-the-full-tree-rule) requires.
 - **Editing a JSDoc summary is a multi-file change.** The same summary often repeats on a part declaration, its namespace property, and an `.mdx` page — fix every copy. Editing a summary or an `@example` also changes `apps/www/app/utilities/__snapshots__/components-surface.json` — regenerate it with `pnpm -F @app/www test -u` or CI fails.
-- **Two spans are not yours to edit.** Never rewrite quoted upstream text that carries a `@see` citation — MDN's `autocomplete` values in `input/types.ts` — because an edit forks it from its source. oxlint parses the `oxlint-disable` and `oxlint-enable` directive text, so only the `-- reason` clause after it is prose. A fragment there is fine.
+- **Two spans are not yours to edit.** Never rewrite quoted upstream text that carries a `@see` citation — MDN's `autocomplete` values in `packages/mantle/src/components/input/types.ts` — because an edit forks it from its source. oxlint parses the `oxlint-disable` and `oxlint-enable` directive text, so only the `-- reason` clause after it is prose. A fragment there is fine.
 
 ```tsx
 // ❌ restates the identifier, and the second sentence adds nothing

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Conventions
 
-Single source of truth for code style, patterns, and conventions in the Mantle design system monorepo. All rules below are mandatory — call out and fix violations.
+Single source of truth for code style, prose style, patterns, and conventions in the Mantle design system monorepo. All rules below are mandatory — call out and fix violations.
 
 ## Files & Modules
 
@@ -22,7 +22,7 @@ Single source of truth for code style, patterns, and conventions in the Mantle d
 - Optimize for readability and changeability over terseness or cleverness. Code is read far more often than it is written.
 - Always brace control flow — no single-line `if`/`for` bodies.
 - Descriptive names — `error` not `e`, `event` not `evt`, `element` not `el`. Widely-known initialisms (`URL`, `CSS`, `SSR`) are fine.
-- Comments explain _why_, not _what_. Do not restate the code.
+- Comments explain _why_, not _what_. Do not restate the code. [Writing](#writing) governs how the sentence itself reads.
 - Prefer inline single-use event handlers when they improve locality and readability. Hoist handlers only when reused, memoized, or meaningfully simplifying the render body.
 - Avoid nested ternaries. Prefer early returns or component-based branching. A single ternary is fine; nesting harms readability.
 - Never use `React.FC` / `FC` — use inline function types.
@@ -59,7 +59,7 @@ Single source of truth for code style, patterns, and conventions in the Mantle d
 
 - Add JSDoc to all exported functions, methods, hooks, components, and prop types.
 - Add JSDoc to complex file-local logic whose intent or contract would not be immediately obvious from the implementation and types alone.
-- Prefer concise contract-oriented documentation over implementation commentary.
+- JSDoc prose follows [Writing](#writing): lead with one summary sentence stating the contract, not implementation commentary.
 - JSDoc for functions, hooks, and components SHOULD include at least one concise `@example`.
 - Each `@example` should demonstrate the intended call or render shape with realistic inputs/props and the key expected behavior or result. Keep setup minimal.
 - Generated code, code-gen output, and config files are exempt.
@@ -77,6 +77,108 @@ Single source of truth for code style, patterns, and conventions in the Mantle d
   - framework/runtime boundaries where external typing is impossible to model correctly
 - Type assertions must never be used to silence TypeScript errors or bypass proper type modeling.
 - Prefer discriminated unions, narrowing, and explicit state modeling over optional-property-heavy “bag of props” types.
+
+## Writing
+
+These rules are [ASD-STE100](https://www.asd-ste100.org/) Simplified Technical English, Issue 9, adapted to this repo. Claude Code surfaces the same rules as the `simplified-technical-english` skill; this section is the normative copy.
+
+- **In scope:** code comments, JSDoc, `.changeset/*.md` release notes, `decisions/*.md`, docs-page copy under `apps/www/app/docs/`, commit subjects and bodies, PR descriptions, and these agent docs.
+- **Out of scope:** chat replies, product copy, marketing text, vendored code (`packages/mantle/src/utils/cx/vendor/**`), and the generated code and config files [JSDoc](#jsdoc) already exempts.
+- **Identifier naming** stays with [Readability & Maintainability](#readability--maintainability).
+
+**Scope and status** — the stance is [COMPONENT_SPEC.md § Scope and status](./COMPONENT_SPEC.md#scope-and-status). This is the bar for prose you write or edit. Prose you touch comes up to the bar; the rest waits until someone opts into the work. An audit reports a prose gap; it does not open a migration inside an unrelated PR. Never restyle a shipped `decisions/*.md` — its wording is part of a dated record. Never reflow a verbatim quote, an ASCII composition tree, or an `@example`.
+
+### Words
+
+- **One word, one meaning, within one file.** Reuse one term per concept verbatim. `cache`, `store`, and `buffer` in one file read as three things.
+- **Match the code.** Write the identifier's exact name and casing, in backticks — `ThemeProvider`, `data-slot`, `performance.now()`. Never paraphrase an identifier. The backticks are load-bearing: no word rule below reaches inside a backtick span. That is what keeps `justify-center`, `enabled`, and `oxlint-enable` off the ban list.
+- **Prefer the short common verb** — `use`, `get`, `set`, `add`, `remove`, `keep`, `read`, `write`, `start`, `stop`, `fix`.
+- **Never write** `utilize`, `facilitate`, `orchestrate`, `basically`, `essentially`, `comprehensive`, `robust`, or `ensure`. None of them states a fact. For `ensure`, write `make sure` — [Testing](#testing) already uses it — or name the mechanism that guarantees the outcome.
+- **Never write `simply`.** The ban is word-exact: `simplify`, `simpler`, and `simplified` are fine.
+- **Cut the hedges.** Delete `it seems`, `arguably`, `might possibly`, `should probably`, and `this could be removed`. Keep `must`, `can`, `may`, `never`, and `always` — each states a constraint or a real option.
+- **These six carry a second, earned sense in mantle's prose. Ban the first sense only:**
+  - `provide` — cut the verb; write `pass`, `set`, or `carry`. Write `when set` for `when provided`, and `when omitted` for `if not provided`. The `Provider` and `*Provider` identifiers stay, and so does React context vocabulary (`the context Root provides`).
+  - `leverage` — cut the verb; write `use`. The noun `high-leverage` stays.
+  - `perform` — cut the vague verb, so `performs an action` becomes `runs an action`. The noun `performance` and the API `performance.now()` stay.
+  - `enable` — use the verb for a real flag only (`Whether to enable filtering of command items.`). The adjective `enabled` is the antonym of `disabled`, not the verb. It always stays, and so does `oxlint-enable`.
+  - `just` — where deleting it changes no meaning, cut it. Contrastive `not just`, comparative `just as` and `just like`, temporal `just` (`the index just past the closing quote`), and `justify-*` all stay.
+  - `seamless` — cut the quality adjective. It stays for a tile that repeats with no visible seam (`chart/texture.ts`).
+- **Cap a noun stack at three words.** A backticked identifier counts as one word. `retry backoff config` passes. `user account credential rotation policy handler` fails — add a preposition: `handler for rotating user account credentials`.
+- **Spell out a new abbreviation on first use in the file.** Never invent one. Two lists decide it:
+  - **Bare is fine** — `HTTP`, `API`, `SQL`, `TLS`, `URL`, `DOM`, `CSS`, `HTML`, `JSON`, `SVG`, `JSX`, `UI`, `ID`, `SSR`, `ARIA`, `a11y`, `WAI`, `APG`, `FOUC`, `CDN`, `POJO`, and the initialisms [Readability & Maintainability](#readability--maintainability) allows in identifiers.
+  - **Spell it out** — anything narrower, such as `MQL`, `OTP`, or `TZ`.
+
+### Sentences
+
+- **Use the active voice.** Write `The processor drops the event.`, not `The event is dropped by the processor.` When the actor is unknown or irrelevant, the passive voice is correct.
+- **Use simple tenses only** — present, past, future, imperative, infinitive. Write `renders`, not `will be rendered`. Never use an `-ing` form as the main verb.
+- **Put one idea in each sentence.** When both halves stand alone, split the sentence on `and` or `but`.
+- **The em-dash aside and the prose semicolon are house style. They stay.** When the aside names an exception, a fallback, a consequence, or the mechanism, keep it — `the consumer's own id when they pass one, else the label's generated id`. When it restates the first half, cut it. An aside is not a second idea.
+- **Put the condition first.** Write `If the lease expires, the worker exits.`, not `The worker exits if the lease expires.`
+- **Do not drop words to shorten.** Keep the articles, subjects, and verbs inside a sentence. Concision removes ideas, not grammar: rewrite `// resets cursor on flush` as `// The flush resets the cursor.`
+- **A fragment is correct in three places, and the rule above does not reach them:**
+  - a list item, including a label-colon bullet
+  - a JSDoc summary or prop doc that names a thing — `The click event handler.`
+  - a `Why <topic>:` comment label
+- **Never add a verb to turn one of those three into a sentence.** Most bullets in this file, and most mantle JSDoc summaries, are verbless by design.
+- **Three or more parallel items make a list**, not a longer sentence.
+- **Length is a smell, not a gate.** Keep procedural text — a commit subject, a step, a `TODO` — to 20 words, and descriptive text to 25. The limits do not reach `.changeset/*.md` or `decisions/*.md`. When a descriptive sentence runs past 25 words, ask which one it is:
+  - a clause, a colon, and an enumeration — write a list.
+  - several facts in one sentence — split it.
+  - one contract that needs every word — keep it. Most JSDoc summaries here land near 10 words. A 40-word summary that pins a whole contract beats four vague ones.
+
+### Comments and JSDoc
+
+- **State the constraint, the trade-off, or the surprise.** The code already states what it does — see [Readability & Maintainability](#readability--maintainability). Never restate the identifier.
+- **Prefer the `Why <topic>:` label for a constraint** — `// Why: navigator.platform is deprecated…`, `// Why no asChild:`, `// Why event delegation:`. Do not expand a label into a sentence.
+- **Never narrate the investigation.** What you checked, tried, or read belongs in the PR description.
+- **Put the warning above the code it guards.**
+- **Lead with one summary sentence, then state the contract** — inputs, outputs, errors, units, invariants. [JSDoc](#jsdoc) says which exports need one. [COMPONENT_SPEC.md §4](./COMPONENT_SPEC.md#4-jsdoc) owns _what_ a component's JSDoc must contain; this section owns _how_ those sentences read.
+- **Restructure instead of explaining.** If a comment excuses confusing code, rename or split the code.
+- **`@example` prose follows these rules; the code in the fence does not.** Never paraphrase example code. Never de-duplicate the repeated full-tree examples [COMPONENT_SPEC.md §4.2](./COMPONENT_SPEC.md#42-compound-components-the-full-tree-rule) requires.
+- **Editing a JSDoc summary is a multi-file change.** The same summary often repeats on a part declaration, its namespace property, and an `.mdx` page — fix every copy. Editing a summary or an `@example` also changes `apps/www/app/utilities/__snapshots__/components-surface.json` — regenerate it with `pnpm -F @app/www test -u` or CI fails.
+- **Two spans are not yours to edit.** Never rewrite quoted upstream text that carries a `@see` citation — MDN's `autocomplete` values in `input/types.ts` — because an edit forks it from its source. oxlint parses the `oxlint-disable` and `oxlint-enable` directive text, so only the `-- reason` clause after it is prose. A fragment there is fine.
+
+```tsx
+// ❌ restates the identifier, and the second sentence adds nothing
+/** The input component for the Command. It provides the input for the command palette. */
+// ✅ names what this part does that a sibling does not
+/** The palette's query field. */
+```
+
+Worked before/after pairs live in the `simplified-technical-english` skill, out of always-on context.
+
+### Changesets, decision docs, and docs pages
+
+- **A changeset is release notes, not a commit message.** `.changeset/*.md` ships verbatim into the public `CHANGELOG.md`, for a consumer who will never read the diff. The word bans hold; the length limits and the commit rules do not. [COMPONENT_SPEC.md §2.5](./COMPONENT_SPEC.md#25-changesets) owns what the body must cover.
+- **Write a new decision doc to these rules.** Leave the shipped ones alone.
+- **Docs-page copy follows these rules.** [COMPONENT_SPEC.md §7.4](./COMPONENT_SPEC.md#74-prose-rules) owns what that copy must cover.
+
+### Commit messages and PR descriptions
+
+- **Write the subject in the imperative, after the conventional-commit prefix this repo uses** — `fix(breadcrumb): mute current page text`. Keep it to ten words or fewer after the prefix, with no trailing period. The `(#1234)` suffix GitHub appends on squash-merge does not count.
+- **The one-idea rule governs prose sentences, not the subject line.** A multi-part change gets one subject, and the parts go in the body — `feat(command): add SearchTrigger, a stateful DialogRoot, and ⌘K`.
+- **When the subject is not enough, add a body.** State the reason for the change. Then state how the behavior changes. Files are not behavior.
+- **Never list the changed files.** The diff is the changelog.
+- **This repo ships no PR template, so this is the section order:**
+  - **Why** — the problem, the trigger, and the intended outcome.
+  - **How** — the approach in one or two sentences. Do not tour the diff.
+  - **Validation** — one line per check. Include only what a reviewer cannot read off CI.
+  - Investigation detail, rejected alternatives, and links belong here, not in the source.
+- **Cut the boilerplate.** No generated footer, no empty section, no restated file list.
+
+### Self-check
+
+Before you return text or report a diff complete, read what you wrote for:
+
+- a banned word that no carve-out covers
+- the passive voice, a compound tense, or an `-ing` form as the main verb
+- a sentence with two independent ideas, or a condition at the end
+- a noun stack over three words, or an unexpanded abbreviation that is not exempt
+- a comment or summary that restates the identifier, the code, or itself
+- a changed JSDoc summary whose other copies and `components-surface.json` snapshot are still stale
+
+Fix what you find. Report it in the `Conventions pass:` note [AGENTS.md](./AGENTS.md) requires.
 
 ## className Composition
 
@@ -183,7 +285,7 @@ For logic that is stringified into an inline `<script>`, evaluate the produced s
 - **No arbitrary sleeps.** `await new Promise((resolve) => setTimeout(resolve, 100))` is a race, not a wait. Use `waitFor`, `findBy*`, or `expect.poll` on the state you actually need — for observer-driven measurement, poll the measured value itself.
 - Never mutate state inside a `waitFor` callback; it can run many times.
 - Install spies **after** `userEvent.setup()`. `setup()` swaps `navigator.clipboard` for its own stub, so a patch applied before it is silently discarded.
-- Every test-bearing package sets `restoreMocks`, `unstubEnvs`, and `unstubGlobals` in its Vitest config (both mantle projects, `apps/www`, `mantle-vite-plugins`, `mantle-server-syntax-highlighter`), so `vi.spyOn` spies and `vi.stubGlobal`/`vi.stubEnv` stubs are torn down between tests automatically. A trailing `spy.mockRestore()` in a test body is dead code — and relying on one is a leak, since a test that throws never reaches it. `restoreMocks` does **not** clear a `vi.fn()`'s implementation or call history, so a `vi.fn()` shared across tests still needs `mockReset()` — put it in `beforeEach`, or just create the mock there. A spy that must survive across tests in a file goes in `beforeEach`, not `beforeAll`.
+- Every test-bearing package sets `restoreMocks`, `unstubEnvs`, and `unstubGlobals` in its Vitest config (both mantle projects, `apps/www`, `mantle-vite-plugins`, `mantle-server-syntax-highlighter`), so `vi.spyOn` spies and `vi.stubGlobal`/`vi.stubEnv` stubs are torn down between tests automatically. A trailing `spy.mockRestore()` in a test body is dead code — and relying on one is a leak, since a test that throws never reaches it. `restoreMocks` does **not** clear a `vi.fn()`'s implementation or call history, so a `vi.fn()` shared across tests still needs `mockReset()` — put it in `beforeEach`, or create the mock there. A spy that must survive across tests in a file goes in `beforeEach`, not `beforeAll`.
 - No test may depend on another test having run. Verify with `pnpm vitest run --project unit --sequence.shuffle.tests --sequence.shuffle.files --sequence.seed=<n>` across a few seeds.
 - Locale- and timezone-sensitive assertions rely on `TZ`/`LC_ALL` being pinned in the Vitest config, not in a package script — a pin in a script is lost the moment anyone runs a single file directly. The happy-dom project pins them via `test.env`; the browser project pins Chromium's own `locale`/`timezoneId` through the Playwright `contextOptions`, which `process.env` cannot reach.
 - Never assert a wall-clock duration or a throughput threshold. Benchmarks belong in `bench()`, not `test()`.

--- a/decisions/2026-07-30-simplified-technical-english.md
+++ b/decisions/2026-07-30-simplified-technical-english.md
@@ -1,0 +1,216 @@
+# Adopt Simplified Technical English for comments, JSDoc, changesets, and PR prose
+
+**Date:** 2026-07-30
+**Status:** Accepted
+**Applies to:** every comment, JSDoc block, changeset, decision doc, docs page, commit subject, and pull-request description written in this repo
+**Distilled rules:** [CONVENTIONS.md → Writing](../CONVENTIONS.md#writing)
+**Source:** [ngrok-private/ngrok#45954](https://github.com/ngrok-private/ngrok/pull/45954), which added these rules to the ngrok monorepo as a Claude Code skill. Upstream standard: [ASD-STE100](https://www.asd-ste100.org/).
+
+## Context
+
+Agent-written prose in this repo over-explains. It restates the code, it hedges, and it narrates the
+investigation. A pass over `packages/mantle/src`, `apps/www`, and the agent docs found four repeating
+shapes:
+
+- **The summary restates the identifier.** `command/command.tsx:374` reads
+  `The input component for the Command. It provides the input for the command palette.` Sentence two says
+  nothing sentence one did not. That shape repeats at eight more part declarations in the same file, and
+  the namespace copies degrade further — `:954` reads `The input component for the Command component.`
+  `theme/theme-provider.tsx:51` and `:58` carry one sentence twice, on a context and on its provider.
+- **One sentence carries four ideas.** `select/select.tsx:188` runs 55 words on a single line, drops into a
+  lowercase `if` mid-block, and states the default in the future passive:
+  `By default the selected item's text will be rendered.`
+- **The comment names nothing.** `card/card.tsx:9` reads
+  `A container that can be used to display content in a box resembling a physical card.`
+  `table/table.tsx:7` promises `styling and additional functionality`. Neither tells a reader what the part
+  does that a sibling does not.
+- **The comment narrates the investigation.** `table/table.tsx:415` ships `// This could be removed, or simplified`
+  inside a live `cx()` call. `hooks/use-breakpoint.tsx:102` narrates the implementation instead of stating
+  the contract.
+
+Every one of those lines costs a reader on each read, and every one of them ships. JSDoc is the surface for
+IntelliSense, `llms.txt`, `/api/components.json`, and each agent that reads the library, so bad prose
+propagates into generated consumer code.
+
+ASD-STE100 Simplified Technical English is a controlled-language standard from aerospace maintenance
+documentation. Its rules answer these four shapes directly: one term per concept, active voice, simple
+tenses, one idea per sentence, condition first, and no comment that restates the code. ngrok adopted a
+subset of the standard in ngrok-private/ngrok#45954. This record adopts the same subset here, with mantle's
+own artifacts and carve-outs added.
+
+## Decisions
+
+### 1. CONVENTIONS.md owns the rules
+
+A new top-level `## Writing` section in [CONVENTIONS.md](../CONVENTIONS.md#writing) holds them. It sits
+after `### TypeScript` and before `## className Composition`, in the file's whole-repo group.
+
+Two facts decide the placement:
+
+- **The rules stay in context.** `AGENTS.md` inlines the whole file with `@./CONVENTIONS.md`, so a Claude
+  Code session loads the section before it writes a line. A skill file loads on demand.
+- **Every harness reads it.** `AGENTS.md` is the canonical agent file for amp, Codex, Cursor, and Claude
+  Code. A rule in CONVENTIONS.md reaches all four. A rule under `.claude/` reaches one.
+
+The section also takes over two rules that already sat in `Code Quality`. The
+`Comments explain _why_, not _what_` bullet and the
+`Prefer concise contract-oriented documentation over implementation commentary` bullet become pointers,
+because the repo keeps one home per rule.
+
+### 2. The skill is the Claude Code trigger, and it defers
+
+`.claude/skills/simplified-technical-english/SKILL.md` is thin. Claude Code matches its `description`
+against the task and loads it at write time. The body holds the before/after table and the self-check, and
+it names CONVENTIONS.md § Writing as normative. It states no rule of its own.
+
+Be honest about what it buys, because the section is already always-on:
+
+- a model-invocation hook that fires when the model writes prose, rather than a rule the model must
+  remember to re-read;
+- a home for the long examples, which stay out of every session's context window.
+
+It defers on conflict, exactly as `/audit-component` defers to COMPONENT_SPEC.md
+(`If a workflow disagrees with the spec, the spec wins`). If the skill and the section disagree, the section
+wins, and the reporter fixes the skill rather than the prose.
+
+### 3. No sweep
+
+The rules apply to prose you write or edit. They do not license a repo-wide rewrite. This follows
+[COMPONENT_SPEC.md → Scope and status](../COMPONENT_SPEC.md#scope-and-status): new work meets the bar, the
+parts you touch meet the bar, and the rest waits until someone opts into the work. An audit reports the gap.
+
+Two exclusions are permanent, not deferred:
+
+- **A shipped `decisions/*.md` keeps its wording.** Do not restyle one. All three `comprehensive` hits in
+  the repo live in one 2025 ADR, and rewriting them would edit the repo's decision history. Note that this
+  is new normative content: `COMPONENT_SPEC.md §1.8` owns decision-doc policy today and says nothing about
+  editing a shipped one.
+- **Quoted upstream text keeps its source wording.** `input/types.ts:1-12` is verbatim MDN prose with an
+  `@see` citation. An STE pass would fork it from its source and lose the citation's value.
+
+### 4. The banned-word list ships with its carve-outs
+
+Source rule 3 bans a word list. A word-boundary scan of that list over this repo hits real vocabulary, so
+the section publishes each carve-out beside the ban:
+
+- **`provide`** — ban the verb. `Provider` and every `*Provider` identifier stay, because rule 2 requires
+  the identifier's exact name (`ThemeProvider` ×56, `TooltipProvider` ×37 of 88 prose hits). Rewrite
+  `when provided` as `when set` or `when omitted`, and imperative advice as `Pass` or `Set`.
+- **`just`** — ban the filler that deletes with no change of meaning. Contrastive `not just`, comparative
+  `just as` / `just like`, and temporal `just` stay: none of the 32 mantle hits is the filler the rule
+  targets. `justify-*` is on 320 lines, so no scan may match a substring or a stem.
+- **`enable`** — keep the flag-only rule for the verb. The adjective `enabled` is the antonym of `disabled`
+  and stays, as does the `oxlint-enable` directive. Roughly 20 of 35 hits name a row state, not an action.
+- **`perform`** — ban the verb as a substitute for a specific one. `performance` and `performance.now()`
+  stay; six of ten hits are the noun or the API, three of them inside `@example` blocks that rule 2 forbids
+  paraphrasing.
+- **`seamless`** — ban the quality adjective. The tiling term of art stays, because it names a real
+  geometric property: `chart/texture.ts:57`, pinned by `texture.test.ts:47`.
+- **`leverage`** — ban the verb. The noun `high-leverage` stays.
+- **`ensure`** — no carve-out. `make sure`, the standard's replacement, already has one precedent in
+  `CONVENTIONS.md § Testing`.
+
+Two mechanical rules follow. First, any scan must skip backtick spans; 5,720 comment lines in
+`packages/mantle/src` carry a backtick, which is how the repo satisfies rule 2. Second, `simply` is
+word-exact and never stem-matched, or `simplify` and `simplified` trip it — both appear in CONVENTIONS.md
+itself.
+
+### 5. Rule 10 governs sentences, not labels
+
+Source rule 10 reads `Do not drop words to shorten. Keep the articles, subjects, and verbs.` Read literally,
+it outlaws the repo's own list and JSDoc style:
+
+- `CONVENTIONS.md § Testing` has 14 consecutive verbless bullets — the browser-mode API list that rule 11
+  asks for by name.
+- 640 of 818 `The …` / `A …` summary phrases in `packages/mantle/src` carry no finite verb.
+  `COMPONENT_SPEC.md §4.1` requires one noun phrase per prop, so this is by design.
+- The `// Why <topic>:` label is a fragment by mandate (`CONVENTIONS.md § Readability & Maintainability`,
+  `COMPONENT_SPEC.md §1.7`) with 19 sites, and it is the cleanest expression of rule 13.
+
+Resolution: rule 10 applies to sentences. A list item may be a labeled fragment, and a JSDoc summary may be
+a noun phrase. The rule's real target is the mid-sentence word drop it names — `// resets cursor on flush`
+becomes `The flush resets the cursor.`
+
+Two more house forms survive by name. The em-dash aside stays: it appears 1,339 times on 1,283 comment lines
+in `packages/mantle/src` and it carries the exception, so rule 8's `split the sentence on and, but, or ;`
+does not reach it. The boundary is meaning — an aside that restates is cuttable, an aside that names the
+exception is not. The prose semicolon stays with it, on 454 mantle lines, so the adopted rule drops `;` from
+the split list. The `-- reason` clause on an `oxlint-disable` line also stays as written, fragment and
+semicolon included, because oxlint parses the directive text.
+
+### 6. The word limits are a smell, not a gate
+
+Measured over 2,296 JSDoc summary sentences in `packages/mantle/src`: median 10 words, p90 21 words, 253
+(11.0%) over 20 words, and 129 (5.6%) over 25.
+
+The cap catches the wrong prose. All eight worst over-explaining comments found in the corpus pass the
+20-word cap: `command.tsx:374` is 6 words, `select.tsx:188` is 7, `card.tsx:9` is 16. Meanwhile the
+over-limit summaries cluster in the newest components, which were built to the current spec bar — 30% of
+`list`, 28% of `avatar`, 19% of `chart`. `avatar.tsx:93` spends 49 words to pin the whole initials contract,
+and it should keep them.
+
+So the section keeps the limits as a smell and names the productive rewrite. A summary past 25 words is
+almost always one clause, a colon, and an enumeration. That is rule 11's problem — write a list — not a word
+count problem.
+
+Two surfaces take no descriptive cap at all:
+
+- **`.changeset/*.md`** — 52% of shipped changelog sentences run over 20 words by design. Rules 18 to 20 are
+  commit rules. A changeset explains a shipped API to a consumer who never sees the diff, so
+  `the diff is the changelog` is false there. Note that a changeset is a live file, not a record: fix one
+  you wrote.
+- **`decisions/*.md`** — dated records, and 89 semicolon-joined lines.
+
+The commit cap takes a counting rule for the same reason. Ten words after the `type(scope):` prefix flags 8
+of the last 60 merged subjects, so the section states that the prefix and the `(#1234)` squash suffix do not
+count, and it keeps the number as a target.
+
+Rule 5's exempt list also grows. `HTTP, API, SQL, TLS` is too small for this repo: `DOM` appears unexpanded
+159 times, `CSS` 122, `HTML` 77, `ARIA` 76, `SSR` 49. `CONVENTIONS.md § Readability & Maintainability`
+already set the precedent for identifiers (`Widely-known initialisms (URL, CSS, SSR) are fine`), so the
+section extends the exemption to the same web-platform and accessibility vocabulary instead of declaring a
+rival list. `POJO` is on the exempt list because `CONVENTIONS.md § Compound Components` uses it bare.
+
+## Alternatives rejected
+
+### (a) The skill alone, with no CONVENTIONS.md section
+
+Cost: the rules reach Claude Code and nothing else. `AGENTS.md` is the canonical agent file for amp, Codex,
+and Cursor, and none of them read `.claude/skills/`. The rules would also load only when the model chooses
+to load them, so the prose that needs them most — a one-line comment inside a large refactor — is the prose
+that never triggers a match on the skill description.
+
+### (b) A new top-level `WRITING.md`
+
+Cost: a fourth canonical doc, a fourth clause in AGENTS.md's precedence sentence, and one more precedence
+rule to keep correct. The gain is zero. `CONVENTIONS.md` already calls itself the single source of truth for
+code style, and it already hosts a top-level section with sub-parts (`## Testing`). A separate file would
+also fall out of the always-on context that `@./CONVENTIONS.md` supplies, which is the reason for the
+placement in the first place.
+
+### (c) COMPONENT_SPEC.md
+
+Cost: wrong scope. The spec governs `packages/mantle/src/components/`. These rules govern commit subjects,
+changesets, decision docs, `apps/www` docs pages, and every comment in `packages/mantle-vite-plugins` and
+`packages/mantle-server-syntax-highlighter`. The spec takes three pointer lines instead — in `## Precedence`,
+under `## 4. JSDoc`, and under `### 7.4. Prose rules`: the spec owns what the prose must cover, and
+CONVENTIONS.md § Writing owns how the sentences read.
+
+## Consequences
+
+- `AGENTS.md` gains a `Prose` bullet in the diff-audit checklist, so the checklist covers every diff, and
+  its precedence sentence changes from `governs code style` to `governs code and prose style`.
+- The adoption PR fixes four violations in the agent docs themselves: `Ensure they pass`,
+  `Ensure all packages are built`, and `leverages turbo caching` in `AGENTS.md`, plus a filler `just` in
+  `CONVENTIONS.md § Testing`. A rule cannot ship 40 lines from a violation in the file that loads it.
+- `.github/copilot-instructions.md` gains one line. Copilot's review is the one automated reader that would
+  otherwise ask for longer, more formal, more hedged phrasing.
+- Editing a JSDoc summary stays a multi-file change. The summary and every `@example` feed
+  `apps/www/app/utilities/__snapshots__/components-surface.json`, and CI fails until
+  `pnpm -F @app/www test -u` regenerates it. A cleanup pass must budget for that, and for the duplicated
+  text — `select.tsx:188`, `select.tsx:831`, and `select.mdx:441` are one sentence in three places.
+- No changeset. The adoption diff touches no file under `packages/mantle/src` and nothing published changes.
+- There is no linter for any of this. `oxlint` does not read markdown, and `fmt:check` only formats it. The
+  diff-audit checklist, the skill trigger, and human review are the enforcement.
+- The subset is expected to change. When a carve-out turns out wrong, edit `CONVENTIONS.md § Writing` in the
+  PR that proves it and say so in the PR description. A rule nobody follows is a bug in the rule.

--- a/decisions/2026-07-30-simplified-technical-english.md
+++ b/decisions/2026-07-30-simplified-technical-english.md
@@ -12,20 +12,20 @@ Agent-written prose in this repo over-explains. It restates the code, it hedges,
 investigation. A pass over `packages/mantle/src`, `apps/www`, and the agent docs found four repeating
 shapes:
 
-- **The summary restates the identifier.** `command/command.tsx:374` reads
+- **The summary restates the identifier.** `packages/mantle/src/components/command/command.tsx:374` reads
   `The input component for the Command. It provides the input for the command palette.` Sentence two says
   nothing sentence one did not. That shape repeats at eight more part declarations in the same file, and
   the namespace copies degrade further — `:954` reads `The input component for the Command component.`
-  `theme/theme-provider.tsx:51` and `:58` carry one sentence twice, on a context and on its provider.
-- **One sentence carries four ideas.** `select/select.tsx:188` runs 55 words on a single line, drops into a
+  `packages/mantle/src/components/theme/theme-provider.tsx:51` and `:58` carry one sentence twice, on a context and on its provider.
+- **One sentence carries four ideas.** `packages/mantle/src/components/select/select.tsx:188` runs 55 words on a single line, drops into a
   lowercase `if` mid-block, and states the default in the future passive:
   `By default the selected item's text will be rendered.`
-- **The comment names nothing.** `card/card.tsx:9` reads
+- **The comment names nothing.** `packages/mantle/src/components/card/card.tsx:9` reads
   `A container that can be used to display content in a box resembling a physical card.`
-  `table/table.tsx:7` promises `styling and additional functionality`. Neither tells a reader what the part
+  `packages/mantle/src/components/table/table.tsx:7` promises `styling and additional functionality`. Neither tells a reader what the part
   does that a sibling does not.
-- **The comment narrates the investigation.** `table/table.tsx:415` ships `// This could be removed, or simplified`
-  inside a live `cx()` call. `hooks/use-breakpoint.tsx:102` narrates the implementation instead of stating
+- **The comment narrates the investigation.** `packages/mantle/src/components/table/table.tsx:415` ships `// This could be removed, or simplified`
+  inside a live `cx()` call. `packages/mantle/src/hooks/use-breakpoint.tsx:102` narrates the implementation instead of stating
   the contract.
 
 Every one of those lines costs a reader on each read, and every one of them ships. JSDoc is the surface for
@@ -85,7 +85,7 @@ Two exclusions are permanent, not deferred:
   the repo live in one 2025 ADR, and rewriting them would edit the repo's decision history. Note that this
   is new normative content: `COMPONENT_SPEC.md §1.8` owns decision-doc policy today and says nothing about
   editing a shipped one.
-- **Quoted upstream text keeps its source wording.** `input/types.ts:1-12` is verbatim MDN prose with an
+- **Quoted upstream text keeps its source wording.** `packages/mantle/src/components/input/types.ts:1-12` is verbatim MDN prose with an
   `@see` citation. An STE pass would fork it from its source and lose the citation's value.
 
 ### 4. The banned-word list ships with its carve-outs
@@ -105,7 +105,7 @@ the section publishes each carve-out beside the ban:
   stay; six of ten hits are the noun or the API, three of them inside `@example` blocks that rule 2 forbids
   paraphrasing.
 - **`seamless`** — ban the quality adjective. The tiling term of art stays, because it names a real
-  geometric property: `chart/texture.ts:57`, pinned by `texture.test.ts:47`.
+  geometric property: `packages/mantle/src/components/chart/texture.ts:57`, pinned by `packages/mantle/src/components/chart/texture.test.ts:47`.
 - **`leverage`** — ban the verb. The noun `high-leverage` stays.
 - **`ensure`** — no carve-out. `make sure`, the standard's replacement, already has one precedent in
   `CONVENTIONS.md § Testing`.
@@ -144,9 +144,9 @@ Measured over 2,296 JSDoc summary sentences in `packages/mantle/src`: median 10 
 (11.0%) over 20 words, and 129 (5.6%) over 25.
 
 The cap catches the wrong prose. All eight worst over-explaining comments found in the corpus pass the
-20-word cap: `command.tsx:374` is 6 words, `select.tsx:188` is 7, `card.tsx:9` is 16. Meanwhile the
+20-word cap: `packages/mantle/src/components/command/command.tsx:374` is 6 words, `packages/mantle/src/components/select/select.tsx:188` is 7, `packages/mantle/src/components/card/card.tsx:9` is 16. Meanwhile the
 over-limit summaries cluster in the newest components, which were built to the current spec bar — 30% of
-`list`, 28% of `avatar`, 19% of `chart`. `avatar.tsx:93` spends 49 words to pin the whole initials contract,
+`list`, 28% of `avatar`, 19% of `chart`. `packages/mantle/src/components/avatar/avatar.tsx:93` spends 49 words to pin the whole initials contract,
 and it should keep them.
 
 So the section keeps the limits as a smell and names the productive rewrite. A summary past 25 words is
@@ -208,7 +208,7 @@ CONVENTIONS.md § Writing owns how the sentences read.
 - Editing a JSDoc summary stays a multi-file change. The summary and every `@example` feed
   `apps/www/app/utilities/__snapshots__/components-surface.json`, and CI fails until
   `pnpm -F @app/www test -u` regenerates it. A cleanup pass must budget for that, and for the duplicated
-  text — `select.tsx:188`, `select.tsx:831`, and `select.mdx:441` are one sentence in three places.
+  text — `packages/mantle/src/components/select/select.tsx:188`, `packages/mantle/src/components/select/select.tsx:831`, and `apps/www/app/docs/components/forms/select.mdx:441` are one sentence in three places.
 - No changeset. The adoption diff touches no file under `packages/mantle/src` and nothing published changes.
 - There is no linter for any of this. `oxlint` does not read markdown, and `fmt:check` only formats it. The
   diff-audit checklist, the skill trigger, and human review are the enforcement.


### PR DESCRIPTION
### Why

Agent-written prose in this repo over-explains. A corpus pass over `packages/mantle/src`, `apps/www`, and the agent docs found four repeating shapes:

- **The summary restates the identifier.** `command.tsx:374` — `The input component for the Command. It provides the input for the command palette.` The same shape repeats at 8 more part declarations, and the namespace copies degrade into `The input component for the Command component.`
- **One sentence carries four ideas.** `select.tsx:188` runs 55 words on one line, drops into a lowercase `if` mid-block, and states the default in the future passive.
- **The comment names nothing.** `table.tsx:7` promises `styling and additional functionality`.
- **The comment narrates the investigation.** `table.tsx:415` ships `// This could be removed, or simplified` inside a live `cx()` call.

That prose ships. JSDoc is the surface for IntelliSense, `llms.txt`, `/api/components.json`, and every agent that reads the library, so it propagates into generated consumer code.

This pulls in the ASD-STE100 subset from ngrok-private/ngrok#45954 and adapts it to mantle.

### How

`CONVENTIONS.md` gains a top-level `## Writing` section that **owns** the rules. `AGENTS.md` inlines that file into every session, so the rules stay in context and reach amp, Codex, and Cursor — not only Claude Code. `.claude/skills/simplified-technical-english/SKILL.md` is a thin trigger that defers to the section, exactly as `/audit-component` defers to `COMPONENT_SPEC.md`. Two rules that already sat in `Code Quality` become pointers, so each rule keeps one home.

The adaptation is where the work went. Applying the upstream rules verbatim would have fought the codebase, so each carve-out is grounded in a count:

- **The banned-word list ships with its carve-outs.** `Provider` (88 prose hits, and rule 2 requires the identifier's exact name), the adjective `enabled` (the antonym of `disabled`), `performance` / `performance.now()`, contrastive `not just` (0 of 32 `just` hits are the filler the rule targets, and `justify-*` is on 320 lines), `high-leverage`, and `seamless` for a tile that repeats with no visible seam.
- **The word limits are a smell, not a gate.** Over 2,296 JSDoc summaries the median is 10 words and 11% exceed 20. But all eight worst offenders **pass** the 20-word cap (`command.tsx:374` is 6 words), while the over-limit summaries cluster in the newest spec-compliant components — 30% of `list`, 28% of `avatar`. A summary past 25 words almost always wants a list, not a trim. `.changeset/*.md` takes no cap at all: 52% of shipped changelog sentences exceed 20 words by design.
- **Rule 10 governs sentences, not labels.** 640 of 818 JSDoc summary phrases are verbless by design, `COMPONENT_SPEC.md` requires a noun phrase per prop, and the `// Why <topic>:` label is a mandated fragment. The em-dash aside (1,339 uses) and the prose semicolon (454 lines) are named as house style, so `;` is dropped from the split rule.
- **A changeset is release notes, not a commit message.** The commit rules do not aim at it.
- **Rule 5's exempt list grows** to the web-platform and accessibility vocabulary the repo already uses bare (`DOM` 159 unexpanded uses, `CSS` 122, `ARIA` 76), and defers to the initialism precedent already in `CONVENTIONS.md`.

The rules also fix four violations in the files that carry them: `Ensure they pass`, `Ensure all packages are built`, and `leverages turbo caching` in `AGENTS.md`, plus a filler `just` in `CONVENTIONS.md § Testing`. A rule cannot ship 40 lines from a violation in the file that loads it.

**No sweep.** Per `COMPONENT_SPEC.md § Scope and status`, this is the bar for prose you write or edit. Existing comments come up over time. A shipped `decisions/*.md` and quoted upstream text (MDN in `input/types.ts`) are permanent exclusions.

`decisions/2026-07-30-simplified-technical-english.md` records the placement decision, the rejected alternatives (skill-only, a new `WRITING.md`, `COMPONENT_SPEC.md`), and every tension above.

### Validation

- `pnpm -w run fmt:check`, `pnpm -w run lint`, `pnpm -w run typecheck` — clean. `oxfmt` formats markdown, so the tables are padded.
- `pnpm -w run test` skipped: no file under `packages/mantle/` changed, and no test reads the agent docs.
- No changeset: nothing published changes.
- Checked by hand, since no command covers them — every new `#writing` anchor resolves from all six inbound links, and a scan of the new prose for banned words outside backtick spans returns only carve-out hits.