### PR TITLE
feat(parfait): add a page of titled sections beside their content

### DIFF
--- a/.changeset/parfait.md
+++ b/.changeset/parfait.md
@@ -1,0 +1,62 @@
+---
+"@ngrok/mantle": minor
+---
+
+Add `Parfait`, a page of titled sections where each one's title and description sit beside its content. It is
+the shape of a settings page, a resource configuration editor, and any form long enough that each group needs
+its own sentence — see [the docs](https://mantle.ngrok.com/components/structure/parfait).
+
+```tsx
+import { Parfait } from "@ngrok/mantle/parfait";
+
+<Parfait.Root>
+	<Parfait.Section>
+		<Parfait.Header>
+			<Parfait.Title>Providers</Parfait.Title>
+			<Parfait.Description>What providers keys may call.</Parfait.Description>
+		</Parfait.Header>
+		<Parfait.Body>
+			<ProviderScopePicker />
+		</Parfait.Body>
+	</Parfait.Section>
+	<Parfait.Section>
+		<Parfait.Header>
+			<Parfait.Title>Routing rules</Parfait.Title>
+			<Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+		</Parfait.Header>
+		<Parfait.Body>
+			<RoutingRuleList />
+		</Parfait.Body>
+	</Parfait.Section>
+</Parfait.Root>;
+```
+
+The parts:
+
+- **`Root`** is the stack. It rules a hairline between adjacent `Section` children — never above the first or
+  below the last — and it scopes `--parfait-columns` for all of them.
+- **`Section`** is one titled band, and it owns its own vertical rhythm (`py-8 first:pt-0`) rather than taking
+  it from `Root`, so a lone section reads correctly. Below the `md` breakpoint it stacks `Header` above `Body`;
+  at `md` and up it splits the two into a `1fr 2fr` grid.
+- **`Header`** is the introductory column — `Title` and `Description`, spaced by `gap-2`. It renders a semantic
+  `<header>`, which is generic rather than a second `banner` landmark because it sits inside `Section`'s
+  `<section>`.
+- **`Title`** renders an `<h2>`, one level below the page's `<h1>`. Compose `asChild` with the right element
+  when the sections sit deeper in the outline.
+- **`Description`** renders a `<p>` in muted body text. Optional.
+- **`Body`** is the content column, and its `gap-4` spaces stacked controls.
+
+`Section` takes no accessible name, so a page of sections adds no `region` landmarks — the `Title` headings
+already carry the outline, and a landmark list only stays useful while `main` and `nav` are easy to find in it.
+Set `aria-labelledby` to the `Title`'s `id` only when a section is a destination a reader jumps back to. To tell
+apart controls that read alike across two sections, reach for `Field.Set` and `Field.Legend` instead —
+assistive technology announces a landmark on entry, never per control.
+
+Public CSS variable:
+
+| CSS Variable        | Default   | Description                                                                                                          |
+| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--parfait-columns` | `1fr 2fr` | The `grid-template-columns` value at `md` and up. Set it on `Root` to re-split every section, or on one `Section` to move only that one. |
+
+Every part stamps a `data-slot` (`parfait`, `parfait-section`, `parfait-header`, `parfait-title`,
+`parfait-description`, `parfait-body`) and accepts `asChild`.

--- a/.changeset/vite-plugins-know-parfait.md
+++ b/.changeset/vite-plugins-know-parfait.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle-vite-plugins": patch
+---
+
+Teach `mantleTwSourcePlugin` about the new `parfait` subpath, so a consumer importing
+`@ngrok/mantle/parfait` gets its classes scanned by Tailwind instead of an unstyled stack of sections.
+Generated from `@ngrok/mantle`'s export map — no behavior change for any other component.

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -109,7 +109,7 @@ export const componentsByCategory = {
 	// Structure: contains, divides, or arranges arbitrary content — vs Data
 	// Display, which presents specific content. Page/viewport structure
 	// belongs to the top-level Layouts section, not here.
-	Structure: ["Card", "Media Object", "Separator", "Well"],
+	Structure: ["Card", "Media Object", "Parfait", "Separator", "Well"],
 } as const satisfies Record<ComponentCategory, readonly string[]>;
 
 /** Display name of a production-ready component. */
@@ -175,6 +175,7 @@ export const prodReadyComponentRouteLookup = {
 	"Multi Select": "/components/forms/multi-select",
 	"OTP Input": "/components/forms/otp-input",
 	Pagination: "/components/navigation/pagination",
+	Parfait: "/components/structure/parfait",
 	"Password Input": "/components/forms/password-input",
 	Popover: "/components/overlays/popover",
 	"Progress Bar": "/components/feedback/progress-bar",

--- a/apps/www/app/docs/components/structure/parfait.mdx
+++ b/apps/www/app/docs/components/structure/parfait.mdx
@@ -1,0 +1,315 @@
+---
+title: Parfait
+description: A page of titled sections, each one explained beside its content — the shape of a settings page or a configuration editor.
+---
+
+import { CodeExample } from "~/components/code-example";
+
+# Parfait
+
+A page of titled sections, each one explained beside its content. Every section pairs a header — its title and description — with the controls that header describes. `Parfait.Root` stacks the sections with a hairline between them. It is the shape of a settings page, a resource configuration editor, and any form long enough that each group needs its own sentence.
+
+Below the `md` breakpoint the header stacks above its own content, so a narrow viewport keeps the pairing rather than squeezing two columns into one. The component owns structure only: the grid, the vertical rhythm, and the rules between sections. Form state, validation, and the controls themselves arrive as composed JSX.
+
+Reach for [Card](/components/structure/card) when a group needs a raised surface of its own, for [Media Object](/components/structure/media-object) when the thing beside the text is an image or an icon, and for [Description List](/components/data-display/description-list) when the pairs are read-only term and value data rather than headed sections.
+
+Each demo below runs in its own framed document, so its media queries track the frame instead of your browser window. Switch the frame to tablet — Tailwind's `md` boundary, where the split is at its narrowest — and then to mobile, where every header stacks above its own controls.
+
+<CodeExample.Root>
+	<CodeExample.PreviewFrame example="parfait" title="Parfait demo" />
+	<CodeExample.Code>
+
+```tsx
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { Main } from "@ngrok/mantle/main";
+import { Parfait } from "@ngrok/mantle/parfait";
+import { RadioGroup } from "@ngrok/mantle/radio-group";
+import { PlusIcon } from "@phosphor-icons/react/Plus";
+import { useState } from "react";
+
+export function AccessKeyConfiguration() {
+	const [providerScope, setProviderScope] = useState("allow-only");
+
+	return (
+		<Main className="mx-auto min-h-full max-w-5xl px-6 py-8">
+			<h1 className="text-strong mb-4 text-2xl font-medium">corby-pickles-config</h1>
+			<Parfait.Root>
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Providers</Parfait.Title>
+						<Parfait.Description>What providers keys may call.</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<RadioGroup.Root
+							className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+							value={providerScope}
+							onChange={setProviderScope}
+						>
+							<RadioGroup.Card className="flex" value="allow-all">
+								<RadioGroup.ItemContent className="flex-1 space-y-1 text-sm">
+									<span className="text-strong font-medium">Allow all</span>
+									<p className="text-body">No provider restrictions.</p>
+								</RadioGroup.ItemContent>
+								<RadioGroup.Indicator />
+							</RadioGroup.Card>
+							<RadioGroup.Card className="flex" value="allow-only">
+								<RadioGroup.ItemContent className="flex-1 space-y-1 text-sm">
+									<span className="text-strong font-medium">Allow only</span>
+									<p className="text-body">Limit keys to selected providers.</p>
+								</RadioGroup.ItemContent>
+								<RadioGroup.Indicator />
+							</RadioGroup.Card>
+						</RadioGroup.Root>
+					</Parfait.Body>
+				</Parfait.Section>
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Routing rules</Parfait.Title>
+						<Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<div className="flex justify-end">
+							<Button type="button" appearance="outlined" intent="neutral" icon={<PlusIcon />}>
+								Add rule
+							</Button>
+						</div>
+						<div className="border-card divide-card-muted divide-y rounded-md border text-sm">
+							<div className="flex items-center gap-2 px-3 py-2">
+								OpenAI <Badge appearance="muted">Custom</Badge>
+							</div>
+							<div className="flex items-center gap-2 px-3 py-2">
+								Anthropic <Badge appearance="muted">Custom</Badge>
+							</div>
+						</div>
+					</Parfait.Body>
+				</Parfait.Section>
+			</Parfait.Root>
+		</Main>
+	);
+}
+```
+
+    </CodeExample.Code>
+
+</CodeExample.Root>
+
+## Composition
+
+```text showLineNumbers=false
+Parfait.Root
+└── Parfait.Section
+    ├── Parfait.Header
+    │   ├── Parfait.Title
+    │   └── Parfait.Description
+    └── Parfait.Body
+```
+
+- **`Root`** is the stack. It rules a hairline between adjacent `Section` children — never above the first or below the last — and it is the place to set `--parfait-columns` for every section at once.
+- **`Section`** is one titled band. It owns its own vertical rhythm (`py-8 first:pt-0`) rather than taking it from `Root`, so a single section reads correctly on a page with nothing else on it. Below `md` it stacks `Header` above `Body`; at `md` and up it splits them into a `1fr 2fr` grid.
+- **`Header`** is the introductory column — `Title` and `Description`, spaced by `gap-2`. It renders a semantic `<header>`, which groups the introductory content of its own `<section>`; see [Accessibility](#accessibility) for why that is not a second `banner` landmark.
+- **`Title`** renders an `<h2>`, one level below the page's `<h1>`. Compose `asChild` when a page nests its sections deeper.
+- **`Description`** is the sentence that says what the section's controls do. Optional — a section whose title says everything may omit it.
+- **`Body`** is the content column: the controls, cards, or table the header describes. Its `gap-4` spaces stacked children, and a consumer's own `gap-*` replaces it.
+
+## Polymorphism
+
+Every part accepts `asChild`, so the structure composes onto the element a page actually needs. `Root` renders as the `<form>` below, which keeps the form element outside every section instead of repeating one per band. `Title` renders as an `<h3>` because this section sits under a sub-heading rather than directly under the page `<h1>`.
+
+<CodeExample.Root>
+	<CodeExample.PreviewFrame example="parfait-polymorphism" title="Parfait polymorphism demo" />
+	<CodeExample.Code>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Main } from "@ngrok/mantle/main";
+import { Parfait } from "@ngrok/mantle/parfait";
+
+export function AdvancedSettings() {
+	return (
+		<Main className="mx-auto min-h-full max-w-5xl px-6 py-8">
+			<h1 className="text-strong text-2xl font-medium">corby-pickles-config</h1>
+			<h2 className="text-strong mt-6 mb-4 text-xl font-medium">Advanced</h2>
+			<Parfait.Root asChild>
+				<form onSubmit={(event) => event.preventDefault()}>
+					<Parfait.Section>
+						<Parfait.Header>
+							<Parfait.Title asChild>
+								<h3>Danger zone</h3>
+							</Parfait.Title>
+							<Parfait.Description>Deleting a configuration cannot be undone.</Parfait.Description>
+						</Parfait.Header>
+						<Parfait.Body>
+							<div className="flex justify-end">
+								<Button type="submit" appearance="outlined" intent="danger">
+									Delete configuration
+								</Button>
+							</div>
+						</Parfait.Body>
+					</Parfait.Section>
+				</form>
+			</Parfait.Root>
+		</Main>
+	);
+}
+```
+
+    </CodeExample.Code>
+
+</CodeExample.Root>
+
+## Column split
+
+At `md` and up, `Section` reads its `grid-template-columns` from `--parfait-columns`, defaulting to `1fr 2fr`. Set the variable on `Root` to re-split every section at once, or on a single `Section` to move only that one — custom properties inherit, so the nearest declaration wins. Below `md` the variable goes quiet, because the two parts stack.
+
+The default suits a short label beside a wide set of controls. When the explanation carries as much weight as the controls, an even split reads better — switch the frame to mobile to watch both splits collapse to the same stack:
+
+<CodeExample.Root>
+	<CodeExample.PreviewFrame example="parfait-columns" title="Parfait column split demo" />
+	<CodeExample.Code>
+
+```tsx
+import { Main } from "@ngrok/mantle/main";
+import { Parfait } from "@ngrok/mantle/parfait";
+
+export function ModelSettings() {
+	return (
+		<Main className="mx-auto min-h-full max-w-5xl px-6 py-8">
+			<h1 className="text-strong mb-4 text-2xl font-medium">Model access</h1>
+			<Parfait.Root className="[--parfait-columns:1fr_1fr]">
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Models</Parfait.Title>
+						<Parfait.Description>
+							An even split gives a long explanation the same room as its controls.
+						</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<div className="border-card text-body rounded-md border px-3 py-2 text-sm">
+							Allow all models
+						</div>
+					</Parfait.Body>
+				</Parfait.Section>
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Rate limits</Parfait.Title>
+						<Parfait.Description>
+							Requests over the limit receive a 429 until the window resets.
+						</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<div className="border-card text-body rounded-md border px-3 py-2 text-sm">
+							60 requests per minute
+						</div>
+					</Parfait.Body>
+				</Parfait.Section>
+			</Parfait.Root>
+		</Main>
+	);
+}
+```
+
+    </CodeExample.Code>
+
+</CodeExample.Root>
+
+## Accessibility
+
+- **Sections carry no landmark, by design.** `Section` renders a `<section>` with no accessible name, so it stays generic in the accessibility tree. Its `Title` heading is the navigation affordance instead. A heading outline can run long and nest deeply; a landmark list only stays useful while it is short enough that `main` and `nav` are one keypress away. A named `<section>` is a `region` landmark, so one per section turns that list into a second table of contents the headings already provide.
+- **A landmark does not disambiguate controls.** When two sections hold controls that read alike — two radio groups both offering "Allow all" — reach for [`Field.Set` and `Field.Legend`](/components/forms/field#fieldset), which name the group on every control inside it. Assistive technology announces a landmark once, on entry, so naming the `Section` fixes nothing here.
+- **Name a `Section` only when it is a destination.** Pass `aria-labelledby` pointing at the `Title`'s `id` when a returning user jumps straight to that section _and_ its container beats its heading as the landing spot — a live log, a status readout, or a chart whose heading is separated from its content by a toolbar. One or two such sections on a page is already a lot. Past that, headings do the job better.
+- **Header is not a second banner.** `Header` renders a `<header>`, which maps to the `banner` landmark only when its nearest sectioning ancestor is the document body. Nested inside `Section`'s `<section>`, it is generic, so a page carries as many headers as it has sections.
+- **Heading level is yours.** `Title` defaults to `<h2>` for a section directly under a page `<h1>`. When the sections sit deeper, compose `asChild` with the correct level rather than letting the outline skip — mantle cannot see the surrounding document.
+- **Controls keep their own labels.** The `Title` is a heading, not a label. A group of inputs inside `Body` still needs its own [Field](/components/forms/field) legend or label; a heading above a group names the section, not the control.
+
+## API Reference
+
+### Parfait.Root
+
+The stack of sections. Rules a hairline between adjacent `Parfait.Section` children — never above the first or below the last — and scopes `--parfait-columns` for all of them.
+
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                         |
+| ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Parfait.Root` styling onto alternative element types or your own components. |
+
+| Data Attribute | Value       | Description                                                        |
+| -------------- | ----------- | ------------------------------------------------------------------ |
+| `data-slot`    | `"parfait"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+
+Every part joins an incoming `data-slot` chain ahead of its own name, so composing a part through an ancestor's `asChild` yields `data-slot="parfait parfait-section"` rather than losing one of the two.
+
+### Parfait.Section
+
+One titled band of the page. Stacks `Parfait.Header` above `Parfait.Body` below the `md` breakpoint, then splits the two into a grid at `md` and up. Carries its own vertical rhythm (`py-8 first:pt-0`).
+
+All props from [section](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                            |
+| ---------- | --------- | ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Parfait.Section` styling onto alternative element types or your own components. |
+
+| CSS Variable        | Default   | Description                                                                                                                           |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parfait-columns` | `1fr 2fr` | The `grid-template-columns` value at `md` and up. Set it on `Parfait.Root` to re-split every section, or here for this section alone. |
+
+| Data Attribute | Value               | Description                                                        |
+| -------------- | ------------------- | ------------------------------------------------------------------ |
+| `data-slot`    | `"parfait-section"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+
+### Parfait.Header
+
+A section's introductory column — its `Parfait.Title` and `Parfait.Description`, spaced by `gap-2`. Renders a semantic `<header>`, which is generic rather than a `banner` landmark inside `Parfait.Section`.
+
+All props from [header](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                           |
+| ---------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Parfait.Header` styling onto alternative element types or your own components. |
+
+| Data Attribute | Value              | Description                                                        |
+| -------------- | ------------------ | ------------------------------------------------------------------ |
+| `data-slot`    | `"parfait-header"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+
+### Parfait.Title
+
+The section's heading. Renders an `<h2>`, one level below the page's `<h1>`. Compose `asChild` with the right element when a page nests its sections deeper.
+
+All props from [h2](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                          |
+| ---------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Parfait.Title` styling onto alternative element types or your own components. |
+
+| Data Attribute | Value             | Description                                                        |
+| -------------- | ----------------- | ------------------------------------------------------------------ |
+| `data-slot`    | `"parfait-title"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+
+### Parfait.Description
+
+The sentence that says what the section's controls do. Renders a `<p>` in muted body text beneath `Parfait.Title`. Optional.
+
+All props from [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                                |
+| ---------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Parfait.Description` styling onto alternative element types or your own components. |
+
+| Data Attribute | Value                   | Description                                                        |
+| -------------- | ----------------------- | ------------------------------------------------------------------ |
+| `data-slot`    | `"parfait-description"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+
+### Parfait.Body
+
+The section's content column — the controls, cards, or table `Parfait.Header` describes. Its `gap-4` spaces stacked children, and a consumer's own `gap-*` replaces it.
+
+All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                         |
+| ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Parfait.Body` styling onto alternative element types or your own components. |
+
+| Data Attribute | Value            | Description                                                        |
+| -------------- | ---------------- | ------------------------------------------------------------------ |
+| `data-slot`    | `"parfait-body"` | Stable styling hook. Survives `className` overrides and `asChild`. |

--- a/apps/www/app/features/parfait-demos.tsx
+++ b/apps/www/app/features/parfait-demos.tsx
@@ -1,0 +1,161 @@
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { Main } from "@ngrok/mantle/main";
+import { Parfait } from "@ngrok/mantle/parfait";
+import { RadioGroup } from "@ngrok/mantle/radio-group";
+import { PlusIcon } from "@phosphor-icons/react/Plus";
+import { useState } from "react";
+
+/**
+ * The primary Parfait composition for the docs: two sections of a resource
+ * configuration editor, the page shape this component came from. Renders as an
+ * entire framed-preview document (see preview-registry.ts), so the frame's
+ * viewport switcher drives the `md` breakpoint — mobile stacks each header above
+ * its own controls, and the page owns a real `h1` above the sections' `h2`s.
+ *
+ * The provider scope is real state, so the radio cards answer a click instead of
+ * standing in as a picture of controls.
+ */
+export function ParfaitExample() {
+	const [providerScope, setProviderScope] = useState("allow-only");
+
+	return (
+		<Main className="mx-auto min-h-full max-w-5xl px-6 py-8">
+			<h1 className="text-strong mb-4 text-2xl font-medium">corby-pickles-config</h1>
+			<Parfait.Root>
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Providers</Parfait.Title>
+						<Parfait.Description>What providers keys may call.</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<RadioGroup.Root
+							className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+							value={providerScope}
+							onChange={setProviderScope}
+						>
+							<RadioGroup.Card className="flex" value="allow-all">
+								<RadioGroup.ItemContent className="flex-1 space-y-1 text-sm">
+									<span className="text-strong font-medium">Allow all</span>
+									<p className="text-body">No provider restrictions.</p>
+								</RadioGroup.ItemContent>
+								<RadioGroup.Indicator />
+							</RadioGroup.Card>
+							<RadioGroup.Card className="flex" value="allow-only">
+								<RadioGroup.ItemContent className="flex-1 space-y-1 text-sm">
+									<span className="text-strong font-medium">Allow only</span>
+									<p className="text-body">Limit keys to selected providers.</p>
+								</RadioGroup.ItemContent>
+								<RadioGroup.Indicator />
+							</RadioGroup.Card>
+						</RadioGroup.Root>
+					</Parfait.Body>
+				</Parfait.Section>
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Routing rules</Parfait.Title>
+						<Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<div className="flex justify-end">
+							<Button type="button" appearance="outlined" intent="neutral" icon={<PlusIcon />}>
+								Add rule
+							</Button>
+						</div>
+						<div className="border-card divide-card-muted divide-y rounded-md border text-sm">
+							<div className="flex items-center gap-2 px-3 py-2">
+								OpenAI <Badge appearance="muted">Custom</Badge>
+							</div>
+							<div className="flex items-center gap-2 px-3 py-2">
+								Anthropic <Badge appearance="muted">Custom</Badge>
+							</div>
+						</div>
+					</Parfait.Body>
+				</Parfait.Section>
+			</Parfait.Root>
+		</Main>
+	);
+}
+
+/**
+ * The polymorphism composition for the docs: `Root` renders as the `<form>`, so
+ * the form element sits outside every section instead of repeating once per
+ * band, and `Title` renders as an `<h3>` for a section that sits under a
+ * sub-heading. Renders as an entire framed-preview document (see
+ * preview-registry.ts), which is why it carries the `h1` the `h2` and `h3`
+ * below it need.
+ *
+ * Why no `aria-labelledby` on the `Section`: naming it would make it a `region`
+ * landmark, and a delete button is not a destination a reader jumps to. The
+ * docs page states the test.
+ */
+export function ParfaitPolymorphismExample() {
+	return (
+		<Main className="mx-auto min-h-full max-w-5xl px-6 py-8">
+			<h1 className="text-strong text-2xl font-medium">corby-pickles-config</h1>
+			<h2 className="text-strong mt-6 mb-4 text-xl font-medium">Advanced</h2>
+			<Parfait.Root asChild>
+				<form onSubmit={(event) => event.preventDefault()}>
+					<Parfait.Section>
+						<Parfait.Header>
+							<Parfait.Title asChild>
+								<h3>Danger zone</h3>
+							</Parfait.Title>
+							<Parfait.Description>Deleting a configuration cannot be undone.</Parfait.Description>
+						</Parfait.Header>
+						<Parfait.Body>
+							<div className="flex justify-end">
+								<Button type="submit" appearance="outlined" intent="danger">
+									Delete configuration
+								</Button>
+							</div>
+						</Parfait.Body>
+					</Parfait.Section>
+				</form>
+			</Parfait.Root>
+		</Main>
+	);
+}
+
+/**
+ * The column-split composition for the docs: `--parfait-columns` set on `Root`
+ * moves every section to an even split, for an explanation that carries as much
+ * weight as its controls. Renders as an entire framed-preview document (see
+ * preview-registry.ts), so switching the frame to mobile shows the variable go
+ * quiet once the two columns stack.
+ */
+export function ParfaitColumnsExample() {
+	return (
+		<Main className="mx-auto min-h-full max-w-5xl px-6 py-8">
+			<h1 className="text-strong mb-4 text-2xl font-medium">Model access</h1>
+			<Parfait.Root className="[--parfait-columns:1fr_1fr]">
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Models</Parfait.Title>
+						<Parfait.Description>
+							An even split gives a long explanation the same room as its controls.
+						</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<div className="border-card text-body rounded-md border px-3 py-2 text-sm">
+							Allow all models
+						</div>
+					</Parfait.Body>
+				</Parfait.Section>
+				<Parfait.Section>
+					<Parfait.Header>
+						<Parfait.Title>Rate limits</Parfait.Title>
+						<Parfait.Description>
+							Requests over the limit receive a 429 until the window resets.
+						</Parfait.Description>
+					</Parfait.Header>
+					<Parfait.Body>
+						<div className="border-card text-body rounded-md border px-3 py-2 text-sm">
+							60 requests per minute
+						</div>
+					</Parfait.Body>
+				</Parfait.Section>
+			</Parfait.Root>
+		</Main>
+	);
+}

--- a/apps/www/app/features/preview-registry.ts
+++ b/apps/www/app/features/preview-registry.ts
@@ -10,6 +10,11 @@ import {
 	CenteredLayoutNoticeDemo,
 } from "~/features/centered-layout-demos";
 import {
+	ParfaitColumnsExample,
+	ParfaitExample,
+	ParfaitPolymorphismExample,
+} from "~/features/parfait-demos";
+import {
 	SandbarDemo,
 	SandbarFailedSaveDemo,
 	SandbarPendingPublishDemo,
@@ -105,6 +110,21 @@ export const previewExamples = {
 		title: "Centered layout notice demo",
 		Component: CenteredLayoutNoticeDemo,
 		sourceFile: "centered-layout-demos.tsx",
+	},
+	parfait: {
+		title: "Parfait demo",
+		Component: ParfaitExample,
+		sourceFile: "parfait-demos.tsx",
+	},
+	"parfait-columns": {
+		title: "Parfait column split demo",
+		Component: ParfaitColumnsExample,
+		sourceFile: "parfait-demos.tsx",
+	},
+	"parfait-polymorphism": {
+		title: "Parfait polymorphism demo",
+		Component: ParfaitPolymorphismExample,
+		sourceFile: "parfait-demos.tsx",
 	},
 	sandbar: {
 		title: "Sandbar demo",

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -150,6 +150,7 @@ export default [
 		// structure
 		...docRoute("components/structure/card"),
 		...docRoute("components/structure/media-object"),
+		...docRoute("components/structure/parfait"),
 		...docRoute("components/structure/separator"),
 		...docRoute("components/structure/well"),
 

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -585,6 +585,20 @@
     "jsdoc": "Re-exports for the Pagination component family — `CursorPagination`'s parts for cursor paging, and `useOffsetPagination` for offset paging."
   },
   {
+    "name": "Parfait",
+    "slug": "components/structure/parfait",
+    "kind": "component",
+    "category": "Structure",
+    "status": "stable",
+    "importPath": "@ngrok/mantle/parfait",
+    "summary": "A page of titled sections, each one explained beside its content — the shape of a settings page or a configuration editor.",
+    "jsdoc": "A page of titled sections, each one explained beside its content.",
+    "examples": [
+      "Composition:\n```\nParfait.Root\n└── Parfait.Section\n    ├── Parfait.Header\n    │   ├── Parfait.Title\n    │   └── Parfait.Description\n    └── Parfait.Body\n```",
+      "```tsx\n<Parfait.Root>\n  <Parfait.Section>\n    <Parfait.Header>\n      <Parfait.Title>Providers</Parfait.Title>\n      <Parfait.Description>What providers keys may call.</Parfait.Description>\n    </Parfait.Header>\n    <Parfait.Body>\n      <ProviderScopePicker />\n    </Parfait.Body>\n  </Parfait.Section>\n  <Parfait.Section>\n    <Parfait.Header>\n      <Parfait.Title>Routing rules</Parfait.Title>\n      <Parfait.Description>Define how requests are authenticated.</Parfait.Description>\n    </Parfait.Header>\n    <Parfait.Body>\n      <RoutingRuleList />\n    </Parfait.Body>\n  </Parfait.Section>\n</Parfait.Root>\n```"
+    ]
+  },
+  {
     "name": "Password Input",
     "slug": "components/forms/password-input",
     "kind": "component",

--- a/packages/mantle-vite-plugins/src/mantle-component-name.ts
+++ b/packages/mantle-vite-plugins/src/mantle-component-name.ts
@@ -57,6 +57,7 @@ export const MANTLE_COMPONENT_NAMES = [
 	"multi-select",
 	"otp-input",
 	"pagination",
+	"parfait",
 	"popover",
 	"progress",
 	"qr-code",

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -280,6 +280,11 @@
 			"types": "./dist/pagination.d.ts",
 			"import": "./dist/pagination.js"
 		},
+		"./parfait": {
+			"@ngrok/src-live-types": "./src/components/parfait/index.ts",
+			"types": "./dist/parfait.d.ts",
+			"import": "./dist/parfait.js"
+		},
 		"./popover": {
 			"@ngrok/src-live-types": "./src/components/popover/index.ts",
 			"types": "./dist/popover.d.ts",

--- a/packages/mantle/src/components/parfait/index.ts
+++ b/packages/mantle/src/components/parfait/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Re-exports for the Parfait component.
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait
+ */
+
+export {
+	//,
+	Parfait,
+} from "./parfait.js";

--- a/packages/mantle/src/components/parfait/parfait.browser.test.tsx
+++ b/packages/mantle/src/components/parfait/parfait.browser.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Parfait } from "./parfait.js";
+
+/**
+ * Real-browser computed style for `Parfait.Section`'s column split and
+ * `Parfait.Root`'s hairline. happy-dom substitutes no custom properties and lays
+ * nothing out, so `grid-template-columns` reads back as the author string and
+ * every border width reads back empty — the assertions below would pass whatever
+ * the two parts emit.
+ *
+ * The stylesheet is Tailwind 4.3.3's own output for the utilities these parts
+ * emit, keyed by the same escaped class selectors. Keyed that way on purpose:
+ * misspell `--parfait-columns` in `Section`, or move `divide-y` off `Root`, and
+ * the rule stops matching and these assertions fail.
+ *
+ * The `md:` rule is copied **without** its `@media (width >= 48rem)` wrapper.
+ * The subject is the custom property's name and fallback, not the breakpoint, and
+ * the runner's iframe is narrower than 48rem — keeping the wrapper would make
+ * every assertion here pass for the wrong reason.
+ */
+const STYLE = `
+:root {
+	--spacing: 0.25rem;
+}
+@property --tw-border-style {
+	syntax: "*";
+	inherits: false;
+	initial-value: solid;
+}
+@property --tw-divide-y-reverse {
+	syntax: "*";
+	inherits: false;
+	initial-value: 0;
+}
+.grid { display: grid; }
+.py-8 { padding-block: calc(var(--spacing) * 8); }
+.first\\:pt-0:first-child { padding-top: 0px; }
+.md\\:grid-cols-\\(--parfait-columns\\,1fr_2fr\\) { grid-template-columns: var(--parfait-columns,1fr 2fr); }
+:where(.divide-y > :not(:last-child)) {
+	border-bottom-style: var(--tw-border-style);
+	border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+}
+/* Not a Tailwind class: the contract is that any rule setting the variable on an
+   ancestor reaches the section, so a plain selector states it without pinning a
+   second arbitrary-property spelling. */
+.halves { --parfait-columns: 1fr 1fr; }
+`;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+/** The section's resolved column widths, in CSS pixels. */
+function columnWidths(section: HTMLElement): number[] {
+	return getComputedStyle(section)
+		.gridTemplateColumns.split(" ")
+		.map((width) => Number.parseFloat(width));
+}
+
+/** The body column's width as a multiple of the header column's. */
+function columnRatio(section: HTMLElement): number {
+	const [headerColumn = 0, bodyColumn = 0] = columnWidths(section);
+	return bodyColumn / headerColumn;
+}
+
+/**
+ * A page sized in code rather than by the runner's viewport, so the column
+ * widths do not move with the browser window.
+ */
+function TwoSectionPage({ className }: { className?: string }) {
+	return (
+		<Parfait.Root className={className} style={{ width: 900 }}>
+			<Parfait.Section data-testid="providers">
+				<Parfait.Header>
+					<Parfait.Title>Providers</Parfait.Title>
+				</Parfait.Header>
+				<Parfait.Body>providers</Parfait.Body>
+			</Parfait.Section>
+			<Parfait.Section data-testid="rules">
+				<Parfait.Header>
+					<Parfait.Title>Routing rules</Parfait.Title>
+				</Parfait.Header>
+				<Parfait.Body>rules</Parfait.Body>
+			</Parfait.Section>
+		</Parfait.Root>
+	);
+}
+
+describe("Parfait.Section column split", () => {
+	test("splits the header and body one to two by default", () => {
+		render(<TwoSectionPage />);
+
+		expect(columnWidths(screen.getByTestId("providers"))).toHaveLength(2);
+		expect(columnRatio(screen.getByTestId("providers"))).toBeCloseTo(2, 2);
+	});
+
+	test("--parfait-columns on Root re-splits every section", () => {
+		render(<TwoSectionPage className="halves" />);
+
+		expect(columnRatio(screen.getByTestId("providers"))).toBeCloseTo(1, 2);
+		expect(columnRatio(screen.getByTestId("rules"))).toBeCloseTo(1, 2);
+	});
+
+	test("--parfait-columns on one Section leaves its siblings alone", () => {
+		render(
+			<Parfait.Root style={{ width: 900 }}>
+				<Parfait.Section className="halves" data-testid="providers">
+					<Parfait.Header>
+						<Parfait.Title>Providers</Parfait.Title>
+					</Parfait.Header>
+					<Parfait.Body>providers</Parfait.Body>
+				</Parfait.Section>
+				<Parfait.Section data-testid="rules">
+					<Parfait.Header>
+						<Parfait.Title>Routing rules</Parfait.Title>
+					</Parfait.Header>
+					<Parfait.Body>rules</Parfait.Body>
+				</Parfait.Section>
+			</Parfait.Root>,
+		);
+
+		expect(columnRatio(screen.getByTestId("providers"))).toBeCloseTo(1, 2);
+		expect(columnRatio(screen.getByTestId("rules"))).toBeCloseTo(2, 2);
+	});
+});
+
+describe("Parfait.Root rhythm", () => {
+	test("rules a hairline between sections, and none below the last", () => {
+		render(<TwoSectionPage />);
+
+		expect(getComputedStyle(screen.getByTestId("providers")).borderBottomWidth).toBe("1px");
+		expect(getComputedStyle(screen.getByTestId("rules")).borderBottomWidth).toBe("0px");
+	});
+
+	test("the first section drops its top padding, and later ones keep it", () => {
+		render(<TwoSectionPage />);
+
+		expect(getComputedStyle(screen.getByTestId("providers")).paddingTop).toBe("0px");
+		expect(getComputedStyle(screen.getByTestId("rules")).paddingTop).toBe("32px");
+	});
+});

--- a/packages/mantle/src/components/parfait/parfait.test.tsx
+++ b/packages/mantle/src/components/parfait/parfait.test.tsx
@@ -1,0 +1,388 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createRef } from "react";
+import { describe, expect, test } from "vitest";
+import { Parfait } from "./parfait.js";
+
+type PartCase = {
+	/** The namespace member under test, for the generated test name. */
+	readonly name: string;
+	/** The `data-slot` the part stamps on its own default element. */
+	readonly slot: string;
+	/** Renders the part with the consumer props every case asserts. */
+	readonly element: (ref: (node: HTMLElement | null) => void) => ReactNode;
+};
+
+/**
+ * Every part rendered on its default branch — no `asChild` — with the same
+ * three consumer props. The `asChild` cases below go through `Slot`, which
+ * merges the child's own props, so they stay green even when a part drops
+ * `{...props}` from the branch that renders its own element.
+ */
+const defaultElementCases: readonly PartCase[] = [
+	{
+		name: "Root",
+		slot: "parfait",
+		element: (ref) => (
+			<Parfait.Root
+				className="custom-part"
+				data-analytics="settings"
+				data-testid="part"
+				ref={ref}
+			/>
+		),
+	},
+	{
+		name: "Section",
+		slot: "parfait-section",
+		element: (ref) => (
+			<Parfait.Section
+				className="custom-part"
+				data-analytics="settings"
+				data-testid="part"
+				ref={ref}
+			/>
+		),
+	},
+	{
+		name: "Header",
+		slot: "parfait-header",
+		element: (ref) => (
+			<Parfait.Header
+				className="custom-part"
+				data-analytics="settings"
+				data-testid="part"
+				ref={ref}
+			/>
+		),
+	},
+	{
+		name: "Title",
+		slot: "parfait-title",
+		element: (ref) => (
+			<Parfait.Title
+				className="custom-part"
+				data-analytics="settings"
+				data-testid="part"
+				ref={ref}
+			/>
+		),
+	},
+	{
+		name: "Description",
+		slot: "parfait-description",
+		element: (ref) => (
+			<Parfait.Description
+				className="custom-part"
+				data-analytics="settings"
+				data-testid="part"
+				ref={ref}
+			/>
+		),
+	},
+	{
+		name: "Body",
+		slot: "parfait-body",
+		element: (ref) => (
+			<Parfait.Body
+				className="custom-part"
+				data-analytics="settings"
+				data-testid="part"
+				ref={ref}
+			/>
+		),
+	},
+];
+
+function TwoSectionPage() {
+	return (
+		<Parfait.Root data-testid="root">
+			<Parfait.Section data-testid="providers">
+				<Parfait.Header>
+					<Parfait.Title>Providers</Parfait.Title>
+					<Parfait.Description>What providers keys may call.</Parfait.Description>
+				</Parfait.Header>
+				<Parfait.Body>
+					<button type="button">Add a provider</button>
+				</Parfait.Body>
+			</Parfait.Section>
+			<Parfait.Section data-testid="rules">
+				<Parfait.Header>
+					<Parfait.Title>Routing rules</Parfait.Title>
+					<Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+				</Parfait.Header>
+				<Parfait.Body>
+					<button type="button">Add rule</button>
+				</Parfait.Body>
+			</Parfait.Section>
+		</Parfait.Root>
+	);
+}
+
+describe("Parfait", () => {
+	test("every part stamps its data-slot on the expected element", () => {
+		const { container } = render(<TwoSectionPage />);
+
+		// `data-slot` is public API, so a rename breaks consumer CSS in another
+		// repo. Pin every part's slot name to the element it lands on. A missing
+		// slot reads back as null rather than skipping the assertion.
+		const slots = [
+			"parfait",
+			"parfait-section",
+			"parfait-header",
+			"parfait-title",
+			"parfait-description",
+			"parfait-body",
+		] as const;
+		const tagNames = slots.map(
+			(slot) => container.querySelector(`[data-slot="${slot}"]`)?.tagName ?? null,
+		);
+
+		expect(tagNames).toEqual(["DIV", "SECTION", "HEADER", "H2", "P", "DIV"]);
+	});
+
+	test("renders one heading and one description per section, in document order", () => {
+		render(<TwoSectionPage />);
+
+		expect(
+			screen.getAllByRole("heading", { level: 2 }).map((heading) => heading.textContent),
+		).toEqual(["Providers", "Routing rules"]);
+		expect(screen.getByText("What providers keys may call.")).toBeInTheDocument();
+		expect(screen.getByText("Define how requests are authenticated.")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Add a provider" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Add rule" })).toBeInTheDocument();
+	});
+
+	test("each Header carries its own section's title, not the page's", () => {
+		const { container } = render(<TwoSectionPage />);
+		const headers = container.querySelectorAll('[data-slot="parfait-header"]');
+
+		expect(headers).toHaveLength(2);
+		expect(headers[0]).toHaveTextContent("Providers");
+		expect(headers[1]).toHaveTextContent("Routing rules");
+	});
+
+	test("Title renders a level-2 heading, and asChild re-levels it", () => {
+		const { rerender } = render(<Parfait.Title>Providers</Parfait.Title>);
+		expect(screen.getByRole("heading", { level: 2, name: "Providers" })).toBeInTheDocument();
+
+		rerender(
+			<Parfait.Title asChild>
+				<h3>Providers</h3>
+			</Parfait.Title>,
+		);
+		expect(screen.getByRole("heading", { level: 3, name: "Providers" })).toBeInTheDocument();
+		expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+	});
+
+	test("Header is a header element nested directly in its own Section", () => {
+		const { container } = render(<TwoSectionPage />);
+		const headers = container.querySelectorAll('[data-slot="parfait-header"]');
+
+		// Why not getByRole("banner"): HTML-AAM maps `<header>` to `banner` only
+		// when no sectioning ancestor scopes it, and testing-library's role mapping
+		// does not model that condition — it reports both headers as banners. The
+		// nesting below is the half mantle owns; browsers apply the scoping.
+		expect(Array.from(headers, (header) => header.tagName)).toEqual(["HEADER", "HEADER"]);
+		expect(Array.from(headers, (header) => header.closest("section"))).toEqual(
+			Array.from(headers, (header) => header.parentElement),
+		);
+	});
+
+	test("Section takes no accessible name, so it adds no region landmark", () => {
+		render(<TwoSectionPage />);
+
+		expect(screen.queryAllByRole("region")).toHaveLength(0);
+	});
+
+	// The docs discourage naming a Section, but the escape hatch has to work: a
+	// section that is a real destination needs the landmark, so `aria-labelledby`
+	// must reach the `<section>` rather than being swallowed by the part.
+	test("Section becomes a region landmark once a consumer names it", () => {
+		render(
+			<Parfait.Root>
+				<Parfait.Section aria-labelledby="providers-title">
+					<Parfait.Header>
+						<Parfait.Title id="providers-title">Providers</Parfait.Title>
+					</Parfait.Header>
+					<Parfait.Body>content</Parfait.Body>
+				</Parfait.Section>
+			</Parfait.Root>,
+		);
+
+		expect(screen.getByRole("region", { name: "Providers" })).toBeInTheDocument();
+	});
+
+	test.each(defaultElementCases)(
+		"$name forwards className, data-*, and the ref to its own default element",
+		({ slot, element }) => {
+			const refNodes: Array<HTMLElement | null> = [];
+			render(
+				element((node) => {
+					refNodes.push(node);
+				}),
+			);
+
+			const part = screen.getByTestId("part");
+			expect(part).toHaveAttribute("data-slot", slot);
+			expect(part).toHaveAttribute("data-analytics", "settings");
+			expect(part.className).toContain("custom-part");
+			expect(refNodes.at(-1)).toBe(part);
+		},
+	);
+
+	test("Root forwards className, data-*, and the ref through an asChild swap", () => {
+		const ref = createRef<HTMLElement>();
+		render(
+			<Parfait.Root asChild className="custom-root">
+				<main data-testid="root" data-region="settings" ref={ref}>
+					content
+				</main>
+			</Parfait.Root>,
+		);
+
+		const root = screen.getByTestId("root");
+		expect(root.tagName).toBe("MAIN");
+		expect(root).toHaveAttribute("data-slot", "parfait");
+		expect(root).toHaveAttribute("data-region", "settings");
+		expect(root.className).toContain("custom-root");
+		expect(ref.current).toBe(root);
+	});
+
+	test("Section forwards className, data-*, and the ref through an asChild swap", () => {
+		const ref = createRef<HTMLFieldSetElement>();
+		render(
+			<Parfait.Section asChild className="custom-section">
+				<fieldset data-testid="section" data-group="providers" ref={ref}>
+					content
+				</fieldset>
+			</Parfait.Section>,
+		);
+
+		const section = screen.getByTestId("section");
+		expect(section.tagName).toBe("FIELDSET");
+		expect(section).toHaveAttribute("data-slot", "parfait-section");
+		expect(section).toHaveAttribute("data-group", "providers");
+		expect(section.className).toContain("custom-section");
+		expect(ref.current).toBe(section);
+	});
+
+	test("Header forwards className, data-*, and the ref through an asChild swap", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<Parfait.Header asChild className="custom-header">
+				<div data-testid="header" data-density="tight" ref={ref}>
+					content
+				</div>
+			</Parfait.Header>,
+		);
+
+		const header = screen.getByTestId("header");
+		expect(header.tagName).toBe("DIV");
+		expect(header).toHaveAttribute("data-slot", "parfait-header");
+		expect(header).toHaveAttribute("data-density", "tight");
+		expect(header.className).toContain("custom-header");
+		expect(ref.current).toBe(header);
+	});
+
+	test("Title forwards className, data-*, and the ref through an asChild swap", () => {
+		const ref = createRef<HTMLHeadingElement>();
+		render(
+			<Parfait.Title asChild className="custom-title">
+				<h3 data-testid="title" data-tone="loud" ref={ref}>
+					Providers
+				</h3>
+			</Parfait.Title>,
+		);
+
+		const title = screen.getByTestId("title");
+		expect(title.tagName).toBe("H3");
+		expect(title).toHaveAttribute("data-slot", "parfait-title");
+		expect(title).toHaveAttribute("data-tone", "loud");
+		expect(title.className).toContain("custom-title");
+		expect(ref.current).toBe(title);
+	});
+
+	test("Description forwards className, data-*, and the ref through an asChild swap", () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<Parfait.Description asChild className="custom-description">
+				<div data-testid="description" data-tone="quiet" ref={ref}>
+					What providers keys may call.
+				</div>
+			</Parfait.Description>,
+		);
+
+		const description = screen.getByTestId("description");
+		expect(description.tagName).toBe("DIV");
+		expect(description).toHaveAttribute("data-slot", "parfait-description");
+		expect(description).toHaveAttribute("data-tone", "quiet");
+		expect(description.className).toContain("custom-description");
+		expect(ref.current).toBe(description);
+	});
+
+	test("Body forwards className, data-*, and the ref through an asChild swap", () => {
+		const ref = createRef<HTMLFormElement>();
+		render(
+			<Parfait.Body asChild className="custom-body">
+				<form data-testid="body" data-state="dirty" ref={ref}>
+					content
+				</form>
+			</Parfait.Body>,
+		);
+
+		const body = screen.getByTestId("body");
+		expect(body.tagName).toBe("FORM");
+		expect(body).toHaveAttribute("data-slot", "parfait-body");
+		expect(body).toHaveAttribute("data-state", "dirty");
+		expect(body.className).toContain("custom-body");
+		expect(ref.current).toBe(body);
+	});
+
+	test("asChild composition accumulates the data-slot chain in DOM order", () => {
+		render(
+			<Parfait.Section asChild>
+				<Parfait.Body data-testid="body">content</Parfait.Body>
+			</Parfait.Section>,
+		);
+
+		expect(screen.getByTestId("body")).toHaveAttribute("data-slot", "parfait-section parfait-body");
+	});
+
+	test("asChild data-slot chains extend through nested composition to the rendered element", () => {
+		render(
+			<Parfait.Root asChild>
+				<Parfait.Section asChild>
+					<section data-slot="access-scope" data-testid="section">
+						content
+					</section>
+				</Parfait.Section>
+			</Parfait.Root>,
+		);
+
+		expect(screen.getByTestId("section")).toHaveAttribute(
+			"data-slot",
+			"parfait parfait-section access-scope",
+		);
+	});
+
+	// tailwind-merge override contract: the consumer's spacing must beat the
+	// part's own default, or a page cannot tighten one section.
+	test("a consumer's className replaces Section's vertical rhythm", () => {
+		render(<Parfait.Section className="py-4" data-testid="section" />);
+
+		const section = screen.getByTestId("section");
+		expect(section.className).toContain("py-4");
+		expect(section.className).not.toContain("py-8");
+	});
+
+	// tailwind-merge override contract, as above — Body's default gap is a
+	// starting point, not a floor.
+	test("a consumer's className replaces Body's gap", () => {
+		render(<Parfait.Body className="gap-8" data-testid="body" />);
+
+		const body = screen.getByTestId("body");
+		expect(body.className).toContain("gap-8");
+		expect(body.className).not.toContain("gap-4");
+	});
+});

--- a/packages/mantle/src/components/parfait/parfait.tsx
+++ b/packages/mantle/src/components/parfait/parfait.tsx
@@ -1,0 +1,668 @@
+import type { ComponentProps } from "react";
+import type { WithAsChild } from "../../types/as-child.js";
+import { cx } from "../../utils/cx/cx.js";
+import type { WithDataSlot } from "../../utils/data-slot.js";
+import { joinDataSlot } from "../../utils/data-slot.js";
+import { Slot } from "../slot/index.js";
+
+/**
+ * The stack of sections. Renders a `<div>` with `divide-card-muted divide-y`, so
+ * a hairline falls between adjacent `Parfait.Section` children and never above
+ * the first or below the last. Vertical rhythm belongs to `Section`
+ * (`py-8 first:pt-0`) rather than here, which keeps a lone `Section` usable
+ * without a `Root` around it. Set `--parfait-columns` on `Root` to re-split
+ * every section at once — custom properties inherit, so one declaration reaches
+ * all of them.
+ *
+ * | Data Attribute | Value       | Description                                                        |
+ * | -------------- | ----------- | ------------------------------------------------------------------ |
+ * | `data-slot`    | `"parfait"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait#parfaitroot
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Root = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"div"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "div";
+
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "parfait")}
+			className={cx("divide-card-muted divide-y", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
+
+/**
+ * One titled band of the page. Renders a `<section>` that stacks
+ * `Parfait.Header` above `Parfait.Body` below the `md` breakpoint, then splits
+ * the two into a `1fr 2fr` grid at `md` and up. It carries its own vertical
+ * rhythm (`py-8 first:pt-0`), so it reads correctly as the only child of a
+ * `Root` and as one of many.
+ *
+ * The `<section>` takes no accessible name, which keeps it generic in the
+ * accessibility tree instead of adding one `region` landmark per band — the
+ * `Parfait.Title` headings already carry the page outline, and a landmark list
+ * only stays useful while `main` and `nav` are easy to find in it. Set
+ * `aria-labelledby` to the `Title`'s `id` only when the section is a
+ * destination a reader jumps back to, not merely a division of the page. To
+ * tell apart controls that read alike across two sections, reach for
+ * `Field.Set` and `Field.Legend` instead — assistive technology announces a
+ * landmark on entry, never per control.
+ *
+ * | CSS Variable        | Default   | Description                                                                                                                 |
+ * | ------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+ * | `--parfait-columns` | `1fr 2fr` | The `grid-template-columns` value at `md` and up. Set it on `Parfait.Root` to re-split every section, or here for this section alone. |
+ *
+ * | Data Attribute | Value               | Description                                                        |
+ * | -------------- | ------------------- | ------------------------------------------------------------------ |
+ * | `data-slot`    | `"parfait-section"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait#parfaitsection
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Section = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"section"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "section";
+
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "parfait-section")}
+			className={cx(
+				"grid gap-6 py-8 first:pt-0",
+				"md:grid-cols-(--parfait-columns,1fr_2fr) md:gap-12",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
+
+/**
+ * A section's introductory column — its `Parfait.Title` and
+ * `Parfait.Description`. Renders a `<header>` with `flex flex-col gap-2`, so
+ * anything else composed in (a `Badge`, a count) picks up the same spacing. At
+ * `md` and up it takes the grid's first column; below the breakpoint it stacks
+ * above `Parfait.Body`.
+ *
+ * Why `<header>`: it groups the introductory content of its nearest sectioning
+ * ancestor, which is `Parfait.Section`'s `<section>`. Nested inside sectioning
+ * content, a `<header>` is not the `banner` landmark, so a page carries as many
+ * as it has sections.
+ *
+ * | Data Attribute | Value              | Description                                                        |
+ * | -------------- | ------------------ | ------------------------------------------------------------------ |
+ * | `data-slot`    | `"parfait-header"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait#parfaitheader
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Header = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"header"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "header";
+
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "parfait-header")}
+			className={cx("flex flex-col gap-2", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
+
+/**
+ * The section's heading. Renders an `<h2>`, one level below the page's `<h1>`,
+ * because a `Parfait.Section` is a top-level division of its page. Compose
+ * `asChild` with the right element when a page nests its sections deeper —
+ * heading level is document structure, so mantle does not guess it.
+ *
+ * | Data Attribute | Value             | Description                                                        |
+ * | -------------- | ----------------- | ------------------------------------------------------------------ |
+ * | `data-slot`    | `"parfait-title"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait#parfaittitle
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Title = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"h2"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "h2";
+
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "parfait-title")}
+			className={cx("text-strong text-base font-medium", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
+
+/**
+ * The sentence that says what the section's controls do, and what changing them
+ * costs. Renders a `<p>` in muted body text beneath `Parfait.Title`. Optional —
+ * a section whose title says everything may omit it.
+ *
+ * | Data Attribute | Value                   | Description                                                        |
+ * | -------------- | ----------------------- | ------------------------------------------------------------------ |
+ * | `data-slot`    | `"parfait-description"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait#parfaitdescription
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Description = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"p"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "p";
+
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "parfait-description")}
+			className={cx("text-body text-sm", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
+
+/**
+ * The section's content column — the controls, cards, or table that
+ * `Parfait.Header` describes. Renders a `<div>` with `flex flex-col gap-4`, so
+ * stacked controls space themselves and a consumer's own `gap-*` replaces the
+ * default cleanly. At `md` and up it takes the grid's second column; below the
+ * breakpoint it stacks under the header.
+ *
+ * | Data Attribute | Value            | Description                                                        |
+ * | -------------- | ---------------- | ------------------------------------------------------------------ |
+ * | `data-slot`    | `"parfait-body"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait#parfaitbody
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Body = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	...props
+}: ComponentProps<"div"> & WithAsChild & WithDataSlot) => {
+	const Comp = asChild ? Slot : "div";
+
+	return (
+		<Comp
+			data-slot={joinDataSlot(dataSlot, "parfait-body")}
+			className={cx("flex flex-col gap-4", className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+};
+
+/**
+ * A page of titled sections, each one explained beside its content. Every
+ * section pairs a `Parfait.Header` — its `Title` and `Description` — with a
+ * `Parfait.Body` of controls. `Parfait.Root` stacks the sections with a
+ * hairline between them. Below the `md` breakpoint the header stacks above its
+ * own content, so the pairing survives a narrow viewport. It is the shape of a
+ * settings page, a resource configuration editor, and any form long enough that
+ * each group needs its own explanation.
+ *
+ * It owns structure only — the grid, the rhythm, and the rules between sections.
+ * Reach for [Card](https://mantle.ngrok.com/components/structure/card) when a
+ * group needs a raised surface of its own, for
+ * [MediaObject](https://mantle.ngrok.com/components/structure/media-object)
+ * when the thing beside the text is an image or an icon, and for
+ * [DescriptionList](https://mantle.ngrok.com/components/data-display/description-list)
+ * when the pairs are read-only term/value data rather than headed sections.
+ *
+ * @see https://mantle.ngrok.com/components/structure/parfait
+ *
+ * @example
+ * Composition:
+ * ```
+ * Parfait.Root
+ * └── Parfait.Section
+ *     ├── Parfait.Header
+ *     │   ├── Parfait.Title
+ *     │   └── Parfait.Description
+ *     └── Parfait.Body
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <Parfait.Root>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Providers</Parfait.Title>
+ *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <ProviderScopePicker />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ *   <Parfait.Section>
+ *     <Parfait.Header>
+ *       <Parfait.Title>Routing rules</Parfait.Title>
+ *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+ *     </Parfait.Header>
+ *     <Parfait.Body>
+ *       <RoutingRuleList />
+ *     </Parfait.Body>
+ *   </Parfait.Section>
+ * </Parfait.Root>
+ * ```
+ */
+const Parfait = {
+	/**
+	 * The stack of sections. Renders a `<div>` with `divide-card-muted divide-y`,
+	 * so a hairline falls between adjacent `Section` children and never above the
+	 * first or below the last. Vertical rhythm belongs to `Section`
+	 * (`py-8 first:pt-0`) rather than here, which keeps a lone `Section` usable
+	 * without a `Root` around it. Set `--parfait-columns` on `Root` to re-split
+	 * every section at once.
+	 *
+	 * | Data Attribute | Value       | Description                                                        |
+	 * | -------------- | ----------- | ------------------------------------------------------------------ |
+	 * | `data-slot`    | `"parfait"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/parfait#parfaitroot
+	 *
+	 * @example
+	 * ```tsx
+	 * <Parfait.Root>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Providers</Parfait.Title>
+	 *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <ProviderScopePicker />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Routing rules</Parfait.Title>
+	 *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <RoutingRuleList />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 * </Parfait.Root>
+	 * ```
+	 */
+	Root,
+	/**
+	 * One titled band of the page. Renders a `<section>` that stacks `Header`
+	 * above `Body` below the `md` breakpoint, then splits the two into a
+	 * `1fr 2fr` grid at `md` and up, and carries its own vertical rhythm
+	 * (`py-8 first:pt-0`). It takes no accessible name, which keeps it generic in
+	 * the accessibility tree instead of adding one `region` landmark per band —
+	 * the `Title` headings already carry the page outline. Set `aria-labelledby`
+	 * to the `Title`'s `id` only when the section is a destination a reader jumps
+	 * back to, not merely a division of the page. To tell apart controls that read
+	 * alike across two sections, reach for `Field.Set` and `Field.Legend` instead
+	 * — assistive technology announces a landmark on entry, never per control.
+	 *
+	 * | CSS Variable        | Default   | Description                                                                                                            |
+	 * | ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------- |
+	 * | `--parfait-columns` | `1fr 2fr` | The `grid-template-columns` value at `md` and up. Set it on `Root` to re-split every section, or here for this section alone. |
+	 *
+	 * | Data Attribute | Value               | Description                                                        |
+	 * | -------------- | ------------------- | ------------------------------------------------------------------ |
+	 * | `data-slot`    | `"parfait-section"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/parfait#parfaitsection
+	 *
+	 * @example
+	 * ```tsx
+	 * <Parfait.Root>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Providers</Parfait.Title>
+	 *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <ProviderScopePicker />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Routing rules</Parfait.Title>
+	 *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <RoutingRuleList />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 * </Parfait.Root>
+	 * ```
+	 */
+	Section,
+	/**
+	 * A section's introductory column — its `Title` and `Description`. Renders a
+	 * `<header>` with `flex flex-col gap-2`, so anything else composed in picks
+	 * up the same spacing. At `md` and up it takes the grid's first column; below
+	 * the breakpoint it stacks above `Body`. Nested inside `Section`'s
+	 * `<section>`, a `<header>` is not the `banner` landmark, so a page carries
+	 * as many as it has sections.
+	 *
+	 * | Data Attribute | Value              | Description                                                        |
+	 * | -------------- | ------------------ | ------------------------------------------------------------------ |
+	 * | `data-slot`    | `"parfait-header"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/parfait#parfaitheader
+	 *
+	 * @example
+	 * ```tsx
+	 * <Parfait.Root>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Providers</Parfait.Title>
+	 *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <ProviderScopePicker />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Routing rules</Parfait.Title>
+	 *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <RoutingRuleList />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 * </Parfait.Root>
+	 * ```
+	 */
+	Header,
+	/**
+	 * The section's heading. Renders an `<h2>`, one level below the page's
+	 * `<h1>`, because a `Section` is a top-level division of its page. Compose
+	 * `asChild` with the right element when a page nests its sections deeper —
+	 * heading level is document structure, so mantle does not guess it.
+	 *
+	 * | Data Attribute | Value             | Description                                                        |
+	 * | -------------- | ----------------- | ------------------------------------------------------------------ |
+	 * | `data-slot`    | `"parfait-title"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/parfait#parfaittitle
+	 *
+	 * @example
+	 * ```tsx
+	 * <Parfait.Root>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Providers</Parfait.Title>
+	 *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <ProviderScopePicker />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Routing rules</Parfait.Title>
+	 *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <RoutingRuleList />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 * </Parfait.Root>
+	 * ```
+	 */
+	Title,
+	/**
+	 * The sentence that says what the section's controls do, and what changing
+	 * them costs. Renders a `<p>` in muted body text beneath `Title`. Optional —
+	 * a section whose title says everything may omit it.
+	 *
+	 * | Data Attribute | Value                   | Description                                                        |
+	 * | -------------- | ----------------------- | ------------------------------------------------------------------ |
+	 * | `data-slot`    | `"parfait-description"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/parfait#parfaitdescription
+	 *
+	 * @example
+	 * ```tsx
+	 * <Parfait.Root>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Providers</Parfait.Title>
+	 *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <ProviderScopePicker />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Routing rules</Parfait.Title>
+	 *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <RoutingRuleList />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 * </Parfait.Root>
+	 * ```
+	 */
+	Description,
+	/**
+	 * The section's content column — the controls, cards, or table that `Header`
+	 * describes. Renders a `<div>` with `flex flex-col gap-4`, so stacked
+	 * controls space themselves and a consumer's own `gap-*` replaces the default
+	 * cleanly. At `md` and up it takes the grid's second column; below the
+	 * breakpoint it stacks under the header.
+	 *
+	 * | Data Attribute | Value            | Description                                                        |
+	 * | -------------- | ---------------- | ------------------------------------------------------------------ |
+	 * | `data-slot`    | `"parfait-body"` | Stable styling hook. Survives `className` overrides and `asChild`. |
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/parfait#parfaitbody
+	 *
+	 * @example
+	 * ```tsx
+	 * <Parfait.Root>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Providers</Parfait.Title>
+	 *       <Parfait.Description>What providers keys may call.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <ProviderScopePicker />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 *   <Parfait.Section>
+	 *     <Parfait.Header>
+	 *       <Parfait.Title>Routing rules</Parfait.Title>
+	 *       <Parfait.Description>Define how requests are authenticated.</Parfait.Description>
+	 *     </Parfait.Header>
+	 *     <Parfait.Body>
+	 *       <RoutingRuleList />
+	 *     </Parfait.Body>
+	 *   </Parfait.Section>
+	 * </Parfait.Root>
+	 * ```
+	 */
+	Body,
+} as const;
+
+export {
+	//,
+	Parfait,
+};


### PR DESCRIPTION
## Why

A settings page and a resource configuration editor share one shape: a titled band per group, with its
explanation beside its controls. Mantle had no component for that shape, so each page built the grid, the
vertical rhythm, and the rule between bands on its own — and they drift.

`Parfait` owns that structure and nothing else. Form state, validation, and the controls themselves arrive as
composed JSX.

## How

Six parts, all `asChild`-capable, all stamping a `data-slot` that joins an incoming chain ahead of its own
name. `Root` stacks the sections and rules a hairline between them; `Section` splits its `Header` from its
`Body` into a `1fr 2fr` grid at `md` and up and stacks the two below that breakpoint, carrying its own
`py-8 first:pt-0` rhythm so a lone section still reads correctly. `--parfait-columns` re-splits every section
from `Root`, or one section from itself.

`Section` takes no accessible name on purpose. A named `<section>` is a `region` landmark, and one per band
turns the landmark list into a second table of contents the `Title` headings already carry. The docs page
states when to reach for the `aria-labelledby` escape hatch, and when `Field.Set` is the right answer instead.

## Validation

- All five COMPONENT_SPEC §9 commands pass, run with `--force` so nothing replayed from turbo cache.
- Column split, the hairline, and the first-section padding are pinned in browser mode against real computed
  style, with the load-bearing CSS injected inline — happy-dom substitutes no custom properties, so those
  assertions would pass for the wrong reason there.
- Mutation-checked the forwarding tests: deleting `{...props}` from `Root`, `Header`, and `Description`'s
  default branch passed the whole suite before this PR, because every forwarding case went through `Slot`.
  The table-driven default-element test added here fails on exactly those three.

## Audit notes

Audited against COMPONENT_SPEC before opening. Surface, implementation, and wiring came back clean. Three gaps
closed in the branch:

- §6 — no data-attribute table anywhere. Added a `data-slot` row to all twelve JSDoc declarations and all six
  API-reference subsections, plus the chain-joining note under `Parfait.Root`.
- §8 — the default render branch was untested, per the mutation above.
- §2.1 — the `@ngrok/mantle-vite-plugins` changeset for the regenerated subpath list was missing. Every prior
  component-addition PR ships one.

One item left for review rather than fixed: `Parfait.Root` carries no `--parfait-columns` table. That is
correct per §5.3 — `Section` is the part that reads it — but both the docs and the JSDoc tell consumers to
*set* it on `Root`, so a cross-reference row there may read better.
