### PR TITLE
feat(dialog): add appearance to Dialog.Content for full-page and full-bleed

### DIFF
--- a/.changeset/dialog-content-appearance.md
+++ b/.changeset/dialog-content-appearance.md
@@ -1,0 +1,46 @@
+---
+"@ngrok/mantle": patch
+---
+
+Add `appearance` to `Dialog.Content`, so a full-page or edge-to-edge dialog is one prop instead of a
+class recipe.
+
+```tsx
+// a card, capped — the default, unchanged
+<Dialog.Content preferredWidth="max-w-2xl">
+
+// fills the 16px-inset box, still a rounded card
+<Dialog.Content appearance="full-page">
+
+// fills the whole viewport, square and unbordered
+<Dialog.Content appearance="full-bleed">
+```
+
+| `appearance`   | Width                      | Viewport inset | Corners and border   |
+| -------------- | -------------------------- | -------------- | -------------------- |
+| `"centered"`   | capped at `preferredWidth` | 16px           | rounded and bordered |
+| `"full-page"`  | fills the box              | 16px           | rounded and bordered |
+| `"full-bleed"` | fills the box              | none           | square, no border    |
+
+- **Every dialog already sat 16px from each viewport edge.** `Dialog.Content` positions itself inside a
+  `fixed inset-4` wrapper, which nothing documented, so filling that box meant discovering
+  `preferredWidth="max-w-none"` and adding `h-full` by hand. Going edge to edge meant more: the wrapper takes
+  no props, so the only way out was `fixed inset-0` on the content, which escapes the wrapper only because the
+  wrapper happens not to be a containing block for fixed elements. `appearance="full-bleed"` sets the
+  wrapper's inset directly instead.
+- **The three values move together as one decision**, because a dialog that fills the viewport has no width
+  left to cap and no corner left to round. `preferredWidth` therefore belongs to `"centered"` only —
+  `<Dialog.Content appearance="full-bleed" preferredWidth="max-w-lg" />` is a type error rather than a prop
+  that silently does nothing. A computed `appearance` still typechecks, so a consumer can toggle between
+  appearances from state.
+- **`"full-bleed"` keeps its backdrop.** The content opens at `zoom-in-95`, so a sliver of viewport edge stays
+  uncovered for the length of the animation, and the overlay is what fills it.
+- **`Dialog.Content` now stamps `data-appearance`** with the resolved value, so consumer CSS can target a
+  full-bleed dialog without threading a class through.
+- `appearance` defaults to `"centered"`, which paints exactly what `Dialog.Content` painted before, so no
+  existing call site changes.
+
+`Dialog` also ships its first test file, covering the three appearances, the width cap, dismissal, and the
+type-level contract.
+
+Docs: https://mantle.ngrok.com/components/overlays/dialog#full-page-dialog

--- a/apps/www/app/docs/components/overlays/dialog.mdx
+++ b/apps/www/app/docs/components/overlays/dialog.mdx
@@ -133,23 +133,34 @@ Dialog.Root
 
 ## Full-page dialog
 
-`Dialog.Content` positions itself inside a `fixed inset-4` wrapper, so every dialog already sits 16px from each viewport edge. Two props fill the rest of that box: `preferredWidth="max-w-none"` drops the width cap, and `className="h-full"` stretches the content to the wrapper's height. The 16px gutter stays.
+Every dialog already sits 16px from each viewport edge — `Dialog.Content` positions itself inside a `fixed inset-4` wrapper, so you never add that margin yourself. `appearance` decides how much of the box it claims from there:
 
-The parts keep their roles at this size. Because `Dialog.Content` is a flex column with `Dialog.Body` at `flex-1 overflow-y-auto`, the header and footer stay pinned while the body scrolls.
+| `appearance`   | Width                      | Viewport inset | Corners and border   |
+| -------------- | -------------------------- | -------------- | -------------------- |
+| `"centered"`   | capped at `preferredWidth` | 16px           | rounded and bordered |
+| `"full-page"`  | fills the box              | 16px           | rounded and bordered |
+| `"full-bleed"` | fills the box              | none           | square, no border    |
+
+The three values move together as one decision, because a dialog that fills the viewport has no width left to cap and no corner left to round. `preferredWidth` therefore belongs to `"centered"` only — passing it beside `"full-page"` or `"full-bleed"` is a type error, not a prop that silently does nothing.
+
+```tsx
+// a card, capped — the default
+<Dialog.Content preferredWidth="max-w-2xl">
+
+// fills the 16px-inset box, still a rounded card
+<Dialog.Content appearance="full-page">
+
+// fills the whole viewport, square and unbordered
+<Dialog.Content appearance="full-bleed">
+```
+
+The parts keep their roles at every appearance. Because `Dialog.Content` is a flex column with `Dialog.Body` at `flex-1 overflow-y-auto`, the header and footer stay pinned while the body scrolls.
 
 When the content needs the whole viewport, reach for this — a request log, a diff, a media preview, a multi-column editor. When the content deserves its own URL, a back button, or a shareable link, a route beats a dialog.
 
-### Going edge to edge
+`"full-bleed"` keeps its backdrop. The content opens at `zoom-in-95`, so a sliver of viewport edge stays uncovered for the length of the animation, and the overlay is what fills it.
 
-To drop the 16px gutter too, re-position the content over the wrapper. `Dialog.Content` sets no `position` of its own. The `inset-4` wrapper is also not a containing block for fixed elements. Content at `fixed inset-0` therefore measures against the viewport. Three classes make the switch:
-
-- `fixed inset-0` — pins the content to the four viewport edges.
-- `rounded-none` — squares the corners that meet those edges.
-- `border-0` — removes the 1px border, which otherwise traces the viewport edge.
-
-The base `max-h-full` needs no override. A fixed element measures against the viewport, so `max-h-full` already resolves to the full viewport height.
-
-The switch in the demo body toggles between the two.
+The switch in the demo body swaps `"full-page"` for `"full-bleed"`.
 
 <Example className="w-full">
 	<FullPageDialogDemo />
@@ -158,7 +169,6 @@ The switch in the demo body toggles between the two.
 ```tsx
 import { Badge } from "@ngrok/mantle/badge";
 import { Button } from "@ngrok/mantle/button";
-import { cx } from "@ngrok/mantle/cx";
 import { Dialog } from "@ngrok/mantle/dialog";
 import { Label } from "@ngrok/mantle/label";
 import { Switch } from "@ngrok/mantle/switch";
@@ -179,7 +189,7 @@ const requestLog = Array.from({ length: 7 })
 	.map((request, index) => ({ ...request, id: `req_${4200 + index}` }));
 
 function RequestLogDialog() {
-	const [edgeToEdge, setEdgeToEdge] = useState(false);
+	const [fullBleed, setFullBleed] = useState(false);
 	const switchId = useId();
 
 	return (
@@ -189,18 +199,15 @@ function RequestLogDialog() {
 					Open full-page dialog
 				</Button>
 			</Dialog.Trigger>
-			<Dialog.Content
-				preferredWidth="max-w-none"
-				className={cx("h-full", edgeToEdge && "fixed inset-0 rounded-none border-0")}
-			>
+			<Dialog.Content appearance={fullBleed ? "full-bleed" : "full-page"}>
 				<Dialog.Header>
 					<Dialog.Title>Request log</Dialog.Title>
 					<Dialog.CloseIconButton />
 				</Dialog.Header>
 				<Dialog.Body className="p-0">
 					<div className="border-dialog-muted bg-dialog sticky top-0 flex items-center gap-2 border-b px-6 py-3">
-						<Switch id={switchId} checked={edgeToEdge} onCheckedChange={setEdgeToEdge} />
-						<Label htmlFor={switchId}>Edge to edge</Label>
+						<Switch id={switchId} checked={fullBleed} onCheckedChange={setFullBleed} />
+						<Label htmlFor={switchId}>Full bleed</Label>
 					</div>
 					<div className="divide-card-muted divide-y font-mono text-sm">
 						{requestLog.map((request) => (
@@ -614,11 +621,17 @@ The container for the dialog content. Renders on top of the overlay and is cente
 
 Renders at Tailwind `z-50`, Mantle's shared floating z-index.
 
-| Prop                 | Type                             | Default      | Description                                                                                                                |
-| -------------------- | -------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `preferredWidth?`    | `` `max-w-${string}` ``          | `"max-w-lg"` | The preferred width of the dialog content as a Tailwind `max-w-` class. Controls the maximum width of the dialog.          |
-| `onEscapeKeyDown?`   | `(event: KeyboardEvent) => void` |              | Event handler called when the escape key is down. It can be prevented by calling `event.preventDefault`.                   |
-| `onInteractOutside?` | `(event: Event) => void`         |              | Event handler called when the user interacts outside the component. It can be prevented by calling `event.preventDefault`. |
+| Prop                 | Type                                            | Default      | Description                                                                                                                                                |
+| -------------------- | ----------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appearance?`        | `"centered"` \| `"full-page"` \| `"full-bleed"` | `"centered"` | How much of the viewport the dialog claims. See [Full-page dialog](#full-page-dialog).                                                                     |
+| `preferredWidth?`    | `` `max-w-${string}` ``                         | `"max-w-lg"` | The maximum width of a `"centered"` dialog, as a Tailwind `max-w-` class. Accepted for `appearance="centered"` only — a filled dialog has no width to cap. |
+| `onEscapeKeyDown?`   | `(event: KeyboardEvent) => void`                |              | Event handler called when the escape key is down. It can be prevented by calling `event.preventDefault`.                                                   |
+| `onInteractOutside?` | `(event: Event) => void`                        |              | Event handler called when the user interacts outside the component. It can be prevented by calling `event.preventDefault`.                                 |
+
+| Data Attribute    | Value                                           | Description                                            |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| `data-appearance` | `"centered"` \| `"full-page"` \| `"full-bleed"` | Reflects the resolved `appearance`.                    |
+| `data-state`      | `"open"` \| `"closed"`                          | Stamped by Radix; drives the open and close animation. |
 
 ### Dialog.Header
 

--- a/apps/www/app/docs/components/overlays/dialog.mdx
+++ b/apps/www/app/docs/components/overlays/dialog.mdx
@@ -9,6 +9,7 @@ import { Sheet } from "@ngrok/mantle/sheet";
 import { Tooltip } from "@ngrok/mantle/tooltip";
 import { TrashSimpleIcon } from "@phosphor-icons/react/TrashSimple";
 import { Example } from "~/components/example";
+import { FullPageDialogDemo } from "~/examples/dialog/dialog-full-page-demo";
 import { TanStackFormDemo } from "~/examples/dialog/dialog-tanstack-form-demo";
 
 # Dialog
@@ -128,6 +129,106 @@ Dialog.Root
     ├── Dialog.Body
     └── Dialog.Footer
         └── Dialog.Close
+```
+
+## Full-page dialog
+
+`Dialog.Content` positions itself inside a `fixed inset-4` wrapper, so every dialog already sits 16px from each viewport edge. Two props fill the rest of that box: `preferredWidth="max-w-none"` drops the width cap, and `className="h-full"` stretches the content to the wrapper's height. The 16px gutter stays.
+
+The parts keep their roles at this size. Because `Dialog.Content` is a flex column with `Dialog.Body` at `flex-1 overflow-y-auto`, the header and footer stay pinned while the body scrolls.
+
+When the content needs the whole viewport, reach for this — a request log, a diff, a media preview, a multi-column editor. When the content deserves its own URL, a back button, or a shareable link, a route beats a dialog.
+
+### Going edge to edge
+
+To drop the 16px gutter too, re-position the content over the wrapper. `Dialog.Content` sets no `position` of its own. The `inset-4` wrapper is also not a containing block for fixed elements. Content at `fixed inset-0` therefore measures against the viewport. Three classes make the switch:
+
+- `fixed inset-0` — pins the content to the four viewport edges.
+- `rounded-none` — squares the corners that meet those edges.
+- `border-0` — removes the 1px border, which otherwise traces the viewport edge.
+
+The base `max-h-full` needs no override. A fixed element measures against the viewport, so `max-h-full` already resolves to the full viewport height.
+
+The switch in the demo body toggles between the two.
+
+<Example className="w-full">
+	<FullPageDialogDemo />
+</Example>
+
+```tsx
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { cx } from "@ngrok/mantle/cx";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { Label } from "@ngrok/mantle/label";
+import { Switch } from "@ngrok/mantle/switch";
+import { useId, useState } from "react";
+
+const sampleRequests = [
+	{ method: "GET", path: "/api/v2/endpoints", status: 200, durationMs: 12 },
+	{ method: "POST", path: "/api/v2/tunnels", status: 201, durationMs: 84 },
+	{ method: "GET", path: "/api/v2/reserved_domains", status: 200, durationMs: 21 },
+	{ method: "DELETE", path: "/api/v2/endpoints/ep_2f8c1a", status: 204, durationMs: 33 },
+	{ method: "GET", path: "/api/v2/edges/https/edghts_1x9d", status: 502, durationMs: 1204 },
+	{ method: "PATCH", path: "/api/v2/api_keys/ak_71bd", status: 200, durationMs: 47 },
+];
+
+// The sample repeats so the log overflows `Dialog.Body` at full height.
+const requestLog = Array.from({ length: 7 })
+	.flatMap(() => sampleRequests)
+	.map((request, index) => ({ ...request, id: `req_${4200 + index}` }));
+
+function RequestLogDialog() {
+	const [edgeToEdge, setEdgeToEdge] = useState(false);
+	const switchId = useId();
+
+	return (
+		<Dialog.Root>
+			<Dialog.Trigger asChild>
+				<Button type="button" appearance="filled" intent="neutral">
+					Open full-page dialog
+				</Button>
+			</Dialog.Trigger>
+			<Dialog.Content
+				preferredWidth="max-w-none"
+				className={cx("h-full", edgeToEdge && "fixed inset-0 rounded-none border-0")}
+			>
+				<Dialog.Header>
+					<Dialog.Title>Request log</Dialog.Title>
+					<Dialog.CloseIconButton />
+				</Dialog.Header>
+				<Dialog.Body className="p-0">
+					<div className="border-dialog-muted bg-dialog sticky top-0 flex items-center gap-2 border-b px-6 py-3">
+						<Switch id={switchId} checked={edgeToEdge} onCheckedChange={setEdgeToEdge} />
+						<Label htmlFor={switchId}>Edge to edge</Label>
+					</div>
+					<div className="divide-card-muted divide-y font-mono text-sm">
+						{requestLog.map((request) => (
+							<div
+								key={request.id}
+								className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-3 px-4 py-2 sm:px-6"
+							>
+								<span className="text-muted">{request.method}</span>
+								<span className="text-strong truncate">{request.path}</span>
+								<Badge appearance="muted" color={request.status >= 500 ? "danger" : "success"}>
+									{request.status}
+								</Badge>
+								<span className="text-muted text-right">{request.durationMs}ms</span>
+							</div>
+						))}
+					</div>
+				</Dialog.Body>
+				<Dialog.Footer>
+					<Dialog.Close asChild>
+						<Button type="button" appearance="outlined" intent="neutral">
+							Close
+						</Button>
+					</Dialog.Close>
+				</Dialog.Footer>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+}
 ```
 
 ## Combining with a Tooltip

--- a/apps/www/app/examples/dialog/dialog-full-page-demo.test.tsx
+++ b/apps/www/app/examples/dialog/dialog-full-page-demo.test.tsx
@@ -29,53 +29,24 @@ describe("FullPageDialogDemo", () => {
 		expect(label?.getAttribute("for")).toBe(toggle.id);
 	});
 
-	it("fills the wrapper at full width and full height, and leaves the gutter alone", () => {
+	it("opens as a full-page dialog, keeping the 16px gutter", () => {
 		const content = openDialog();
 
-		// tailwind-merge override contract: `max-w-none` has to replace the
-		// `max-w-lg` default, or the dialog stays narrow at full height.
-		expect(content.className).toContain("max-w-none");
-		expect(content.className).not.toContain("max-w-lg");
-		expect(content.className).toContain("h-full");
-		// `Dialog.Content`'s own wrapper owns the 16px gutter, so the content must
-		// not re-position itself while the switch is off.
-		expect(content.className).not.toContain("inset-0");
+		expect(content.dataset.appearance).toBe("full-page");
 	});
 
-	it("replaces the rounded, bordered, wrapper-bound defaults when the switch goes on", () => {
+	it("swaps to full-bleed when the switch goes on, and back when it goes off", () => {
 		const content = openDialog();
 		const toggle = screen.getByRole("switch");
 
 		expect(toggle.getAttribute("aria-checked")).toBe("false");
+
 		fireEvent.click(toggle);
 		expect(toggle.getAttribute("aria-checked")).toBe("true");
-
-		// tailwind-merge override contract: edge to edge only works if each of these
-		// replaces its default instead of landing beside it, where source order
-		// would pick the winner.
-		expect(content.className).toContain("fixed");
-		expect(content.className).toContain("inset-0");
-		expect(content.className).toContain("rounded-none");
-		expect(content.className).not.toContain("rounded-xl");
-		expect(content.className).toContain("border-0");
-		// The base cap stays on purpose. A fixed element measures against the
-		// viewport, so `max-h-full` already resolves to the full viewport height —
-		// and `cx` cannot merge `max-h-none` over it, because the vendored
-		// tailwind-merge config omits `none` from its `max-h` group.
-		expect(content.className).toContain("max-h-full");
-	});
-
-	it("restores the gutter and the rounded corners when the switch goes off again", () => {
-		const content = openDialog();
-		const toggle = screen.getByRole("switch");
+		expect(content.dataset.appearance).toBe("full-bleed");
 
 		fireEvent.click(toggle);
-		fireEvent.click(toggle);
-
 		expect(toggle.getAttribute("aria-checked")).toBe("false");
-		expect(content.className).toContain("rounded-xl");
-		expect(content.className).not.toContain("rounded-none");
-		expect(content.className).not.toContain("inset-0");
-		expect(content.className).toContain("max-h-full");
+		expect(content.dataset.appearance).toBe("full-page");
 	});
 });

--- a/apps/www/app/examples/dialog/dialog-full-page-demo.test.tsx
+++ b/apps/www/app/examples/dialog/dialog-full-page-demo.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import { FullPageDialogDemo } from "./dialog-full-page-demo";
 
@@ -7,20 +8,18 @@ afterEach(() => {
 	cleanup();
 });
 
-function openDialog(): HTMLElement {
+async function openDialog() {
+	const user = userEvent.setup();
 	render(<FullPageDialogDemo />);
-	fireEvent.click(screen.getByRole("button", { name: "Open full-page dialog" }));
+	await user.click(screen.getByRole("button", { name: "Open full-page dialog" }));
 
-	const content = document.querySelector('[data-slot="dialog-content"]');
-	if (!(content instanceof HTMLElement)) {
-		throw new Error("dialog content not found");
-	}
-	return content;
+	const content = await screen.findByRole("dialog");
+	return { content, user };
 }
 
 describe("FullPageDialogDemo", () => {
-	it("names the switch through the label so a click on the caption reaches it", () => {
-		openDialog();
+	it("names the switch through the label so a click on the caption reaches it", async () => {
+		await openDialog();
 
 		const toggle = screen.getByRole("switch");
 		const label = document.querySelector('[data-slot="dialog-body"] [data-slot="label"]');
@@ -29,24 +28,34 @@ describe("FullPageDialogDemo", () => {
 		expect(label?.getAttribute("for")).toBe(toggle.id);
 	});
 
-	it("opens as a full-page dialog, keeping the 16px gutter", () => {
-		const content = openDialog();
+	it("opens as a full-page dialog, keeping the 16px gutter", async () => {
+		const { content } = await openDialog();
 
 		expect(content.dataset.appearance).toBe("full-page");
 	});
 
-	it("swaps to full-bleed when the switch goes on, and back when it goes off", () => {
-		const content = openDialog();
+	it("swaps to full-bleed when the switch goes on, and back when it goes off", async () => {
+		const { content, user } = await openDialog();
 		const toggle = screen.getByRole("switch");
 
 		expect(toggle.getAttribute("aria-checked")).toBe("false");
 
-		fireEvent.click(toggle);
+		await user.click(toggle);
 		expect(toggle.getAttribute("aria-checked")).toBe("true");
 		expect(content.dataset.appearance).toBe("full-bleed");
 
-		fireEvent.click(toggle);
+		await user.click(toggle);
 		expect(toggle.getAttribute("aria-checked")).toBe("false");
 		expect(content.dataset.appearance).toBe("full-page");
+	});
+
+	it("toggles from a click on the label, not just the switch", async () => {
+		const { content, user } = await openDialog();
+		const label = screen.getByText("Full bleed");
+
+		await user.click(label);
+
+		expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+		expect(content.dataset.appearance).toBe("full-bleed");
 	});
 });

--- a/apps/www/app/examples/dialog/dialog-full-page-demo.test.tsx
+++ b/apps/www/app/examples/dialog/dialog-full-page-demo.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FullPageDialogDemo } from "./dialog-full-page-demo";
+
+afterEach(() => {
+	cleanup();
+});
+
+function openDialog(): HTMLElement {
+	render(<FullPageDialogDemo />);
+	fireEvent.click(screen.getByRole("button", { name: "Open full-page dialog" }));
+
+	const content = document.querySelector('[data-slot="dialog-content"]');
+	if (!(content instanceof HTMLElement)) {
+		throw new Error("dialog content not found");
+	}
+	return content;
+}
+
+describe("FullPageDialogDemo", () => {
+	it("names the switch through the label so a click on the caption reaches it", () => {
+		openDialog();
+
+		const toggle = screen.getByRole("switch");
+		const label = document.querySelector('[data-slot="dialog-body"] [data-slot="label"]');
+
+		expect(toggle.id).not.toBe("");
+		expect(label?.getAttribute("for")).toBe(toggle.id);
+	});
+
+	it("fills the wrapper at full width and full height, and leaves the gutter alone", () => {
+		const content = openDialog();
+
+		// tailwind-merge override contract: `max-w-none` has to replace the
+		// `max-w-lg` default, or the dialog stays narrow at full height.
+		expect(content.className).toContain("max-w-none");
+		expect(content.className).not.toContain("max-w-lg");
+		expect(content.className).toContain("h-full");
+		// `Dialog.Content`'s own wrapper owns the 16px gutter, so the content must
+		// not re-position itself while the switch is off.
+		expect(content.className).not.toContain("inset-0");
+	});
+
+	it("replaces the rounded, bordered, wrapper-bound defaults when the switch goes on", () => {
+		const content = openDialog();
+		const toggle = screen.getByRole("switch");
+
+		expect(toggle.getAttribute("aria-checked")).toBe("false");
+		fireEvent.click(toggle);
+		expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+		// tailwind-merge override contract: edge to edge only works if each of these
+		// replaces its default instead of landing beside it, where source order
+		// would pick the winner.
+		expect(content.className).toContain("fixed");
+		expect(content.className).toContain("inset-0");
+		expect(content.className).toContain("rounded-none");
+		expect(content.className).not.toContain("rounded-xl");
+		expect(content.className).toContain("border-0");
+		// The base cap stays on purpose. A fixed element measures against the
+		// viewport, so `max-h-full` already resolves to the full viewport height —
+		// and `cx` cannot merge `max-h-none` over it, because the vendored
+		// tailwind-merge config omits `none` from its `max-h` group.
+		expect(content.className).toContain("max-h-full");
+	});
+
+	it("restores the gutter and the rounded corners when the switch goes off again", () => {
+		const content = openDialog();
+		const toggle = screen.getByRole("switch");
+
+		fireEvent.click(toggle);
+		fireEvent.click(toggle);
+
+		expect(toggle.getAttribute("aria-checked")).toBe("false");
+		expect(content.className).toContain("rounded-xl");
+		expect(content.className).not.toContain("rounded-none");
+		expect(content.className).not.toContain("inset-0");
+		expect(content.className).toContain("max-h-full");
+	});
+});

--- a/apps/www/app/examples/dialog/dialog-full-page-demo.tsx
+++ b/apps/www/app/examples/dialog/dialog-full-page-demo.tsx
@@ -1,0 +1,84 @@
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { cx } from "@ngrok/mantle/cx";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { Label } from "@ngrok/mantle/label";
+import { Switch } from "@ngrok/mantle/switch";
+import { useId, useState } from "react";
+
+const sampleRequests = [
+	{ method: "GET", path: "/api/v2/endpoints", status: 200, durationMs: 12 },
+	{ method: "POST", path: "/api/v2/tunnels", status: 201, durationMs: 84 },
+	{ method: "GET", path: "/api/v2/reserved_domains", status: 200, durationMs: 21 },
+	{ method: "DELETE", path: "/api/v2/endpoints/ep_2f8c1a", status: 204, durationMs: 33 },
+	{ method: "GET", path: "/api/v2/edges/https/edghts_1x9d", status: 502, durationMs: 1204 },
+	{ method: "PATCH", path: "/api/v2/api_keys/ak_71bd", status: 200, durationMs: 47 },
+];
+
+// The sample repeats so the log overflows `Dialog.Body` at full height.
+const requestLog = Array.from({ length: 7 })
+	.flatMap(() => sampleRequests)
+	.map((request, index) => ({ ...request, id: `req_${4200 + index}` }));
+
+/**
+ * Demonstrates a full-page `Dialog`. `preferredWidth="max-w-none"` and `h-full`
+ * fill the 16px-inset box that `Dialog.Content` positions itself in. The body's
+ * switch toggles the edge-to-edge override, which trades that inset and the
+ * rounded corners for the whole viewport.
+ *
+ * @example
+ * <FullPageDialogDemo />
+ */
+export function FullPageDialogDemo() {
+	const [edgeToEdge, setEdgeToEdge] = useState(false);
+	const switchId = useId();
+
+	return (
+		<Dialog.Root>
+			<Dialog.Trigger asChild>
+				<Button type="button" appearance="filled" intent="neutral">
+					Open full-page dialog
+				</Button>
+			</Dialog.Trigger>
+			{/* Why no max-h override: a fixed element measures against the viewport,
+			    so the base `max-h-full` already resolves to the full viewport height. */}
+			<Dialog.Content
+				preferredWidth="max-w-none"
+				className={cx("h-full", edgeToEdge && "fixed inset-0 rounded-none border-0")}
+			>
+				<Dialog.Header>
+					<Dialog.Title>Request log</Dialog.Title>
+					<Dialog.CloseIconButton />
+				</Dialog.Header>
+				<Dialog.Body className="p-0">
+					<div className="border-dialog-muted bg-dialog sticky top-0 flex items-center gap-2 border-b px-6 py-3">
+						<Switch id={switchId} checked={edgeToEdge} onCheckedChange={setEdgeToEdge} />
+						<Label htmlFor={switchId}>Edge to edge</Label>
+					</div>
+					<div className="divide-card-muted divide-y font-mono text-sm">
+						{requestLog.map((request) => (
+							<div
+								key={request.id}
+								className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-3 px-4 py-2 sm:px-6"
+							>
+								<span className="text-muted">{request.method}</span>
+								<span className="text-strong truncate">{request.path}</span>
+								<Badge appearance="muted" color={request.status >= 500 ? "danger" : "success"}>
+									{request.status}
+								</Badge>
+								<span className="text-muted text-right">{request.durationMs}ms</span>
+							</div>
+						))}
+					</div>
+				</Dialog.Body>
+				<Dialog.Footer>
+					<Dialog.Close asChild>
+						<Button type="button" appearance="outlined" intent="neutral">
+							Close
+						</Button>
+					</Dialog.Close>
+				</Dialog.Footer>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+}

--- a/apps/www/app/examples/dialog/dialog-full-page-demo.tsx
+++ b/apps/www/app/examples/dialog/dialog-full-page-demo.tsx
@@ -1,6 +1,5 @@
 import { Badge } from "@ngrok/mantle/badge";
 import { Button } from "@ngrok/mantle/button";
-import { cx } from "@ngrok/mantle/cx";
 import { Dialog } from "@ngrok/mantle/dialog";
 import { Label } from "@ngrok/mantle/label";
 import { Switch } from "@ngrok/mantle/switch";
@@ -21,16 +20,16 @@ const requestLog = Array.from({ length: 7 })
 	.map((request, index) => ({ ...request, id: `req_${4200 + index}` }));
 
 /**
- * Demonstrates a full-page `Dialog`. `preferredWidth="max-w-none"` and `h-full`
- * fill the 16px-inset box that `Dialog.Content` positions itself in. The body's
- * switch toggles the edge-to-edge override, which trades that inset and the
- * rounded corners for the whole viewport.
+ * Demonstrates a full-page `Dialog`. `appearance="full-page"` fills the
+ * 16px-inset box that `Dialog.Content` positions itself in, and the body's
+ * switch swaps to `"full-bleed"`, which trades that inset and the rounded
+ * corners for the whole viewport.
  *
  * @example
  * <FullPageDialogDemo />
  */
 export function FullPageDialogDemo() {
-	const [edgeToEdge, setEdgeToEdge] = useState(false);
+	const [fullBleed, setFullBleed] = useState(false);
 	const switchId = useId();
 
 	return (
@@ -40,20 +39,15 @@ export function FullPageDialogDemo() {
 					Open full-page dialog
 				</Button>
 			</Dialog.Trigger>
-			{/* Why no max-h override: a fixed element measures against the viewport,
-			    so the base `max-h-full` already resolves to the full viewport height. */}
-			<Dialog.Content
-				preferredWidth="max-w-none"
-				className={cx("h-full", edgeToEdge && "fixed inset-0 rounded-none border-0")}
-			>
+			<Dialog.Content appearance={fullBleed ? "full-bleed" : "full-page"}>
 				<Dialog.Header>
 					<Dialog.Title>Request log</Dialog.Title>
 					<Dialog.CloseIconButton />
 				</Dialog.Header>
 				<Dialog.Body className="p-0">
 					<div className="border-dialog-muted bg-dialog sticky top-0 flex items-center gap-2 border-b px-6 py-3">
-						<Switch id={switchId} checked={edgeToEdge} onCheckedChange={setEdgeToEdge} />
-						<Label htmlFor={switchId}>Edge to edge</Label>
+						<Switch id={switchId} checked={fullBleed} onCheckedChange={setFullBleed} />
+						<Label htmlFor={switchId}>Full bleed</Label>
 					</div>
 					<div className="divide-card-muted divide-y font-mono text-sm">
 						{requestLog.map((request) => (

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -46,6 +46,7 @@
     "@react-router/dev": "8.3.0",
     "@tailwindcss/vite": "catalog:",
     "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/hast": "3.0.5",
     "@types/mdast": "4.0.4",
     "@types/react": "catalog:",

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -464,7 +464,7 @@
 		"@testing-library/dom": "catalog:",
 		"@testing-library/jest-dom": "catalog:",
 		"@testing-library/react": "16.3.2",
-		"@testing-library/user-event": "14.6.1",
+		"@testing-library/user-event": "catalog:",
 		"@tsdown/css": "catalog:",
 		"@types/d3-scale": "4.0.9",
 		"@types/d3-shape": "3.1.8",

--- a/packages/mantle/src/components/dialog/dialog.test.tsx
+++ b/packages/mantle/src/components/dialog/dialog.test.tsx
@@ -1,0 +1,180 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { Dialog } from "./dialog.js";
+
+afterEach(() => {
+	cleanup();
+});
+
+type DialogAppearance = "centered" | "full-page" | "full-bleed";
+
+async function open(appearance: DialogAppearance = "centered") {
+	const user = userEvent.setup();
+	render(
+		<Dialog.Root>
+			<Dialog.Trigger asChild>
+				<button type="button">Open</button>
+			</Dialog.Trigger>
+			<Dialog.Content appearance={appearance}>
+				<Dialog.Header>
+					<Dialog.Title>Request log</Dialog.Title>
+					<Dialog.CloseIconButton />
+				</Dialog.Header>
+				<Dialog.Body>Body</Dialog.Body>
+			</Dialog.Content>
+		</Dialog.Root>,
+	);
+	await user.click(screen.getByRole("button", { name: "Open" }));
+
+	const content = await screen.findByRole("dialog");
+	const wrapper = content.parentElement;
+	if (!(wrapper instanceof HTMLElement)) {
+		throw new Error("dialog content wrapper not found");
+	}
+	return { content, user, wrapper };
+}
+
+describe("Dialog.Content", () => {
+	describe("appearance", () => {
+		it("defaults to centered and reflects it on data-appearance", async () => {
+			const user = userEvent.setup();
+			render(
+				<Dialog.Root>
+					<Dialog.Trigger asChild>
+						<button type="button">Open</button>
+					</Dialog.Trigger>
+					<Dialog.Content>
+						<Dialog.Title>Request log</Dialog.Title>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+			await user.click(screen.getByRole("button", { name: "Open" }));
+
+			const content = await screen.findByRole("dialog");
+			expect(content.dataset.appearance).toBe("centered");
+			expect(content.dataset.slot).toBe("dialog-content");
+		});
+
+		it.each([
+			{ appearance: "centered", inset: "inset-4" },
+			{ appearance: "full-page", inset: "inset-4" },
+			{ appearance: "full-bleed", inset: "inset-0" },
+		] as const)(
+			"positions $appearance content at $inset and reflects the appearance",
+			async ({ appearance, inset }) => {
+				const { content, wrapper } = await open(appearance);
+
+				expect(content.dataset.appearance).toBe(appearance);
+				// Cross-element pin: the appearance decides the wrapper's inset, and the
+				// wrapper takes no props, so this pairing is observable nowhere else.
+				// happy-dom reports zero geometry, so assert the class.
+				expect(wrapper.className).toContain(inset);
+			},
+		);
+
+		it("caps a centered dialog at preferredWidth and drops the default", async () => {
+			render(
+				<Dialog.Root defaultOpen>
+					<Dialog.Content preferredWidth="max-w-2xl">
+						<Dialog.Title>Request log</Dialog.Title>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			const content = await screen.findByRole("dialog");
+			// tailwind-merge override contract: the consumer's cap has to replace the
+			// max-w-lg default, not land beside it where source order would decide.
+			expect(content.className).toContain("max-w-2xl");
+			expect(content.className).not.toContain("max-w-lg");
+		});
+
+		it.each(["full-page", "full-bleed"] as const)(
+			"uncaps the width for %s, which accepts no preferredWidth",
+			async (appearance) => {
+				const { content } = await open(appearance);
+
+				expect(content.className).toContain("max-w-none");
+				expect(content.className).not.toContain("max-w-lg");
+			},
+		);
+
+		it.each([
+			{ appearance: "centered", rounded: true },
+			{ appearance: "full-page", rounded: true },
+			{ appearance: "full-bleed", rounded: false },
+		] as const)(
+			"paints $appearance with rounded=$rounded corners and a matching border",
+			async ({ appearance, rounded }) => {
+				const { content } = await open(appearance);
+
+				// The radius and border are the only observable difference between
+				// full-page and full-bleed: neither emits a data attribute, and happy-dom
+				// computes no styles for them.
+				expect(content.className.includes("rounded-xl")).toBe(rounded);
+				expect(content.className.includes("border-dialog")).toBe(rounded);
+			},
+		);
+
+		it("keeps the overlay at full bleed so the zoom-in animation has a backdrop", async () => {
+			await open("full-bleed");
+
+			expect(document.querySelector('[data-slot="dialog-overlay"]')).not.toBeNull();
+		});
+
+		it("lets a consumer className beat the appearance defaults", async () => {
+			render(
+				<Dialog.Root defaultOpen>
+					<Dialog.Content appearance="full-bleed" className="rounded-lg">
+						<Dialog.Title>Request log</Dialog.Title>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			const content = await screen.findByRole("dialog");
+			// tailwind-merge override contract: consumer className merges last.
+			expect(content.className).toContain("rounded-lg");
+		});
+	});
+
+	describe("dismissal", () => {
+		it("closes on the close icon button", async () => {
+			const { user } = await open("full-bleed");
+
+			await user.click(screen.getByRole("button", { name: "Close Dialog" }));
+
+			expect(screen.queryByRole("dialog")).toBeNull();
+		});
+
+		it("closes on Escape", async () => {
+			const { user } = await open("full-page");
+
+			await user.keyboard("{Escape}");
+
+			expect(screen.queryByRole("dialog")).toBeNull();
+		});
+	});
+});
+
+/**
+ * Type-level contracts, owned by `pnpm typecheck` rather than by a `test()`: a
+ * `@ts-expect-error` that compiles is the assertion, and pairing it with a runtime
+ * `expect` would read as coverage the vitest run does not have.
+ *
+ * `preferredWidth` caps a `"centered"` dialog. A `"full-page"` or `"full-bleed"` one
+ * fills its box, so there is no width left to cap and the prop would silently do
+ * nothing. A computed `appearance` still typechecks, which is what lets a consumer
+ * toggle between appearances from state.
+ */
+export function typeLevelContracts({ fullBleed }: { fullBleed: boolean }) {
+	return (
+		<>
+			{/* @ts-expect-error -- a full-bleed dialog has no width to cap */}
+			<Dialog.Content appearance="full-bleed" preferredWidth="max-w-lg" />
+			{/* @ts-expect-error -- neither does a full-page one */}
+			<Dialog.Content appearance="full-page" preferredWidth="max-w-lg" />
+			<Dialog.Content preferredWidth="max-w-2xl" />
+			<Dialog.Content appearance={fullBleed ? "full-bleed" : "centered"} />
+		</>
+	);
+}

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -205,17 +205,77 @@ const Overlay = ({ className, ref, ...props }: ComponentProps<typeof DialogPrimi
 	/>
 );
 
-type ContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
-	/**
-	 * The preferred width of the `Dialog.Content` as a tailwind `max-w-` class.
-	 *
-	 * By default, a `Dialog`'s content width is responsive with a default
-	 * preferred width: the maximum width of the `Dialog.Content`
-	 *
-	 * @default `max-w-lg`
-	 */
-	preferredWidth?: `max-w-${string}`;
+/**
+ * How much of the viewport a `Dialog.Content` claims, and what it looks like
+ * there. The three values move together as one decision, because a dialog that
+ * fills the viewport has no width to cap and no corner left to round.
+ *
+ * - `"centered"` — a card capped at `preferredWidth`, inset 16px from every
+ *   viewport edge, rounded and bordered.
+ * - `"full-page"` — fills that same 16px-inset box, still rounded and bordered.
+ * - `"full-bleed"` — fills the whole viewport, square and unbordered.
+ */
+type DialogAppearance = "centered" | "full-page" | "full-bleed";
+
+/**
+ * The viewport inset each {@link DialogAppearance} positions its content in. A
+ * complete `Record` (not cva) so adding an appearance without its classes is a
+ * compile error.
+ */
+const wrapperClassName: Record<DialogAppearance, string> = {
+	centered: "inset-4",
+	"full-page": "inset-4",
+	"full-bleed": "inset-0",
 };
+
+/**
+ * The box each {@link DialogAppearance} paints inside that inset. `"centered"`
+ * takes its width from `preferredWidth` instead, so it sets none here.
+ */
+const contentClassName: Record<DialogAppearance, string> = {
+	centered: "border-dialog rounded-xl border",
+	"full-page": "border-dialog h-full max-w-none rounded-xl border",
+	"full-bleed": "h-full max-w-none",
+};
+
+type ContentProps = ComponentProps<typeof DialogPrimitive.Content> &
+	(
+		| {
+				/**
+				 * How much of the viewport the dialog claims. `"centered"` is a card
+				 * capped at `preferredWidth`; `"full-page"` fills the 16px-inset box
+				 * `Dialog.Content` already positions itself in; `"full-bleed"` fills the
+				 * viewport edge to edge, square and unbordered.
+				 *
+				 * Reflected as `data-appearance`.
+				 *
+				 * @default "centered"
+				 */
+				appearance?: "centered";
+				/**
+				 * The maximum width of a `"centered"` dialog, as a Tailwind `max-w-`
+				 * class. The dialog stays responsive below it.
+				 *
+				 * @default "max-w-lg"
+				 */
+				preferredWidth?: `max-w-${string}`;
+		  }
+		| {
+				/**
+				 * How much of the viewport the dialog claims. `"full-page"` fills the
+				 * 16px-inset box `Dialog.Content` already positions itself in;
+				 * `"full-bleed"` fills the whole viewport, square and unbordered.
+				 *
+				 * Reflected as `data-appearance`.
+				 */
+				appearance: "full-page" | "full-bleed";
+				/**
+				 * Never set here. A `"full-page"` or `"full-bleed"` dialog fills its box,
+				 * so it has no width to cap — pass `appearance="centered"` to cap it.
+				 */
+				preferredWidth?: never;
+		  }
+	);
 
 /**
  * The container for the dialog content.
@@ -224,6 +284,15 @@ type ContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
  * `Dialog.Content` renders its floating layer at Tailwind `z-50`, Mantle's
  * shared floating z-index. When multiple shared layers are open, the most
  * recently mounted layer renders on top.
+ *
+ * `appearance` decides how much of the viewport the dialog claims. `"centered"`
+ * caps it at `preferredWidth`, `"full-page"` fills the 16px-inset box, and
+ * `"full-bleed"` fills the whole viewport.
+ *
+ * | Data Attribute    | Value                                            | Description                                                          |
+ * | ----------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
+ * | `data-appearance` | `"centered"` \| `"full-page"` \| `"full-bleed"`   | Reflects the resolved `appearance`.                                  |
+ * | `data-state`      | `"open"` \| `"closed"`                           | Stamped by Radix; drives the open and close animation.               |
  *
  * @see https://mantle.ngrok.com/components/overlays/dialog#dialogcontent
  *
@@ -251,26 +320,58 @@ type ContentProps = ComponentProps<typeof DialogPrimitive.Content> & {
  *   </Dialog.Content>
  * </Dialog.Root>
  * ```
+ *
+ * @example
+ * Full bleed, for content that needs the whole viewport:
+ * ```tsx
+ * <Dialog.Root>
+ *   <Dialog.Trigger asChild>
+ *     <Button type="button" appearance="filled" intent="neutral">Open Dialog</Button>
+ *   </Dialog.Trigger>
+ *   <Dialog.Content appearance="full-bleed">
+ *     <Dialog.Header>
+ *       <Dialog.Title>Request log</Dialog.Title>
+ *       <Dialog.CloseIconButton />
+ *     </Dialog.Header>
+ *     <Dialog.Body>
+ *       <p>This is the dialog content.</p>
+ *     </Dialog.Body>
+ *     <Dialog.Footer>
+ *       <Dialog.Close asChild>
+ *         <Button type="button" appearance="outlined" intent="neutral">Close</Button>
+ *       </Dialog.Close>
+ *     </Dialog.Footer>
+ *   </Dialog.Content>
+ * </Dialog.Root>
+ * ```
  */
 const Content = ({
+	appearance = "centered",
 	children,
 	className,
-	preferredWidth = "max-w-lg",
+	preferredWidth,
 	ref,
 	...props
 }: ContentProps) => (
 	<Portal>
+		{/* Why the overlay stays at full bleed: the content opens at `zoom-in-95`,
+		    so a sliver of viewport edge is uncovered for the length of the
+		    animation and would otherwise show the raw page. */}
 		<Overlay />
-		<div className="fixed inset-4 z-50 flex items-center justify-center">
+		<div
+			className={cx("fixed z-50 flex items-center justify-center", wrapperClassName[appearance])}
+		>
 			<DialogPrimitive.Content
+				data-appearance={appearance}
 				data-mantle-modal-content
 				data-slot="dialog-content"
 				className={cx(
 					"flex max-h-full w-full flex-1 flex-col",
 					"outline-hidden focus-within:outline-hidden",
-					"border-dialog bg-dialog rounded-xl border shadow-lg transition-transform duration-200",
+					"bg-dialog shadow-lg transition-transform duration-200",
 					"data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95",
-					preferredWidth,
+					contentClassName[appearance],
+					appearance === "centered" && (preferredWidth ?? "max-w-lg"),
 					className,
 				)}
 				ref={ref}
@@ -755,6 +856,15 @@ const Dialog = {
 	 * shared floating z-index. When multiple shared layers are open, the most
 	 * recently mounted layer renders on top.
 	 *
+	 * `appearance` decides how much of the viewport the dialog claims. `"centered"`
+	 * caps it at `preferredWidth`, `"full-page"` fills the 16px-inset box, and
+	 * `"full-bleed"` fills the whole viewport.
+	 *
+	 * | Data Attribute    | Value                                            | Description                                                          |
+	 * | ----------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
+	 * | `data-appearance` | `"centered"` \| `"full-page"` \| `"full-bleed"`   | Reflects the resolved `appearance`.                                  |
+	 * | `data-state`      | `"open"` \| `"closed"`                           | Stamped by Radix; drives the open and close animation.               |
+	 *
 	 * @see https://mantle.ngrok.com/components/overlays/dialog#dialogcontent
 	 *
 	 * @example
@@ -777,6 +887,30 @@ const Dialog = {
 	 *         <Button type="button" appearance="outlined" intent="neutral">Cancel</Button>
 	 *       </Dialog.Close>
 	 *       <Button type="button" appearance="filled" intent="neutral">Save</Button>
+	 *     </Dialog.Footer>
+	 *   </Dialog.Content>
+	 * </Dialog.Root>
+	 * ```
+	 *
+	 * @example
+	 * Full bleed, for content that needs the whole viewport:
+	 * ```tsx
+	 * <Dialog.Root>
+	 *   <Dialog.Trigger asChild>
+	 *     <Button type="button" appearance="filled" intent="neutral">Open Dialog</Button>
+	 *   </Dialog.Trigger>
+	 *   <Dialog.Content appearance="full-bleed">
+	 *     <Dialog.Header>
+	 *       <Dialog.Title>Request log</Dialog.Title>
+	 *       <Dialog.CloseIconButton />
+	 *     </Dialog.Header>
+	 *     <Dialog.Body>
+	 *       <p>This is the dialog content.</p>
+	 *     </Dialog.Body>
+	 *     <Dialog.Footer>
+	 *       <Dialog.Close asChild>
+	 *         <Button type="button" appearance="outlined" intent="neutral">Close</Button>
+	 *       </Dialog.Close>
 	 *     </Dialog.Footer>
 	 *   </Dialog.Content>
 	 * </Dialog.Root>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@testing-library/react':
       specifier: 16.3.2
       version: 16.3.2
+    '@testing-library/user-event':
+      specifier: 14.6.1
+      version: 14.6.1
     '@tsdown/css':
       specifier: 0.22.14
       version: 0.22.14
@@ -203,6 +206,9 @@ importers:
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/hast':
         specifier: 3.0.5
         version: 3.0.5
@@ -355,7 +361,7 @@ importers:
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/user-event':
-        specifier: 14.6.1
+        specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@tsdown/css':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ catalog:
   "@testing-library/dom": "10.4.1"
   "@testing-library/jest-dom": "7.0.0"
   "@testing-library/react": "16.3.2"
+  "@testing-library/user-event": "14.6.1"
   "@tsdown/css": "0.22.14"
   "@types/node": "24.13.3"
   "@vitest/browser-playwright": "4.1.10"


### PR DESCRIPTION
## Why

Every dialog already sat **16px from each viewport edge** — `Dialog.Content` positions itself inside a `fixed inset-4` wrapper. Nothing documented that, so filling the box meant discovering `preferredWidth="max-w-none"` and adding `h-full` by hand. Going edge to edge meant more: the wrapper takes no props, so the only way out was `fixed inset-0` on the content, which escapes the wrapper only because the wrapper happens not to be a containing block for fixed elements.

This started as a docs page for those recipes. It became API instead, because the recipe leaned on an implementation detail and let a consumer forget half of it — `fixed inset-0` without `rounded-none` gives rounded corners at the viewport edge.

## How

One prop on `Dialog.Content`:

| `appearance`   | Width                      | Viewport inset | Corners and border   |
| -------------- | -------------------------- | -------------- | -------------------- |
| `"centered"`   | capped at `preferredWidth` | 16px           | rounded and bordered |
| `"full-page"`  | fills the box              | 16px           | rounded and bordered |
| `"full-bleed"` | fills the box              | none           | square, no border    |

The three values move together as one decision, because a dialog that fills the viewport has no width left to cap and no corner left to round. `preferredWidth` therefore belongs to `"centered"` only, via a discriminated union — `appearance="full-bleed" preferredWidth="max-w-lg"` is a compile error rather than a prop that silently does nothing. A computed `appearance` still typechecks, so the docs demo can toggle from state.

`"full-bleed"` sets the wrapper's inset directly instead of escaping it, and keeps its overlay: the content opens at `zoom-in-95`, so a sliver of viewport edge stays uncovered for the length of the animation.

Scoped to `Dialog` per review — `AlertDialog`, `Sheet`, and `Popover` keep `preferredWidth` unchanged, and `dialog/primitive.tsx` is untouched.

## Validation

- Measured in Chromium at 1280x800: `full-page` 16/16/16/16 with a 12px radius and 1px border, `full-bleed` 0/0/0/0 with no radius or border, and back. Wrapper reports `position: fixed` with `top` flipping 16px ↔ 0px, confirming the inset moves rather than the content escaping.
- **No-regression check:** the page's plain `<Dialog.Content>` still measures 512px wide (`max-w-lg`) with a 12px radius, and reports `data-appearance="centered"`.
- 390x844: no horizontal overflow.
- `Dialog` had **no test file**; this adds one — 14 tests across the three appearances, the wrapper-inset pairing, the width cap, the `className` merge, overlay retention, dismissal by button and Escape, plus `@ts-expect-error` type-level contracts.
- All five §9 commands pass: `lint`, `fmt:check`, `typecheck`, `build -F @ngrok/mantle`, and the unscoped `test` (2340 mantle + 242 www).
- `components-surface.json` verified unchanged on purpose: it projects only namespace-level JSDoc, and this edits `Dialog.Content`'s part JSDoc.

## Two notes for the reviewer

**Bump is `patch` at your direction.** COMPONENT_SPEC §2.5 says "new export, part, or prop on a shipped component → `minor`", and 0.83.0 shipped a new component plus a removal as one minor. Flagged and overridden deliberately; it is a one-word change if you want it back.

**Unrelated `cx` gap found along the way.** The vendored tailwind-merge config omits `none` from its `max-h` group (`packages/mantle/src/utils/cx/vendor/lib/default-config.ts:907`), so `cx("max-h-full", "max-h-none")` returns **both**. `min-h` and `max-w` both list `none`, and `max-h-none` is a real Tailwind v4 utility. It does not affect this PR — no appearance needs a `max-h` override — and patching vendored code did not belong here, so the group is untouched.