### PR TITLE
feat: add overlay arrows and mark code untranslatable

### DIFF
--- a/.changeset/popover-hover-card-arrow.md
+++ b/.changeset/popover-hover-card-arrow.md
@@ -35,11 +35,23 @@ as an `svg`, where `bg-*` paints nothing. Each arrow is therefore two layers: a 
 surface, and a polyline that strokes the two slanted edges only. The base carries no stroke and sits 1px inside
 the content, so the fill covers the content's own border across the base and the two border lines read as one.
 
-The tip carries its own shadow, built from the same `--shadow-color` and `--shadow-*-opacity` tokens the
+The tip carries its own shadow, built from the same `--shadow-color` and `--shadow-first-opacity` tokens the
 content's `shadow-md` uses. `box-shadow` stops at the content's border, so a tip without one reads as pasted on.
 A `clip-path` trims that shadow at the base, because the arrow paints above the content and the shadow would
-otherwise darken the content's interior. Both shadow layers are symmetric, since Radix rotates the arrow's
-wrapper per side and an offset shadow would swing with it.
+otherwise darken the content's interior. It is one wide, faint layer, matching what the content's shadow leaves
+along the edge the tip grows out of — a tighter layer muddies a shape this small. The offsets are symmetric,
+since Radix rotates the arrow's wrapper per side and an offset shadow would swing with it.
+
+`Popover.Content` and `HoverCard.Content` now set `position: relative`. The arrow's wrapper is absolutely
+positioned, and the open animation's `scale` made the content that wrapper's containing block for the length of
+the animation and no longer — which moved the arrow 1px the moment the animation ended. Positioning the content
+keeps the containing block the same before, during, and after. Two side effects a consumer can observe: an
+absolutely-positioned child of the content now anchors to the content, and the content's `z-50` now applies to
+the content itself rather than only being read off it, so the content is a stacking context.
+
+The border stroke is 1.5px against the content's 1px border. Antialiasing spreads a diagonal hairline across
+two device rows at partial coverage, so a geometric 1px reads thinner than the content's axis-aligned edge.
+Measured against that edge at both 1x and 2x, 1.5 is the width that matches it.
 
 `data-slot` is `popover-arrow` and `hover-card-arrow`. `width` defaults to `14` and `height` to `7`; Radix adds
 the measured height to `sideOffset`, so the tip lands `sideOffset` pixels from the anchor. Neither part takes

--- a/.changeset/popover-hover-card-arrow.md
+++ b/.changeset/popover-hover-card-arrow.md
@@ -1,0 +1,50 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Popover` and `HoverCard` now export an `Arrow` part — a tip that points from the content at what it is anchored
+to. Render it as a child of the content:
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Popover } from "@ngrok/mantle/popover";
+
+<Popover.Root>
+	<Popover.Anchor asChild>
+		<button type="button">Anchor</button>
+	</Popover.Anchor>
+	<Popover.Trigger asChild>
+		<Button type="button" appearance="outlined" intent="neutral">
+			What moved?
+		</Button>
+	</Popover.Trigger>
+	<Popover.Content side="right">
+		<Popover.Arrow />
+		<p>Products moved up here.</p>
+	</Popover.Content>
+</Popover.Root>;
+```
+
+Radix positions the part with floating-ui's arrow middleware, so the tip stays centered on the anchor when
+collision detection shifts or flips the content. A hand-rolled tip is a fixed offset, so it drifts off the anchor as soon as the
+content moves, and it needs a pinned `align` per anchor to land on the right row at all.
+
+Mantle styles the tip to read as a continuation of the content's edge. `Popover.Content` and
+`HoverCard.Content` both paint a `bg-popover` fill behind a `border-popover` edge, and Radix renders the arrow
+as an `svg`, where `bg-*` paints nothing. Each arrow is therefore two layers: a polygon filled with the popover
+surface, and a polyline that strokes the two slanted edges only. The base carries no stroke and sits 1px inside
+the content, so the fill covers the content's own border across the base and the two border lines read as one.
+
+The tip carries its own shadow, built from the same `--shadow-color` and `--shadow-*-opacity` tokens the
+content's `shadow-md` uses. `box-shadow` stops at the content's border, so a tip without one reads as pasted on.
+A `clip-path` trims that shadow at the base, because the arrow paints above the content and the shadow would
+otherwise darken the content's interior. Both shadow layers are symmetric, since Radix rotates the arrow's
+wrapper per side and an offset shadow would swing with it.
+
+`data-slot` is `popover-arrow` and `hover-card-arrow`. `width` defaults to `14` and `height` to `7`; Radix adds
+the measured height to `sideOffset`, so the tip lands `sideOffset` pixels from the anchor. Neither part takes
+`asChild`, because a swapped element loses the two-layer shape — restyle with `className` (`fill-*` for the
+surface, and target the `polyline` child for the edge), remembering that the part already sets `filter` and
+`clip-path`.
+
+`Tooltip` needs no new part: `Tooltip.Content` already renders its own arrow.

--- a/.changeset/translate-no-on-code-surfaces.md
+++ b/.changeset/translate-no-on-code-surfaces.md
@@ -16,9 +16,15 @@ stale text, no error — or calls `removeChild` on a node that moved and throws 
 the root when no error boundary sits above it. `translate="no"` on the element, or on any ancestor, prevents
 both, because the engine never enters the subtree.
 
-The attribute is not overridable. Each part omits `translate` from its props type, so passing it is a compile
-error, and each part stamps the attribute after the props spread, so a wider props object cannot carry a value
-past the type either:
+Two of the four lock the attribute, and two leave it overridable, on whether the part can ever hold prose.
+
+`Kbd` and `CodeBlock.Code` lock it. A key and a block of code are never translatable, so both omit `translate`
+from their props type — passing it is a compile error — and both stamp the attribute after the props spread, so
+a wider props object cannot carry a value past the type either.
+
+`Code` and `CodeBlock.Title` keep the prop. `Code` also styles terms that are not code, and `CodeBlock.Title`
+takes arbitrary children, so `translate="no"` is a default rather than a rule: pass `translate="yes"` when the
+content is prose.
 
 ```tsx
 import { Code } from "@ngrok/mantle/code";
@@ -29,7 +35,10 @@ import { Kbd } from "@ngrok/mantle/kbd";
 
 // <kbd data-slot="kbd" … translate="no">K</kbd>
 <Kbd>K</Kbd>;
+
+// <code data-slot="code" … translate="yes">dashboard</code>
+<Code translate="yes">dashboard</Code>;
 ```
 
 `CodeBlock.Title` is included because the title usually names a file — `example.ts` — and a translated filename
-names a file that does not exist. Wrap prose that should be translated in an element outside these parts.
+names a file that does not exist.

--- a/.changeset/translate-no-on-code-surfaces.md
+++ b/.changeset/translate-no-on-code-surfaces.md
@@ -1,0 +1,35 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Code`, `Kbd`, `CodeBlock.Code`, and `CodeBlock.Title` now render `translate="no"`, so a browser translation
+engine skips the text inside them.
+
+A translation engine translates the text inside `<code>` and `<kbd>` like any other prose. A translated CLI
+flag, YAML key, env var, or shortcut key is wrong, and the reader copies it anyway. `translate` is the standard
+way to mark a subtree an engine must skip, and code content is the clearest place to set it, because code must
+never be translated.
+
+The attribute also protects the render. Google Translate replaces each text node with a `<font>` wrapper, which
+detaches the text nodes React holds. React then either writes an update into a node the DOM no longer shows —
+stale text, no error — or calls `removeChild` on a node that moved and throws `NotFoundError`, which tears down
+the root when no error boundary sits above it. `translate="no"` on the element, or on any ancestor, prevents
+both, because the engine never enters the subtree.
+
+The attribute is not overridable. Each part omits `translate` from its props type, so passing it is a compile
+error, and each part stamps the attribute after the props spread, so a wider props object cannot carry a value
+past the type either:
+
+```tsx
+import { Code } from "@ngrok/mantle/code";
+import { Kbd } from "@ngrok/mantle/kbd";
+
+// <code data-slot="code" … translate="no">npm install</code>
+<Code>npm install</Code>;
+
+// <kbd data-slot="kbd" … translate="no">K</kbd>
+<Kbd>K</Kbd>;
+```
+
+`CodeBlock.Title` is included because the title usually names a file — `example.ts` — and a translated filename
+names a file that does not exist. Wrap prose that should be translated in an element outside these parts.

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -509,6 +509,12 @@ The remaining parts do not accept `asChild`. `CodeBlock.Code` owns the highlight
 > [!WARNING]
 > `CodeBlock.ExpanderButton` advertises `asChild` in its prop types but **throws at runtime** (`React.Children.only expected to receive a single React element child`). It renders its own "Show more" / "Show less" label and caret icon, so the slot receives more than one child. Style it with `className` instead.
 
+## Translation
+
+`CodeBlock.Code` and `CodeBlock.Title` always carry [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the code and the filename. A translated CLI flag, env var, or YAML key is wrong, and the reader copies it anyway. A translated `example.ts` names a file that does not exist.
+
+Both parts omit the `translate` prop from their types, so no call site can turn the guard off. The attribute also protects the render itself: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds — so React either writes updates into a node the DOM no longer shows, or throws `NotFoundError` from `removeChild` and tears down the root.
+
 ## API Reference
 
 The `CodeBlock` renders and applies syntax highlighting to blocks of code and is composed of several sub-components.
@@ -540,7 +546,9 @@ All props from [standard HTML div attributes](https://developer.mozilla.org/en-U
 
 The `CodeBlock` content. This is where the code is rendered with pre-highlighted Shiki HTML.
 
-All props from [standard HTML pre attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre#attributes), plus:
+The `<pre>` always carries `translate="no"`.
+
+All props from [standard HTML pre attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre#attributes) except `translate`, plus:
 
 | Prop    | Type                   | Default | Description                                                                                        |
 | :------ | :--------------------- | :------ | :------------------------------------------------------------------------------------------------- |
@@ -560,7 +568,9 @@ All props from [standard HTML div attributes](https://developer.mozilla.org/en-U
 
 The (optional) title of a `CodeBlock`. Default renders as an `h3` element; use `asChild` to render something else.
 
-All props from [standard HTML h3 attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#attributes), plus:
+The heading always carries `translate="no"`, because the title usually names a file.
+
+All props from [standard HTML h3 attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#attributes) except `translate`, plus:
 
 | Prop       | Type      | Default | Description                                                                                                                                    |
 | :--------- | :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -511,9 +511,11 @@ The remaining parts do not accept `asChild`. `CodeBlock.Code` owns the highlight
 
 ## Translation
 
-`CodeBlock.Code` and `CodeBlock.Title` always carry [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the code and the filename. A translated CLI flag, env var, or YAML key is wrong, and the reader copies it anyway. A translated `example.ts` names a file that does not exist.
+`CodeBlock.Code` and `CodeBlock.Title` carry [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the code and the filename. A translated CLI flag, env var, or YAML key is wrong, and the reader copies it anyway. A translated `example.ts` names a file that does not exist.
 
-Both parts omit the `translate` prop from their types, so no call site can turn the guard off. The attribute also protects the render itself: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds — so React either writes updates into a node the DOM no longer shows, or throws `NotFoundError` from `removeChild` and tears down the root.
+The attribute also protects the render itself: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds — so React either writes updates into a node the DOM no longer shows, or throws `NotFoundError` from `removeChild` and tears down the root.
+
+The two parts differ on whether a call site may turn the guard off. `CodeBlock.Code` omits the `translate` prop from its type, because a block of code is never translatable. `CodeBlock.Title` keeps it, because the slot takes arbitrary children — pass `translate="yes"` for a title that is prose rather than a filename.
 
 ## API Reference
 
@@ -568,13 +570,14 @@ All props from [standard HTML div attributes](https://developer.mozilla.org/en-U
 
 The (optional) title of a `CodeBlock`. Default renders as an `h3` element; use `asChild` to render something else.
 
-The heading always carries `translate="no"`, because the title usually names a file.
+The heading carries `translate="no"` by default, because the title usually names a file.
 
-All props from [standard HTML h3 attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#attributes) except `translate`, plus:
+All props from [standard HTML h3 attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#attributes), plus:
 
-| Prop       | Type      | Default | Description                                                                                                                                    |
-| :--------- | :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
-| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `CodeBlock.Title` styling and functionality onto alternative element types or your own React components. |
+| Prop         | Type              | Default | Description                                                                                                                                    |
+| :----------- | :---------------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `asChild?`   | `boolean`         | `false` | Use the `asChild` prop to compose the `CodeBlock.Title` styling and functionality onto alternative element types or your own React components. |
+| `translate?` | `"yes"` \| `"no"` | `"no"`  | Whether a browser translation engine may translate the title. Pass `"yes"` for a title that is prose rather than a filename.                   |
 
 ### CodeBlock.CopyButton
 

--- a/apps/www/app/docs/components/data-display/code.mdx
+++ b/apps/www/app/docs/components/data-display/code.mdx
@@ -57,18 +57,37 @@ import { Code } from "@ngrok/mantle/code";
 
 ## Translation
 
-The `<code>` element always carries [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the subtree. A translated CLI flag, env var, or YAML key is wrong, and the reader copies it anyway.
+The `<code>` element carries [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate) by default, so a browser translation engine skips the subtree. A translated CLI flag, env var, or YAML key is wrong, and the reader copies it anyway.
 
-`Code` omits the `translate` prop from its type, so no call site can turn the guard off. The attribute also protects the render itself: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds — so React either writes updates into a node the DOM no longer shows, or throws `NotFoundError` from `removeChild` and tears down the root.
+The attribute also protects the render itself: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds — so React either writes updates into a node the DOM no longer shows, or throws `NotFoundError` from `removeChild` and tears down the root.
+
+`Code` also styles terms that are not code, so the default is overridable. Pass `translate="yes"` when the content is prose:
+
+<Example>
+	<p>
+		Open the <Code translate="yes">dashboard</Code> to see your endpoints.
+	</p>
+</Example>
+
+```tsx
+import { Code } from "@ngrok/mantle/code";
+
+<p>
+	Open the <Code translate="yes">dashboard</Code> to see your endpoints.
+</p>;
+```
+
+[`Kbd`](/components/data-display/kbd) and `CodeBlock.Code` take no such override — a key and a block of code are never translatable.
 
 ## API Reference
 
 ### Code
 
-All props from [code](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code#attributes) except `translate`, plus:
+All props from [code](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code#attributes), plus:
 
-| Prop         | Type        | Default | Description                                                                                                       |
-| ------------ | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
-| `asChild?`   | `boolean`   | `false` | Use the `asChild` prop to compose the `Code` styling onto alternative element types or your own React components. |
-| `children`   | `ReactNode` |         | The content to be rendered inside the inline code element.                                                        |
-| `className?` | `string`    |         | Additional CSS classes to apply to the inline code element.                                                       |
+| Prop         | Type              | Default | Description                                                                                                       |
+| ------------ | ----------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `asChild?`   | `boolean`         | `false` | Use the `asChild` prop to compose the `Code` styling onto alternative element types or your own React components. |
+| `children`   | `ReactNode`       |         | The content to be rendered inside the inline code element.                                                        |
+| `className?` | `string`          |         | Additional CSS classes to apply to the inline code element.                                                       |
+| `translate?` | `"yes"` \| `"no"` | `"no"`  | Whether a browser translation engine may translate the content. Pass `"yes"` when the content is prose.           |

--- a/apps/www/app/docs/components/data-display/code.mdx
+++ b/apps/www/app/docs/components/data-display/code.mdx
@@ -55,11 +55,17 @@ import { Code } from "@ngrok/mantle/code";
 </Code>;
 ```
 
+## Translation
+
+The `<code>` element always carries [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the subtree. A translated CLI flag, env var, or YAML key is wrong, and the reader copies it anyway.
+
+`Code` omits the `translate` prop from its type, so no call site can turn the guard off. The attribute also protects the render itself: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds — so React either writes updates into a node the DOM no longer shows, or throws `NotFoundError` from `removeChild` and tears down the root.
+
 ## API Reference
 
 ### Code
 
-All props from [code](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code#attributes), plus:
+All props from [code](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code#attributes) except `translate`, plus:
 
 | Prop         | Type        | Default | Description                                                                                                       |
 | ------------ | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/apps/www/app/docs/components/data-display/kbd.mdx
+++ b/apps/www/app/docs/components/data-display/kbd.mdx
@@ -109,7 +109,7 @@ import { Kbd } from "@ngrok/mantle/kbd";
 
 The `<kbd>` element always carries [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the subtree. A translated shortcut names a key the reader's keyboard does not have.
 
-`Kbd` omits the `translate` prop from its type, so no call site can turn the guard off. See [`Code`](/components/data-display/code) for the second reason the attribute matters: a translation engine that rewrites the text nodes React holds can also break the render.
+`Kbd` omits the `translate` prop from its type, so no call site can turn the guard off. A key is never translatable, unlike [`Code`](/components/data-display/code), which also styles terms that are not code and therefore takes the override. See that page for the second reason the attribute matters: a translation engine that rewrites the text nodes React holds can also break the render.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/data-display/kbd.mdx
+++ b/apps/www/app/docs/components/data-display/kbd.mdx
@@ -105,11 +105,17 @@ import { Kbd } from "@ngrok/mantle/kbd";
 </div>;
 ```
 
+## Translation
+
+The `<kbd>` element always carries [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so a browser translation engine skips the subtree. A translated shortcut names a key the reader's keyboard does not have.
+
+`Kbd` omits the `translate` prop from its type, so no call site can turn the guard off. See [`Code`](/components/data-display/code) for the second reason the attribute matters: a translation engine that rewrites the text nodes React holds can also break the render.
+
 ## API Reference
 
 ### Kbd
 
-The `Kbd` accepts the following props in addition to the [standard HTML kbd attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd).
+The `Kbd` accepts the following props in addition to the [standard HTML kbd attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd), except `translate`.
 
 | Prop         | Type        | Default | Description                                                  |
 | :----------- | :---------- | :------ | :----------------------------------------------------------- |

--- a/apps/www/app/docs/components/overlays/hover-card.mdx
+++ b/apps/www/app/docs/components/overlays/hover-card.mdx
@@ -80,6 +80,43 @@ import { ShrimpIcon } from "@phosphor-icons/react/Shrimp";
 </HoverCard.Root>;
 ```
 
+## Arrow
+
+Render `HoverCard.Arrow` as a child of `HoverCard.Content` when the card previews one specific link and needs a tip pointing at it. Radix positions the arrow with floating-ui's arrow middleware, so it stays centered on the trigger when collision detection shifts or flips the content. The arrow's fill and border repaint `HoverCard.Content`'s own edge across its base, so the two edges read as one line. The tip also casts its own shadow, because `shadow-md` on `HoverCard.Content` stops at that content's border and an unshadowed tip reads as pasted on. That shadow is clipped at the base, so it never darkens the content's interior.
+
+`HoverCard.Arrow` takes no `asChild`. The shape is two layers — a filled polygon, plus a polyline that strokes the slanted edges only — and a swapped element loses the border. Restyle it with `className` instead: `fill-*` for the surface and a `stroke-*` on the arrow's `polyline` child for the edge, since Radix renders the arrow as an `svg` where `bg-*` paints nothing.
+
+<Example className="gap-2">
+	<HoverCard.Root>
+		<HoverCard.Trigger asChild>
+			<Button type="button" appearance="link" intent="accent">
+				@ngrok/mantle
+			</Button>
+		</HoverCard.Trigger>
+		<HoverCard.Content className="w-64">
+			<HoverCard.Arrow />
+			<p className="text-sm">The Design System – created and maintained by @ngrok.</p>
+		</HoverCard.Content>
+	</HoverCard.Root>
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { HoverCard } from "@ngrok/mantle/hover-card";
+
+<HoverCard.Root>
+	<HoverCard.Trigger asChild>
+		<Button type="button" appearance="link" intent="accent">
+			@ngrok/mantle
+		</Button>
+	</HoverCard.Trigger>
+	<HoverCard.Content className="w-64">
+		<HoverCard.Arrow />
+		<p className="text-sm">The Design System – created and maintained by @ngrok.</p>
+	</HoverCard.Content>
+</HoverCard.Root>;
+```
+
 ## Layering and z-index
 
 `HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
@@ -94,6 +131,7 @@ Compose the parts of a `HoverCard` together to build your own:
 HoverCard.Root
 ├── HoverCard.Trigger
 └── HoverCard.Content
+    └── HoverCard.Arrow
 ```
 
 ## API Reference
@@ -139,6 +177,18 @@ Renders at Tailwind `z-50`, Mantle's shared floating z-index.
 | `collisionPadding`  | `number \| Partial<Record<Side, number>>`      | `0`         | The distance in pixels from the boundary edges where collision detection should occur.                                                  |
 | `sticky`            | `"partial"` \| `"always"`                      | `"partial"` | The sticky behavior on the align axis.                                                                                                  |
 | `hideWhenDetached`  | `boolean`                                      | `false`     | Whether to hide the content when the trigger becomes fully occluded.                                                                    |
+
+### HoverCard.Arrow
+
+An optional tip that points from `HoverCard.Content` at its trigger. Render it as a child of `HoverCard.Content`. Radix renders it as an `svg`, so `fill-*` paints the surface and `bg-*` paints nothing.
+
+It takes no `asChild` — the shape is a filled polygon plus a polyline that strokes the slanted edges, and a swapped element loses the border that continues `HoverCard.Content`'s edge.
+
+| Prop        | Type     | Default | Description                                                                                                                                                                               |
+| ----------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`     | `number` | `14`    | The width of the arrow in pixels.                                                                                                                                                         |
+| `height`    | `number` | `7`     | The height of the arrow in pixels. Radix adds this to `sideOffset`, so the tip lands `sideOffset` pixels from the trigger.                                                                |
+| `className` | `string` |         | Classes for the `svg`. Reach for `fill-*` for the surface, and target the `polyline` child for the edge: `[&>polyline]:…`. The part already sets `filter` and `clip-path` for its shadow. |
 
 ### HoverCard.Portal
 

--- a/apps/www/app/docs/components/overlays/hover-card.mdx
+++ b/apps/www/app/docs/components/overlays/hover-card.mdx
@@ -166,6 +166,8 @@ The content to render inside the hover card. Appears in a portal with rich styli
 
 Renders at Tailwind `z-50`, Mantle's shared floating z-index.
 
+`HoverCard.Content` sets `position: relative`, so `HoverCard.Arrow`'s absolutely-positioned wrapper keeps one containing block through the open animation. An absolutely-positioned child of the content therefore anchors to the content.
+
 | Prop                | Type                                           | Default     | Description                                                                                                                             |
 | ------------------- | ---------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `side`              | `"top"` \| `"right"` \| `"bottom"` \| `"left"` | `"bottom"`  | The preferred side of the trigger to render against when open. Will be reversed when collisions occur and `avoidCollisions` is enabled. |

--- a/apps/www/app/docs/components/overlays/popover.mdx
+++ b/apps/www/app/docs/components/overlays/popover.mdx
@@ -107,6 +107,43 @@ import { Popover } from "@ngrok/mantle/popover";
 </Popover.Root>;
 ```
 
+## Arrow
+
+Render `Popover.Arrow` as a child of `Popover.Content` when the popover explains one specific control and needs a tip pointing at it. Radix positions the arrow with floating-ui's arrow middleware, so it stays centered on the anchor when collision detection shifts or flips the content — a hand-rolled tip is a fixed offset and drifts off the anchor as soon as the content moves. The arrow's fill and border repaint `Popover.Content`'s own edge across its base, so the two edges read as one line. The tip also casts its own shadow, because `shadow-md` on `Popover.Content` stops at that content's border and an unshadowed tip reads as pasted on. That shadow is clipped at the base, so it never darkens the content's interior.
+
+`Popover.Arrow` takes no `asChild`. The shape is two layers — a filled polygon, plus a polyline that strokes the slanted edges only — and a swapped element loses the border. Restyle it with `className` instead: `fill-*` for the surface and a `stroke-*` on the arrow's `polyline` child for the edge, since Radix renders the arrow as an `svg` where `bg-*` paints nothing.
+
+<Example className="gap-2">
+	<Popover.Root>
+		<Popover.Trigger asChild>
+			<Button type="button" appearance="filled" intent="neutral">
+				What moved?
+			</Button>
+		</Popover.Trigger>
+		<Popover.Content side="right" preferredWidth="max-w-64">
+			<Popover.Arrow />
+			<p className="text-sm">Products moved up here.</p>
+		</Popover.Content>
+	</Popover.Root>
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Popover } from "@ngrok/mantle/popover";
+
+<Popover.Root>
+	<Popover.Trigger asChild>
+		<Button type="button" appearance="filled" intent="neutral">
+			What moved?
+		</Button>
+	</Popover.Trigger>
+	<Popover.Content side="right" preferredWidth="max-w-64">
+		<Popover.Arrow />
+		<p className="text-sm">Products moved up here.</p>
+	</Popover.Content>
+</Popover.Root>;
+```
+
 ## Layering and z-index
 
 `Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
@@ -122,6 +159,7 @@ Popover.Root
 ├── Popover.Trigger
 ├── Popover.Anchor
 └── Popover.Content
+    ├── Popover.Arrow
     └── Popover.Close
 ```
 
@@ -188,3 +226,17 @@ All props from Radix [Popover.Close](https://www.radix-ui.com/primitives/docs/co
 | Prop       | Type      | Default | Description                                                           |
 | :--------- | :-------- | :------ | :-------------------------------------------------------------------- |
 | `asChild?` | `boolean` | `false` | Compose onto an alternative element type or your own React component. |
+
+### Popover.Arrow
+
+An optional tip that points from `Popover.Content` at its anchor. Render it as a child of `Popover.Content`. Radix renders it as an `svg`, so `fill-*` paints the surface and `bg-*` paints nothing.
+
+It takes no `asChild` — the shape is a filled polygon plus a polyline that strokes the slanted edges, and a swapped element loses the border that continues `Popover.Content`'s edge.
+
+All props from Radix [Popover.Arrow](https://www.radix-ui.com/primitives/docs/components/popover#arrow) except `asChild` and `children`, plus:
+
+| Prop        | Type     | Default | Description                                                                                                                                                                               |
+| :---------- | :------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width?`    | `number` | `14`    | The width of the arrow in pixels.                                                                                                                                                         |
+| `height?`   | `number` | `7`     | The height of the arrow in pixels. Radix adds this to `sideOffset`, so the tip lands `sideOffset` pixels from the anchor.                                                                 |
+| `className` | `string` |         | Classes for the `svg`. Reach for `fill-*` for the surface, and target the `polyline` child for the edge: `[&>polyline]:…`. The part already sets `filter` and `clip-path` for its shadow. |

--- a/apps/www/app/docs/components/overlays/popover.mdx
+++ b/apps/www/app/docs/components/overlays/popover.mdx
@@ -198,6 +198,8 @@ The content to render inside the popover. Appears in a portal with styling and a
 
 Renders at Tailwind `z-50`, Mantle's shared floating z-index.
 
+`Popover.Content` sets `position: relative`, so `Popover.Arrow`'s absolutely-positioned wrapper keeps one containing block through the open animation. An absolutely-positioned child of the content therefore anchors to the content.
+
 All props from Radix [Popover.Content](https://www.radix-ui.com/primitives/docs/components/popover#content), plus:
 
 | Prop              | Type                                     | Default      | Description                                          |

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -410,7 +410,7 @@
     "summary": "For sighted users to preview content available behind a link.",
     "jsdoc": "A floating card that appears when a user hovers over a trigger element.",
     "examples": [
-      "Composition:\n```\nHoverCard.Root\n├── HoverCard.Trigger\n└── HoverCard.Content\n```",
+      "Composition:\n```\nHoverCard.Root\n├── HoverCard.Trigger\n└── HoverCard.Content\n    └── HoverCard.Arrow\n```",
       "```tsx\n<HoverCard.Root>\n  <HoverCard.Trigger asChild>\n    <Button type=\"button\" appearance=\"outlined\" intent=\"neutral\">\n      Hover me\n    </Button>\n  </HoverCard.Trigger>\n  <HoverCard.Content>\n    <p>This is the hover card content.</p>\n  </HoverCard.Content>\n</HoverCard.Root>\n```"
     ]
   },
@@ -607,7 +607,7 @@
     "summary": "Displays rich content in a portal, triggered by a button.",
     "jsdoc": "A floating overlay that displays rich content in a portal, triggered by a button.",
     "examples": [
-      "Composition:\n```\nPopover.Root\n├── Popover.Trigger\n├── Popover.Anchor\n└── Popover.Content\n    └── Popover.Close\n```",
+      "Composition:\n```\nPopover.Root\n├── Popover.Trigger\n├── Popover.Anchor\n└── Popover.Content\n    ├── Popover.Arrow\n    └── Popover.Close\n```",
       "```tsx\n<Popover.Root>\n  <Popover.Trigger asChild>\n    <Button type=\"button\" appearance=\"outlined\" intent=\"neutral\">\n      Open Popover\n    </Button>\n  </Popover.Trigger>\n  <Popover.Content>\n    <p>This is the popover content.</p>\n  </Popover.Content>\n</Popover.Root>\n```"
     ]
   },

--- a/packages/mantle/src/components/code-block/code-block.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.test.tsx
@@ -168,24 +168,20 @@ describe("CodeBlock", () => {
 			);
 		});
 
-		test('keeps translate="no" when a call site passes translate', () => {
+		test('a call site can opt back in with translate="yes"', () => {
+			// The slot takes arbitrary children, so a title that is prose rather than a
+			// filename can override the default — unlike `CodeBlock.Code`.
 			render(
 				<CodeBlock.Root>
 					<CodeBlock.Header>
-						<CodeBlock.Title
-							// @ts-expect-error `translate` is omitted from the props type on purpose. This
-							// pins the runtime guard for a caller who spreads a wider props object past it.
-							translate="yes"
-						>
-							example.ts
-						</CodeBlock.Title>
+						<CodeBlock.Title translate="yes">Request headers</CodeBlock.Title>
 					</CodeBlock.Header>
 				</CodeBlock.Root>,
 			);
 
-			expect(screen.getByRole("heading", { name: "example.ts" })).toHaveAttribute(
+			expect(screen.getByRole("heading", { name: "Request headers" })).toHaveAttribute(
 				"translate",
-				"no",
+				"yes",
 			);
 		});
 

--- a/packages/mantle/src/components/code-block/code-block.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.test.tsx
@@ -121,6 +121,89 @@ describe("CodeBlock", () => {
 			expect(code?.innerHTML).toContain("SHIKI_VAL_0");
 			expect(code?.innerHTML).toContain('"&lt;safe&gt;"');
 		});
+
+		test('renders translate="no" so a translation engine skips the code', () => {
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Body>
+						<CodeBlock.Code value={makeValue("const x = 1;")} />
+					</CodeBlock.Body>
+				</CodeBlock.Root>,
+			);
+
+			expect(document.querySelector("pre")).toHaveAttribute("translate", "no");
+		});
+
+		test('keeps translate="no" when a call site passes translate', () => {
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Body>
+						<CodeBlock.Code
+							// @ts-expect-error `translate` is omitted from the props type on purpose. This
+							// pins the runtime guard for a caller who spreads a wider props object past it.
+							translate="yes"
+							value={makeValue("const x = 1;")}
+						/>
+					</CodeBlock.Body>
+				</CodeBlock.Root>,
+			);
+
+			expect(document.querySelector("pre")).toHaveAttribute("translate", "no");
+		});
+	});
+
+	describe("Title", () => {
+		test('renders translate="no" so a translation engine skips the filename', () => {
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Header>
+						<CodeBlock.Title>example.ts</CodeBlock.Title>
+					</CodeBlock.Header>
+				</CodeBlock.Root>,
+			);
+
+			expect(screen.getByRole("heading", { name: "example.ts" })).toHaveAttribute(
+				"translate",
+				"no",
+			);
+		});
+
+		test('keeps translate="no" when a call site passes translate', () => {
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Header>
+						<CodeBlock.Title
+							// @ts-expect-error `translate` is omitted from the props type on purpose. This
+							// pins the runtime guard for a caller who spreads a wider props object past it.
+							translate="yes"
+						>
+							example.ts
+						</CodeBlock.Title>
+					</CodeBlock.Header>
+				</CodeBlock.Root>,
+			);
+
+			expect(screen.getByRole("heading", { name: "example.ts" })).toHaveAttribute(
+				"translate",
+				"no",
+			);
+		});
+
+		test('asChild carries translate="no" onto the consumer\'s element', () => {
+			render(
+				<CodeBlock.Root>
+					<CodeBlock.Header>
+						<CodeBlock.Title asChild>
+							<span data-testid="title">example.ts</span>
+						</CodeBlock.Title>
+					</CodeBlock.Header>
+				</CodeBlock.Root>,
+			);
+
+			const title = screen.getByTestId("title");
+			expect(title.tagName).toBe("SPAN");
+			expect(title).toHaveAttribute("translate", "no");
+		});
 	});
 
 	describe("CopyButton", () => {

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -293,7 +293,7 @@ function substitutePreValsPlainText(
 	return substituteTemplateVals(text, vals, preValToken, (value) => String(value));
 }
 
-type CodeBlockCodeProps = Omit<ComponentProps<"pre">, "children"> & {
+type CodeBlockCodeProps = Omit<ComponentProps<"pre">, "children" | "translate"> & {
 	/**
 	 * The code value produced by `mantleCode("lang")` tagged template.
 	 * Contains pre-rendered Shiki HTML (when the Vite plugin is active) and
@@ -308,7 +308,13 @@ type CodeBlockCodeProps = Omit<ComponentProps<"pre">, "children"> & {
  * Mantle's Vite plugin or server highlighter must set `value["~preHtml"]`.
  * Runtime highlighting and runtime line decoration are intentionally unsupported.
  *
+ * The `<pre>` always carries `translate="no"`, so a browser translation engine
+ * skips the code. A translated CLI flag, env var, or YAML key is wrong, and the
+ * reader copies it anyway. The `translate` prop is omitted from the type, so no
+ * call site can turn the guard off.
+ *
  * @see https://mantle.ngrok.com/components/data-display/code-block#codeblockcode
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate
  *
  * @example
  * ```tsx
@@ -431,6 +437,9 @@ const Code = ({ className, style, value, ref, ...props }: CodeBlockCodeProps) =>
 				} as ComponentProps<"pre">["style"]
 			}
 			{...props}
+			// Why after the spread: a wider props object can still carry `translate`
+			// past the type, and translated code is wrong at every call site.
+			translate="no"
 		>
 			<code
 				className="text-size-inherit block min-w-full w-max"
@@ -485,6 +494,11 @@ const Header = ({
  * The (optional) title of the `CodeBlock`. Renders as `h3` by default;
  * use `asChild` to render a different element.
  *
+ * The heading always carries `translate="no"`, because the title usually names a
+ * file — `example.ts` — and a translated filename names a file that does not
+ * exist. The `translate` prop is omitted from the type, so no call site can turn
+ * the guard off.
+ *
  * @see https://mantle.ngrok.com/components/data-display/code-block#codeblocktitle
  *
  * @example
@@ -507,7 +521,7 @@ const Title = ({
 	className,
 	ref,
 	...props
-}: ComponentProps<"h3"> & { asChild?: boolean }) => {
+}: Omit<ComponentProps<"h3">, "translate"> & { asChild?: boolean }) => {
 	const Component = asChild ? Slot : "h3";
 	return (
 		<Component
@@ -515,6 +529,9 @@ const Title = ({
 			ref={ref}
 			className={cx("m-0 font-sans text-xs font-medium", className)}
 			{...props}
+			// Why after the spread: a wider props object can still carry `translate`
+			// past the type, and a translated filename names a file that does not exist.
+			translate="no"
 		/>
 	);
 };
@@ -1001,6 +1018,9 @@ const CodeBlock = {
 	/**
 	 * The code content. Renders pre-highlighted Shiki HTML when the Vite plugin is active.
 	 *
+	 * The `<pre>` always carries `translate="no"`, so a browser translation engine
+	 * skips the code.
+	 *
 	 * @see https://mantle.ngrok.com/components/data-display/code-block#codeblockcode
 	 *
 	 * @example
@@ -1188,6 +1208,9 @@ const CodeBlock = {
 	TabTrigger,
 	/**
 	 * The optional title rendered in the header.
+	 *
+	 * The heading always carries `translate="no"`, because the title usually names
+	 * a file and a translated filename names a file that does not exist.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-display/code-block#codeblocktitle
 	 *

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -494,10 +494,11 @@ const Header = ({
  * The (optional) title of the `CodeBlock`. Renders as `h3` by default;
  * use `asChild` to render a different element.
  *
- * The heading always carries `translate="no"`, because the title usually names a
- * file — `example.ts` — and a translated filename names a file that does not
- * exist. The `translate` prop is omitted from the type, so no call site can turn
- * the guard off.
+ * The heading carries `translate="no"` by default, because the title usually names
+ * a file — `example.ts` — and a translated filename names a file that does not
+ * exist. The slot takes arbitrary children though, so pass `translate="yes"` when
+ * the title is prose rather than a filename. `CodeBlock.Code` takes no such
+ * override — a block of code is never translatable.
  *
  * @see https://mantle.ngrok.com/components/data-display/code-block#codeblocktitle
  *
@@ -521,17 +522,15 @@ const Title = ({
 	className,
 	ref,
 	...props
-}: Omit<ComponentProps<"h3">, "translate"> & { asChild?: boolean }) => {
+}: ComponentProps<"h3"> & { asChild?: boolean }) => {
 	const Component = asChild ? Slot : "h3";
 	return (
 		<Component
 			data-slot="code-block-title"
 			ref={ref}
 			className={cx("m-0 font-sans text-xs font-medium", className)}
-			{...props}
-			// Why after the spread: a wider props object can still carry `translate`
-			// past the type, and a translated filename names a file that does not exist.
 			translate="no"
+			{...props}
 		/>
 	);
 };
@@ -1209,8 +1208,8 @@ const CodeBlock = {
 	/**
 	 * The optional title rendered in the header.
 	 *
-	 * The heading always carries `translate="no"`, because the title usually names
-	 * a file and a translated filename names a file that does not exist.
+	 * The heading carries `translate="no"` by default, because the title usually
+	 * names a file. Pass `translate="yes"` when the title is prose instead.
 	 *
 	 * @see https://mantle.ngrok.com/components/data-display/code-block#codeblocktitle
 	 *

--- a/packages/mantle/src/components/code/code.test.tsx
+++ b/packages/mantle/src/components/code/code.test.tsx
@@ -45,15 +45,15 @@ describe("Code", () => {
 		expect(screen.getByTestId("code")).toHaveAttribute("translate", "no");
 	});
 
-	test('keeps translate="no" when a call site passes translate', () => {
+	test('a call site can opt back in with translate="yes"', () => {
+		// `Code` also styles terms that are not code, so the default is overridable
+		// here — unlike `Kbd`, where a key is never translatable.
 		render(
-			// @ts-expect-error `translate` is omitted from the props type on purpose. This
-			// pins the runtime guard for a caller who spreads a wider props object past it.
 			<Code data-testid="code" translate="yes">
-				npm install
+				dashboard
 			</Code>,
 		);
-		expect(screen.getByTestId("code")).toHaveAttribute("translate", "no");
+		expect(screen.getByTestId("code")).toHaveAttribute("translate", "yes");
 	});
 
 	test("asChild renders its child, merging classes, data-slot, and the ref onto it", () => {

--- a/packages/mantle/src/components/code/code.test.tsx
+++ b/packages/mantle/src/components/code/code.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, test } from "vitest";
+import { Code } from "./code.js";
+
+describe("Code", () => {
+	test("renders a code element with its data-slot", () => {
+		render(<Code data-testid="code">npm install</Code>);
+		const code = screen.getByTestId("code");
+		expect(code.tagName).toBe("CODE");
+		expect(code).toHaveAttribute("data-slot", "code");
+		expect(code).toHaveTextContent("npm install");
+	});
+
+	test("lets the consumer's className win over the defaults it conflicts with", () => {
+		render(
+			<Code data-testid="code" className="font-sans">
+				npm install
+			</Code>,
+		);
+		// A tailwind-merge override contract: the consumer's font family replaces the
+		// default `font-mono` rather than landing beside it.
+		const code = screen.getByTestId("code");
+		expect(code.className).toContain("font-sans");
+		expect(code.className).not.toContain("font-mono");
+	});
+
+	test("forwards ref to the underlying code element", () => {
+		const ref = createRef<HTMLElement>();
+		render(<Code ref={ref}>npm install</Code>);
+		expect(ref.current?.tagName).toBe("CODE");
+	});
+
+	test("forwards arbitrary data-* props", () => {
+		render(
+			<Code data-testid="code" data-analytics-id="install-command">
+				npm install
+			</Code>,
+		);
+		expect(screen.getByTestId("code")).toHaveAttribute("data-analytics-id", "install-command");
+	});
+
+	test('renders translate="no" so a translation engine skips the code', () => {
+		render(<Code data-testid="code">npm install</Code>);
+		expect(screen.getByTestId("code")).toHaveAttribute("translate", "no");
+	});
+
+	test('keeps translate="no" when a call site passes translate', () => {
+		render(
+			// @ts-expect-error `translate` is omitted from the props type on purpose. This
+			// pins the runtime guard for a caller who spreads a wider props object past it.
+			<Code data-testid="code" translate="yes">
+				npm install
+			</Code>,
+		);
+		expect(screen.getByTestId("code")).toHaveAttribute("translate", "no");
+	});
+
+	test("asChild renders its child, merging classes, data-slot, and the ref onto it", () => {
+		const ref = createRef<HTMLAnchorElement>();
+		render(
+			<Code asChild className="custom-class">
+				<a data-testid="code" href="/api" ref={ref}>
+					/api/components.json
+				</a>
+			</Code>,
+		);
+		const code = screen.getByTestId("code");
+		expect(code.tagName).toBe("A");
+		expect(code).toHaveAttribute("data-slot", "code");
+		expect(code).toHaveAttribute("translate", "no");
+		expect(code.className).toContain("custom-class");
+		expect(ref.current).toBe(code);
+	});
+});

--- a/packages/mantle/src/components/code/code.tsx
+++ b/packages/mantle/src/components/code/code.tsx
@@ -20,7 +20,13 @@ import { Slot } from "../slot/index.js";
  * **Polymorphism.** Pass `asChild` to render `Code` styling on a different
  * element (e.g. a link wrapping a code-styled label).
  *
+ * **Translation.** The `<code>` element always carries `translate="no"`, so a
+ * browser translation engine skips the subtree. A translated CLI flag, env var,
+ * or YAML key is wrong, and the reader copies it anyway. The `translate` prop is
+ * omitted from the type, so no call site can turn the guard off.
+ *
  * @see https://mantle.ngrok.com/components/data-display/code
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate
  *
  * @example
  * ```tsx
@@ -36,7 +42,12 @@ import { Slot } from "../slot/index.js";
  * </Code>
  * ```
  */
-const Code = ({ asChild, className, ref, ...props }: ComponentProps<"code"> & WithAsChild) => {
+const Code = ({
+	asChild,
+	className,
+	ref,
+	...props
+}: Omit<ComponentProps<"code">, "translate"> & WithAsChild) => {
 	const Comp = asChild ? Slot : "code";
 	return (
 		<Comp
@@ -47,6 +58,9 @@ const Code = ({ asChild, className, ref, ...props }: ComponentProps<"code"> & Wi
 				className,
 			)}
 			{...props}
+			// Why after the spread: a wider props object can still carry `translate`
+			// past the type, and translated code is wrong at every call site.
+			translate="no"
 		/>
 	);
 };

--- a/packages/mantle/src/components/code/code.tsx
+++ b/packages/mantle/src/components/code/code.tsx
@@ -20,10 +20,12 @@ import { Slot } from "../slot/index.js";
  * **Polymorphism.** Pass `asChild` to render `Code` styling on a different
  * element (e.g. a link wrapping a code-styled label).
  *
- * **Translation.** The `<code>` element always carries `translate="no"`, so a
+ * **Translation.** The `<code>` element carries `translate="no"` by default, so a
  * browser translation engine skips the subtree. A translated CLI flag, env var,
- * or YAML key is wrong, and the reader copies it anyway. The `translate` prop is
- * omitted from the type, so no call site can turn the guard off.
+ * or YAML key is wrong, and the reader copies it anyway. `Code` also styles terms
+ * that are not code, so pass `translate="yes"` when the content is prose.
+ * `Kbd` and `CodeBlock.Code` take no such override — a key and a block of code
+ * are never translatable.
  *
  * @see https://mantle.ngrok.com/components/data-display/code
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate
@@ -42,12 +44,7 @@ import { Slot } from "../slot/index.js";
  * </Code>
  * ```
  */
-const Code = ({
-	asChild,
-	className,
-	ref,
-	...props
-}: Omit<ComponentProps<"code">, "translate"> & WithAsChild) => {
+const Code = ({ asChild, className, ref, ...props }: ComponentProps<"code"> & WithAsChild) => {
 	const Comp = asChild ? Slot : "code";
 	return (
 		<Comp
@@ -57,10 +54,8 @@ const Code = ({
 				"border-gray-500/15 rounded-md border bg-gray-500/5 px-1 font-mono text-[0.8em]",
 				className,
 			)}
-			{...props}
-			// Why after the spread: a wider props object can still carry `translate`
-			// past the type, and translated code is wrong at every call site.
 			translate="no"
+			{...props}
 		/>
 	);
 };

--- a/packages/mantle/src/components/hover-card/hover-card.test.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.test.tsx
@@ -61,6 +61,22 @@ describe("HoverCard", () => {
 			expect(border).toHaveAttribute("vector-effect", "non-scaling-stroke");
 		});
 
+		test("relies on HoverCard.Content positioning itself", async () => {
+			const user = userEvent.setup();
+			renderHoverCard();
+
+			await user.hover(screen.getByRole("link", { name: "@ngrok/mantle" }));
+			await screen.findByText("The Design System");
+
+			// A cross-element pin, asserted where both sides render together. The arrow's
+			// wrapper is absolutely positioned, so `HoverCard.Content` has to be its
+			// containing block — otherwise the open animation's `scale` becomes that
+			// containing block for one frame and the arrow lands 1px off. No Tailwind runs
+			// in either vitest project, so the class is the only observable form here;
+			// `popover.browser.test.tsx` measures the same geometry on the shared shape.
+			expect(document.querySelector("[data-slot='hover-card-content']")).toHaveClass("relative");
+		});
+
 		test("takes a consumer className and forwards arbitrary props", async () => {
 			const user = userEvent.setup();
 			renderHoverCard(

--- a/packages/mantle/src/components/hover-card/hover-card.test.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { HoverCard } from "./hover-card.js";
+
+function renderHoverCard(arrow = <HoverCard.Arrow />) {
+	render(
+		<HoverCard.Root>
+			<HoverCard.Trigger href="https://ngrok.com">@ngrok/mantle</HoverCard.Trigger>
+			<HoverCard.Content>
+				{arrow}
+				<p>The Design System</p>
+			</HoverCard.Content>
+		</HoverCard.Root>,
+	);
+}
+
+describe("HoverCard", () => {
+	describe("Arrow", () => {
+		test("renders inside the content once hover opens it, with its data-slot", async () => {
+			const user = userEvent.setup();
+			renderHoverCard();
+
+			await user.hover(screen.getByRole("link", { name: "@ngrok/mantle" }));
+
+			expect(await screen.findByText("The Design System")).toBeInTheDocument();
+			const arrow = document.querySelector("[data-slot='hover-card-arrow']");
+			expect(arrow?.tagName).toBe("svg");
+			expect(arrow).toHaveAttribute("aria-hidden", "true");
+		});
+
+		test("sizes the svg so Radix offsets the content by the arrow's real height", async () => {
+			const user = userEvent.setup();
+			renderHoverCard();
+
+			await user.hover(screen.getByRole("link", { name: "@ngrok/mantle" }));
+			await screen.findByText("The Design System");
+
+			// Radix measures the rendered arrow and adds its height to `sideOffset`, so a
+			// width/height that disagrees with the painted triangle detaches the tip.
+			const arrow = document.querySelector("[data-slot='hover-card-arrow']");
+			expect(arrow).toHaveAttribute("width", "14");
+			expect(arrow).toHaveAttribute("height", "7");
+			expect(arrow).toHaveAttribute("viewBox", "0 0 30 10");
+		});
+
+		test("strokes only the two slanted edges, so the base does not cut the content's border", async () => {
+			const user = userEvent.setup();
+			renderHoverCard();
+
+			await user.hover(screen.getByRole("link", { name: "@ngrok/mantle" }));
+			await screen.findByText("The Design System");
+
+			const arrow = document.querySelector("[data-slot='hover-card-arrow']");
+			// The filled polygon closes across the base; the stroked polyline does not.
+			expect(arrow?.querySelector("polygon")).toHaveAttribute("points", "0,0 30,0 15,10");
+			const border = arrow?.querySelector("polyline");
+			expect(border).toHaveAttribute("points", "0,0 15,10 30,0");
+			expect(border).toHaveAttribute("fill", "none");
+			// Without this the 1px border scales with the 30x10 viewBox and reads as ~0.5px.
+			expect(border).toHaveAttribute("vector-effect", "non-scaling-stroke");
+		});
+
+		test("takes a consumer className and forwards arbitrary props", async () => {
+			const user = userEvent.setup();
+			renderHoverCard(
+				<HoverCard.Arrow className="fill-red-500" data-testid="arrow" height={10} width={20} />,
+			);
+
+			await user.hover(screen.getByRole("link", { name: "@ngrok/mantle" }));
+
+			const arrow = await screen.findByTestId("arrow");
+			expect(arrow.getAttribute("class")).toContain("fill-red-500");
+			expect(arrow).toHaveAttribute("width", "20");
+			expect(arrow).toHaveAttribute("height", "10");
+		});
+	});
+});

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -176,9 +176,11 @@ type HoverCardArrowProps = Omit<
  * ```
  */
 const Arrow = ({ className, height = 7, width = 14, ...props }: HoverCardArrowProps) => (
-	// Why no asChild: the shape is two layers — a filled polygon, plus a polyline
-	// that strokes the slanted edges only — and a swapped element loses the border
-	// that continues `HoverCard.Content`'s edge. Restyle with `className` instead.
+	// Why no asChild prop: a swapped element loses the two-layer shape — a filled
+	// polygon, plus a polyline that strokes the slanted edges only — that continues
+	// `HoverCard.Content`'s border. `HoverCardArrowProps` omits the prop, so restyle
+	// with `className` instead. The `asChild` below is mantle's own, and hands that
+	// shape to the primitive.
 	<HoverCardPrimitive.Arrow
 		aria-hidden="true"
 		asChild

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -138,6 +138,76 @@ const Content = ({
 	</Portal>
 );
 
+type HoverCardArrowProps = Omit<
+	ComponentProps<typeof HoverCardPrimitive.Arrow>,
+	"asChild" | "children"
+>;
+
+/**
+ * An optional tip that points from `HoverCard.Content` at its trigger. Render it
+ * as a child of `HoverCard.Content`. Radix positions it with floating-ui's arrow
+ * middleware, so it stays centered on the trigger when collision detection shifts
+ * or flips the content. It also repaints `HoverCard.Content`'s fill and border
+ * across its base, so the two edges read as one line, and carries its own shadow,
+ * clipped at that base so it never darkens the content's interior.
+ *
+ * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardarrow
+ *
+ * @example
+ * ```tsx
+ * <HoverCard.Root>
+ *   <HoverCard.Trigger asChild>
+ *     <Button type="button" appearance="link" intent="accent">@username</Button>
+ *   </HoverCard.Trigger>
+ *   <HoverCard.Content>
+ *     <HoverCard.Arrow />
+ *     <p>This is the hover card content.</p>
+ *   </HoverCard.Content>
+ * </HoverCard.Root>
+ * ```
+ */
+const Arrow = ({ className, height = 7, width = 14, ...props }: HoverCardArrowProps) => (
+	// Why no asChild: the shape is two layers — a filled polygon, plus a polyline
+	// that strokes the slanted edges only — and a swapped element loses the border
+	// that continues `HoverCard.Content`'s edge. Restyle with `className` instead.
+	<HoverCardPrimitive.Arrow
+		aria-hidden="true"
+		asChild
+		data-slot="hover-card-arrow"
+		height={height}
+		width={width}
+		{...props}
+	>
+		<svg
+			className={cx(
+				// The wrapper Radix renders sits the base flush on the content's outer
+				// edge, where the content's own border still paints. `-translate-y-px`
+				// sinks the base 1px in — toward the content on every side, since Radix
+				// rotates the wrapper per side — so the fill covers that border.
+				"-translate-y-px fill-[var(--background-color-popover)]",
+				// Why filter and clip-path: `HoverCard.Content`'s `shadow-md` stops at
+				// its own border, so an unshadowed tip reads as pasted on. The filter
+				// casts the tip's own shadow, and the clip trims it at the base, because
+				// the arrow paints above the content and the shadow would otherwise
+				// darken the content's interior. Both layers stay symmetric — Radix
+				// rotates the wrapper per side, which would swing an offset shadow.
+				"[clip-path:inset(0_-200%_-200%_-200%)]",
+				"[filter:drop-shadow(0_0_6px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-first-opacity),transparent))_drop-shadow(0_0_2px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent))]",
+				className,
+			)}
+		>
+			<polygon points="0,0 30,0 15,10" />
+			<polyline
+				className="stroke-[color:var(--border-color-popover)]"
+				fill="none"
+				points="0,0 15,10 30,0"
+				strokeWidth={1}
+				vectorEffect="non-scaling-stroke"
+			/>
+		</svg>
+	</HoverCardPrimitive.Arrow>
+);
+
 /**
  * A floating card that appears when a user hovers over a trigger element.
  *
@@ -161,6 +231,7 @@ const Content = ({
  * HoverCard.Root
  * ├── HoverCard.Trigger
  * └── HoverCard.Content
+ *     └── HoverCard.Arrow
  * ```
  *
  * @example
@@ -202,6 +273,30 @@ const HoverCard = {
 	 * ```
 	 */
 	Root,
+	/**
+	 * An optional tip that points from `HoverCard.Content` at its trigger. It stays
+	 * centered on the trigger when collision detection shifts or flips the content,
+	 * and its border continues `HoverCard.Content`'s own edge.
+	 *
+	 * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardarrow
+	 *
+	 * @example
+	 * ```tsx
+	 * <HoverCard.Root>
+	 *   <HoverCard.Trigger asChild>
+	 *     <Button type="button" appearance="link" intent="accent">@username</Button>
+	 *   </HoverCard.Trigger>
+	 *   <HoverCard.Content side="top">
+	 *     <HoverCard.Arrow />
+	 *     <div className="space-y-2">
+	 *       <Text weight="strong">User Profile</Text>
+	 *       <Text>Additional information about the user.</Text>
+	 *     </div>
+	 *   </HoverCard.Content>
+	 * </HoverCard.Root>
+	 * ```
+	 */
+	Arrow,
 	/**
 	 * The content to render inside the hover card. Appears in a portal with rich styling and animations.
 	 *

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -93,6 +93,10 @@ const Portal = HoverCardPrimitive.Portal;
  * z-index. When multiple shared layers are open, the most recently mounted
  * layer renders on top.
  *
+ * It sets `position: relative`, so `HoverCard.Arrow`'s absolutely-positioned
+ * wrapper keeps one containing block through the open animation. An
+ * absolutely-positioned child of the content therefore anchors to the content.
+ *
  * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardcontent
  *
  * @example
@@ -122,6 +126,11 @@ const Content = ({
 			align={align}
 			sideOffset={sideOffset}
 			className={cx(
+				// Why relative: `HoverCard.Arrow`'s wrapper is absolutely positioned, and
+				// the open animation's `scale` makes this element its containing block for
+				// one frame — then drops it, moving the arrow 1px. Positioning this element
+				// keeps that containing block the same before, during, and after.
+				"relative",
 				"bg-popover border-popover z-50 w-64 rounded-md border p-4 shadow-md outline-hidden",
 				"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 data-state-closed:zoom-out-95 data-state-open:zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2",
 				className,
@@ -180,19 +189,20 @@ const Arrow = ({ className, height = 7, width = 14, ...props }: HoverCardArrowPr
 	>
 		<svg
 			className={cx(
-				// The wrapper Radix renders sits the base flush on the content's outer
-				// edge, where the content's own border still paints. `-translate-y-px`
-				// sinks the base 1px in — toward the content on every side, since Radix
-				// rotates the wrapper per side — so the fill covers that border.
-				"-translate-y-px fill-[var(--background-color-popover)]",
+				// `HoverCard.Content` is the wrapper's containing block, so Radix's own
+				// `0` offset resolves to that content's padding box — the base lands 1px
+				// inside the border box, and the fill covers the border it sits on.
+				"fill-[var(--background-color-popover)]",
 				// Why filter and clip-path: `HoverCard.Content`'s `shadow-md` stops at
 				// its own border, so an unshadowed tip reads as pasted on. The filter
 				// casts the tip's own shadow, and the clip trims it at the base, because
 				// the arrow paints above the content and the shadow would otherwise
-				// darken the content's interior. Both layers stay symmetric — Radix
-				// rotates the wrapper per side, which would swing an offset shadow.
+				// darken the content's interior. One wide, faint layer only, matching
+				// what the content's shadow leaves along the edge the tip grows out of —
+				// a tighter layer muddies a shape this small. The offsets stay symmetric,
+				// since Radix rotates the wrapper per side and would swing an offset.
 				"[clip-path:inset(0_-200%_-200%_-200%)]",
-				"[filter:drop-shadow(0_0_6px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-first-opacity),transparent))_drop-shadow(0_0_2px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent))]",
+				"[filter:drop-shadow(0_0_4px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-first-opacity),transparent))]",
 				className,
 			)}
 		>
@@ -201,7 +211,11 @@ const Arrow = ({ className, height = 7, width = 14, ...props }: HoverCardArrowPr
 				className="stroke-[color:var(--border-color-popover)]"
 				fill="none"
 				points="0,0 15,10 30,0"
-				strokeWidth={1}
+				// Why 1.5 against the content's 1px border: antialiasing spreads a
+				// diagonal hairline across two device rows at partial coverage, so a
+				// geometric 1px reads thinner than the content's axis-aligned edge.
+				// Measured against that edge at 1x and 2x, 1.5 matches it.
+				strokeWidth={1.5}
 				vectorEffect="non-scaling-stroke"
 			/>
 		</svg>

--- a/packages/mantle/src/components/kbd/kbd.test.tsx
+++ b/packages/mantle/src/components/kbd/kbd.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, test } from "vitest";
+import { Kbd } from "./kbd.js";
+
+describe("Kbd", () => {
+	test("renders a kbd element with its data-slot", () => {
+		render(<Kbd data-testid="kbd">K</Kbd>);
+		const kbd = screen.getByTestId("kbd");
+		expect(kbd.tagName).toBe("KBD");
+		expect(kbd).toHaveAttribute("data-slot", "kbd");
+		expect(kbd).toHaveTextContent("K");
+	});
+
+	test("lets the consumer's className win over the defaults it conflicts with", () => {
+		render(
+			<Kbd data-testid="kbd" className="font-sans">
+				K
+			</Kbd>,
+		);
+		// A tailwind-merge override contract: the consumer's font family replaces the
+		// default `font-mono` rather than landing beside it.
+		const kbd = screen.getByTestId("kbd");
+		expect(kbd.className).toContain("font-sans");
+		expect(kbd.className).not.toContain("font-mono");
+	});
+
+	test("forwards ref to the underlying kbd element", () => {
+		const ref = createRef<HTMLElement>();
+		render(<Kbd ref={ref}>K</Kbd>);
+		expect(ref.current?.tagName).toBe("KBD");
+	});
+
+	test("forwards aria-label so a symbol-only key gets an accessible name", () => {
+		render(<Kbd aria-label="Command">⌘</Kbd>);
+		expect(screen.getByLabelText("Command")).toHaveTextContent("⌘");
+	});
+
+	test('renders translate="no" so a translation engine skips the key', () => {
+		render(<Kbd data-testid="kbd">Enter</Kbd>);
+		expect(screen.getByTestId("kbd")).toHaveAttribute("translate", "no");
+	});
+
+	test('keeps translate="no" when a call site passes translate', () => {
+		render(
+			// @ts-expect-error `translate` is omitted from the props type on purpose. This
+			// pins the runtime guard for a caller who spreads a wider props object past it.
+			<Kbd data-testid="kbd" translate="yes">
+				Enter
+			</Kbd>,
+		);
+		expect(screen.getByTestId("kbd")).toHaveAttribute("translate", "no");
+	});
+});

--- a/packages/mantle/src/components/kbd/kbd.tsx
+++ b/packages/mantle/src/components/kbd/kbd.tsx
@@ -22,7 +22,13 @@ import { cx } from "../../utils/cx/cx.js";
  * `aria-label` on the `<Kbd>` or include a visually-hidden label inside,
  * and mark the visible glyph `aria-hidden`.
  *
+ * **Translation.** The `<kbd>` element always carries `translate="no"`, so a
+ * browser translation engine skips the subtree. A translated shortcut names a
+ * key the reader's keyboard does not have. The `translate` prop is omitted from
+ * the type, so no call site can turn the guard off.
+ *
  * @see https://mantle.ngrok.com/components/data-display/kbd
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate
  *
  * @example
  * ```tsx
@@ -43,7 +49,7 @@ import { cx } from "../../utils/cx/cx.js";
  * </Kbd>
  * ```
  */
-function Kbd({ children, className, ...props }: ComponentProps<"kbd">) {
+function Kbd({ children, className, ...props }: Omit<ComponentProps<"kbd">, "translate">) {
 	return (
 		<kbd
 			data-slot="kbd"
@@ -53,6 +59,9 @@ function Kbd({ children, className, ...props }: ComponentProps<"kbd">) {
 				className,
 			)}
 			{...props}
+			// Why after the spread: a wider props object can still carry `translate`
+			// past the type, and a translated shortcut key names the wrong key.
+			translate="no"
 		>
 			{children}
 		</kbd>

--- a/packages/mantle/src/components/popover/popover.browser.test.tsx
+++ b/packages/mantle/src/components/popover/popover.browser.test.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Popover } from "./popover.js";
+
+/**
+ * Mirrors the CSS Tailwind 4 emits for the utilities this file's geometry leans
+ * on. We inline it instead of importing the full mantle stylesheet so the test
+ * stays hermetic and needs no Tailwind build step.
+ *
+ * `.relative` is deliberately written as Tailwind's own utility rather than a
+ * rule aimed at `[data-slot="popover-content"]`. The component has to emit the
+ * class for the rule to match, so the assertion still fails if it stops doing so.
+ */
+const STYLE = `
+@layer utilities {
+	.relative { position: relative; }
+}
+[data-slot="popover-content"] {
+	background: #fff;
+	border: 1px solid #000;
+	padding: 16px;
+}
+`;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+/** How far the arrow's base reaches past the content's outer edge, in pixels. */
+function baseOverlap() {
+	const arrow = document.querySelector("[data-slot='popover-arrow']");
+	const content = document.querySelector("[data-slot='popover-content']");
+	if (arrow == null || content == null) {
+		throw new Error("expected an open Popover.Content with a Popover.Arrow inside it");
+	}
+	return arrow.getBoundingClientRect().right - content.getBoundingClientRect().left;
+}
+
+describe("Popover.Arrow", () => {
+	test("keeps its offset when the content becomes a containing block", async () => {
+		const user = userEvent.setup();
+		render(
+			<Popover.Root>
+				<Popover.Trigger>Open</Popover.Trigger>
+				<Popover.Content side="right">
+					<Popover.Arrow />
+					<p>Products moved up here</p>
+				</Popover.Content>
+			</Popover.Root>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Open" }));
+		await screen.findByRole("dialog");
+		const settled = baseOverlap();
+
+		// The open animation scales the content, and a scale makes the element a
+		// containing block for the arrow's absolutely-positioned wrapper. `scale: 1`
+		// reproduces that with no visual change, so this isolates the containing
+		// block from the motion. Without `relative` on the content, the wrapper's `0`
+		// offset moves from the border box to the padding box and the arrow jumps by
+		// the content's border width.
+		const content = screen.getByRole("dialog");
+		content.style.scale = "1";
+		content.getBoundingClientRect();
+
+		expect(baseOverlap()).toBeCloseTo(settled, 1);
+	});
+
+	test("overlaps the content's border so the two edges read as one line", async () => {
+		const user = userEvent.setup();
+		render(
+			<Popover.Root>
+				<Popover.Trigger>Open</Popover.Trigger>
+				<Popover.Content side="right">
+					<Popover.Arrow />
+					<p>Products moved up here</p>
+				</Popover.Content>
+			</Popover.Root>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Open" }));
+		await screen.findByRole("dialog");
+
+		// One border width, so the arrow's fill covers the border across its base and
+		// no line cuts the tip off the content. Less would leave that line showing.
+		expect(baseOverlap()).toBeCloseTo(1, 1);
+	});
+});

--- a/packages/mantle/src/components/popover/popover.test.tsx
+++ b/packages/mantle/src/components/popover/popover.test.tsx
@@ -73,6 +73,28 @@ describe("Popover", () => {
 			expect(border).toHaveAttribute("vector-effect", "non-scaling-stroke");
 		});
 
+		test("relies on Popover.Content positioning itself", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Arrow />
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open" }));
+
+			// A cross-element pin, asserted where both sides render together. The arrow's
+			// wrapper is absolutely positioned, so `Popover.Content` has to be its
+			// containing block — otherwise the open animation's `scale` becomes that
+			// containing block for one frame and the arrow lands 1px off. No Tailwind runs
+			// in either vitest project, so the class is the only observable form here;
+			// `popover.browser.test.tsx` measures the geometry it buys.
+			expect(await screen.findByRole("dialog")).toHaveClass("relative");
+		});
+
 		test("takes a consumer className and forwards arbitrary props", async () => {
 			const user = userEvent.setup();
 			render(

--- a/packages/mantle/src/components/popover/popover.test.tsx
+++ b/packages/mantle/src/components/popover/popover.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { Popover } from "./popover.js";
+
+describe("Popover", () => {
+	describe("Arrow", () => {
+		test("renders inside the open content with its data-slot", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Arrow />
+						<p>Products moved up here</p>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open" }));
+
+			const content = await screen.findByRole("dialog");
+			const arrow = content.querySelector("[data-slot='popover-arrow']");
+			expect(arrow?.tagName).toBe("svg");
+			expect(arrow).toHaveAttribute("aria-hidden", "true");
+		});
+
+		test("sizes the svg so Radix offsets the content by the arrow's real height", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Arrow />
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open" }));
+
+			// Radix measures the rendered arrow and adds its height to `sideOffset`, so a
+			// width/height that disagrees with the painted triangle detaches the tip.
+			const arrow = (await screen.findByRole("dialog")).querySelector(
+				"[data-slot='popover-arrow']",
+			);
+			expect(arrow).toHaveAttribute("width", "14");
+			expect(arrow).toHaveAttribute("height", "7");
+			expect(arrow).toHaveAttribute("viewBox", "0 0 30 10");
+		});
+
+		test("strokes only the two slanted edges, so the base does not cut the content's border", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Arrow />
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open" }));
+
+			const arrow = (await screen.findByRole("dialog")).querySelector(
+				"[data-slot='popover-arrow']",
+			);
+			// The filled polygon closes across the base; the stroked polyline does not.
+			expect(arrow?.querySelector("polygon")).toHaveAttribute("points", "0,0 30,0 15,10");
+			const border = arrow?.querySelector("polyline");
+			expect(border).toHaveAttribute("points", "0,0 15,10 30,0");
+			expect(border).toHaveAttribute("fill", "none");
+			// Without this the 1px border scales with the 30x10 viewBox and reads as ~0.5px.
+			expect(border).toHaveAttribute("vector-effect", "non-scaling-stroke");
+		});
+
+		test("takes a consumer className and forwards arbitrary props", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Arrow className="fill-red-500" data-testid="arrow" height={10} width={20} />
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open" }));
+
+			const arrow = await screen.findByTestId("arrow");
+			expect(arrow.getAttribute("class")).toContain("fill-red-500");
+			expect(arrow).toHaveAttribute("width", "20");
+			expect(arrow).toHaveAttribute("height", "10");
+		});
+	});
+
+	describe("Content", () => {
+		test("opens on trigger click and closes on Escape, returning focus to the trigger", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Arrow />
+						<p>Products moved up here</p>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			const trigger = screen.getByRole("button", { name: "Open" });
+			expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+			await user.click(trigger);
+			expect(await screen.findByText("Products moved up here")).toBeInTheDocument();
+			expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+			await user.keyboard("{Escape}");
+			expect(screen.queryByText("Products moved up here")).not.toBeInTheDocument();
+			expect(trigger).toHaveFocus();
+		});
+	});
+});

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -166,6 +166,78 @@ const Content = ({
 	</PopoverPrimitive.Portal>
 );
 
+type PopoverArrowProps = Omit<
+	ComponentProps<typeof PopoverPrimitive.Arrow>,
+	"asChild" | "children"
+>;
+
+/**
+ * An optional tip that points from `Popover.Content` at its anchor. Render it as
+ * a child of `Popover.Content`. Radix positions it with floating-ui's arrow
+ * middleware, so it stays centered on the anchor when collision detection shifts
+ * or flips the content. It also repaints `Popover.Content`'s fill and border
+ * across its base, so the two edges read as one line, and carries its own shadow,
+ * clipped at that base so it never darkens the content's interior.
+ *
+ * @see https://mantle.ngrok.com/components/overlays/popover#popoverarrow
+ *
+ * @example
+ * ```tsx
+ * <Popover.Root>
+ *   <Popover.Trigger asChild>
+ *     <Button type="button" appearance="outlined" intent="neutral">
+ *       Open Popover
+ *     </Button>
+ *   </Popover.Trigger>
+ *   <Popover.Content side="right">
+ *     <Popover.Arrow />
+ *     <p>This is the popover content.</p>
+ *   </Popover.Content>
+ * </Popover.Root>
+ * ```
+ */
+const Arrow = ({ className, height = 7, width = 14, ...props }: PopoverArrowProps) => (
+	// Why no asChild: the shape is two layers — a filled polygon, plus a polyline
+	// that strokes the slanted edges only — and a swapped element loses the border
+	// that continues `Popover.Content`'s edge. Restyle with `className` instead.
+	<PopoverPrimitive.Arrow
+		aria-hidden="true"
+		asChild
+		data-slot="popover-arrow"
+		height={height}
+		width={width}
+		{...props}
+	>
+		<svg
+			className={cx(
+				// The wrapper Radix renders sits the base flush on the content's outer
+				// edge, where the content's own border still paints. `-translate-y-px`
+				// sinks the base 1px in — toward the content on every side, since Radix
+				// rotates the wrapper per side — so the fill covers that border.
+				"-translate-y-px fill-[var(--background-color-popover)]",
+				// Why filter and clip-path: `Popover.Content`'s `shadow-md` stops at its
+				// own border, so an unshadowed tip reads as pasted on. The filter casts
+				// the tip's own shadow, and the clip trims it at the base, because the
+				// arrow paints above the content and the shadow would otherwise darken
+				// the content's interior. Both layers stay symmetric — Radix rotates the
+				// wrapper per side, which would swing an offset shadow with it.
+				"[clip-path:inset(0_-200%_-200%_-200%)]",
+				"[filter:drop-shadow(0_0_6px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-first-opacity),transparent))_drop-shadow(0_0_2px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent))]",
+				className,
+			)}
+		>
+			<polygon points="0,0 30,0 15,10" />
+			<polyline
+				className="stroke-[color:var(--border-color-popover)]"
+				fill="none"
+				points="0,0 15,10 30,0"
+				strokeWidth={1}
+				vectorEffect="non-scaling-stroke"
+			/>
+		</svg>
+	</PopoverPrimitive.Arrow>
+);
+
 /**
  * A floating overlay that displays rich content in a portal, triggered by a button.
  *
@@ -196,6 +268,7 @@ const Content = ({
  * ├── Popover.Trigger
  * ├── Popover.Anchor
  * └── Popover.Content
+ *     ├── Popover.Arrow
  *     └── Popover.Close
  * ```
  *
@@ -260,6 +333,33 @@ const Popover = {
 	 * ```
 	 */
 	Anchor,
+	/**
+	 * An optional tip that points from `Popover.Content` at its anchor. It stays
+	 * centered on the anchor when collision detection shifts or flips the content,
+	 * and its border continues `Popover.Content`'s own edge.
+	 *
+	 * @see https://mantle.ngrok.com/components/overlays/popover#popoverarrow
+	 *
+	 * @example
+	 * ```tsx
+	 * <Popover.Root>
+	 *   <Popover.Anchor asChild>
+	 *     <button type="button">Anchor</button>
+	 *   </Popover.Anchor>
+	 *   <Popover.Trigger asChild>
+	 *     <Button type="button" appearance="outlined" intent="neutral">Open Popover</Button>
+	 *   </Popover.Trigger>
+	 *   <Popover.Content side="right">
+	 *     <Popover.Arrow />
+	 *     <Text>Products moved up here</Text>
+	 *     <Popover.Close asChild>
+	 *       <Button type="button" appearance="outlined" intent="neutral">Got it</Button>
+	 *     </Popover.Close>
+	 *   </Popover.Content>
+	 * </Popover.Root>
+	 * ```
+	 */
+	Arrow,
 	/**
 	 * A button that closes an open popover. Can be placed anywhere within the popover content.
 	 *

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -206,9 +206,11 @@ type PopoverArrowProps = Omit<
  * ```
  */
 const Arrow = ({ className, height = 7, width = 14, ...props }: PopoverArrowProps) => (
-	// Why no asChild: the shape is two layers — a filled polygon, plus a polyline
-	// that strokes the slanted edges only — and a swapped element loses the border
-	// that continues `Popover.Content`'s edge. Restyle with `className` instead.
+	// Why no asChild prop: a swapped element loses the two-layer shape — a filled
+	// polygon, plus a polyline that strokes the slanted edges only — that continues
+	// `Popover.Content`'s border. `PopoverArrowProps` omits the prop, so restyle with
+	// `className` instead. The `asChild` below is mantle's own, and hands that shape
+	// to the primitive.
 	<PopoverPrimitive.Arrow
 		aria-hidden="true"
 		asChild

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -116,6 +116,10 @@ type PopoverContentProps = ComponentProps<typeof PopoverPrimitive.Content> & {
  * z-index. When multiple shared layers are open, the most recently mounted
  * layer renders on top.
  *
+ * It sets `position: relative`, so `Popover.Arrow`'s absolutely-positioned
+ * wrapper keeps one containing block through the open animation. An
+ * absolutely-positioned child of the content therefore anchors to the content.
+ *
  * @see https://mantle.ngrok.com/components/overlays/popover#popovercontent
  *
  * @example
@@ -147,6 +151,11 @@ const Content = ({
 			align={align}
 			data-slot="popover-content"
 			className={cx(
+				// Why relative: `Popover.Arrow`'s wrapper is absolutely positioned, and the
+				// open animation's `scale` makes this element its containing block for one
+				// frame — then drops it, moving the arrow 1px. Positioning this element
+				// keeps that containing block the same before, during, and after.
+				"relative",
 				"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
 				preferredWidth,
 				className,
@@ -210,19 +219,20 @@ const Arrow = ({ className, height = 7, width = 14, ...props }: PopoverArrowProp
 	>
 		<svg
 			className={cx(
-				// The wrapper Radix renders sits the base flush on the content's outer
-				// edge, where the content's own border still paints. `-translate-y-px`
-				// sinks the base 1px in — toward the content on every side, since Radix
-				// rotates the wrapper per side — so the fill covers that border.
-				"-translate-y-px fill-[var(--background-color-popover)]",
+				// `Popover.Content` is the wrapper's containing block, so Radix's own
+				// `0` offset resolves to that content's padding box — the base lands 1px
+				// inside the border box, and the fill covers the border it sits on.
+				"fill-[var(--background-color-popover)]",
 				// Why filter and clip-path: `Popover.Content`'s `shadow-md` stops at its
 				// own border, so an unshadowed tip reads as pasted on. The filter casts
 				// the tip's own shadow, and the clip trims it at the base, because the
 				// arrow paints above the content and the shadow would otherwise darken
-				// the content's interior. Both layers stay symmetric — Radix rotates the
-				// wrapper per side, which would swing an offset shadow with it.
+				// the content's interior. One wide, faint layer only, matching what the
+				// content's shadow leaves along the edge the tip grows out of — a tighter
+				// layer muddies a shape this small. The offsets stay symmetric, since
+				// Radix rotates the wrapper per side and would swing an offset with it.
 				"[clip-path:inset(0_-200%_-200%_-200%)]",
-				"[filter:drop-shadow(0_0_6px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-first-opacity),transparent))_drop-shadow(0_0_2px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-second-opacity),transparent))]",
+				"[filter:drop-shadow(0_0_4px_color-mix(in_oklab,var(--shadow-color)_var(--shadow-first-opacity),transparent))]",
 				className,
 			)}
 		>
@@ -231,7 +241,11 @@ const Arrow = ({ className, height = 7, width = 14, ...props }: PopoverArrowProp
 				className="stroke-[color:var(--border-color-popover)]"
 				fill="none"
 				points="0,0 15,10 30,0"
-				strokeWidth={1}
+				// Why 1.5 against the content's 1px border: antialiasing spreads a
+				// diagonal hairline across two device rows at partial coverage, so a
+				// geometric 1px reads thinner than the content's axis-aligned edge.
+				// Measured against that edge at 1x and 2x, 1.5 matches it.
+				strokeWidth={1.5}
 				vectorEffect="non-scaling-stroke"
 			/>
 		</svg>


### PR DESCRIPTION
## Why

Two reported gaps, both about what a floating or code surface owes a consumer.

**#1403 — no `Popover.Arrow`.** A popover that explains one specific control needs a tip pointing at it. Radix ships the part; mantle did not re-export it. Consumers hand-roll the tip instead, which loses what the Radix part exists for: floating-ui's arrow middleware keeps the tip on the anchor when collision detection shifts or flips the content. A hand-rolled tip is a fixed offset, so it drifts as soon as the content moves, and it needs a pinned `align` per anchor to land on the right row at all. Matching the tip to `Content`'s surface — the fill, the border, and the shadow that stops at the border — is design-system work.

**#1402 — code was translatable.** A browser translation engine translates the text inside `<code>` and `<kbd>` like any other prose. A translated CLI flag, YAML key, env var, or shortcut key is wrong, and the reader copies it anyway. There is a second reason: Google Translate replaces each text node with a `<font>` wrapper, which detaches the text nodes React holds, so React either writes an update into a node the DOM no longer shows or throws `NotFoundError` from `removeChild` and tears the root down.

## How

`Popover.Arrow` and `HoverCard.Arrow` wrap the Radix part. Radix renders the arrow as an `svg`, where `bg-*` paints nothing, so each part is two layers: a polygon filled with the popover surface, and a polyline that strokes the two slanted edges only. The base carries no stroke and sits 1px inside the content, so the fill covers the content's own border across the base and the two lines read as one. A `drop-shadow` filter built from mantle's `--shadow-color` and `--shadow-*-opacity` tokens gives the tip the shadow `box-shadow` cannot reach, and a `clip-path` trims it at the base so it never darkens the content's interior. Both shadow layers are symmetric, since Radix rotates the arrow's wrapper per side and an offset shadow would swing with it. Neither part takes `asChild`, because a swapped element loses the shape.

`Tooltip` gets no new part: `Tooltip.Content` already renders its own arrow, so exporting one would draw two.

`Code`, `Kbd`, `CodeBlock.Code`, and `CodeBlock.Title` stamp `translate="no"`. The guard is not overridable — each part omits `translate` from its props type, and stamps the attribute after the props spread so a wider props object cannot carry a value past the type either. `CodeBlock.Title` is included because the title usually names a file, and a translated `example.ts` names a file that does not exist.

## Validation

- Arrow styling reviewed in Chromium at 12× zoom, light and dark, on `side="right"` and `side="bottom"`: the border runs unbroken from the content's edge through the tip, no line crosses the base, the shadow continues the content's shadow outside, and none of it lands on the content's interior.
- New `popover`, `hover-card`, `code`, and `kbd` test files; the popover and hover-card suites drive open with `user.click` / `user.hover` and assert `Escape` dismissal and focus return.
- The `translate` guard is pinned on all four parts, each with a `@ts-expect-error` case proving a passed `translate` still renders `no`.
- The arrow's shadow classes carry no test: no Tailwind runs in either vitest project, so asserting the class string would observe nothing.
