### PR TITLE
fix: wrap text children so browser translation cannot crash the page

### DIFF
--- a/.changeset/translation-safe-labels.md
+++ b/.changeset/translation-safe-labels.md
@@ -1,0 +1,11 @@
+---
+"@ngrok/mantle": patch
+---
+
+Fix a crash on browser-translated pages. `Button` threw `DOMException: Failed to execute 'insertBefore' on 'Node'` the moment `isLoading` turned on, which tore down the React root and blanked the page. `Badge`, `Anchor`, `DataTable.HeaderSortButton`, and `DataTable.ActionHeader` shared the same failure.
+
+Google Translate wraps each text node in a `<font>` element, which reparents the original node: React's reference to it stays alive, but its parent is now the `<font>`. An `insertBefore` aimed at that node then names a child its parent no longer owns, and the DOM raises `NotFoundError`. Every affected component rendered a conditional element immediately before bare `children`, so the first click of any submit button threw before the loading spinner could render.
+
+`Button`, `Badge`, and `Anchor` now render `children` inside a span carrying a new `data-slot` — `button-label`, `badge-label`, and `anchor-label`. Each one is public API: target it to style the label, for example with `min-w-0 truncate` to clamp a long one. `DataTable.HeaderSortButton` keeps its screen-reader sort announcer mounted at all times, and `DataTable.ActionHeader` renders its sticky-column indicator after `children`.
+
+One layout note. The label is a single flex item, so `Button`'s and `Badge`'s `gap` falls between the icon slot and the label, never between two `children`. A call site that passed an icon as a child instead of through `icon` loses that gap, and `<Button icon={<PlusIcon />}>Create endpoint</Button>` is the intended shape. A call site that keeps a trailing hint as a child owns its own spacing.

--- a/apps/www/app/components/command-palette.tsx
+++ b/apps/www/app/components/command-palette.tsx
@@ -192,7 +192,10 @@ export function CommandPalette() {
 			>
 				<span className="sr-only">Search Mantle</span>
 				Search
-				<span className="inline-flex gap-1 items-center pointer-events-none select-none">
+				{/* `ms-1.5` because Button's children share one label slot, so the
+				    button's own `gap` falls between the icon and the label — not
+				    between the word and this shortcut hint. */}
+				<span className="ms-1.5 inline-flex gap-1 items-center pointer-events-none select-none">
 					<MetaKey />
 					<Kbd>K</Kbd>
 				</span>

--- a/apps/www/app/docs/components/actions/button.mdx
+++ b/apps/www/app/docs/components/actions/button.mdx
@@ -6,6 +6,7 @@ description: Initiates an action, such as completing a task or submitting inform
 import { Button, IconButton } from "@ngrok/mantle/button";
 import { CopyIcon } from "@phosphor-icons/react/Copy";
 import { FireIcon } from "@phosphor-icons/react/Fire";
+import { PlusIcon } from "@phosphor-icons/react/Plus";
 import { Link, href } from "react-router";
 import { Example } from "~/components/example";
 
@@ -231,6 +232,35 @@ import { CopyIcon } from "@phosphor-icons/react/Copy";
 />;
 ```
 
+An icon is also not a child. `children` share one label slot, so an icon passed as a child sits flush against the text — the button's `gap` falls between the `icon` slot and the label, not between two children. Pass it through `icon`.
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { PlusIcon } from "@phosphor-icons/react/Plus";
+
+// ❌ Wrong — the icon lands inside the label slot, with no gap
+<Button appearance="filled" intent="neutral">
+	<PlusIcon />
+	Create endpoint
+</Button>;
+```
+
+<Example>
+	<Button appearance="filled" intent="neutral" icon={<PlusIcon />}>
+		Create endpoint
+	</Button>
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { PlusIcon } from "@phosphor-icons/react/Plus";
+
+// ✅ Correct — `icon` gets its own slot beside the label
+<Button appearance="filled" intent="neutral" icon={<PlusIcon />}>
+	Create endpoint
+</Button>;
+```
+
 ## isLoading
 
 `isLoading` sets whether the button is in a loading state, default `false`. Setting `isLoading` replaces any `icon` with a spinner, or adds one when the button has no icon. It also disables user interaction with the button and sets `aria-disabled`.
@@ -343,3 +373,10 @@ All props from [button](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 | `isLoading?`     | `boolean`                                           | `false`    | Whether the button is in a loading state. Setting `isLoading` replaces any `icon` with a spinner, or adds one when the button has no icon. It also disables user interaction with the button and sets `aria-disabled`.                                                                                                                                                                                     |
 | `size?`          | `"xs"` \| `"sm"` \| `"md"` \| `"lg"` \| `"xl"`      | `"md"`     | The size of the `Button`, controlling its box height and horizontal padding. Shared scale with `IconButton` — the same size name renders the same box height. Has no effect when `appearance="link"`.                                                                                                                                                                                                      |
 | `type?`          | `"button"` \| `"reset"` \| `"submit"`               | `"button"` | The behavior of the `Button` when activated. Defaults to `"button"`, so a `Button` inside a `<form>` will **not** submit it — pass `type="submit"` to submit the form. When `asChild` is used, `type` has no effect and is not forwarded to the child. See [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type) for more information.                                     |
+
+#### Data attributes
+
+| Data Attribute | Value            | Description                                                                                                                                     |
+| -------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-slot`    | `"button"`       | On the button element. Stable styling hook that survives a `className` override or an `asChild` swap.                                           |
+| `data-slot`    | `"button-label"` | On the `<span>` wrapping `children`, beside the `icon` slot. Target it to style the label — for example `min-w-0 truncate` to clamp a long one. |

--- a/apps/www/app/docs/components/data-display/badge.mdx
+++ b/apps/www/app/docs/components/data-display/badge.mdx
@@ -88,3 +88,10 @@ All props from [span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
 | `asChild?`   | `boolean`                                                                                                                                                                                                                                                   | `false`     | Use the `asChild` prop to compose the `Badge` styling onto alternative element types or your own React components. |
 | `color?`     | `"neutral"` \| `"danger"` \| `"important"` \| `"info"` \| `"success"` \| `"warning"` \| `"blue"` \| `"cyan"` \| `"fuchsia"` \| `"gray"` \| `"green"` \| `"indigo"` \| `"lime"` \| `"orange"` \| `"pink"` \| `"purple"` \| `"red"` \| `"teal"` \| `"yellow"` | `"neutral"` | The color variant of the `Badge`. Supports all [named colors](/base/colors), both functional and from the palette. |
 | `icon?`      | `ReactNode`                                                                                                                                                                                                                                                 |             | An icon to render inside the badge. Will be automatically sized for you.                                           |
+
+#### Data attributes
+
+| Data Attribute | Value           | Description                                                                                          |
+| -------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
+| `data-slot`    | `"badge"`       | On the badge element. Stable styling hook that survives a `className` override or an `asChild` swap. |
+| `data-slot`    | `"badge-label"` | On the `<span>` wrapping `children`, beside the `icon` slot. Target it to style the label text.      |

--- a/apps/www/app/docs/components/feedback/empty.mdx
+++ b/apps/www/app/docs/components/feedback/empty.mdx
@@ -21,8 +21,7 @@ inside tables, lists, or pages that have no results.
 			<p>Create your first endpoint to get started.</p>
 		</Empty.Description>
 		<Empty.Actions>
-			<Button type="button" appearance="filled" intent="neutral">
-				<PlusIcon />
+			<Button type="button" appearance="filled" intent="neutral" icon={<PlusIcon />}>
 				Create endpoint
 			</Button>
 		</Empty.Actions>
@@ -41,8 +40,7 @@ import { GhostIcon, PlusIcon } from "@phosphor-icons/react";
 		<p>Create your first endpoint to get started.</p>
 	</Empty.Description>
 	<Empty.Actions>
-		<Button type="button" appearance="filled" intent="neutral">
-			<PlusIcon />
+		<Button type="button" appearance="filled" intent="neutral" icon={<PlusIcon />}>
 			Create endpoint
 		</Button>
 	</Empty.Actions>

--- a/apps/www/app/docs/components/navigation/anchor.mdx
+++ b/apps/www/app/docs/components/navigation/anchor.mdx
@@ -111,3 +111,10 @@ All props from [a](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#a
 | `icon?`          | `ReactNode`          |           | An icon to render inside the anchor.                                                                                |
 | `iconPlacement?` | `"start"` \| `"end"` | `"start"` | The side that the icon will render on, if one is present.                                                           |
 | `asChild?`       | `boolean`            | `false`   | Use the `asChild` prop to compose the `Anchor` styling onto alternative element types or your own React components. |
+
+#### Data attributes
+
+| Data Attribute | Value            | Description                                                                                            |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `data-slot`    | `"anchor"`       | On the anchor element. Stable styling hook that survives a `className` override or an `asChild` swap.  |
+| `data-slot`    | `"anchor-label"` | On the inline `<span>` wrapping `children`, between the two `icon` slots. Target it to style the text. |

--- a/apps/www/app/docs/components/structure/well.mdx
+++ b/apps/www/app/docs/components/structure/well.mdx
@@ -74,8 +74,7 @@ container should also be a more semantic element, such as a labelled
 					<p>Try adjusting your search or filters to find what you're looking for.</p>
 				</Empty.Description>
 				<Empty.Actions>
-					<Button type="button" appearance="filled" intent="neutral">
-						<PlusIcon />
+					<Button type="button" appearance="filled" intent="neutral" icon={<PlusIcon />}>
 						Create new
 					</Button>
 				</Empty.Actions>
@@ -99,8 +98,7 @@ import { MagnifyingGlassIcon, PlusIcon } from "@phosphor-icons/react";
 				<p>Try adjusting your search or filters to find what you're looking for.</p>
 			</Empty.Description>
 			<Empty.Actions>
-				<Button type="button" appearance="filled" intent="neutral">
-					<PlusIcon />
+				<Button type="button" appearance="filled" intent="neutral" icon={<PlusIcon />}>
 					Create new
 				</Button>
 			</Empty.Actions>

--- a/decisions/2026-08-04-translation-safe-label-wrappers.md
+++ b/decisions/2026-08-04-translation-safe-label-wrappers.md
@@ -1,0 +1,148 @@
+# Wrap bare text children so a browser translation engine cannot crash the page
+
+**Date:** 2026-08-04
+**Status:** Accepted
+**Applies to:** `@ngrok/mantle/button`, `@ngrok/mantle/badge`, `@ngrok/mantle/anchor`, `@ngrok/mantle/data-table`, and every future part that renders a conditional element beside bare text children
+**Issue:** [ngrok/mantle#1407](https://github.com/ngrok/mantle/issues/1407)
+
+## Context
+
+On a page that a browser translation engine has translated, `Button` threw as
+soon as `isLoading` turned on:
+
+```
+DOMException: Failed to execute 'insertBefore' on 'Node': The node before which
+the new node is to be inserted is not a child of this node.
+```
+
+React re-throws the raw `DOMException`. Without an error boundary above the
+button, the React root tears down. The page then goes blank. `Badge`, `Anchor`,
+`DataTable.HeaderSortButton`, and `DataTable.ActionHeader` shared the shape and
+the failure.
+
+### The mechanism
+
+Google Translate wraps each text node in a `<font style="vertical-align:
+inherit;">`. It **reparents** the original text node: React's reference to it
+stays alive, but its parent is now the `<font>` rather than the element React
+rendered it into.
+
+Every affected component rendered a conditional element immediately before bare
+`{children}`:
+
+```tsx
+{icon && <Icon svg={icon} … />}
+{children}
+```
+
+When `icon` appears, React inserts it before the children text node — it calls
+`button.insertBefore(icon, childrenTextNode)`. That text node is no longer a
+child of the button, so the DOM raises `NotFoundError`.
+
+`isLoading` is what made this fire on ordinary use, because `Button` synthesizes
+the icon from it. The first click of any submit button threw before the loading
+state could render. `iconPlacement="end"` did not help: that placement is CSS
+`order-last`, so the DOM order is unchanged.
+
+### What the mutation does and does not break
+
+The failure needs React to insert before, or remove, a **text** node that
+translation reparented:
+
+| Update                                          | Result                                  |
+| ----------------------------------------------- | --------------------------------------- |
+| Insert an element before a translated text node | Throws                                  |
+| Remove a text child while siblings remain       | Throws                                  |
+| A text child changes type to an element         | Throws                                  |
+| Change a text child's value                     | Safe. The translation reverts.          |
+| Reorder or remove **element** children          | Safe. Elements are never reparented.    |
+| **Append** after a translated text node         | Safe.                                   |
+| Unmount the whole subtree                       | Safe. React removes the outermost node. |
+| A **lone** expression child                     | Safe, and self-healing.                 |
+
+The last row is the one to design toward. When `children` is the only child of a
+host element, React updates it through `setTextContent`, which falls back to
+`node.textContent = text` whenever the first child is not a text node. That
+write wipes the `<font>` wrapper and repairs the subtree instead of fighting it.
+
+## Decisions
+
+### 1. A component's text children get a stable element wrapper
+
+`Button`, `Badge`, and `Anchor` wrap `children` in a span carrying a
+`data-slot`, so a newly-appearing icon inserts before an **element** sibling:
+
+```tsx
+{icon && <Icon svg={icon} … />}
+<span data-slot="button-label">{children}</span>
+```
+
+The slot names are `button-label`, `badge-label`, and `anchor-label`. Each is
+public API — a consumer may target it to style the label, for example to clamp a
+long one with `min-w-0 truncate`. `Select.Item` was already the precedent in the
+library: it has the identical `{icon && …}` shape but wraps children in
+`SelectPrimitive.ItemText`, so it never threw.
+
+Both the plain and the `asChild` path wrap, because both render the same shape.
+
+### 2. The label is one flex item. Pass an icon through `icon`, not as a child
+
+`Button` and `Badge` are flex containers, and bare text children were an
+anonymous flex item. A real span is one flex item too, so a single-child button
+lays out identically — but multiple children now share one item, and the
+container's `gap` no longer falls between them.
+
+This is the trade-off the decision accepts, and it points call sites at the API
+that was always intended: `<Button icon={<PlusIcon />}>Create endpoint</Button>`,
+never `<Button><PlusIcon />Create endpoint</Button>`. A call site that keeps a
+trailing hint as a child owns its own spacing.
+
+We considered a `display: contents` wrapper, which would preserve the flex
+structure exactly. We rejected it: it makes the new `data-slot` unstylable,
+which defeats half the reason to name it.
+
+### 3. An always-mounted announcer takes a lone string child
+
+Wrapping a component's own children does not help a part that renders a
+conditional element beside children it received. `DataTable.HeaderSortButton`
+mounted its screen-reader sort announcement only while sorted, immediately before
+the header label, so the first click on any sortable column threw.
+
+That announcer is now always mounted and takes a single computed string from the
+pure `sortStateAnnouncement` function — an empty string when the column is
+unsorted. Every sort change is then a `textContent` write, which is both safe and
+self-healing. The announcer is `sr-only`, so it is absolutely positioned and
+never a flex item; mounting it unconditionally costs no layout.
+
+### 4. A decorative, absolutely positioned sibling moves after children
+
+`DataTable.ActionHeader` mounted its sticky-column indicator before `children`
+once the table had rows, so a table loading its first page threw. The indicator
+is `aria-hidden`, `pointer-events-none`, and absolutely positioned outside the
+cell's content box, so DOM order buys nothing there. Rendering it last turns the
+mount into an `appendChild`.
+
+Prefer this over a wrapper when the conditional element is decorative and
+out of flow. It adds no DOM.
+
+## Consequences
+
+- Consumer CSS that targeted a button's, badge's, or anchor's text through a
+  structural selector may need the new `data-slot` instead.
+- The pattern to avoid is now nameable in review: **never render a conditional
+  element immediately before bare text children.** Wrap the text, move the
+  element after it, or mount the element unconditionally.
+- `IconButton` needed no change. Both its children are always mounted, and its
+  `sr-only` label already takes a lone string child.
+
+## Caveats
+
+The regression tests reproduce the mutation in happy-dom. A hand check confirms
+Chromium matches on all three counts: `insertBefore` and `removeChild` both raise
+`NotFoundError` against a reparented text node, and a `textContent` write removes
+the `<font>` wrapper. The sortable `DataTable` header also sorts twice with no
+page error against a translated DOM.
+
+The model is a reparent, which is what Google Translate does. An engine that
+instead detaches and replaces the text node would produce a different symptom.
+Safari and Firefox translation are unverified.

--- a/packages/mantle/src/components/anchor/anchor.test.tsx
+++ b/packages/mantle/src/components/anchor/anchor.test.tsx
@@ -1,5 +1,54 @@
+import { BookIcon } from "@phosphor-icons/react/Book";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
-import { resolveRel } from "./anchor.js";
+import { translateTextNodes } from "../../test-utils/translate-text-nodes.js";
+import { Anchor, resolveRel } from "./anchor.js";
+
+describe("Anchor", () => {
+	test(`wraps children in a span carrying data-slot="anchor-label"`, () => {
+		render(<Anchor href="https://ngrok.com/">ngrok.com</Anchor>);
+
+		const label = screen.getByRole("link").querySelector("[data-slot='anchor-label']");
+		expect(label?.tagName).toBe("SPAN");
+		expect(label).toHaveTextContent("ngrok.com");
+	});
+
+	describe("on a browser-translated page", () => {
+		test("keeps rendering when a leading `icon` appears", () => {
+			const { rerender } = render(<Anchor href="https://ngrok.com/docs">ngrok docs</Anchor>);
+			translateTextNodes(screen.getByRole("link"));
+
+			rerender(
+				<Anchor href="https://ngrok.com/docs" icon={<BookIcon />}>
+					ngrok docs
+				</Anchor>,
+			);
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveTextContent("[ngrok docs-es]");
+			expect(link.querySelector("svg")).toBeInTheDocument();
+		});
+
+		test("keeps rendering when a leading `icon` appears with `asChild`", () => {
+			const { rerender } = render(
+				<Anchor asChild>
+					<a href="https://ngrok.com/docs">ngrok docs</a>
+				</Anchor>,
+			);
+			translateTextNodes(screen.getByRole("link"));
+
+			rerender(
+				<Anchor asChild icon={<BookIcon />}>
+					<a href="https://ngrok.com/docs">ngrok docs</a>
+				</Anchor>,
+			);
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveTextContent("[ngrok docs-es]");
+			expect(link.querySelector("svg")).toBeInTheDocument();
+		});
+	});
+});
 
 describe("resolveRel", () => {
 	test("given nothing or undefined, returns undefined", () => {

--- a/packages/mantle/src/components/anchor/anchor.tsx
+++ b/packages/mantle/src/components/anchor/anchor.tsx
@@ -71,6 +71,14 @@ type AnchorProps = Omit<ComponentProps<"a">, "rel"> &
  * here" / "read more". For purely decorative icons, no extra labeling is
  * needed; for icon-only links, pass an `aria-label`.
  *
+ * **Structure.** `children` render inside an inline
+ * `<span data-slot="anchor-label">`, between the two `icon` slots. Target that
+ * slot to style the link text.
+ *
+ * | Data Attribute | Value            | Description                                                                 |
+ * | -------------- | ---------------- | --------------------------------------------------------------------------- |
+ * | `data-slot`    | `"anchor-label"` | On the `<span>` wrapping `children`. Stable styling hook for the link text. |
+ *
  * @see https://mantle.ngrok.com/components/navigation/anchor
  *
  * @example
@@ -134,7 +142,8 @@ const Anchor = ({
 						{icon && iconPlacement === "start" && (
 							<Icon className="inline-block mr-1.5" svg={icon} />
 						)}
-						{grandchildren}
+						{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+						<span data-slot="anchor-label">{grandchildren}</span>
 						{icon && iconPlacement === "end" && <Icon className="inline-block ml-1.5" svg={icon} />}
 					</>,
 				)}
@@ -145,7 +154,8 @@ const Anchor = ({
 	return (
 		<a {...componentProps}>
 			{icon && iconPlacement === "start" && <Icon className="inline-block mr-1.5" svg={icon} />}
-			{children}
+			{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+			<span data-slot="anchor-label">{children}</span>
 			{icon && iconPlacement === "end" && <Icon className="inline-block ml-1.5" svg={icon} />}
 		</a>
 	);

--- a/packages/mantle/src/components/badge/badge.test.tsx
+++ b/packages/mantle/src/components/badge/badge.test.tsx
@@ -1,0 +1,59 @@
+import { CheckCircleIcon } from "@phosphor-icons/react/CheckCircle";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { translateTextNodes } from "../../test-utils/translate-text-nodes.js";
+import { Badge } from "./badge.js";
+
+describe("Badge", () => {
+	test(`wraps children in a span carrying data-slot="badge-label"`, () => {
+		render(
+			<Badge appearance="muted" color="success">
+				Succeeded
+			</Badge>,
+		);
+
+		const badge = screen.getByText("Succeeded", { selector: "[data-slot='badge-label']" });
+		expect(badge.tagName).toBe("SPAN");
+		expect(badge.closest("[data-slot='badge']")).toBeInTheDocument();
+	});
+
+	describe("on a browser-translated page", () => {
+		test("keeps rendering when an `icon` appears", () => {
+			const { rerender } = render(
+				<Badge appearance="muted" color="success" data-testid="badge">
+					Succeeded
+				</Badge>,
+			);
+			translateTextNodes(screen.getByTestId("badge"));
+
+			rerender(
+				<Badge appearance="muted" color="success" data-testid="badge" icon={<CheckCircleIcon />}>
+					Succeeded
+				</Badge>,
+			);
+
+			const badge = screen.getByTestId("badge");
+			expect(badge).toHaveTextContent("[Succeeded-es]");
+			expect(badge.querySelector("svg")).toBeInTheDocument();
+		});
+
+		test("keeps rendering when an `icon` appears with `asChild`", () => {
+			const { rerender } = render(
+				<Badge appearance="muted" color="info" asChild>
+					<a href="/status">Operational</a>
+				</Badge>,
+			);
+			translateTextNodes(screen.getByRole("link"));
+
+			rerender(
+				<Badge appearance="muted" color="info" asChild icon={<CheckCircleIcon />}>
+					<a href="/status">Operational</a>
+				</Badge>,
+			);
+
+			const badge = screen.getByRole("link");
+			expect(badge).toHaveTextContent("[Operational-es]");
+			expect(badge.querySelector("svg")).toBeInTheDocument();
+		});
+	});
+});

--- a/packages/mantle/src/components/badge/badge.tsx
+++ b/packages/mantle/src/components/badge/badge.tsx
@@ -50,6 +50,13 @@ type BadgeProps = ComponentProps<"span"> &
  * element — useful when the badge wraps a link or other semantic element
  * while keeping the badge styling.
  *
+ * **Structure.** `children` render inside a `<span data-slot="badge-label">`,
+ * beside the `icon` slot. Target that slot to style the label text.
+ *
+ * | Data Attribute | Value           | Description                                                                  |
+ * | -------------- | --------------- | ---------------------------------------------------------------------------- |
+ * | `data-slot`    | `"badge-label"` | On the `<span>` wrapping `children`. Stable styling hook for the label text. |
+ *
  * @see https://mantle.ngrok.com/components/data-display/badge
  *
  * @example
@@ -102,7 +109,8 @@ const Badge = ({
 					{},
 					<>
 						{icon && <SvgOnly className="size-4" svg={icon} />}
-						{grandchildren}
+						{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+						<span data-slot="badge-label">{grandchildren}</span>
 					</>,
 				)}
 			</Slot>
@@ -112,7 +120,8 @@ const Badge = ({
 	return (
 		<span data-slot="badge" className={badgeClasses} {...props}>
 			{icon && <SvgOnly className="size-4" svg={icon} />}
-			{children}
+			{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+			<span data-slot="badge-label">{children}</span>
 		</span>
 	);
 };

--- a/packages/mantle/src/components/button/button.test.tsx
+++ b/packages/mantle/src/components/button/button.test.tsx
@@ -1,7 +1,9 @@
+import { PlusIcon } from "@phosphor-icons/react/Plus";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { act, useState } from "react";
 import { describe, expect, test } from "vitest";
+import { translateTextNodes } from "../../test-utils/translate-text-nodes.js";
 import { Button } from "./button.js";
 
 describe("Button", () => {
@@ -322,5 +324,98 @@ describe("Button", () => {
 		expect(screen.getByRole("button")).toHaveAttribute("data-loading", "true");
 		expect(screen.getByTestId("submit-state")).toHaveTextContent("idle");
 		expect(screen.getByTestId("click-state")).toHaveTextContent("idle");
+	});
+
+	describe("on a browser-translated page", () => {
+		test("keeps rendering when `isLoading` turns on", () => {
+			const { rerender } = render(
+				<Button appearance="filled" intent="neutral">
+					Save changes
+				</Button>,
+			);
+			translateTextNodes(screen.getByRole("button"));
+
+			rerender(
+				<Button appearance="filled" intent="neutral" isLoading>
+					Save changes
+				</Button>,
+			);
+
+			const button = screen.getByRole("button");
+			expect(button).toHaveAttribute("data-loading", "true");
+			// The label span takes the spinner's `insertBefore`, so the translated
+			// text node stays where the translation engine put it.
+			expect(button).toHaveTextContent("[Save changes-es]");
+			expect(button.querySelector("svg")).toBeInTheDocument();
+		});
+
+		test("keeps rendering when an `icon` appears", () => {
+			const { rerender } = render(
+				<Button appearance="outlined" intent="neutral">
+					Deploy
+				</Button>,
+			);
+			translateTextNodes(screen.getByRole("button"));
+
+			rerender(
+				<Button appearance="outlined" intent="neutral" icon={<PlusIcon />}>
+					Deploy
+				</Button>,
+			);
+
+			const button = screen.getByRole("button");
+			expect(button).toHaveTextContent("[Deploy-es]");
+			expect(button.querySelector("svg")).toBeInTheDocument();
+		});
+
+		test(`keeps rendering when \`isLoading\` turns on with iconPlacement="end"`, () => {
+			const { rerender } = render(
+				<Button appearance="outlined" intent="neutral" iconPlacement="end">
+					Continue
+				</Button>,
+			);
+			translateTextNodes(screen.getByRole("button"));
+
+			rerender(
+				<Button appearance="outlined" intent="neutral" iconPlacement="end" isLoading>
+					Continue
+				</Button>,
+			);
+
+			const button = screen.getByRole("button");
+			expect(button).toHaveAttribute("data-loading", "true");
+			expect(button).toHaveTextContent("[Continue-es]");
+		});
+
+		test("keeps rendering when `isLoading` turns on with `asChild`", () => {
+			const { rerender } = render(
+				<Button appearance="filled" intent="neutral" asChild>
+					<a href="#yolo">Save changes</a>
+				</Button>,
+			);
+			translateTextNodes(screen.getByRole("link"));
+
+			rerender(
+				<Button appearance="filled" intent="neutral" asChild isLoading>
+					<a href="#yolo">Save changes</a>
+				</Button>,
+			);
+
+			const link = screen.getByRole("link");
+			expect(link).toHaveAttribute("data-loading", "true");
+			expect(link).toHaveTextContent("[Save changes-es]");
+		});
+	});
+
+	test(`wraps children in a span carrying data-slot="button-label"`, () => {
+		render(
+			<Button appearance="filled" intent="neutral">
+				Save changes
+			</Button>,
+		);
+
+		const label = screen.getByRole("button").querySelector("[data-slot='button-label']");
+		expect(label?.tagName).toBe("SPAN");
+		expect(label).toHaveTextContent("Save changes");
 	});
 });

--- a/packages/mantle/src/components/button/button.tsx
+++ b/packages/mantle/src/components/button/button.tsx
@@ -239,6 +239,16 @@ type ButtonProps = ComponentProps<"button"> &
  * while `IconButton` requires a screen-reader `label` and renders a square
  * box on the same shared size scale.
  *
+ * **Structure.** `children` render inside a `<span data-slot="button-label">`,
+ * beside the `icon` slot. Target that slot to style the label — for example, to
+ * clamp a long one with `min-w-0 truncate`. The label is one flex item, so the
+ * button's `gap` falls between the icon and the label, never between two
+ * `children`: pass an icon through `icon`, not as a child.
+ *
+ * | Data Attribute | Value            | Description                                                                  |
+ * | -------------- | ---------------- | ---------------------------------------------------------------------------- |
+ * | `data-slot`    | `"button-label"` | On the `<span>` wrapping `children`. Stable styling hook for the label text. |
+ *
  * @see https://mantle.ngrok.com/components/actions/button
  *
  * @example
@@ -326,7 +336,8 @@ const Button = ({
 					{},
 					<>
 						{icon && <Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />}
-						{children.props.children}
+						{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+						<span data-slot="button-label">{children.props.children}</span>
 					</>,
 				)}
 			</Slot>
@@ -337,7 +348,8 @@ const Button = ({
 		// oxlint-disable-next-line react/button-has-type -- `type` defaults to "button" at runtime via the `?? "button"` fallback; the static analyzer can't resolve that expression.
 		<button {...buttonProps} type={type ?? "button"}>
 			{icon && <Icon svg={icon} className={clsx(iconPlacement === "end" && "order-last")} />}
-			{children}
+			{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+			<span data-slot="button-label">{children}</span>
 		</button>
 	);
 };

--- a/packages/mantle/src/components/data-table/data-table.test.tsx
+++ b/packages/mantle/src/components/data-table/data-table.test.tsx
@@ -3,6 +3,7 @@ import { userEvent } from "@testing-library/user-event";
 import { type ComponentProps, Fragment, type MouseEvent, useMemo, useState } from "react";
 import invariant from "tiny-invariant";
 import { describe, expect, test, vi } from "vitest";
+import { translateTextNodes } from "../../test-utils/translate-text-nodes.js";
 import type { ButtonAppearance, ButtonIntent, IconButtonAppearance } from "../button/index.js";
 import {
 	DataTable,
@@ -140,6 +141,92 @@ describe("DataTable.HeaderSortButton", () => {
 		render(<SortableHarness intent="danger" />);
 		const button = screen.getByRole("button", { name: "Name" });
 		expect(button).not.toHaveClass("text-muted");
+	});
+
+	test("announces the sort direction only once the column is sorted", async () => {
+		const user = userEvent.setup();
+		render(<SortableHarness />);
+		expect(screen.getByRole("button", { name: "Name" })).toHaveAttribute(
+			"data-sort-direction",
+			"unsorted",
+		);
+
+		await user.click(screen.getByRole("button", { name: "Name" }));
+
+		const sorted = screen.getByRole("button", { name: /Column sorted in ascending order/ });
+		expect(sorted).toHaveAttribute("data-sort-direction", "asc");
+
+		await user.click(sorted);
+
+		expect(
+			screen.getByRole("button", { name: /Column sorted in descending order/ }),
+		).toHaveAttribute("data-sort-direction", "desc");
+	});
+
+	test("keeps rendering when the first click sorts a browser-translated header", async () => {
+		const user = userEvent.setup();
+		render(<SortableHarness />);
+		const button = screen.getByRole("button", { name: "Name" });
+		translateTextNodes(button);
+
+		await user.click(button);
+
+		const sorted = screen.getByRole("button");
+		expect(sorted).toHaveAttribute("data-sort-direction", "asc");
+		// The announcer is always mounted, so the sort state arrives as a text
+		// rewrite rather than an insert aimed at the translated header text.
+		expect(sorted).toHaveTextContent("Column sorted in ascending order");
+		expect(sorted).toHaveTextContent("[Name-es]");
+	});
+});
+
+/**
+ * Renders a table whose action column header carries text, so `ActionHeader`'s
+ * empty-to-populated transition can be exercised against a translated header.
+ */
+function ActionHeaderHarness({ rows }: { rows: Row[] }) {
+	const actionColumns = useMemo(
+		() => [
+			columnHelper.accessor("name", {
+				id: "name",
+				header: () => <DataTable.Header>Name</DataTable.Header>,
+				cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+			}),
+			columnHelper.display({
+				id: "actions",
+				header: () => <DataTable.ActionHeader>Actions</DataTable.ActionHeader>,
+				cell: () => <DataTable.ActionCell>Edit</DataTable.ActionCell>,
+			}),
+		],
+		[],
+	);
+	const table = useReactTable({
+		data: rows,
+		columns: actionColumns,
+		getCoreRowModel: getCoreRowModel(),
+	});
+	return (
+		<DataTable.Root table={table}>
+			<DataTable.Head />
+			<DataTable.Body>
+				{table.getRowModel().rows.map((row) => (
+					<DataTable.Row key={row.id} row={row} />
+				))}
+			</DataTable.Body>
+		</DataTable.Root>
+	);
+}
+
+describe("DataTable.ActionHeader", () => {
+	test("keeps rendering when the first page of rows arrives on a browser-translated page", () => {
+		const { rerender } = render(<ActionHeaderHarness rows={[]} />);
+		const header = screen.getByRole("columnheader", { name: "Actions" });
+		translateTextNodes(header);
+
+		rerender(<ActionHeaderHarness rows={data} />);
+
+		expect(screen.getByRole("columnheader", { name: "[Actions-es]" })).toBeInTheDocument();
+		expect(screen.getByRole("cell", { name: "Alice" })).toBeInTheDocument();
 	});
 });
 

--- a/packages/mantle/src/components/data-table/data-table.tsx
+++ b/packages/mantle/src/components/data-table/data-table.tsx
@@ -158,6 +158,48 @@ type DataTableHeaderSortButtonProps<TData, TValue> = Omit<
 		  }
 	);
 
+type SortStateAnnouncementOptions = {
+	/** Whether the column can sort at all. */
+	canSort: boolean;
+	/** The column's current sort direction. */
+	sortDirection: SortDirection;
+	/** The column's sorting mode, absent when sorting is disabled. */
+	sortingMode: SortingMode | undefined;
+};
+
+/**
+ * The screen-reader announcement for a column's current sort state. Returns an
+ * empty string for a column that cannot sort or sits unsorted, so the announcer
+ * element stays mounted with nothing to read out.
+ *
+ * @example
+ * ```ts
+ * sortStateAnnouncement({ canSort: true, sortDirection: "asc", sortingMode: "alphanumeric" })
+ * // => "Column sorted in ascending order"
+ *
+ * sortStateAnnouncement({ canSort: true, sortDirection: "asc", sortingMode: "time" })
+ * // => "Column sorted in oldest-to-newest order"
+ *
+ * sortStateAnnouncement({ canSort: true, sortDirection: "unsorted", sortingMode: "alphanumeric" })
+ * // => ""
+ * ```
+ */
+function sortStateAnnouncement({
+	canSort,
+	sortDirection,
+	sortingMode,
+}: SortStateAnnouncementOptions): string {
+	if (!canSort || sortDirection === "unsorted") {
+		return "";
+	}
+
+	if (sortingMode === "alphanumeric") {
+		return `Column sorted in ${sortDirection === "asc" ? "ascending" : "descending"} order`;
+	}
+
+	return `Column sorted in ${$timeSortingDirection(sortDirection)} order`;
+}
+
 /**
  * A sortable button toggle for a column header in a data table. Renders a sort
  * icon that reflects the current direction, handles ARIA announcements, and
@@ -240,17 +282,13 @@ function HeaderSortButton<TData, TValue>({
 			type="button"
 			{...props}
 		>
-			{canSort && sortDirection !== "unsorted" && (
-				<span className="sr-only">
-					Column sorted in{" "}
-					{sortingMode === "alphanumeric"
-						? sortDirection === "asc"
-							? "ascending"
-							: "descending"
-						: $timeSortingDirection(sortDirection)}{" "}
-					order
-				</span>
-			)}
+			{/* Always mounted, with one string child: mounting it only while sorted
+			    would aim an `insertBefore` at the label, which throws once a
+			    browser translation engine has reparented that text node. See
+			    decisions/2026-08-04-translation-safe-label-wrappers.md. */}
+			<span className="sr-only">
+				{sortStateAnnouncement({ canSort, sortDirection, sortingMode })}
+			</span>
 			{children}
 		</Button>
 	);
@@ -648,8 +686,13 @@ function ActionHeader({ children, className, ...props }: DataTableActionHeaderPr
 			)}
 			{...props}
 		>
-			{hasRows && <StickyColIndicator />}
 			{children}
+			{/* Last, not first: the indicator is absolutely positioned outside the
+			    cell's content box, so DOM order costs nothing here — and mounting it
+			    before `children` would aim an `insertBefore` at header text that a
+			    browser translation engine has reparented, which throws. See
+			    decisions/2026-08-04-translation-safe-label-wrappers.md. */}
+			{hasRows && <StickyColIndicator />}
 		</Table.Header>
 	);
 }

--- a/packages/mantle/src/test-utils/translate-text-nodes.ts
+++ b/packages/mantle/src/test-utils/translate-text-nodes.ts
@@ -1,0 +1,64 @@
+/**
+ * Test-only helper that reproduces what a browser translation engine does to
+ * the DOM, so a component's update path can be asserted against it.
+ *
+ * Google Translate wraps each text node in a `<font>` element. The original
+ * text node is _reparented_ — React's reference to it stays alive, but its
+ * parent is now the `<font>` rather than the element React rendered it into.
+ * A later `insertBefore` or `removeChild` that React aims at that node then
+ * names a node its parent no longer owns, and the DOM raises `NotFoundError`.
+ */
+
+/**
+ * Wrap every non-blank text node under `root` in a `<font>` element and mark
+ * its text, the way Google Translate does. Mutates the subtree in place.
+ *
+ * The `-es` suffix stands in for a translated string, so a test can tell the
+ * translated text apart from what React rendered.
+ *
+ * @param root - The subtree to translate in place.
+ *
+ * @example
+ * ```ts
+ * render(
+ *   <Button appearance="filled" intent="neutral">
+ *     Save changes
+ *   </Button>,
+ * );
+ * translateTextNodes(screen.getByRole("button"));
+ * // => <button …><span data-slot="button-label">
+ * //      <font style="vertical-align: inherit;">[Save changes-es]</font>
+ * //    </span></button>
+ * ```
+ */
+function translateTextNodes(root: Node): void {
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+	const translatable: { node: Node; text: string }[] = [];
+
+	// Collect first, then mutate. Wrapping as the walker advances would make it
+	// step into the `<font>` elements this adds.
+	for (let node = walker.nextNode(); node != null; node = walker.nextNode()) {
+		const text = node.nodeValue?.trim();
+		if (text) {
+			translatable.push({ node, text });
+		}
+	}
+
+	for (const { node, text } of translatable) {
+		const { parentNode } = node;
+		if (parentNode == null) {
+			continue;
+		}
+
+		const font = document.createElement("font");
+		font.setAttribute("style", "vertical-align: inherit;");
+		parentNode.insertBefore(font, node);
+		font.appendChild(node);
+		node.nodeValue = `[${text}-es]`;
+	}
+}
+
+export {
+	//,
+	translateTextNodes,
+};


### PR DESCRIPTION
Closes #1407

## Why

On a page a browser translation engine has translated, `Button` threw as soon as `isLoading` turned on:

```
DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

Google Translate wraps each text node in a `<font>`, which reparents the original node. React's reference stays alive, but its parent is now the `<font>`. Each affected component rendered a conditional element immediately before bare `{children}`, so React aimed an `insertBefore` at a node the parent no longer owned. React re-throws the raw `DOMException`, so the root tears down and the page goes blank.

`isLoading` is what made this fire on ordinary use, because `Button` synthesizes the icon from it. Any submit button threw on its first click. `Badge`, `Anchor`, `DataTable.HeaderSortButton`, and `DataTable.ActionHeader` shared the shape and the failure.

## How

Each site takes the remedy that fits it, rather than one wrapper everywhere.

| Site | Remedy |
| --- | --- |
| `Button`, `Badge`, `Anchor` (plain and `asChild`) | `children` render inside `<span data-slot="…-label">`, so the icon inserts before an element sibling |
| `DataTable.HeaderSortButton` | The sort announcer is always mounted and takes one string from a new pure `sortStateAnnouncement`, so every change is a `textContent` write |
| `DataTable.ActionHeader` | The sticky indicator renders after `children`; it is `aria-hidden` and absolutely positioned outside the content box, so the mount becomes an `appendChild` |

Wrapping `Button`'s children does not cover `HeaderSortButton`, whose own conditional span sat before the children it received — hence its own remedy. `IconButton` needed no change: both its children are always mounted.

`decisions/2026-08-04-translation-safe-label-wrappers.md` records the rule, because a wrapper span with no visible job invites deletion. Each of the six sites carries a one-line pointer to it.

### The layout trade-off

`children` are now one flex item, so a button's `gap` no longer falls between two of them. That points call sites at the API that was always intended — `<Button icon={<PlusIcon />}>Create endpoint</Button>` — and this repo's own docs had four call sites doing it the other way. Those are fixed, Common mistakes now covers it, and the docs header's ⌘K hint takes an explicit `ms-1.5` where it used to lean on the gap.

A `display: contents` wrapper would keep the flex structure exactly. Rejected: it makes the new `data-slot` unstylable, which defeats half the reason to name it.

`patch`, not `minor`: the API is unchanged and nothing stops compiling. The only effect is a spacing shift on call sites that passed an icon as a child, which reads as VERSIONING's "visual or styling change that keeps the API."

## Validation

- **Red then green.** With the four implementation files stashed and the tests kept, all 13 new assertions fail with the exact `DOMException` from the issue.
- **Chromium, closing the issue's open caveat.** `insertBefore` and `removeChild` both raise `NotFoundError` against a reparented text node, and a `textContent` write removes the `<font>`. Against the running docs site with a translated DOM, the sortable header sorts twice with zero page errors.
- **Visual check.** Screenshotted the icon, size, and `isLoading` rows, badges with and without icons, anchor start and end icons, the Empty and Well examples, and the sorted table. Spacing is unchanged throughout.
- `components-surface.json` needs no regeneration — it captures the first JSDoc sentence and `@example` blocks, neither of which changed.
- Unrelated, and present on clean `main`: `code-block.test.tsx`'s "fires onCopyError when clipboard write fails" fails under `--sequence.shuffle --sequence.seed=7`.