### PR TITLE
fix(choice): publish the per-part JSDoc in the built types

### DIFF
--- a/.changeset/choice-part-jsdoc-emit.md
+++ b/.changeset/choice-part-jsdoc-emit.md
@@ -1,0 +1,19 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix `Choice` publishing none of its per-part documentation, so hovering `Choice.Root` in an editor showed
+nothing.
+
+Each `Choice` part carries a summary, a `@see` link to its docs anchor, and an `@example` in the source, and
+none of it reached the published types. The namespace object was declared with an explicit type annotation —
+`const Choice: { Root: typeof Root; … } = { … } as const` — and the build emits the annotation in place of
+the documented object literal. `dist` shipped a bare member list. `Choice` was the only namespace in the
+package written that way, so every other compound component already documented its parts here.
+
+The annotation is gone. `as const` alone emits the same named member types and keeps the documentation, and
+it restores the `readonly` modifiers the annotation was discarding: `readonly Root: typeof Root` instead of
+`Root: typeof Root`. The parts, their props, and their runtime behavior are unchanged.
+
+`COMPONENT_SPEC.md` asks for the annotation when a member's type comes from a third-party namespace, and it
+now records this cost, because the published types are the only channel that feeds editor tooltips.

--- a/COMPONENT_SPEC.md
+++ b/COMPONENT_SPEC.md
@@ -454,7 +454,7 @@ const MyComponent = {
   type. Without it an `@types/react` bump surfaces `TS2883` at build time — which is why
   [§9](#9-verification) runs the build.
 - **The annotation costs every member's JSDoc.** The build emits the annotation in place of the object
-  literal, so each member's summary, `@see`, and `@example` drops out of the published `.d.ts` — the only
+  literal, so each member's summary, `@see`, and `@example` drop out of the published `.d.ts` — the only
   channel that feeds editor tooltips. The annotation also discards the `readonly` modifiers `as const` adds.
   Reach for it only when a member's type comes from outside the package, because `as const` alone already
   emits `readonly Root: typeof Root`.

--- a/COMPONENT_SPEC.md
+++ b/COMPONENT_SPEC.md
@@ -453,6 +453,11 @@ const MyComponent = {
   (`const MyComponent: { Root: typeof Root; … } = { … }`) so `.d.ts` emit does not synthesize a non-portable
   type. Without it an `@types/react` bump surfaces `TS2883` at build time — which is why
   [§9](#9-verification) runs the build.
+- **The annotation costs every member's JSDoc.** The build emits the annotation in place of the object
+  literal, so each member's summary, `@see`, and `@example` drops out of the published `.d.ts` — the only
+  channel that feeds editor tooltips. The annotation also discards the `readonly` modifiers `as const` adds.
+  Reach for it only when a member's type comes from outside the package, because `as const` alone already
+  emits `readonly Root: typeof Root`.
 - Providers and standalone utilities stay as their own named exports beside the namespace, never folded in
   (the Toast/Toaster pattern).
 - Leaf components (`Button`, `Icon`) stay standalone exports so they tree-shake cleanly.

--- a/packages/mantle/src/components/choice/choice.tsx
+++ b/packages/mantle/src/components/choice/choice.tsx
@@ -467,14 +467,7 @@ const Description = ({ asChild, className, ref, ...props }: ComponentProps<"p"> 
  * </Choice.Root>
  * ```
  */
-const Choice: {
-	Root: typeof Root;
-	Indicator: typeof Indicator;
-	Content: typeof Content;
-	Label: typeof ChoiceLabel;
-	Title: typeof Title;
-	Description: typeof Description;
-} = {
+const Choice = {
 	/**
 	 * Root: the layout + id/association owner. Reads `FieldControlContext` when
 	 * present so a `Field`'s id/name/aria flow onto the control.


### PR DESCRIPTION
### Why

`Choice` publishes none of its per-part documentation. Hovering `Choice.Root` in an editor shows nothing, and the same for all six parts — even though every one of them carries a summary, a `@see` link, and an `@example` in the source.

`packages/mantle/package.json` sets `"files": ["dist", "package.json"]`, so `src/` never ships. The `.d.ts` is the only channel a consumer's editor can read, which is what makes an empty one a real API defect rather than a cosmetic one.

`Choice` was the **only** namespace in the package declared with an explicit type annotation:

```ts
const Choice: {
	Root: typeof Root;
	Indicator: typeof Indicator;
	// …
} = { /* …every member documented here… */ } as const;
```

The build emits the annotation, not the object literal, and the annotation's members carry no JSDoc. 43 of the 44 published namespaces document every member correctly, because they use the plain `as const` form.

`COMPONENT_SPEC.md §3.4` asks for that annotation when a member's type comes from a third-party namespace, so `Choice` was following the spec. The spec never mentioned what the annotation costs.

### How

Drop the annotation. `as const` alone emits the same named member types, so this is additive with no API change.

Verified against the real emit before and after:

```
BEFORE  declare const Choice: { Root: typeof Root; Indicator: typeof Indicator; … };

AFTER   declare const Choice: {
          /**
           * Root: the layout + id/association owner. Reads `FieldControlContext`…
           * @see https://mantle.ngrok.com/components/forms/choice
           * @example …
           */
          readonly Root: typeof Root;
          …
        };
```

Note the second, unrelated regression it also fixes: the annotation was discarding the `readonly` modifiers `as const` adds, so the published members were mutable.

`choice.tsx` imports only `react`, `tiny-invariant`, and mantle-internal modules, so it never met the spec's condition for annotating in the first place.

`COMPONENT_SPEC.md §3.4` gains a bullet naming the cost, so the next author does not reintroduce it: reach for the annotation only when a member's type comes from outside the package, because `as const` already emits `readonly Root: typeof Root`.

### Validation

- All five component verification commands pass: `lint`, `fmt:check`, `typecheck`, `test`, `build -F @ngrok/mantle`.
- Emit inspected directly in `dist/choice-*.d.ts` both with and without the annotation — the before/after above is copied from those two builds.
- `grep -rn "^const [A-Z][A-Za-z]*: {$" packages/mantle/src` returns nothing after this change, confirming no sibling namespace has the same shape.
- Patch changeset included. Runtime behavior, props, and the exported parts are unchanged.
