### PR TITLE
fix(sidebar): make the header token a first-row band

### DIFF
--- a/.changeset/sidebar-header-band.md
+++ b/.changeset/sidebar-header-band.md
@@ -1,0 +1,40 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Sidebar.Header` now stacks rows below its alignment band, so a pinned search row can sit under the product
+switcher without resizing the `AppLayout.Header` toolbar.
+
+`--sidebar-header-height` did two jobs at once: it fixed the header's height, and it named the band an
+`AppLayout.Header` toolbar matches. Stacking a switcher row and a `Sidebar.SearchTrigger` in the header
+therefore meant raising the token, which grew the toolbar from 54px to 78px and left neither row on the
+toolbar's center.
+
+The header is now a grid whose first track is that token. Its first child centers on the band, every later
+child takes its own row below, and the header grows to fit. The toolbar keeps matching the switcher row alone:
+
+```tsx
+<Sidebar.Header>
+	{/* the first child keeps the band, so the toolbar keeps its 54px */}
+	<Sidebar.SwitcherTrigger>…</Sidebar.SwitcherTrigger>
+	{/* its own row below, pinned above the scrolling body */}
+	<Sidebar.SearchTrigger>…</Sidebar.SearchTrigger>
+</Sidebar.Header>
+```
+
+Rows after the first stack flush, the way rows stack in `Sidebar.Footer` — the band's own lower half is the
+space between them. The second row also inherits the header's gutter, so it lines up with the navigation rows
+without a copy of `Sidebar.Body`'s padding. The header reserves no scrollbar gutter, so on a platform whose
+scrollbars take space the row runs wider than the rows inside `Sidebar.Body`.
+
+A single-row header with no layout overrides on it renders exactly as before, pixel for pixel. If you already
+stack two rows in `Sidebar.Header`, check three things:
+
+- **Delete the `--sidebar-header-height` override you raised for the taller header.** The token is now the
+  first row's band, so a raised value moves the switcher row and the toolbar down together while the header
+  keeps growing for the second row — and everything below the header moves down with it.
+- Keep the aligned row as the header's **first direct child**. A wrapper around both rows takes the band
+  itself, and a first row taller than the band overflows it — raise the token instead.
+- The header is a grid now, so `items-*` is what centers the first row on the band (under the old flex column
+  it only moved rows horizontally), a flex property on a direct child (`flex-1`) no longer sizes it, and a
+  `className` that replaces the header's `display` drops the band with it.

--- a/apps/www/app/docs/components/navigation/sidebar.mdx
+++ b/apps/www/app/docs/components/navigation/sidebar.mdx
@@ -1309,6 +1309,13 @@ The row is styling only. Wrap it in
 `aria-keyshortcuts`, and the behavior that makes typing or pasting into the row open the palette with that text
 already in the query — and in `Sidebar.Tooltip` so the row keeps a visible label once the panel collapses.
 
+`Sidebar.Body` is the default home — above the first `Sidebar.Group`, in the same column as the navigation
+rows. Put the row in [`Sidebar.Header`](#sidebarheader) instead when it has to stay put while the navigation
+scrolls: the switcher keeps the header's alignment band, the search row takes its own row below, and the
+[`AppLayout.Header`](/layouts/app-layout#applayoutheader) toolbar keeps matching the switcher row alone. The
+header reserves no scrollbar gutter, so on a platform whose scrollbars take space a row there runs wider than
+the rows inside `Sidebar.Body`.
+
 Collapse the panel to watch the row join the icon column, or press `⌘K` inside the preview.
 
 <CodeExample.Root>
@@ -1689,9 +1696,16 @@ chips under `Sidebar.Root keyboardShortcut={false}`.
 ### Sidebar.Header
 
 The pinned structural container at the top of `Sidebar.Nav` — the app/product switcher row lives here. Its
-height is the public `--sidebar-header-height` token (default `4.5rem`); when the sidebar composes into an
-`AppLayout`, [`AppLayout.Header`](/layouts/app-layout#applayoutheader) derives its own height from the same
-token, so the two rows stay center-aligned by construction.
+**first child** owns a band exactly `--sidebar-header-height` tall (default `4.5rem`) and centers inside it.
+When the sidebar composes into an `AppLayout`,
+[`AppLayout.Header`](/layouts/app-layout#applayoutheader) derives its own height from the same token, so the
+two rows stay center-aligned by construction.
+
+Every child after the first stacks below the band in its own row, and the header grows to fit. That is how a
+[search row](#the-search-row) pins under the switcher: the band — and with it the toolbar — stays the height
+of the switcher row alone, and the row inherits the header's gutter, so neither the token nor the padding
+needs a copy. The alignment is positional, so keep the aligned row as the header's first direct child. A
+wrapper around both rows takes the band itself, and a first row taller than the band overflows it.
 
 > [!NOTE]
 > **The alignment is a desktop-only coupling.** `AppLayout.Header` finds the sidebar header with
@@ -1708,9 +1722,9 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 | ---------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Sidebar.Header` styling onto alternative element types or your own React components. |
 
-| CSS Variable              | Default  | Description                                                                                                                                                                                                                                      |
-| ------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--sidebar-header-height` | `4.5rem` | The header row height (72px). Set it on a common ancestor of the sidebar and [`AppLayout.Header`](/layouts/app-layout#applayoutheader) — e.g. `AppLayout.Root` — not on `Sidebar.Nav`, so both rows read the same value and stay center-aligned. |
+| CSS Variable              | Default  | Description                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--sidebar-header-height` | `4.5rem` | The first child's band (72px) — the height [`AppLayout.Header`](/layouts/app-layout#applayoutheader) matches, not a cap on the header, which grows for every row after the first. Set it on a common ancestor of the sidebar and the app-layout header — e.g. `AppLayout.Root` — not on `Sidebar.Nav`, so both rows read the same value and stay center-aligned. |
 
 ### Sidebar.Body
 
@@ -1806,8 +1820,10 @@ All props from `button` plus:
 
 ### Sidebar.SearchTrigger
 
-The search row for `Sidebar.Body` — the row that opens a search or command palette. Place it above the first
-`Sidebar.Group` so it shares the column the navigation rows use in both panel states.
+The row that opens a search or command palette. Place it in `Sidebar.Body` above the first `Sidebar.Group`, so
+it shares the column the navigation rows use in both panel states and scrolls with them, or in
+[`Sidebar.Header`](#sidebarheader) when it has to stay pinned while the navigation scrolls — see
+[The search row](#the-search-row).
 
 It is deliberately a navigation row and not a text field. The row is the same chrome as a
 `Sidebar.ItemButton` — same height, padding, radius, hover, and the same 28px chip in the collapsed icon rail —

--- a/apps/www/app/docs/for-ai-agents.mdx
+++ b/apps/www/app/docs/for-ai-agents.mdx
@@ -23,7 +23,7 @@ utilities have their own manifests at /api/hooks.json and /api/utils.json.
 | URL                                                | Purpose                                                                                                                                                                                                                                                                                                                                                                               |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`/llms.txt`](/llms.txt)                           | Curated index of every docs page (title, description, html + markdown URLs). Follows the [llms.txt convention](https://llmstxt.org).                                                                                                                                                                                                                                                  |
-| [`/llms-full.txt`](/llms-full.txt)                 | Concatenated plain-markdown of every docs page. Drop into a context window when full coverage is needed.                                                                                                                                                                                                                                                                              |
+| [`/llms-full.txt`](/llms-full.txt)                 | Concatenated plain-markdown of every docs page, then `# Framed preview sources` — the whole React source of the app-shell and layout demos the pages embed. Drop into a context window when full coverage is needed, and read a preview's source rather than a page's fence when you are building a shell.                                                                            |
 | [`/api/components.json`](/api/components.json)     | Structured component manifest. Each entry has `name`, `slug`, `kind`, `status`, `importPath`, `docsUrl`, `markdownUrl`, a one-line `summary`, the source `jsdoc` first sentence, and `examples` — the body of each `@example` block, which for a compound component is the full part tree. `kind: "component"` entries also carry `category` (layouts are a flat family and omit it). |
 | [`/api/hooks.json`](/api/hooks.json)               | Structured hooks manifest. Each entry has `name`, `importPath`, `docsUrl`, `markdownUrl`, and an optional `summary`.                                                                                                                                                                                                                                                                  |
 | [`/api/utils.json`](/api/utils.json)               | Structured utilities manifest. Same shape as hooks.                                                                                                                                                                                                                                                                                                                                   |
@@ -62,7 +62,10 @@ design system. Conventions:
   delay or hover settings.
 - All external dependencies must be exact-pinned (no `^` or `~`).
 - Reference the canonical docs at https://mantle.ngrok.com or fetch
-  https://mantle.ngrok.com/llms.txt for the full index.
+  https://mantle.ngrok.com/llms.txt for the full index. When building an
+  app shell, read the demo sources under `# Framed preview sources` in
+  https://mantle.ngrok.com/llms-full.txt — the fences on the docs pages
+  are shorter excerpts of them.
 ```
 
 ## Conventions agents should know

--- a/apps/www/app/docs/layouts/app-layout.mdx
+++ b/apps/www/app/docs/layouts/app-layout.mdx
@@ -702,7 +702,8 @@ overflow-clip rounded-xl border shadow-sm`. It insets **itself** with its own ma
   beneath it). The natural home for a `Sidebar.Trigger` in its top-left, followed by
   [Breadcrumb](/components/navigation/breadcrumb) navigation or page actions. It is `h-14` standalone; with a
   `Sidebar.Header` in the shell it derives its height from the sidebar's `--sidebar-header-height` token
-  instead, so the app switcher and content header stay center-aligned as one row by construction. It is
+  instead — the band that header's first row sits on — so the app switcher and the toolbar stay center-aligned
+  as one row by construction, however many rows the sidebar header stacks below the band. It is
   pinned by `shrink-0`, not by `sticky` — it sits **outside** the scroll container, so it cannot scroll away,
   cannot be overlapped by a page's own `sticky top-0`, and does not steal height from a page asking for
   `h-full`. Optional standalone, but effectively **required** once you compose a `Sidebar` — see
@@ -2055,9 +2056,9 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 | ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `AppLayout.Content` styling onto alternative element types or your own components. |
 
-| CSS Variable               | Default  | Description                                                                                                                                                                                                                                                      |
-| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--app-layout-card-gutter` | `0.5rem` | The gap between the card and the window edge, the notice above it, and the rail beside it (8px). `AppLayout.Header` subtracts twice this value when deriving its height, so overriding it keeps the toolbar aligned with the sidebar header instead of drifting. |
+| CSS Variable               | Default  | Description                                                                                                                                                                                                                                                             |
+| -------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--app-layout-card-gutter` | `0.5rem` | The gap between the card and the window edge, the notice above it, and the rail beside it (8px). `AppLayout.Header` subtracts twice this value when deriving its height, so overriding it keeps the toolbar aligned with the sidebar header's band instead of drifting. |
 
 ### AppLayout.Header
 
@@ -2080,9 +2081,12 @@ Optional standalone; effectively required once a `Sidebar` is composed (see
 contains a `Sidebar.Header` (detected with `:has()` from `AppLayout.Root`), the toolbar instead derives its
 height from the sidebar's public `--sidebar-header-height` token as
 `calc(var(--sidebar-header-height, 4.5rem) - 2 * var(--app-layout-card-gutter, 0.5rem) - 2px)` — subtracting
-twice the card gutter and twice the card's hairline border — which keeps the two rows' vertical centers on
-the same band for any header height. Override `--sidebar-header-height` on a common ancestor (e.g.
-`AppLayout.Root`'s `className`) and both rows move together.
+twice the card gutter and twice the card's hairline border — which keeps this toolbar's vertical center on
+the band that token names, for any band height. The band belongs to the
+[sidebar header's first row](/components/navigation/sidebar#sidebarheader), so a header that stacks a second
+row grows downward while this toolbar keeps matching the switcher row alone. Override
+`--sidebar-header-height` on a common ancestor (e.g. `AppLayout.Root`'s `className`) and both rows move
+together.
 
 > [!NOTE]
 > The alignment is a **desktop-only** coupling. Below the sidebar's `mobileBreakpoint` the sidebar renders
@@ -2097,10 +2101,10 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 | ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `AppLayout.Header` styling onto alternative element types (e.g. a `<header>` when the shell does not own the `main` landmark) or your own components. |
 
-| CSS Variable               | Default  | Description                                                                                                                                                                                                                                       |
-| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--sidebar-header-height`  | `4.5rem` | Read (not set) by `AppLayout.Header` when the shell contains a [`Sidebar.Header`](/components/navigation/sidebar#sidebarheader), which owns the token. Set it on a common ancestor of both (e.g. `AppLayout.Root`) so the two rows move together. |
-| `--app-layout-card-gutter` | `0.5rem` | Read (not set) by `AppLayout.Header`; owned by [`AppLayout.Content`](#applayoutcontent). The derived height subtracts twice its value, so changing the card gutter keeps the two rows aligned.                                                    |
+| CSS Variable               | Default  | Description                                                                                                                                                                                                                                                                        |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--sidebar-header-height`  | `4.5rem` | Read (not set) by `AppLayout.Header` when the shell contains a [`Sidebar.Header`](/components/navigation/sidebar#sidebarheader), which owns the token — the band its first row sits on. Set it on a common ancestor of both (e.g. `AppLayout.Root`) so the two rows move together. |
+| `--app-layout-card-gutter` | `0.5rem` | Read (not set) by `AppLayout.Header`; owned by [`AppLayout.Content`](#applayoutcontent). The derived height subtracts twice its value, so changing the card gutter keeps the two rows aligned.                                                                                     |
 
 ### AppLayout.Body
 

--- a/apps/www/app/features/app-shell-demo.tsx
+++ b/apps/www/app/features/app-shell-demo.tsx
@@ -933,12 +933,7 @@ export function AppShellDemo() {
 		// `md` (not the `lg` default ngrok's dashboards use) keeps the desktop
 		// panel visible at the framed preview's desktop and tablet widths
 		<Sidebar.Root mobileBreakpoint="md">
-			{/* --sidebar-header-height: the sidebar header is a fixed height so it can
-			    align with AppLayout.Header's toolbar, and the switcher and search row
-			    stacked need the taller value. It goes on the common ancestor of both
-			    rows — custom properties only inherit downward, so setting it on
-			    Sidebar.Nav would leave AppLayout.Header on the 4.5rem default. */}
-			<AppLayout.Root className="fixed inset-0 [--sidebar-header-height:6rem]">
+			<AppLayout.Root className="fixed inset-0">
 				<SkipToMainLink />
 				<AppLayout.Notice>
 					{showNotice && (
@@ -1252,12 +1247,7 @@ export function BridgeShellDemo() {
 		// `md` (not the `lg` default ngrok's dashboards use) keeps the desktop
 		// panel visible at the framed preview's desktop and tablet widths
 		<Sidebar.Root mobileBreakpoint="md">
-			{/* --sidebar-header-height: the sidebar header is a fixed height so it can
-			    align with AppLayout.Header's toolbar, and the switcher and search row
-			    stacked need the taller value. It goes on the common ancestor of both
-			    rows — custom properties only inherit downward, so setting it on
-			    Sidebar.Nav would leave AppLayout.Header on the 4.5rem default. */}
-			<AppLayout.Root className="fixed inset-0 [--sidebar-header-height:6rem]">
+			<AppLayout.Root className="fixed inset-0">
 				<SkipToMainLink />
 				<AppLayout.Notice>
 					{showNotice && (

--- a/apps/www/app/features/preview-registry.ts
+++ b/apps/www/app/features/preview-registry.ts
@@ -31,6 +31,13 @@ type PreviewExample = {
 	 * `SkipToMainLink`).
 	 */
 	Component: ComponentType;
+	/**
+	 * `Component`'s module, named relative to `app/features/`. `/llms-full.txt`
+	 * publishes that file verbatim, so an agent reading the offline docs builds
+	 * against the code the preview runs rather than a docs-page excerpt of it.
+	 * Several examples may name one module.
+	 */
+	sourceFile: string;
 };
 
 /**
@@ -52,62 +59,77 @@ export const previewExamples = {
 	"alert-center-shell": {
 		title: "Alert Center app shell demo",
 		Component: AlertCenterShellDemo,
+		sourceFile: "alert-center-demos.tsx",
 	},
 	"app-shell": {
 		title: "App shell demo",
 		Component: AppShellDemo,
+		sourceFile: "app-shell-demo.tsx",
 	},
 	"command-search-shell": {
 		title: "Sidebar search trigger demo",
 		Component: CommandSearchShellDemo,
+		sourceFile: "command-demos.tsx",
 	},
 	"bridge-shell": {
 		title: "Bridge shell demo",
 		Component: BridgeShellDemo,
+		sourceFile: "app-shell-demo.tsx",
 	},
 	"app-layout-standalone": {
 		title: "Standalone app layout demo",
 		Component: AppLayoutDemo,
+		sourceFile: "app-layout-demos.tsx",
 	},
 	"app-layout-editor": {
 		title: "Editor page demo",
 		Component: AppLayoutEditorDemo,
+		sourceFile: "app-layout-editor-demo.tsx",
 	},
 	"app-layout-pinned-footer": {
 		title: "Pinned footer demo",
 		Component: AppLayoutPinnedFooterDemo,
+		sourceFile: "app-layout-editor-demo.tsx",
 	},
 	"centered-layout": {
 		title: "Centered layout demo",
 		Component: CenteredLayoutDemo,
+		sourceFile: "centered-layout-demos.tsx",
 	},
 	"centered-layout-header": {
 		title: "Centered layout header demo",
 		Component: CenteredLayoutHeaderDemo,
+		sourceFile: "centered-layout-demos.tsx",
 	},
 	"centered-layout-notice": {
 		title: "Centered layout notice demo",
 		Component: CenteredLayoutNoticeDemo,
+		sourceFile: "centered-layout-demos.tsx",
 	},
 	sandbar: {
 		title: "Sandbar demo",
 		Component: SandbarDemo,
+		sourceFile: "sandbar-demos.tsx",
 	},
 	"sandbar-failed-save": {
 		title: "Sandbar failed save demo",
 		Component: SandbarFailedSaveDemo,
+		sourceFile: "sandbar-demos.tsx",
 	},
 	"sandbar-pending-publish": {
 		title: "Sandbar pending publish demo",
 		Component: SandbarPendingPublishDemo,
+		sourceFile: "sandbar-demos.tsx",
 	},
 	"sandbar-reduced-motion": {
 		title: "Sandbar reduced motion demo",
 		Component: SandbarReducedMotionDemo,
+		sourceFile: "sandbar-demos.tsx",
 	},
 	"sidebar-persistence": {
 		title: "Sidebar persistence demo",
 		Component: SidebarPersistenceDemo,
+		sourceFile: "sidebar-demos.tsx",
 	},
 } as const satisfies Record<string, PreviewExample>;
 

--- a/apps/www/app/routes/llms-full[.]txt.tsx
+++ b/apps/www/app/routes/llms-full[.]txt.tsx
@@ -1,6 +1,7 @@
 import { canonicalHref } from "~/utilities/canonical-origin";
 import { rawDocContent, urlToFileMap } from "~/utilities/docs";
 import { etagFor } from "~/utilities/etag";
+import { collectPreviewSources } from "~/utilities/preview-source.server";
 import { renderMdxToMarkdown } from "~/utilities/render-mdx-to-markdown.server";
 import type { Route } from "./+types/llms-full[.]txt";
 
@@ -12,7 +13,7 @@ function buildBody(): string {
 	const sections: string[] = [
 		"# @ngrok/mantle — Full Documentation",
 		"",
-		"> Concatenated markdown for every page on https://mantle.ngrok.com. Each section is preceded by its canonical docs URL. JSX preview blocks (`<Example>`) are dropped; code fences are preserved verbatim.",
+		"> Concatenated markdown for every page on https://mantle.ngrok.com. Each section is preceded by its canonical docs URL. JSX preview blocks (`<Example>`) are dropped; code fences are preserved verbatim. The framed demos those pages embed follow the last page, under `# Framed preview sources`.",
 		"",
 		`Docs index: ${canonicalHref("/llms.txt")}`,
 		`Component manifest: ${canonicalHref("/api/components.json")}`,
@@ -44,6 +45,34 @@ function buildBody(): string {
 		);
 	}
 
+	// The docs pages' own fences are hand-written excerpts, so an agent reading
+	// them offline builds a simpler shell than the framed demo beside them
+	// renders. Publish the demo modules themselves, whole, so the richer
+	// composition is readable without the browser.
+	sections.push(
+		"# Framed preview sources",
+		"",
+		"> The React source of the framed demos the pages above embed, verbatim. Each module renders one or more previews at `/preview/<name>` and is the code that preview actually runs — the fences on the docs pages are shorter, hand-written excerpts. The preview URLs a module serves are listed above it.",
+		"",
+		"---",
+		"",
+	);
+
+	for (const { path, previewNames, source } of collectPreviewSources()) {
+		const previewUrls = previewNames.map((name) => canonicalHref(`/preview/${name}`)).join(", ");
+		sections.push(
+			`<!-- source: ${path} -->`,
+			`<!-- previews: ${previewUrls} -->`,
+			"",
+			"```tsx",
+			source.trimEnd(),
+			"```",
+			"",
+			"---",
+			"",
+		);
+	}
+
 	return sections.join("\n");
 }
 
@@ -68,13 +97,15 @@ function getPayload(): { body: string; etag: string } {
 }
 
 /**
- * Serve `/llms-full.txt` — the concatenated markdown of every docs page,
- * suitable for shoving into an LLM context window when an agent needs
- * full coverage of the library rather than just the per-page index.
+ * Serve `/llms-full.txt` — the concatenated markdown of every docs page, then
+ * the React source of every framed preview those pages embed, suitable for
+ * shoving into an LLM context window when an agent needs full coverage of the
+ * library rather than just the per-page index.
  *
- * Each section is delimited by a heading with the docs URL so agents can
+ * Each page section is delimited by a heading with the docs URL so agents can
  * cite specific pages, and content is the same plain-markdown rendering
- * served at `/<slug>.md`.
+ * served at `/<slug>.md`. Each preview module follows under `# Framed preview
+ * sources`, in a `tsx` fence headed by its repo path and preview URLs.
  */
 export async function loader({ request }: Route.LoaderArgs) {
 	const { body, etag } = getPayload();

--- a/apps/www/app/routes/llms[.]txt.tsx
+++ b/apps/www/app/routes/llms[.]txt.tsx
@@ -124,6 +124,8 @@ async function buildBody(): Promise<string> {
 		"",
 		"Every docs page is also available as plain markdown by appending `.md` to its URL (e.g. `/components/actions/button.md`).",
 		"",
+		"The framed app-shell and layout demos embedded in those pages ship their full React source in `/llms-full.txt`, under `# Framed preview sources`. Read those rather than a page's fence when you are building a shell — the fences are shorter excerpts.",
+		"",
 	];
 
 	const hooksManifest = await buildHooksManifest();

--- a/apps/www/app/utilities/preview-source.server.test.ts
+++ b/apps/www/app/utilities/preview-source.server.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { previewExamples } from "~/features/preview-registry";
+import { collectPreviewSources } from "./preview-source.server";
+
+describe("collectPreviewSources", () => {
+	it("resolves a non-empty module for every registered preview", () => {
+		const modules = collectPreviewSources();
+		const published = modules.flatMap((module) => module.previewNames);
+
+		expect(published.toSorted()).toEqual(Object.keys(previewExamples).toSorted());
+		expect(modules.filter((module) => module.source.length === 0)).toEqual([]);
+	});
+
+	// The registry declares a component and a file name side by side, and nothing
+	// but this makes them agree: rename a demo's export or move it to another
+	// module and the published source stops carrying the component the preview
+	// renders, while `/preview/<name>` keeps working.
+	it("publishes the module that declares each preview's component", () => {
+		const componentNames = collectPreviewSources().flatMap(({ path, previewNames, source }) =>
+			previewNames.map((name) => ({
+				componentName: previewExamples[name].Component.name,
+				path,
+				source,
+			})),
+		);
+		const missing = componentNames
+			.filter(({ componentName, source }) => !source.includes(`export function ${componentName}`))
+			.map(({ componentName, path }) => `${path} declares no ${componentName}`);
+
+		// An anonymous component would turn the substring check into
+		// `includes("export function ")`, which every module satisfies.
+		expect(componentNames.filter(({ componentName }) => componentName.length === 0)).toEqual([]);
+		expect(missing).toEqual([]);
+	});
+
+	it("lists a module once, however many previews it renders", () => {
+		const modules = collectPreviewSources();
+		const paths = modules.map((module) => module.path);
+		const appShell = modules.filter((module) => module.path.endsWith("app-shell-demo.tsx"));
+
+		// deduped and sorted: publishing app-shell-demo.tsx twice would double the
+		// biggest module in /llms-full.txt
+		expect(paths).toEqual([...new Set(paths)].toSorted());
+		expect(appShell).toHaveLength(1);
+		expect(appShell[0]?.previewNames.toSorted()).toEqual(["app-shell", "bridge-shell"]);
+	});
+
+	// `/llms-full.txt` wraps each source in a ```tsx fence. A demo module's own
+	// JSDoc fences are comment-prefixed (` * ```tsx`), so they cannot close it —
+	// but a fence at the start of a line would, and the rest of the module would
+	// spill out of the code block as broken markdown.
+	it("publishes no source that could close the markdown fence around it", () => {
+		const closesTheFence = collectPreviewSources()
+			.filter((module) => /^ {0,3}`{3,}/m.test(module.source))
+			.map((module) => module.path);
+
+		expect(closesTheFence).toEqual([]);
+	});
+});

--- a/apps/www/app/utilities/preview-source.server.ts
+++ b/apps/www/app/utilities/preview-source.server.ts
@@ -1,0 +1,75 @@
+import type { PreviewExampleName } from "~/features/preview-registry";
+import { isPreviewExampleName, previewExamples } from "~/features/preview-registry";
+
+/**
+ * Raw source for every demo module under `app/features/`, bundled by Vite so
+ * serverless runtimes can publish it without reading from the filesystem — the
+ * same approach `mantle-source.server.ts` takes for the package's own source.
+ * The two patterns cover the naming every demo module already follows and leave
+ * their test files out, since those never render a preview.
+ */
+const rawDemoSources: Record<string, string> = import.meta.glob<string>(
+	["../features/*-demo.tsx", "../features/*-demos.tsx"],
+	{
+		eager: true,
+		import: "default",
+		query: "?raw",
+	},
+);
+
+const sourcePrefix = "../features/";
+
+/** One demo module, with every framed preview it renders. */
+type PreviewSourceModule = {
+	/** The module's path from the repo root, for the reader who wants to edit it. */
+	path: string;
+	/** Every registered preview the module renders, in registry order. */
+	previewNames: Array<PreviewExampleName>;
+	/** The module's verbatim source. */
+	source: string;
+};
+
+/**
+ * Every demo module that owns a framed preview, deduped and sorted by path.
+ * Several previews can share one module (`app-shell` and `bridge-shell` both
+ * live in `app-shell-demo.tsx`), so each module appears once and names all of
+ * them. Throws when a registered `sourceFile` matches no module, because that is
+ * a renamed file the registry never heard about — and the alternative is a
+ * silent hole in the published docs.
+ *
+ * @example
+ * ```ts
+ * for (const { path, previewNames, source } of collectPreviewSources()) {
+ *   console.log(path, previewNames, source.length);
+ * }
+ * ```
+ */
+export function collectPreviewSources(): Array<PreviewSourceModule> {
+	const modules = new Map<string, PreviewSourceModule>();
+
+	// The guard, rather than `Object.entries`, because `Object.keys` widens a
+	// `Record`'s keys to `string` and the loop body needs the registered names.
+	for (const name of Object.keys(previewExamples).filter(isPreviewExampleName)) {
+		const { sourceFile } = previewExamples[name];
+		const existing = modules.get(sourceFile);
+		if (existing) {
+			existing.previewNames.push(name);
+			continue;
+		}
+
+		const source = rawDemoSources[`${sourcePrefix}${sourceFile}`];
+		if (source == null) {
+			throw new Error(
+				`previewExamples["${name}"].sourceFile is "${sourceFile}", which no module under app/features/ matches.`,
+			);
+		}
+
+		modules.set(sourceFile, {
+			path: `apps/www/app/features/${sourceFile}`,
+			previewNames: [name],
+			source,
+		});
+	}
+
+	return [...modules.values()].toSorted((a, b) => a.path.localeCompare(b.path));
+}

--- a/apps/www/app/utilities/render-mdx-to-markdown.server.test.ts
+++ b/apps/www/app/utilities/render-mdx-to-markdown.server.test.ts
@@ -29,7 +29,10 @@ describe("renderMdxToMarkdown", () => {
 		expect(result).not.toContain("omitted in markdown output");
 	});
 
-	test("drops the self-closing CodeExample.PreviewFrame and keeps the fence", () => {
+	test("replaces the self-closing CodeExample.PreviewFrame with a source pointer", () => {
+		// The page's fence is a hand-written excerpt of the framed demo, so a reader
+		// of the `.md` twin gets the preview's name and where its full source lives
+		// (issue #1399) instead of a silently dropped element.
 		const result = renderMdxToMarkdown(
 			[
 				"<CodeExample.Root>",
@@ -47,8 +50,20 @@ describe("renderMdxToMarkdown", () => {
 
 		expect(result).toContain("const answer = 42;");
 		expect(result).not.toContain("CodeExample");
-		expect(result).not.toContain("centered-layout");
+		expect(result).toContain(
+			'<!-- framed preview /preview/centered-layout — full source in /llms-full.txt under "# Framed preview sources" -->',
+		);
 		expect(result).not.toContain("omitted in markdown output");
+	});
+
+	test("names no preview when the frame carries no example attribute", () => {
+		const result = renderMdxToMarkdown("<CodeExample.PreviewFrame />\n\nAfter.");
+
+		expect(result).toContain(
+			'<!-- framed preview — full source in /llms-full.txt under "# Framed preview sources" -->',
+		);
+		expect(result).toContain("After.");
+		expect(result).not.toContain("/preview/");
 	});
 
 	test("drops Example previews without a trail comment", () => {

--- a/apps/www/app/utilities/render-mdx-to-markdown.server.ts
+++ b/apps/www/app/utilities/render-mdx-to-markdown.server.ts
@@ -70,18 +70,45 @@ type Handler = (node: MdxJsxElement) => HandlerResult;
  * represented in the plain markdown output. Anything not listed here falls
  * through to {@link defaultHandler}.
  */
+/** A JSX string attribute's value, or `undefined` when it is absent or an expression. */
+function stringAttribute(node: MdxJsxElement, name: string): string | undefined {
+	for (const attribute of node.attributes) {
+		if (attribute.type === "mdxJsxAttribute" && attribute.name === name) {
+			return typeof attribute.value === "string" ? attribute.value : undefined;
+		}
+	}
+	return undefined;
+}
+
 const handlers: Record<string, Handler> = {
 	// `<Example>` wraps a live preview of a component, and is always followed
 	// by a fenced code block that contains the same code in textual form.
 	// Dropping it removes a wall of rendered DOM without losing information.
 	Example: () => ({ kind: "drop" }),
-	// `<CodeExample>` is the tabbed Preview/Code example. The preview panels
-	// wrap a live demo (dropped, like `<Example>`) — `PreviewFrame` is the
-	// iframed variant; every other part is a structural wrapper around real
-	// markdown — unwrap them so the fenced code block inside
+	// `<CodeExample>` is the tabbed Preview/Code example. `Preview` wraps a live
+	// demo and is dropped like `<Example>`; every other part is a structural
+	// wrapper around real markdown — unwrap them so the fenced code block inside
 	// `CodeExample.Code` lands in the markdown output.
 	CodeExample: (node) => {
-		if (node.name === "CodeExample.Preview" || node.name === "CodeExample.PreviewFrame") {
+		if (node.name === "CodeExample.PreviewFrame") {
+			// The iframed variant runs a registered demo module whose whole source
+			// ships in /llms-full.txt, while the fence beside it here is a shorter
+			// hand-written excerpt. Leave the pointer rather than dropping silently:
+			// a reader of the `.md` twin has no other way to learn the fuller source
+			// exists (issue #1399).
+			const example = stringAttribute(node, "example");
+			const preview = example == null ? "framed preview" : `framed preview /preview/${example}`;
+			return {
+				kind: "replace",
+				nodes: [
+					{
+						type: "html",
+						value: `<!-- ${preview} — full source in /llms-full.txt under "# Framed preview sources" -->`,
+					},
+				],
+			};
+		}
+		if (node.name === "CodeExample.Preview") {
 			return { kind: "drop" };
 		}
 		return { kind: "unwrap" };

--- a/packages/mantle/src/components/app-layout/app-layout.test.tsx
+++ b/packages/mantle/src/components/app-layout/app-layout.test.tsx
@@ -320,9 +320,10 @@ describe("AppLayout.Header", () => {
 	});
 
 	test("derives its height from the sidebar header token, net of the card gutter", () => {
-		// The alignment invariant: h = sidebar header height - 2*(gutter + border).
-		// Both the gutter and the border are doubled, which is what keeps the two
-		// rows' centers on the same band for ANY header height.
+		// The alignment invariant: h = sidebar header band - 2*(gutter + border).
+		// Both the gutter and the border are doubled, which is what keeps this
+		// toolbar's center on the band for ANY band height. The band is the sidebar
+		// header's first row, so a header stacking a second row leaves this alone.
 		render(<AppLayout.Header data-testid="header">toolbar</AppLayout.Header>);
 		const { className } = screen.getByTestId("header");
 		expect(className).toContain("h-14");
@@ -343,7 +344,7 @@ describe("AppLayout.Header", () => {
 		render(
 			<AppLayout.Root data-testid="root">
 				<AppLayout.Workspace>
-					<Sidebar.Header>account switcher</Sidebar.Header>
+					<Sidebar.Header data-testid="sidebar-header">account switcher</Sidebar.Header>
 					<AppLayout.Content>
 						<AppLayout.Header data-testid="header">toolbar</AppLayout.Header>
 						<AppLayout.Body>page</AppLayout.Body>
@@ -356,6 +357,13 @@ describe("AppLayout.Header", () => {
 		expect(root.querySelector('[data-slot~="sidebar-header"]')).not.toBeNull();
 		expect(screen.getByTestId("header").className).toContain(
 			"group-has-data-[slot~=sidebar-header]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
+		);
+		// The other half of the token contract: the sidebar header spends the same
+		// variable, with the same fallback, on the grid track its first row sits in.
+		// Two files spelling one token, so they are pinned in one test — rename it on
+		// either side and the toolbar stops matching the switcher row.
+		expect(screen.getByTestId("sidebar-header")).toHaveClass(
+			"grid-rows-(--sidebar-header-height,4.5rem)",
 		);
 	});
 });

--- a/packages/mantle/src/components/app-layout/app-layout.tsx
+++ b/packages/mantle/src/components/app-layout/app-layout.tsx
@@ -228,7 +228,7 @@ const Workspace = ({
  *
  * | CSS Variable | Default | Description |
  * | --- | --- | --- |
- * | `--app-layout-card-gutter` | `0.5rem` | The gap between the card and the window edge, the notice above it, and the rail beside it (8px). `AppLayout.Header` subtracts twice this value when deriving its height, so overriding it keeps the toolbar aligned with the sidebar header. |
+ * | `--app-layout-card-gutter` | `0.5rem` | The gap between the card and the window edge, the notice above it, and the rail beside it (8px). `AppLayout.Header` subtracts twice this value when deriving its height, so overriding it keeps the toolbar aligned with the sidebar header's band. |
  *
  * @see https://mantle.ngrok.com/layouts/app-layout#applayoutcontent
  *
@@ -309,16 +309,18 @@ const Content = ({
  * toolbar is `h-14`. When the shell contains a `Sidebar.Header` (detected via
  * `:has()` from `AppLayout.Root`), the toolbar instead derives its height from
  * the sidebar's public `--sidebar-header-height` token, subtracting twice the
- * card gutter and twice the card's hairline border — which keeps the two rows'
- * vertical centers on the same band by construction, for any header height.
- * Override `--sidebar-header-height` on a common ancestor (e.g.
- * `AppLayout.Root`'s `className`) and both rows move together.
+ * card gutter and twice the card's hairline border — which keeps this toolbar's
+ * vertical center on the band that token names, by construction, for any band
+ * height. The band belongs to the sidebar header's first row, so a header that
+ * stacks a second row grows downward and this toolbar keeps matching the
+ * switcher row alone. Override `--sidebar-header-height` on a common ancestor
+ * (e.g. `AppLayout.Root`'s `className`) and both rows move together.
  *
  * **CSS variables (public API):**
  *
  * | CSS Variable | Default | Description |
  * | --- | --- | --- |
- * | `--sidebar-header-height` | `4.5rem` | Read, not owned: `Sidebar.Header` owns this token and `AppLayout.Header` derives its own height from it whenever a sidebar header is present in the shell. Set it on a common ancestor of both rows (e.g. `AppLayout.Root`), never on one of them, since custom properties only inherit downward. |
+ * | `--sidebar-header-height` | `4.5rem` | Read, not owned: `Sidebar.Header` owns this token — the band its first row sits on — and `AppLayout.Header` derives its own height from it whenever a sidebar header is present in the shell. Set it on a common ancestor of both rows (e.g. `AppLayout.Root`), never on one of them, since custom properties only inherit downward. |
  * | `--app-layout-card-gutter` | `0.5rem` | Read, not owned: `AppLayout.Content` owns this token. The derived height subtracts twice its value, so changing the card gutter keeps the two rows aligned instead of drifting. |
  *
  * @see https://mantle.ngrok.com/layouts/app-layout#applayoutheader
@@ -364,9 +366,11 @@ const Header = ({
 				// With a sidebar header in the shell, derive the height from its
 				// token so the two rows' centers align by construction: this toolbar
 				// sits below the card's gutter and its 1px border, so center parity
-				// needs its height to be the sidebar header's minus twice each.
-				// Overriding --sidebar-header-height at a common ancestor (e.g.
-				// AppLayout.Root) moves both rows together.
+				// needs its height to be the sidebar header's band minus twice each.
+				// The band is the sidebar header's first row, so a header stacking a
+				// second row leaves this height alone. Overriding
+				// --sidebar-header-height at a common ancestor (e.g. AppLayout.Root)
+				// moves both rows together.
 				"group-has-data-[slot~=sidebar-header]/app-layout:h-[calc(var(--sidebar-header-height,4.5rem)-2*var(--app-layout-card-gutter,0.5rem)-2px)]",
 				className,
 			)}

--- a/packages/mantle/src/components/sidebar/header-band.browser.test.tsx
+++ b/packages/mantle/src/components/sidebar/header-band.browser.test.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { AppLayout } from "../app-layout/app-layout.js";
+import { Sidebar } from "./sidebar.js";
+
+/**
+ * Real-browser geometry for `Sidebar.Header`'s alignment band: its first child
+ * sits on a `--sidebar-header-height` track, and `AppLayout.Header` derives its
+ * own height from that same token. happy-dom lays nothing out — every
+ * `getBoundingClientRect()` there returns zeros, so the two centers would agree
+ * no matter what the components emit.
+ *
+ * The stylesheet below is Tailwind 4.3.3's own output for the utilities these two
+ * parts emit, keyed by the same escaped class selectors. Keyed that way rather
+ * than by `data-slot` on purpose: rename the band utility or the derived-height
+ * variant in either component and the rule stops matching, the band disappears,
+ * and these assertions fail. Regenerate it by compiling those class lists
+ * through `@tailwindcss/node`'s `compile()`.
+ */
+const STYLE = `
+/* The layer order is load-bearing: unlayered rules beat every layer, so a bare
+   preflight reset here would win over the utilities and zero out the card's
+   margin and border — the two values the toolbar's derived height subtracts. */
+@layer theme, base, components, utilities;
+@layer theme {
+	:root {
+		--spacing: 0.25rem;
+		--radius-xl: 0.75rem;
+		--tw-border-style: solid;
+	}
+}
+@layer base {
+	*, ::after, ::before, ::backdrop, ::file-selector-button {
+		box-sizing: border-box;
+		margin: 0;
+		padding: 0;
+		border: 0 solid;
+	}
+}
+@layer utilities {
+	.absolute { position: absolute; }
+	.relative { position: relative; }
+	.inset-y-0 { inset-block: 0px; }
+	.left-0 { left: 0px; }
+	.isolate { isolation: isolate; }
+	.m-\\(--app-layout-card-gutter\\,0\\.5rem\\) { margin: var(--app-layout-card-gutter,0.5rem); }
+	.flex { display: flex; }
+	.grid { display: grid; }
+	.h-14 { height: calc(var(--spacing) * 14); }
+	.h-full { height: 100%; }
+	.min-h-0 { min-height: 0px; }
+	.w-\\(--sidebar-width\\,16rem\\) { width: var(--sidebar-width,16rem); }
+	.w-full { width: 100%; }
+	.min-w-0 { min-width: 0px; }
+	.flex-1 { flex: 1; }
+	.shrink-0 { flex-shrink: 0; }
+	.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+	.grid-rows-\\(--sidebar-header-height\\,4\\.5rem\\) { grid-template-rows: var(--sidebar-header-height,4.5rem); }
+	.flex-col { flex-direction: column; }
+	.items-center { align-items: center; }
+	.overflow-clip { overflow: clip; }
+	.overflow-hidden { overflow: hidden; }
+	.overflow-x-hidden { overflow-x: hidden; }
+	.overflow-y-auto { overflow-y: auto; }
+	.border { border-style: var(--tw-border-style); border-width: 1px; }
+	.border-b { border-bottom-style: var(--tw-border-style); border-bottom-width: 1px; }
+	.px-3 { padding-inline: calc(var(--spacing) * 3); }
+	.px-4 { padding-inline: calc(var(--spacing) * 4); }
+	.pt-1\\.5 { padding-top: calc(var(--spacing) * 1.5); }
+	.pb-4 { padding-bottom: calc(var(--spacing) * 4); }
+	.group-has-data-\\[slot\\~\\=sidebar-header\\]\\/app-layout\\:h-\\[calc\\(var\\(--sidebar-header-height\\,4\\.5rem\\)-2\\*var\\(--app-layout-card-gutter\\,0\\.5rem\\)-2px\\)\\]:is(:where(.group\\/app-layout):has([data-slot~="sidebar-header"]) *) {
+		height: calc(var(--sidebar-header-height,4.5rem) - 2 * var(--app-layout-card-gutter,0.5rem) - 2px);
+	}
+	.group-data-\\[state\\=expanded\\]\\/sidebar-nav\\:pr-1:is(:where(.group\\/sidebar-nav)[data-state="expanded"] *) {
+		padding-right: var(--spacing);
+	}
+}
+/* What a consumer writes as \`className="[--sidebar-header-height:6rem]"\`. Spelled
+   as a rule because Tailwind compiles no arbitrary properties into this test. */
+.taller-band { --sidebar-header-height: 6rem; }
+`;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+/** The vertical center of an element, in viewport coordinates. */
+function centerY(element: HTMLElement): number {
+	const { height, top } = element.getBoundingClientRect();
+	return top + height / 2;
+}
+
+/** The element's top edge, in viewport coordinates. */
+function topY(element: HTMLElement): number {
+	return element.getBoundingClientRect().top;
+}
+
+/**
+ * A shell sized in code rather than by the runner's viewport, so the numbers do
+ * not move with the browser window. `Sidebar.Header` needs no `Sidebar.Root`
+ * context and `AppLayout.Header`'s `:has()` finds the header at any depth, so the
+ * rail is a plain sized column: this measures the band against the toolbar, not
+ * the panel's mobile/desktop switch.
+ *
+ * Every row carries an explicit pixel height, because the contract under test is
+ * where the band puts a row — not how tall `Sidebar.SwitcherTrigger` renders.
+ */
+function Shell({ children, className }: { children: ReactNode; className?: string }) {
+	return (
+		<AppLayout.Root className={className} style={{ height: 640, width: 1024 }}>
+			<AppLayout.Workspace>
+				<div className="shrink-0" style={{ width: 256 }}>
+					<Sidebar.Header data-testid="header">{children}</Sidebar.Header>
+				</div>
+				<AppLayout.Content>
+					<AppLayout.Header data-testid="toolbar">toolbar</AppLayout.Header>
+					<AppLayout.Body>page</AppLayout.Body>
+				</AppLayout.Content>
+			</AppLayout.Workspace>
+		</AppLayout.Root>
+	);
+}
+
+const switcherRow = <div data-testid="switcher" style={{ height: 36 }} />;
+const searchRow = <div data-testid="search" style={{ height: 28 }} />;
+
+describe("Sidebar.Header alignment band", () => {
+	test("a single row centers on the band, and the band is the whole header", () => {
+		render(<Shell>{switcherRow}</Shell>);
+		const header = screen.getByTestId("header");
+		// 4.5rem: with one row the header is exactly the band, which is the geometry
+		// every shipped single-row shell already renders.
+		expect(header.getBoundingClientRect().height).toBeCloseTo(72, 1);
+		expect(centerY(screen.getByTestId("switcher")) - topY(header)).toBeCloseTo(36, 1);
+	});
+
+	test("a second row stacks below the band instead of squeezing the first", () => {
+		// Regression (issue #1399): the header was a fixed `h-` band, so a search row
+		// under the switcher either squashed both rows or forced
+		// `--sidebar-header-height` up — which dragged the toolbar up with it.
+		render(
+			<Shell>
+				{switcherRow}
+				{searchRow}
+			</Shell>,
+		);
+		const header = screen.getByTestId("header");
+		expect(centerY(screen.getByTestId("switcher")) - topY(header)).toBeCloseTo(36, 1);
+		// band 72 + row 28, with no gap: the band's lower half is the spacing
+		expect(header.getBoundingClientRect().height).toBeCloseTo(100, 1);
+		expect(topY(screen.getByTestId("search")) - topY(header)).toBeCloseTo(72, 1);
+	});
+
+	test("the first row and the toolbar share one center, with one row and with two", () => {
+		const { unmount } = render(<Shell>{switcherRow}</Shell>);
+		expect(screen.getByTestId("toolbar").getBoundingClientRect().height).toBeCloseTo(54, 1);
+		expect(centerY(screen.getByTestId("switcher"))).toBeCloseTo(
+			centerY(screen.getByTestId("toolbar")),
+			1,
+		);
+		unmount();
+
+		render(
+			<Shell>
+				{switcherRow}
+				{searchRow}
+			</Shell>,
+		);
+		// The second row grows the header downward, so the toolbar keeps matching the
+		// switcher row rather than the whole header.
+		expect(screen.getByTestId("toolbar").getBoundingClientRect().height).toBeCloseTo(54, 1);
+		expect(centerY(screen.getByTestId("switcher"))).toBeCloseTo(
+			centerY(screen.getByTestId("toolbar")),
+			1,
+		);
+	});
+
+	test("overriding the token on a shared ancestor moves the band and the toolbar together", () => {
+		render(
+			<Shell className="taller-band">
+				{switcherRow}
+				{searchRow}
+			</Shell>,
+		);
+		// 6rem band: the toolbar is 96 - 2*8 - 2, and the switcher centers on the
+		// taller band rather than on the header's own midpoint.
+		expect(screen.getByTestId("toolbar").getBoundingClientRect().height).toBeCloseTo(78, 1);
+		expect(
+			centerY(screen.getByTestId("switcher")) - topY(screen.getByTestId("header")),
+		).toBeCloseTo(48, 1);
+		expect(centerY(screen.getByTestId("switcher"))).toBeCloseTo(
+			centerY(screen.getByTestId("toolbar")),
+			1,
+		);
+	});
+
+	test("the band goes to the first direct child, so a wrapper around both rows takes it", () => {
+		// The documented precondition, pinned: the alignment is positional. Wrap the
+		// two rows and the wrapper is what centers on the band, which leaves the
+		// switcher above the toolbar's center. This is what happens when a consumer
+		// ignores "keep the aligned row as the header's first direct child".
+		render(
+			<Shell>
+				<div>
+					{switcherRow}
+					{searchRow}
+				</div>
+			</Shell>,
+		);
+		const header = screen.getByTestId("header");
+		expect(header.getBoundingClientRect().height).toBeCloseTo(72, 1);
+		// the 64px wrapper centers in the 72px band, so the switcher lands at 4 + 18
+		expect(centerY(screen.getByTestId("switcher")) - topY(header)).toBeCloseTo(22, 1);
+		expect(centerY(screen.getByTestId("switcher"))).not.toBeCloseTo(
+			centerY(screen.getByTestId("toolbar")),
+			1,
+		);
+	});
+});

--- a/packages/mantle/src/components/sidebar/sidebar.test.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.test.tsx
@@ -711,6 +711,35 @@ describe("--sidebar-row-width", () => {
 	});
 });
 
+describe("--sidebar-header-height", () => {
+	// The band is a grid track, and a track emits no data attribute — the class is
+	// the only thing that observes it here, and happy-dom lays out nothing, so
+	// header-band.browser.test.tsx measures what the track actually does. These two
+	// assertions cover what that file cannot: the spelling AppLayout.Header's calc()
+	// reads (see app-layout.test.tsx), and the absence of the fixed height that
+	// squeezed a second row before issue #1399.
+	test("the header sizes its first row from the token and caps nothing", () => {
+		render(
+			<Sidebar.Root>
+				<Sidebar.Nav>
+					<Sidebar.Header data-testid="header" />
+				</Sidebar.Nav>
+			</Sidebar.Root>,
+		);
+		const header = screen.getByTestId("header");
+		// toHaveClass matches whole tokens, so a permuted track (grid-rows-2) or a
+		// dropped items-center fails here rather than silently unaligning the toolbar.
+		expect(header).toHaveClass(
+			"grid",
+			"grid-rows-(--sidebar-header-height,4.5rem)",
+			"items-center",
+		);
+		// A `h-*` of any kind would clamp the header again, which is what forced
+		// consumers to raise the token — and the toolbar with it — for two rows.
+		expect([...header.classList].filter((name) => name.startsWith("h-"))).toEqual([]);
+	});
+});
+
 describe("Sidebar.Nav (mobile)", () => {
 	beforeEach(() => {
 		useIsBelowBreakpointMock.mockReturnValue(true);

--- a/packages/mantle/src/components/sidebar/sidebar.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.tsx
@@ -930,19 +930,31 @@ type SidebarHeaderProps = ComponentProps<"div"> & WithAsChild & WithDataSlot;
 /**
  * The top container of a `Sidebar.Nav`, pinned above the scrollable
  * `Sidebar.Body`. Typically holds an app/product switcher built from
- * `Sidebar.SwitcherTrigger` composed with a `DropdownMenu` or `Dialog`. Its
- * height is the public `--sidebar-header-height` CSS variable (default
- * `4.5rem`), which centers the switcher row on the same horizontal band as an
- * `AppLayout.Header` toolbar — when a sidebar header is composed inside an
- * `AppLayout`, the toolbar derives its own height from the same variable, so
- * overriding it at a shared ancestor (e.g. `AppLayout.Root`) moves both rows
- * together and the alignment holds by construction.
+ * `Sidebar.SwitcherTrigger` composed with a `DropdownMenu` or `Dialog`.
+ *
+ * Its **first child** owns a band exactly `--sidebar-header-height` tall
+ * (default `4.5rem`) and centers inside it. When a sidebar header is composed
+ * inside an `AppLayout`, the toolbar derives its own height from the same
+ * variable, so overriding it at a shared ancestor (e.g. `AppLayout.Root`) moves
+ * the switcher row and the toolbar together and the alignment holds by
+ * construction.
+ *
+ * Every child after the first stacks flush below the band in its own row, the
+ * way rows stack in `Sidebar.Footer` — the band's own lower half is the space
+ * between them. The header grows to fit them. The band, and with it the toolbar,
+ * stays the height of the switcher row alone, so a search row pinned under the
+ * switcher (`Sidebar.SearchTrigger`) needs no override and no hand-copied
+ * padding.
+ *
+ * The alignment is positional: keep the aligned row as the header's first direct
+ * child. A wrapper around both rows takes the band itself. A first row taller
+ * than the band overflows it — raise the variable instead.
  *
  * **CSS variables (public API):**
  *
  * | CSS Variable | Default | Description |
  * | --- | --- | --- |
- * | `--sidebar-header-height` | `4.5rem` | The header row height (72px). Set it on a common ancestor of the sidebar and `AppLayout.Header`, not on `Sidebar.Nav`, so both rows read one value. |
+ * | `--sidebar-header-height` | `4.5rem` | The first child's band (72px) — the height an `AppLayout.Header` toolbar matches, not a cap on the header, which grows for every row after the first. Set it on a common ancestor of the sidebar and `AppLayout.Header`, not on `Sidebar.Nav`, so both rows read one value. |
  *
  * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebarheader
  *
@@ -1009,10 +1021,16 @@ const Header = ({
 		<Comp
 			data-slot={joinDataSlot(dataSlot, "sidebar-header")}
 			className={cx(
-				// The height token centers the switcher row on the same line as an
-				// AppLayout.Header toolbar, which derives its height from this same
-				// variable when a sidebar header is present (see AppLayout.Header).
-				"flex h-(--sidebar-header-height,4.5rem) shrink-0 flex-col justify-center gap-2 px-3",
+				// Why grid: the first track is exactly --sidebar-header-height, so the
+				// first child owns the band an AppLayout.Header toolbar sizes itself
+				// against (see AppLayout.Header) while every later child gets its own
+				// auto track below it — a search row stacks under the switcher without
+				// moving it off that band, and neither row needs a token override. The
+				// single minmax(0,1fr) column keeps a long switcher label truncating
+				// instead of widening the track.
+				// No gap: the band's own lower half already separates the first row from
+				// the next, the way Sidebar.Footer stacks its rows flush.
+				"grid grid-cols-1 grid-rows-(--sidebar-header-height,4.5rem) shrink-0 items-center px-3",
 				// When expanded, the adjacent AppLayout.Content contributes the
 				// trailing card gutter with its own margin, so trim the sidebar's
 				// own trailing inset to keep dividers and rows optically centered
@@ -1810,18 +1828,17 @@ type SidebarSearchTriggerProps = ComponentProps<"button"> &
 /**
  * The search row — the row that opens a search or command palette.
  *
- * Put it at the top of `Sidebar.Body`, above the first `Sidebar.Group`: it
- * needs no height change, and it lands in the same `px-3` gutter as the
- * navigation rows, so it shares their column in both panel states.
+ * Put it at the top of `Sidebar.Body`, above the first `Sidebar.Group`: it lands
+ * in the same `px-3` gutter as the navigation rows, so it shares their column in
+ * both panel states, and it scrolls with them.
  *
- * `Sidebar.Header`, under the switcher, also works — the header's own `gap-2`
- * sets the spacing — at the cost of a taller header. That height is a fixed one
- * row so it can align with an `AppLayout.Header` toolbar, so a stack of two
- * needs `--sidebar-header-height` raised on a **common ancestor of both rows**
- * (`<AppLayout.Root className="[--sidebar-header-height:6rem]">`). Setting it on
- * `Sidebar.Nav` only looks right: custom properties inherit downward, so
- * `AppLayout.Header` would keep the `4.5rem` default and the two rows would stop
- * being center-aligned.
+ * `Sidebar.Header`, under the switcher, also works, and pins the row above the
+ * scrolling body instead. The switcher stays the header's first child, so it
+ * keeps the `--sidebar-header-height` band an `AppLayout.Header` toolbar
+ * matches, and this row takes the next row down — the header grows for it, so
+ * nothing needs a token override. The header reserves no scrollbar gutter, so on
+ * a platform whose scrollbars take space the row runs wider than the navigation
+ * rows below it, which sit inside `Sidebar.Body`'s reserved gutter.
  *
  * It is deliberately a navigation row and not a text field. The row is the same
  * chrome as a `Sidebar.ItemButton` — same height, padding, radius, hover, and
@@ -2647,8 +2664,9 @@ const Sidebar = {
 	Trigger,
 	/**
 	 * The pinned top container of the panel, typically holding the app
-	 * switcher (`Sidebar.SwitcherTrigger` + `DropdownMenu`/`Dialog`). Its
-	 * height vertically aligns the switcher with an `AppLayout.Header`.
+	 * switcher (`Sidebar.SwitcherTrigger` + `DropdownMenu`/`Dialog`). Its first
+	 * child owns the band that aligns the switcher with an `AppLayout.Header`;
+	 * later rows stack below the band.
 	 *
 	 * @see https://mantle.ngrok.com/components/navigation/sidebar#sidebarheader
 	 *
@@ -3108,9 +3126,10 @@ const Sidebar = {
 	 */
 	ItemButton,
 	/**
-	 * The search row for `Sidebar.Body`: an item-shaped row whose `shortcut` hint
-	 * appears on hover or focus, and the same chip as any other row in the
-	 * collapsed icon rail. Not state-wired — compose with
+	 * The search row: an item-shaped row whose `shortcut` hint appears on hover or
+	 * focus, and the same chip as any other row in the collapsed icon rail. Goes
+	 * in `Sidebar.Body` to scroll with the navigation, or in `Sidebar.Header` to
+	 * stay pinned above it. Not state-wired — compose with
 	 * `Command.SearchTrigger`.
 	 *
 	 * **Data attributes:**


### PR DESCRIPTION
## Why

Closes #1399.

`--sidebar-header-height` did two jobs at once: it fixed `Sidebar.Header`'s height, and it named the band an
`AppLayout.Header` toolbar matches. So a product switcher plus a `⌘K` search row in the header forced the token
up to `6rem`, which grew the toolbar from 54px to 78px — and left neither row on the toolbar's center. The
dashboard shipped a hand-padded `div` between `Sidebar.Header` and `Sidebar.Body` instead, copying the header's
`px-3` and its expanded `pr-1`; those are `Sidebar` internals, so the copy drifts the moment they change.

The issue offered two ways out. This is option 2 — separate the toolbar's alignment token from the header's
content height — because it leaves the alignment contract as the one thing both parts read, and ships no new
part.

## How

`Sidebar.Header` becomes a single-column grid whose **first row track is the token**:

```
grid grid-cols-1 grid-rows-(--sidebar-header-height,4.5rem) shrink-0 items-center px-3
```

The first child centers on that band, every later child takes its own auto track below it, and the header grows
to fit them. `AppLayout.Header` is untouched — its `calc()` reads the same token, which now means the switcher
row's band rather than the whole header, so the toolbar keeps matching the switcher row alone. The second row
inherits the header's gutter, so the wrapper `div` and its copied padding go away. Rows after the first stack
flush, the way `Sidebar.Footer` stacks its rows; the band's own lower half is the space between them.

Measured at `/preview/app-shell`, which is the two-row composition the issue describes:

| | before | after |
| --- | --- | --- |
| toolbar height | 78px | 54px |
| switcher center vs toolbar center | 22px off | 0.0 |
| header height | 96px, rows squeezed | 100px (band 72 + row 28) |
| single-row header | — | pixel-identical to before |

The alignment is positional: the aligned row has to be the header's **first direct child**. A wrapper around
both rows takes the band itself. That is stated in the JSDoc, both docs pages, and the changeset, and a browser
test pins the wrapped composition so the constraint cannot quietly change.

The issue's second ask — publish the framed preview's source, since `/llms-full.txt` carried only the docs
pages' shorter hand-written fences — ships here too. `previewExamples` entries name their `sourceFile`,
`collectPreviewSources()` resolves and dedupes them through a raw `import.meta.glob`, and `/llms-full.txt`
appends `# Framed preview sources` with all 8 demo modules verbatim, each headed by its repo path and the
`/preview/<name>` URLs it serves. `/llms.txt` and `/for-ai-agents` point at it, and a `.md` page twin now leaves
a pointer where it used to drop `<CodeExample.PreviewFrame>` silently.

## Validation

- `pnpm -w run lint` / `fmt:check` / `typecheck` / `test` / `build`, all with `--force` so nothing replayed from
  the turbo cache.
- New `header-band.browser.test.tsx` measures the invariant in real Chromium: one row, two rows, a `6rem`
  override, and the wrapped composition. Its injected stylesheet is Tailwind's own output for the classes both
  parts emit, keyed by the same escaped selectors, so renaming either half of the token contract breaks the
  geometry rather than passing on a stale rule.
- Mutation-checked: reverting `Sidebar.Header` to the old flex header, and separately dropping `items-center`,
  turns all five browser tests red.
- `app-layout.test.tsx`'s `:has()` pin now asserts both halves of the token contract in one test — the toolbar's
  `calc()` and the header's grid track.
- Verified in the running docs app, expanded and collapsed: the search chip shares the 30px icon column with the
  nav rows in the rail.
- `components-surface.json` and `agent-surface-drift` needed no regeneration; the edited JSDoc lives below the
  namespace-level blocks those snapshot.

## Notes

- The bump is a `patch`: no API changes shape, and the token keeps its name and default. A consumer who
  followed the old "raise it to `6rem`" workaround has to delete that override, and the changeset leads with it.
- The docs pages' hand-written app-shell fences stay excerpts. The published preview source is now the
  canonical full version, which is what #1399 asked for.
- `Sidebar.Toolbar` (the issue's option 1) stays available later if the positional contract ever proves too
  subtle; it would then own the band as a named part instead of by DOM order.
