### PR TITLE
fix(breadcrumb): scroll a long trail sideways instead of wrapping

### DIFF
--- a/.changeset/breadcrumb-scrolling-trail.md
+++ b/.changeset/breadcrumb-scrolling-trail.md
@@ -1,0 +1,37 @@
+---
+"@ngrok/mantle": patch
+---
+
+Keep a long `Breadcrumb` trail on one row: it now scrolls sideways with a faded edge instead of wrapping.
+
+An app header is one row tall, so the trail wrapping onto a second row pushed the page down and left the
+current page in the wrong place. `Breadcrumb.List` is now the scroll container, and its edges carry the same
+`scroll-fade-x` mask as `Tabs.List` — the edge with crumbs beyond it fades out, and the edge with nothing
+beyond it stays flush.
+
+The trail starts at its end, because the end is the current page. It scrolls itself there whenever that end
+moves — on mount, when a navigation swaps the crumbs, and when the row around it resizes — and leaves the
+reader's own scroll position alone the rest of the time, including while a crumb holds focus. Tabbing to a
+crumb the trail has scrolled past stays the browser's own job; the list carries `scroll-padding` the width of
+the fade zone, so that crumb lands clear of the fade rather than under it.
+
+Two supporting changes make that work in a real header:
+
+- `Breadcrumb.Root` carries `min-w-0`, so inside a flex row such as `AppLayout.Header` the landmark gives up
+  width to the row instead of pushing its siblings out of it.
+- `Breadcrumb.Item` and `Breadcrumb.Separator` no longer shrink, so a crumb keeps its label on one line and
+  the trail scrolls instead of breaking a label in two.
+
+No prop, part, or export changed. Two things follow from the mask, both covered on the
+[scroll fade](https://mantle.ngrok.com/base/scroll-fade) page: it fades everything `Breadcrumb.List` paints,
+its own background and border included, so keep that styling on a wrapper; and it owns the element's
+`mask-image`, so a second mask on the same element replaces it.
+
+To keep the old wrapping behavior, hand the scrollport back:
+
+```tsx
+<Breadcrumb.List className="flex-wrap overflow-x-visible">
+```
+
+Without a scroll container the mask has nothing to animate against, so it stays fully opaque and the row wraps
+as before. See https://mantle.ngrok.com/components/navigation/breadcrumb#overflow.

--- a/apps/www/app/docs/components/navigation/breadcrumb.mdx
+++ b/apps/www/app/docs/components/navigation/breadcrumb.mdx
@@ -52,6 +52,36 @@ export function BreadcrumbSlashSeparatorExample() {
 	);
 }
 
+export function BreadcrumbOverflowExample() {
+	return (
+		<div className="border-card-muted bg-card flex w-full max-w-sm items-center gap-2 rounded-lg border px-4 py-3">
+			<Breadcrumb.Root>
+				<Breadcrumb.List>
+					<Breadcrumb.Item>
+						<Breadcrumb.Link href="#">Acme Corp</Breadcrumb.Link>
+					</Breadcrumb.Item>
+					<Breadcrumb.Separator />
+					<Breadcrumb.Item>
+						<Breadcrumb.Link href="#">Endpoints</Breadcrumb.Link>
+					</Breadcrumb.Item>
+					<Breadcrumb.Separator />
+					<Breadcrumb.Item>
+						<Breadcrumb.Link href="#">Cloud Endpoints</Breadcrumb.Link>
+					</Breadcrumb.Item>
+					<Breadcrumb.Separator />
+					<Breadcrumb.Item>
+						<Breadcrumb.Link href="#">Traffic Policy</Breadcrumb.Link>
+					</Breadcrumb.Item>
+					<Breadcrumb.Separator />
+					<Breadcrumb.Item>
+						<Breadcrumb.Page>ep_2h8xyz</Breadcrumb.Page>
+					</Breadcrumb.Item>
+				</Breadcrumb.List>
+			</Breadcrumb.Root>
+		</div>
+	);
+}
+
 export function BreadcrumbRouterLinkExample() {
 	return (
 		<Breadcrumb.Root>
@@ -147,7 +177,7 @@ Breadcrumb.Root
 ```
 
 - **`Root`** is the `<nav>` landmark, labeled `"Breadcrumb"` by default (overridable via `aria-label`). It carries no visual styling of its own.
-- **`List`** is the `<ol>` — an ordered list, because the order of the items **is** the hierarchy, from the root to the current page.
+- **`List`** is the `<ol>` — an ordered list, because the order of the items **is** the hierarchy, from the root to the current page. It lays the crumbs out in one row and scrolls them sideways when the trail is wider than its container (see [Overflow](#overflow)).
 - **`Item`** is one crumb: an `<li>` wrapping a `Link` or the `Page`.
 - **`Link`** is a plain `<a>` to an ancestor page; compose it onto your router's link via `asChild`.
 - **`Page`** marks the current page — a `<span>` with `aria-current="page"`, not a link.
@@ -186,6 +216,61 @@ import { Link, href } from "react-router";
 </Breadcrumb.Root>;
 ```
 
+## Overflow
+
+An app header is one row tall, so a trail wider than that row scrolls sideways instead of wrapping onto a second one. `Breadcrumb.List` is the scroll container, and its edges carry the same [`scroll-fade-x`](/base/scroll-fade#horizontal--scroll-fade-x) mask as [Tabs](/components/navigation/tabs): the edge with crumbs beyond it fades out, and the edge with nothing beyond it stays flush.
+
+The trail starts at its end, because the end is the current page. It scrolls itself there whenever that end moves — on mount, when a navigation swaps the crumbs, and when the row around it resizes — and leaves the reader's own scroll position alone the rest of the time, including while a crumb holds focus. Tabbing to a crumb the trail has scrolled past is the browser's own job; the list carries `scroll-padding` the width of the fade zone, so that crumb lands clear of the fade rather than under it.
+
+For this to work inside a flex row such as [`AppLayout.Header`](/layouts/app-layout#applayoutheader), `Breadcrumb.Root` carries `min-w-0`: the landmark gives up width to the row instead of pushing its siblings out of it. The crumbs themselves never shrink, so a crumb keeps its label on one line.
+
+<Example>
+	<BreadcrumbOverflowExample />
+</Example>
+
+```tsx
+import { Breadcrumb } from "@ngrok/mantle/breadcrumb";
+
+<div className="border-card-muted bg-card flex w-full max-w-sm items-center gap-2 rounded-lg border px-4 py-3">
+	<Breadcrumb.Root>
+		<Breadcrumb.List>
+			<Breadcrumb.Item>
+				<Breadcrumb.Link href="/">Acme Corp</Breadcrumb.Link>
+			</Breadcrumb.Item>
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
+				<Breadcrumb.Link href="/endpoints">Endpoints</Breadcrumb.Link>
+			</Breadcrumb.Item>
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
+				<Breadcrumb.Link href="/endpoints/cloud">Cloud Endpoints</Breadcrumb.Link>
+			</Breadcrumb.Item>
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
+				<Breadcrumb.Link href="/endpoints/cloud/policy">Traffic Policy</Breadcrumb.Link>
+			</Breadcrumb.Item>
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
+				<Breadcrumb.Page>ep_2h8xyz</Breadcrumb.Page>
+			</Breadcrumb.Item>
+		</Breadcrumb.List>
+	</Breadcrumb.Root>
+</div>;
+```
+
+Two constraints come with the mask, both covered in full on the [scroll fade](/base/scroll-fade) page:
+
+- The mask fades everything `Breadcrumb.List` paints, its own background and border included. Keep that styling on a wrapper, as the example above does.
+- The mask owns the element's `mask-image`. A second mask on the same element replaces it.
+
+To wrap instead, hand the scrollport back:
+
+```tsx
+<Breadcrumb.List className="flex-wrap overflow-x-visible">
+```
+
+The mask needs a scroll container to animate against. Without one it stays fully opaque, and the row wraps as it did before.
+
 ## Accessibility
 
 Breadcrumb follows the [APG breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/):
@@ -199,7 +284,7 @@ Breadcrumb follows the [APG breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/
 
 ### Breadcrumb.Root
 
-The `<nav>` landmark containing the trail.
+The `<nav>` landmark containing the trail. It carries no visual styling; its one layout class is `min-w-0`, which lets the landmark shrink inside a flex row so `Breadcrumb.List` scrolls (see [Overflow](#overflow)).
 
 All props from [nav](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav#attributes), plus:
 
@@ -210,7 +295,7 @@ All props from [nav](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/n
 
 ### Breadcrumb.List
 
-The ordered list of crumbs — the order is the hierarchy.
+The ordered list of crumbs — the order is the hierarchy. It is also the scroll container: a trail wider than its container scrolls sideways with a faded edge and starts at the current page, and `className="flex-wrap overflow-x-visible"` trades that back for wrapping (see [Overflow](#overflow)).
 
 All props from [ol](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol#attributes), plus:
 
@@ -220,7 +305,7 @@ All props from [ol](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 
 ### Breadcrumb.Item
 
-A single crumb wrapping a `Link` or the `Page`.
+A single crumb wrapping a `Link` or the `Page`. The crumb never shrinks, so it keeps its label on one line and the trail scrolls instead.
 
 All props from [li](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#attributes), plus:
 
@@ -250,7 +335,7 @@ All props from [span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
 
 ### Breadcrumb.Separator
 
-A purely visual divider between crumbs, hidden from assistive technology.
+A purely visual divider between crumbs, hidden from assistive technology. Like the crumbs it divides, it never shrinks.
 
 All props from [li](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#attributes), plus:
 

--- a/apps/www/app/docs/recipes/breadcrumbs-from-routes.mdx
+++ b/apps/www/app/docs/recipes/breadcrumbs-from-routes.mdx
@@ -725,9 +725,9 @@ describe("RouteBreadcrumbs (through a real router)", () => {
 
 ## Trade-offs
 
-- **No collapsing.** `Breadcrumb` has no ellipsis part, so a long trail wraps (`Breadcrumb.List` is
-  `flex-wrap`) rather than truncating to `Home / … / Current`. Fine to about four levels; past that, consider
-  whether the depth itself is the problem.
+- **No collapsing.** `Breadcrumb` has no ellipsis part, so a long trail scrolls sideways from the current page
+  rather than truncating to `Home / … / Current`. Fine to about four levels; past that, consider whether the
+  depth itself is the problem.
 - **Labels must be synchronous.** That is a real constraint, not just a preference: a label you can only get
   from a query has to either move into the loader or be left out of the trail. See
   [Don't wait on a query for a crumb](#dont-wait-on-a-query-for-a-crumb).

--- a/packages/mantle/src/components/breadcrumb/breadcrumb.browser.test.tsx
+++ b/packages/mantle/src/components/breadcrumb/breadcrumb.browser.test.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { render } from "@testing-library/react";
+import { Fragment } from "react";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Breadcrumb } from "./breadcrumb.js";
+
+/**
+ * Mirrors the CSS Tailwind 4 emits for the utilities this component's layout
+ * rests on. Browser tests load no stylesheet, so without this every metric
+ * below is degenerate and every assertion passes for the wrong reason.
+ *
+ * Keep each declaration identical to Tailwind's output: the geometry these tests
+ * assert is only tied to the component while the class names here match the ones
+ * it renders. `scroll-fade-x` is left out on purpose — a mask changes what paints,
+ * never what measures, and `breadcrumb.test.tsx` pins its spelling.
+ */
+const STYLE = `
+@layer utilities {
+	.flex { display: flex; }
+	.inline-flex { display: inline-flex; }
+	.flex-wrap { flex-wrap: wrap; }
+	.items-center { align-items: center; }
+	.gap-1\\.5 { gap: 0.375rem; }
+	.min-w-0 { min-width: 0; }
+	.shrink-0 { flex-shrink: 0; }
+	.overflow-x-auto { overflow-x: auto; }
+	.overflow-x-visible { overflow-x: visible; }
+	.overscroll-x-none { overscroll-behavior-x: none; }
+	.-m-1 { margin: calc(0.25rem * -1); }
+	.p-1 { padding: 0.25rem; }
+	.scroll-px-10 { scroll-padding-inline: 2.5rem; }
+	.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+}
+
+/* The toolbar the trail has to fit into — AppLayout.Header, narrowed. */
+.test-header {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	width: 240px;
+	font-family: sans-serif;
+}
+.test-trigger { flex: none; width: 2rem; height: 2rem; }
+`;
+
+/** The fade zone `scroll-fade-x` masks at each inline edge, in pixels. */
+const FADE_ZONE = 40;
+
+/** One line of `text-sm` from the stylesheet above, in pixels. */
+const LINE_HEIGHT = 20;
+
+/**
+ * The widest focus indicator a crumb can paint: mantle's rings are `ring-3` and
+ * `ring-4` box shadows, and a bare `Breadcrumb.Link` gets the browser's own
+ * outline. Every one of them paints outside the crumb's own box.
+ */
+const FOCUS_RING = 3;
+
+const LONG_TRAIL = ["Home", "Endpoints", "Cloud Endpoints", "Traffic Policy", "ep_2h8xyz"];
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+const Header = ({
+	crumbs,
+	listClassName,
+}: {
+	crumbs: ReadonlyArray<string>;
+	listClassName?: string;
+}) => (
+	<div className="test-header">
+		<div className="test-trigger" />
+		<Breadcrumb.Root>
+			<Breadcrumb.List className={listClassName}>
+				{crumbs.map((crumb, index) => (
+					<Fragment key={crumb}>
+						{index > 0 && <Breadcrumb.Separator />}
+						<Breadcrumb.Item>
+							{index === crumbs.length - 1 ? (
+								<Breadcrumb.Page>{crumb}</Breadcrumb.Page>
+							) : (
+								<Breadcrumb.Link href={`/${crumb}`}>{crumb}</Breadcrumb.Link>
+							)}
+						</Breadcrumb.Item>
+					</Fragment>
+				))}
+			</Breadcrumb.List>
+		</Breadcrumb.Root>
+	</div>
+);
+
+function queryElement(root: ParentNode, selector: string) {
+	const element = root.querySelector<HTMLElement>(selector);
+	if (element == null) {
+		throw new Error(`nothing matched ${selector}`);
+	}
+
+	return element;
+}
+
+function queryElements(root: ParentNode, selector: string) {
+	return [...root.querySelectorAll<HTMLElement>(selector)];
+}
+
+/**
+ * Scrolls the trail so one named crumb hangs half off the end edge, and returns
+ * that crumb's link. Picking the crumb rather than discovering it keeps the
+ * geometry the same on a machine whose sans-serif measures differently.
+ */
+function hangOffEndEdge(list: HTMLElement, label: string) {
+	const crumb = queryElements(list, "[data-slot~=breadcrumb-link]").find(
+		(candidate) => candidate.textContent === label,
+	);
+	if (crumb == null) {
+		throw new Error(`no crumb labeled ${label}`);
+	}
+
+	list.scrollLeft = 0;
+	list.scrollLeft +=
+		crumb.getBoundingClientRect().right -
+		list.getBoundingClientRect().right -
+		crumb.offsetWidth / 2;
+
+	// The precondition every assertion below rests on, asserted rather than assumed.
+	const listBox = list.getBoundingClientRect();
+	const crumbBox = crumb.getBoundingClientRect();
+	expect(crumbBox.right).toBeGreaterThan(listBox.right);
+	expect(crumbBox.left).toBeLessThan(listBox.right);
+
+	return crumb;
+}
+
+describe("Breadcrumb overflow", () => {
+	test("a trail wider than the row scrolls sideways and stays on one line", () => {
+		const { container } = render(<Header crumbs={LONG_TRAIL} />);
+		const header = queryElement(container, ".test-header");
+		const nav = queryElement(container, "[data-slot~=breadcrumb]");
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const items = queryElements(container, "[data-slot~=breadcrumb-item]");
+
+		// The landmark gives up width instead of pushing the toolbar wider.
+		expect(nav.clientWidth).toBeLessThan(header.clientWidth);
+		expect(list.scrollWidth).toBeGreaterThan(list.clientWidth);
+		// One row: every crumb sits on the same baseline band as the first.
+		expect(new Set(items.map((item) => item.offsetTop)).size).toBe(1);
+	});
+
+	test("a crumb keeps its label on a single line rather than squeezing", () => {
+		const { container } = render(<Header crumbs={LONG_TRAIL} />);
+		const items = queryElements(container, "[data-slot~=breadcrumb-item]");
+
+		// A crumb that gave up width would break its label across two lines, which
+		// shows up as a crumb twice as tall as the row's line.
+		for (const item of items) {
+			expect(item.getBoundingClientRect().height).toBeLessThanOrEqual(LINE_HEIGHT);
+		}
+	});
+
+	test("a multi-word custom separator keeps its own label on one line", () => {
+		const { container } = render(
+			<div className="test-header">
+				<div className="test-trigger" />
+				<Breadcrumb.Root>
+					<Breadcrumb.List>
+						<Breadcrumb.Item>
+							<Breadcrumb.Link href="/endpoints">Cloud Endpoints</Breadcrumb.Link>
+						</Breadcrumb.Item>
+						<Breadcrumb.Separator>then under</Breadcrumb.Separator>
+						<Breadcrumb.Item>
+							<Breadcrumb.Page>ep_2h8xyz</Breadcrumb.Page>
+						</Breadcrumb.Item>
+					</Breadcrumb.List>
+				</Breadcrumb.Root>
+			</div>,
+		);
+		const separator = queryElement(container, "[data-slot~=breadcrumb-separator]");
+
+		expect(separator.getBoundingClientRect().height).toBeLessThanOrEqual(LINE_HEIGHT);
+	});
+
+	test("the trail starts at its end, so the current page is in view", () => {
+		const { container } = render(<Header crumbs={LONG_TRAIL} />);
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const currentPage = queryElement(container, "[data-slot~=breadcrumb-page]");
+
+		expect(list.scrollLeft).toBe(list.scrollWidth - list.clientWidth);
+		expect(list.scrollLeft).toBeGreaterThan(0);
+		// Sub-pixel slack: the current page is flush with the scrollport's end.
+		expect(currentPage.getBoundingClientRect().right).toBeLessThanOrEqual(
+			list.getBoundingClientRect().right + 1,
+		);
+	});
+
+	test("a longer trail re-pins to its new end", () => {
+		const { container, rerender } = render(<Header crumbs={LONG_TRAIL} />);
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const firstEnd = list.scrollWidth - list.clientWidth;
+
+		rerender(<Header crumbs={[...LONG_TRAIL, "Configuration History"]} />);
+
+		const secondEnd = list.scrollWidth - list.clientWidth;
+		expect(secondEnd).toBeGreaterThan(firstEnd);
+		expect(list.scrollLeft).toBe(secondEnd);
+	});
+
+	test("a crumb the reader tabs to lands clear of the fade zone", () => {
+		const { container } = render(<Header crumbs={LONG_TRAIL} />);
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const crumb = hangOffEndEdge(list, "Traffic Policy");
+
+		// Focus is the browser's own scroll trigger, and scroll padding is what tells
+		// it how far in to land: without the padding it leaves this crumb hanging.
+		crumb.focus();
+
+		expect(
+			Math.round(list.getBoundingClientRect().right - crumb.getBoundingClientRect().right),
+		).toBeGreaterThanOrEqual(FADE_ZONE);
+	});
+
+	test("a narrower row re-pins the trail so the current page stays in view", async () => {
+		const { container } = render(<Header crumbs={LONG_TRAIL} />);
+		const header = queryElement(container, ".test-header");
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const currentPage = queryElement(container, "[data-slot~=breadcrumb-page]");
+		expect(list.scrollLeft).toBe(list.scrollWidth - list.clientWidth);
+
+		// A window drag or a sidebar collapse resizes the row with no re-render, and
+		// a narrower row puts the end further away than where the reader was left.
+		header.style.width = "150px";
+
+		await expect.poll(() => list.scrollLeft).toBe(list.scrollWidth - list.clientWidth);
+		expect(currentPage.getBoundingClientRect().right).toBeLessThanOrEqual(
+			list.getBoundingClientRect().right + 1,
+		);
+	});
+
+	test("the row reserves room inside the scrollport for a crumb's focus ring", () => {
+		const { container } = render(<Header crumbs={LONG_TRAIL} />);
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const page = queryElement(container, "[data-slot~=breadcrumb-page]");
+		const listBox = list.getBoundingClientRect();
+		const pageBox = page.getBoundingClientRect();
+
+		// Everything outside the list's border box is clipped twice over — by the
+		// scrollport and by the mask, whose clip box is that border box — so the
+		// room has to be inside it, on all three edges a crumb can reach.
+		expect(pageBox.top - listBox.top).toBeGreaterThanOrEqual(FOCUS_RING);
+		expect(listBox.bottom - pageBox.bottom).toBeGreaterThanOrEqual(FOCUS_RING);
+		expect(listBox.right - pageBox.right).toBeGreaterThanOrEqual(FOCUS_RING);
+	});
+
+	test("a consumer can trade the scrollport back for wrapping", () => {
+		const { container } = render(
+			<Header crumbs={LONG_TRAIL} listClassName="flex-wrap overflow-x-visible" />,
+		);
+		const list = queryElement(container, "[data-slot~=breadcrumb-list]");
+		const items = queryElements(container, "[data-slot~=breadcrumb-item]");
+
+		expect(list.scrollWidth).toBe(list.clientWidth);
+		expect(new Set(items.map((item) => item.offsetTop)).size).toBeGreaterThan(1);
+	});
+});

--- a/packages/mantle/src/components/breadcrumb/breadcrumb.test.tsx
+++ b/packages/mantle/src/components/breadcrumb/breadcrumb.test.tsx
@@ -1,7 +1,28 @@
 import { render, screen } from "@testing-library/react";
-import { createRef } from "react";
-import { describe, expect, test } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import { createRef, Fragment } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
 import { Breadcrumb } from "./breadcrumb.js";
+
+const Trail = ({ crumbs }: { crumbs: ReadonlyArray<string> }) => (
+	<Breadcrumb.Root>
+		<Breadcrumb.List>
+			{crumbs.map((crumb, index) => (
+				<Fragment key={crumb}>
+					{index > 0 && <Breadcrumb.Separator />}
+					<Breadcrumb.Item>
+						{index === crumbs.length - 1 ? (
+							<Breadcrumb.Page>{crumb}</Breadcrumb.Page>
+						) : (
+							<Breadcrumb.Link href={`/${crumb}`}>{crumb}</Breadcrumb.Link>
+						)}
+					</Breadcrumb.Item>
+				</Fragment>
+			))}
+		</Breadcrumb.List>
+	</Breadcrumb.Root>
+);
 
 describe("Breadcrumb", () => {
 	test("Root renders a nav landmark labeled Breadcrumb by default", () => {
@@ -45,13 +66,25 @@ describe("Breadcrumb", () => {
 		expect(root).toHaveAttribute("aria-label", "Breadcrumb");
 	});
 
-	test("Root merges custom className", () => {
+	// tailwind-merge override contract: min-w-0 is what lets the landmark shrink
+	// inside a flex row, so a consumer's className must compose with it rather
+	// than replace it — and a conflicting min-w-* must win outright.
+	test("Root keeps its min-width default beside a consumer className", () => {
 		render(
 			<Breadcrumb.Root className="custom-class" data-testid="root">
 				crumbs
 			</Breadcrumb.Root>,
 		);
-		expect(screen.getByTestId("root").className).toContain("custom-class");
+		expect(screen.getByTestId("root").className).toBe("min-w-0 custom-class");
+	});
+
+	test("Root's min-width default loses to a consumer min-w-* utility", () => {
+		render(
+			<Breadcrumb.Root className="min-w-full" data-testid="root">
+				crumbs
+			</Breadcrumb.Root>,
+		);
+		expect(screen.getByTestId("root").className).toBe("min-w-full");
 	});
 
 	test("Root forwards a ref to the nav element", () => {
@@ -88,7 +121,9 @@ describe("Breadcrumb", () => {
 		expect(list).toHaveAttribute("data-slot", "breadcrumb-list");
 	});
 
-	test("List merges custom className with base classes", () => {
+	// tailwind-merge override contract: a consumer's gap replaces the default one
+	// instead of landing beside it, while the scroll treatment survives.
+	test("List's gap default loses to a consumer gap utility", () => {
 		render(
 			<Breadcrumb.Root>
 				<Breadcrumb.List className="gap-3">
@@ -100,7 +135,24 @@ describe("Breadcrumb", () => {
 		);
 		const list = screen.getByRole("list");
 		expect(list.className).toContain("gap-3");
-		expect(list.className).toContain("flex-wrap");
+		expect(list.className).not.toContain("gap-1.5");
+		expect(list.className).toContain("overflow-x-auto");
+	});
+
+	// Cross-file spelling pin: `scroll-fade-x` is the @utility declared in
+	// packages/mantle/src/mantle.css that masks the scrolled edges, so renaming
+	// the class here without renaming it there silently drops the fade.
+	test("List carries the scroll-fade-x edge mask", () => {
+		render(
+			<Breadcrumb.Root>
+				<Breadcrumb.List>
+					<Breadcrumb.Item>
+						<Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+					</Breadcrumb.Item>
+				</Breadcrumb.List>
+			</Breadcrumb.Root>,
+		);
+		expect(screen.getByRole("list").className).toContain("scroll-fade-x");
 	});
 
 	test("Item renders a listitem and merges custom className", () => {
@@ -268,6 +320,19 @@ describe("Breadcrumb", () => {
 		expect(separator.querySelector("svg")).not.toBeNull();
 	});
 
+	test("Separator merges a consumer className beside its own", () => {
+		render(
+			<Breadcrumb.Root>
+				<Breadcrumb.List>
+					<Breadcrumb.Separator className="mx-2" data-testid="separator" />
+				</Breadcrumb.List>
+			</Breadcrumb.Root>,
+		);
+		// tailwind-merge override contract: mx-2 does not conflict with shrink-0, so
+		// the consumer's spacing lands beside the part's own non-shrinking default.
+		expect(screen.getByTestId("separator").className).toBe("shrink-0 mx-2");
+	});
+
 	test("Separator custom children replace the default caret", () => {
 		render(
 			<Breadcrumb.Root>
@@ -335,5 +400,112 @@ describe("Breadcrumb", () => {
 		expect(items[2]).toHaveTextContent("ep_2h8");
 		expect(screen.getAllByRole("link")).toHaveLength(2);
 		expect(screen.getByText("ep_2h8")).toHaveAttribute("aria-current", "page");
+	});
+
+	describe("List scroll position", () => {
+		// happy-dom reports every layout metric as 0, so the trail's geometry comes
+		// from prototype stubs. `scrollLeft` there is a plain property, which records
+		// whatever offset the component assigns. The end of a trail is its scroll
+		// width less the width of the row it has to fit into.
+		const stubTrail = ({
+			scrollWidth,
+			clientWidth,
+		}: {
+			scrollWidth: number;
+			clientWidth: number;
+		}) => ({
+			scrollWidth: vi
+				.spyOn(HTMLElement.prototype, "scrollWidth", "get")
+				.mockReturnValue(scrollWidth),
+			clientWidth: vi
+				.spyOn(HTMLElement.prototype, "clientWidth", "get")
+				.mockReturnValue(clientWidth),
+		});
+
+		test("the trail starts at its end, so the current page is in view", () => {
+			stubTrail({ scrollWidth: 400, clientWidth: 100 });
+			render(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+			expect(screen.getByRole("list").scrollLeft).toBe(300);
+		});
+
+		test("a navigation that swaps the crumbs re-pins the trail to its new end", () => {
+			const { scrollWidth } = stubTrail({ scrollWidth: 400, clientWidth: 100 });
+			const { rerender } = render(<Trail crumbs={["Home", "Endpoints"]} />);
+			const list = screen.getByRole("list");
+			expect(list.scrollLeft).toBe(300);
+
+			scrollWidth.mockReturnValue(700);
+			rerender(<Trail crumbs={["Home", "Endpoints", "Cloud Endpoints", "ep_2h8"]} />);
+			expect(list.scrollLeft).toBe(600);
+		});
+
+		test("a re-render that leaves the trail unchanged keeps the reader's scroll position", () => {
+			stubTrail({ scrollWidth: 400, clientWidth: 100 });
+			const { rerender } = render(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+			const list = screen.getByRole("list");
+
+			// The reader scrolls back to the root of the hierarchy.
+			list.scrollLeft = 0;
+			rerender(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+			expect(list.scrollLeft).toBe(0);
+		});
+
+		test("a crumb under focus keeps its place when the trail changes around it", async () => {
+			const user = userEvent.setup();
+			const { scrollWidth } = stubTrail({ scrollWidth: 400, clientWidth: 100 });
+			const { rerender } = render(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+			const list = screen.getByRole("list");
+
+			await user.tab();
+			// The reader is reading the crumb they tabbed to, wherever it sits.
+			list.scrollLeft = 40;
+
+			scrollWidth.mockReturnValue(700);
+			rerender(<Trail crumbs={["Home", "Endpoints", "Cloud Endpoints", "ep_2h8"]} />);
+
+			expect(screen.getByRole("link", { name: "Home" })).toHaveFocus();
+			expect(list.scrollLeft).toBe(40);
+		});
+
+		test("a trail that could not be measured at first pins once it can", () => {
+			// A trail first rendered inside a display:none ancestor measures zero on
+			// every axis, so the end it has to reach only exists once it is shown.
+			const { scrollWidth, clientWidth } = stubTrail({ scrollWidth: 0, clientWidth: 0 });
+			const { rerender } = render(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+			const list = screen.getByRole("list");
+
+			scrollWidth.mockReturnValue(400);
+			clientWidth.mockReturnValue(100);
+			rerender(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+
+			expect(list.scrollLeft).toBe(300);
+		});
+	});
+
+	test("the server render carries the whole trail, scroll container and all", () => {
+		const html = renderToString(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+
+		// The scroll pin runs in an effect, so nothing about it may hold the trail
+		// back to the client: the first paint has to be the finished trail, not an
+		// empty row that fills in after hydration.
+		expect(html).toContain('data-slot="breadcrumb-list"');
+		expect(html).toContain("Endpoints");
+		expect(html).toContain('aria-current="page"');
+		expect(html).toContain("ep_2h8");
+	});
+
+	test("focus reaching a crumb scrolls nothing itself", async () => {
+		const user = userEvent.setup();
+		const scrollIntoView = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+		render(<Trail crumbs={["Home", "Endpoints", "ep_2h8"]} />);
+
+		await user.tab();
+
+		// Bringing a tabbed-to crumb into view is the browser's own job, driven by
+		// the list's scroll padding. Doing it here as well would fire between a
+		// press and its release and slide the crumb out from under the pointer,
+		// so the click would land on whatever replaced it.
+		expect(screen.getByRole("link", { name: "Home" })).toHaveFocus();
+		expect(scrollIntoView).not.toHaveBeenCalled();
 	});
 });

--- a/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/mantle/src/components/breadcrumb/breadcrumb.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
 import type { ComponentProps, ReactNode } from "react";
-import { cloneElement, isValidElement } from "react";
+import { cloneElement, isValidElement, useEffect, useRef } from "react";
+import { useIsomorphicLayoutEffect } from "../../hooks/use-isomorphic-layout-effect.js";
 import type { WithAsChild } from "../../types/as-child.js";
+import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
@@ -12,9 +16,12 @@ import { Slot } from "../slot/index.js";
  * The breadcrumb landmark. Renders a `<nav>` with a default
  * `aria-label="Breadcrumb"` per the WAI-ARIA breadcrumb pattern — pass your
  * own `aria-label` to override it (e.g. for localization or when a page has
- * multiple breadcrumb trails). Carries no visual styling of its own.
+ * multiple breadcrumb trails). Carries no visual styling. Its one layout class
+ * is `min-w-0`: inside a flex row such as `AppLayout.Header` the landmark must
+ * shrink below the trail's width, or `Breadcrumb.List` never scrolls and the
+ * crumbs push their siblings out of the row.
  *
- * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+ * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumbroot
  *
  * @example
  * ```tsx
@@ -38,6 +45,7 @@ import { Slot } from "../slot/index.js";
 const Root = ({
 	asChild,
 	children,
+	className,
 	"data-slot": dataSlot,
 	ref,
 	...props
@@ -49,6 +57,7 @@ const Root = ({
 			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "breadcrumb")}
 			aria-label="Breadcrumb"
+			className={cx("min-w-0", className)}
 			{...props}
 		>
 			{children}
@@ -57,11 +66,64 @@ const Root = ({
 };
 
 /**
+ * Scrolls a trail to its end, where the current page is, when that end has moved
+ * since the last pin. A moved end is the only thing that takes the scroll
+ * position away from the reader: their own scroll survives every other commit,
+ * resize, and re-measure.
+ *
+ * @param element - The trail's scroll container.
+ * @param previousEnd - The end offset this last pinned at, or `undefined` before
+ *   the first pin.
+ * @returns The end offset it pinned at, or `previousEnd` when it left the trail
+ *   alone.
+ *
+ * @example
+ * pinnedEnd.current = pinTrailToEnd(list, pinnedEnd.current);
+ */
+function pinTrailToEnd(element: Element, previousEnd: number | undefined) {
+	// The end is an offset, not a width, so a row that narrows around unchanged
+	// crumbs moves it just as a swapped trail does.
+	const end = element.scrollWidth - element.clientWidth;
+	// The end sits where it did, so whatever the reader scrolled to still shows
+	// them what they scrolled it to show.
+	if (end === previousEnd) {
+		return previousEnd;
+	}
+
+	// A crumb under focus outranks the current page: scrolling now would carry the
+	// focus ring out of view, and the reader has no gesture that brings it back.
+	if (element.contains(document.activeElement)) {
+		return previousEnd;
+	}
+
+	element.scrollLeft = end;
+
+	return end;
+}
+
+/**
  * The ordered list of crumbs. Renders an `<ol>` — an **ordered** list, because
  * the order of the items is the hierarchy, from the root to the current page.
- * Lays crumbs out inline with wrapping and muted, small text.
+ * Lays the crumbs out in one row of muted, small text.
  *
- * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+ * A trail wider than its container scrolls sideways instead of wrapping to a
+ * second row, which a one-row app header has no space for. Its edges carry the
+ * same `scroll-fade-x` mask as `Tabs.List`: an edge with crumbs beyond it fades
+ * out, and an edge with nothing beyond it stays flush.
+ *
+ * The trail keeps its end in view, because the end is the current page. It
+ * scrolls itself there whenever that end moves — on mount, when a navigation
+ * swaps the crumbs, and when the row around it resizes — and leaves the reader's
+ * own scroll position alone the rest of the time, including while a crumb holds
+ * focus. Tabbing to a crumb the trail has scrolled past is the browser's own
+ * job, and `scroll-padding` the width of the fade zone is what lands that crumb
+ * clear of the fade rather than under it.
+ *
+ * To wrap instead, pass `className="flex-wrap overflow-x-visible"`. The mask
+ * needs a scrollport to animate against, so without one it renders fully
+ * opaque and the row wraps as it did before.
+ *
+ * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumblist
  *
  * @example
  * ```tsx
@@ -91,12 +153,62 @@ const List = ({
 	...props
 }: ComponentProps<"ol"> & WithAsChild & WithDataSlot) => {
 	const Comp = asChild ? Slot : "ol";
+	const scrollRef = useRef<HTMLOListElement>(null);
+	const composedRef = useComposedRefs(scrollRef, ref);
+	// The end offset the trail last pinned at, which is what tells a commit that
+	// swapped the crumbs apart from one that changed nothing about them.
+	const pinnedEnd = useRef<number | undefined>(undefined);
+
+	// A navigation swaps the crumbs without touching the row's own size, so only a
+	// fresh measurement after the commit can see the end move.
+	useIsomorphicLayoutEffect(() => {
+		const element = scrollRef.current;
+		if (element != null) {
+			pinnedEnd.current = pinTrailToEnd(element, pinnedEnd.current);
+		}
+	});
+
+	useEffect(() => {
+		const element = scrollRef.current;
+		if (element == null) {
+			return;
+		}
+
+		// Why an observer: a window drag, a sidebar collapse, or a zoom change moves
+		// the end with no render to hang a measurement off, and a narrower row moves
+		// the end further away — leaving the current page off to the right, out of
+		// view, until something else re-renders.
+		const observer = new ResizeObserver(() => {
+			pinnedEnd.current = pinTrailToEnd(element, pinnedEnd.current);
+		});
+		observer.observe(element);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, []);
 
 	return (
 		<Comp
-			ref={ref}
+			ref={composedRef}
 			data-slot={joinDataSlot(dataSlot, "breadcrumb-list")}
-			className={cx("text-muted flex flex-wrap items-center gap-1.5 text-sm", className)}
+			className={cx(
+				"text-muted flex items-center gap-1.5 text-sm",
+				// The trail scrolls rather than wraps, masked at both edges like
+				// Tabs.List. min-w-0 is what lets the row shrink — and so scroll —
+				// when the list is itself a flex item.
+				"scroll-fade-x min-w-0 overflow-x-auto overscroll-x-none",
+				// overflow-x-auto promotes overflow-y to auto, and the mask paints
+				// nothing outside the border box, so a focused crumb's ring needs room
+				// reserved inside the scrollport; the negative margin gives that room
+				// back to the surrounding layout. Same trade as CodeBlock.TabList.
+				"-m-1 p-1",
+				// The mask fades 40px at each edge, and the browser scrolls a crumb it
+				// tabs to only as far as the scroll padding asks for — 40px matches the
+				// two, so a focused crumb lands clear of the fade instead of under it.
+				"scroll-px-10",
+				className,
+			)}
 			{...props}
 		>
 			{children}
@@ -108,7 +220,11 @@ const List = ({
  * A single crumb. Renders an `<li>` (`role="listitem"`) that lays out its
  * content — a `Breadcrumb.Link` or `Breadcrumb.Page` — inline.
  *
- * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+ * The crumb never shrinks (`shrink-0`). A squeezed crumb would break its own
+ * label across two lines, so a trail too wide for its container scrolls in
+ * `Breadcrumb.List` instead.
+ *
+ * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumbitem
  *
  * @example
  * ```tsx
@@ -143,7 +259,7 @@ const Item = ({
 		<Comp
 			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "breadcrumb-item")}
-			className={cx("inline-flex items-center gap-1.5", className)}
+			className={cx("inline-flex shrink-0 items-center gap-1.5", className)}
 			{...props}
 		>
 			{children}
@@ -290,7 +406,10 @@ type BreadcrumbSeparatorProps = Omit<ComponentProps<"li">, "children"> &
  * your own children (e.g. a slash) to replace it. With `asChild`, children
  * are required — the child element is what renders.
  *
- * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+ * Like `Breadcrumb.Item`, the divider never shrinks (`shrink-0`), so a trail
+ * too wide for its container scrolls in `Breadcrumb.List` instead.
+ *
+ * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumbseparator
  *
  * @example
  * ```tsx
@@ -314,6 +433,7 @@ type BreadcrumbSeparatorProps = Omit<ComponentProps<"li">, "children"> &
 const Separator = ({
 	asChild,
 	children,
+	className,
 	"data-slot": dataSlot,
 	ref,
 	...props
@@ -330,6 +450,7 @@ const Separator = ({
 		<Comp
 			ref={ref}
 			data-slot={joinDataSlot(dataSlot, "breadcrumb-separator")}
+			className={cx("shrink-0", className)}
 			{...props}
 			role="presentation"
 			aria-hidden="true"
@@ -343,7 +464,8 @@ const Separator = ({
  * Compound component for WAI-ARIA breadcrumb navigation — the path from a
  * root to the current page as an ordered list of links inside a labeled
  * `<nav>` landmark. Router-agnostic: compose `Breadcrumb.Link` onto your app
- * router's link via `asChild`.
+ * router's link via `asChild`. A trail too wide for its row scrolls sideways
+ * with faded edges instead of wrapping, and starts at the current page.
  *
  * @see https://mantle.ngrok.com/components/navigation/breadcrumb
  *
@@ -382,9 +504,10 @@ const Breadcrumb = {
 	/**
 	 * The breadcrumb landmark. Renders a `<nav>` with a default
 	 * `aria-label="Breadcrumb"` — pass your own `aria-label` to override it.
-	 * Carries no visual styling of its own.
+	 * Carries no visual styling; `min-w-0` is what lets the landmark shrink
+	 * inside a flex row so the trail scrolls.
 	 *
-	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumbroot
 	 *
 	 * @example
 	 * ```tsx
@@ -408,9 +531,11 @@ const Breadcrumb = {
 	Root,
 	/**
 	 * The ordered list of crumbs. Renders an `<ol>` — the order of the items
-	 * is the hierarchy, from the root to the current page.
+	 * is the hierarchy, from the root to the current page. A trail wider than
+	 * its container scrolls sideways with a faded edge instead of wrapping, and
+	 * starts at the current page.
 	 *
-	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumblist
 	 *
 	 * @example
 	 * ```tsx
@@ -434,9 +559,10 @@ const Breadcrumb = {
 	List,
 	/**
 	 * A single crumb. Renders an `<li>` containing a `Breadcrumb.Link` or
-	 * `Breadcrumb.Page`.
+	 * `Breadcrumb.Page`. The crumb never shrinks, so a wide trail scrolls
+	 * instead of breaking a label across two lines.
 	 *
-	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumbitem
 	 *
 	 * @example
 	 * ```tsx
@@ -514,9 +640,10 @@ const Breadcrumb = {
 	/**
 	 * A purely visual divider between crumbs, hidden from assistive
 	 * technology (`role="presentation"` + `aria-hidden`). Children default to
-	 * a caret icon; pass your own (e.g. a slash) to replace it.
+	 * a caret icon; pass your own (e.g. a slash) to replace it. Like the crumbs
+	 * it divides, it never shrinks.
 	 *
-	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb
+	 * @see https://mantle.ngrok.com/components/navigation/breadcrumb#breadcrumbseparator
 	 *
 	 * @example
 	 * ```tsx


### PR DESCRIPTION
## Why

A `Breadcrumb` trail wider than its container wrapped onto a second row. An `AppLayout.Header` is one row tall, so a deep trail pushed the page down and left the current page — the crumb a reader needs first — wherever the wrap put it. The trail also widened the header instead of giving up space to it, so the crumbs pushed their siblings out of the row.

## How

`Breadcrumb.List` is now a one-row horizontal scroll container carrying the same `scroll-fade-x` mask as `Tabs.List`, and it keeps its end in view whenever that end moves: on mount, when a navigation swaps the crumbs, and when the row around it resizes. The reader's own scroll position survives everything else, including a crumb holding focus. `Breadcrumb.Root` carries `min-w-0` so the landmark shrinks inside a flex row, `Breadcrumb.Item` and `Breadcrumb.Separator` no longer shrink, and the list's `scroll-px-10` matches the mask's 40px fade so a crumb the browser tabs to lands clear of the fade. To wrap instead: `<Breadcrumb.List className=\"flex-wrap overflow-x-visible\">`.

The end offset — `scrollWidth - clientWidth` — is the signal, not the trail's width: a row that narrows around unchanged crumbs moves the end just as a swapped trail does, and a `ResizeObserver` catches that case because no render accompanies it.

## Validation

- 9 browser tests in Chromium pin the geometry with the load-bearing Tailwind declarations injected inline, and 12 new happy-dom tests pin the pin logic against stubbed metrics. Every class and guard in the diff was mutation-tested: removing `min-w-0`, `shrink-0` on either part, `-m-1 p-1`, `scroll-px-10`, the `ResizeObserver`, the focus guard, the end-unchanged guard, or the layout effect each turns a specific test red.
- Verified live on the docs site in light and dark: the example pins to `scrollLeft` 146 of max 146 with the start edge faded and the end flush, flipping when a reader scrolls back. Narrowing the viewport from 900px to 300px on the recipe demo tracks the new end at every width (0 → 83 → 163) with the current page still visible.
- No consumer depends on the old wrapping: the dashboard's own breadcrumb (`ngrok-private/frontend`, `page-breadcrumb.tsx`) is hand-rolled and never imports `@ngrok/mantle/breadcrumb`. The four in-repo demos and three docs examples carry short trails that do not overflow.
- Not covered: right-to-left rows. The pin assigns a positive `scrollLeft`, which is the trail's start in RTL — consistent with `scroll-fade-x` itself, whose mask gradient is physical (`to right`).

Patch, per the changeset: behavior changes, no prop, part, or export does.