### PR TITLE
feat(oxlint-plugin): add house lint rules for translation crashes

### DIFF
--- a/.changeset/oxlint-plugin-translation-rules.md
+++ b/.changeset/oxlint-plugin-translation-rules.md
@@ -1,0 +1,33 @@
+---
+"@ngrok/oxlint-plugin": minor
+---
+
+Add `@ngrok/oxlint-plugin`, ngrok's house oxlint rules under the `ngrok` namespace. The first three read a JSX
+tree for the shapes a browser translation engine turns into a blank page, so review no longer carries the whole
+burden of `CONVENTIONS.md § Browser Translation`.
+
+`ngrok/jsx-no-conditional-before-text` reports a conditional element that renders immediately before a bare
+text child. Google Translate reparents the text node, so the element's `insertBefore` names a node the parent
+no longer owns, the DOM raises `NotFoundError`, and the root tears down. This is the `Button` crash, and the
+rule catches the `{children}` spelling of it without type information.
+
+`ngrok/jsx-no-conditional-text-with-siblings` reports a conditional text child that can unmount, or change into
+an element, while a sibling stays mounted — the `removeChild` half of the same failure. A conditional whose
+every branch renders text is safe and the rule leaves it alone, because React writes the new value in place.
+
+`ngrok/jsx-require-translate-no` reports an element that holds untranslatable content but carries no
+`translate="no"`. It checks `kbd` and `samp` by default, and `elements` names more.
+
+```json
+{
+	"jsPlugins": ["@ngrok/oxlint-plugin"],
+	"rules": {
+		"ngrok/jsx-no-conditional-before-text": "error",
+		"ngrok/jsx-no-conditional-text-with-siblings": "error",
+		"ngrok/jsx-require-translate-no": ["error", { "elements": ["kbd", "samp", "CodeBlock.Code"] }]
+	}
+}
+```
+
+oxlint's JS plugin support is in alpha and not subject to semver, so an oxlint bump can break the plugin. The
+package needs Node 24 and oxlint 1.77 or later.

--- a/.github/workflows/vibe-check.yml
+++ b/.github/workflows/vibe-check.yml
@@ -207,7 +207,18 @@ jobs:
             --concurrency="${TURBO_TEST_CONCURRENCY}" \
             --continue=always \
             --filter='!@ngrok/mantle' \
+            --filter='!@ngrok/oxlint-plugin' \
             -- --shard="${{ matrix.shard }}/${{ matrix.shard_total }}" --maxWorkers="${TURBO_TEST_CONCURRENCY}" || non_mantle_status=$?
+
+          # `@ngrok/oxlint-plugin` runs unsharded: vitest rejects a shard count that is not below
+          # the number of test files, and this package has fewer files than there are shards. The
+          # whole suite takes about 200ms, so every shard runs it rather than one shard owning it.
+          oxlint_plugin_status=0
+          pnpm exec turbo run test \
+            --concurrency="${TURBO_TEST_CONCURRENCY}" \
+            --continue=always \
+            --filter='@ngrok/oxlint-plugin' \
+            -- --maxWorkers="${TURBO_TEST_CONCURRENCY}" || oxlint_plugin_status=$?
 
           mantle_status=0
           pnpm exec turbo run test \
@@ -217,9 +228,10 @@ jobs:
             -- --project=unit --shard="${{ matrix.shard }}/${{ matrix.shard_total }}" --maxWorkers="${TURBO_TEST_CONCURRENCY}" || mantle_status=$?
 
           echo "non-mantle test status: ${non_mantle_status}"
+          echo "oxlint-plugin test status: ${oxlint_plugin_status}"
           echo "mantle unit test status: ${mantle_status}"
 
-          if [[ "${non_mantle_status}" -ne 0 || "${mantle_status}" -ne 0 ]]; then
+          if [[ "${non_mantle_status}" -ne 0 || "${oxlint_plugin_status}" -ne 0 || "${mantle_status}" -ne 0 ]]; then
             exit 1
           fi
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": ["./packages/oxlint-plugin/src/index.ts"],
   "plugins": [
     "jsdoc",
     "jsx-a11y",
@@ -48,6 +49,9 @@
     "jsdoc/require-property": "off",
     "jsdoc/require-throws-description": "warn",
     "jsdoc/require-yields": "off",
+    "ngrok/jsx-no-conditional-before-text": "error",
+    "ngrok/jsx-no-conditional-text-with-siblings": "error",
+    "ngrok/jsx-require-translate-no": "error",
     "no-explicit-any": "warn",
     "no-fallthrough": "error",
     "no-promise-executor-return": "error",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Required diff-audit checklist:
 - Nullish checks: `== null` / `!= null`, not `=== undefined` / `!== undefined`.
 - Imports: relative paths in `packages/`, `~/...` aliases in `apps/`; named exports; `import type` for type-only imports.
 - className: composed with `cx` from `@ngrok/mantle/cx` — no string interpolation, `+`, or ternaries inside `className`.
-- Translation: no conditional element renders immediately before bare text children. A translated text node makes that insert throw, and the page goes blank. Untranslatable content — code, a key, a filename, an ID, a passcode — carries `translate="no"`, locked out of the props type when the element can never hold prose. See [CONVENTIONS.md § Browser Translation](./CONVENTIONS.md#browser-translation).
+- Translation: no conditional element renders immediately before bare text children. A translated text node makes that insert throw, and the page goes blank. Untranslatable content — code, a key, a filename, an ID, a passcode — carries `translate="no"`, locked out of the props type when the element can never hold prose. `pnpm -w run lint` reports all three shapes through `@ngrok/oxlint-plugin`, but it skips the branch it cannot read statically — so read the section rather than trusting a clean run. See [CONVENTIONS.md § Browser Translation](./CONVENTIONS.md#browser-translation).
 - Deps: exact-pinned versions (no `^`/`~`); shared deps go through the `catalog:` in `pnpm-workspace.yaml`.
 
 ## Setup
@@ -71,6 +71,7 @@ All rules live in [CONVENTIONS.md](./CONVENTIONS.md) and are mandatory. The `@./
   - `mantle` (UI component library, built with tsdown)
   - `mantle-vite-plugins` (Vite + rehype plugins for code-block highlighting and Tailwind CSS source optimization)
   - `mantle-server-syntax-highlighter` (server-side syntax highlighting engine powered by Shiki)
+  - `oxlint-plugin` (ngrok's house oxlint rules, shared with `ngrok-private/frontend`)
 - **Config** (`config/`): `tsconfig` (shared TypeScript configs via `@cfg/tsconfig`)
 
 ```

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -200,6 +200,12 @@ follow, and both bind `packages/` and `apps/` alike. The mechanism, the update-b
 and the rejected alternatives are in
 [`decisions/2026-08-04-translation-safe-label-wrappers.md`](./decisions/2026-08-04-translation-safe-label-wrappers.md).
 
+`oxlint` reports all three shapes through [`@ngrok/oxlint-plugin`](./packages/oxlint-plugin/README.md). This
+repo loads it from source, and any other repo installs it from npm — its README carries the config. The rules
+are not a substitute for reading the section: each one skips the branch it cannot read statically, so
+`{expanded && belowTheFold}` and a component that wraps an untranslatable string both pass a clean lint. Name
+such a component in the `jsx-require-translate-no` `elements` option when you add one.
+
 ### Never render a conditional element immediately before bare text children
 
 ```tsx

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -59,11 +59,12 @@ describes what a consumer has to do about it, and the answer for an additive cha
 
 ## Which packages get a changeset
 
-Only the three published packages:
+Only the four published packages:
 
 - `@ngrok/mantle`
 - `@ngrok/mantle-vite-plugins`
 - `@ngrok/mantle-server-syntax-highlighter`
+- `@ngrok/oxlint-plugin`
 
 `@app/*` and `@cfg/*` are private and sit in the `ignore` list in `.changeset/config.json`. A docs-site-only
 change needs no changeset at all. When one PR touches two published packages, write one changeset per

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "husky",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "turbo run build --filter=@ngrok/mantle --filter=@ngrok/mantle-vite-plugins --filter=@ngrok/mantle-server-syntax-highlighter && changeset publish"
+    "changeset:publish": "turbo run build --filter=@ngrok/mantle --filter=@ngrok/mantle-vite-plugins --filter=@ngrok/mantle-server-syntax-highlighter --filter=@ngrok/oxlint-plugin && changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.7.0",
@@ -29,7 +29,7 @@
     "husky": "9.1.7",
     "lint-staged": "17.3.0",
     "oxfmt": "0.62.0",
-    "oxlint": "1.77.0",
+    "oxlint": "catalog:",
     "tsx": "catalog:",
     "turbo": "2.10.8",
     "vitest": "4.1.10"

--- a/packages/mantle/src/components/button/button.test.tsx
+++ b/packages/mantle/src/components/button/button.test.tsx
@@ -455,6 +455,7 @@ describe("Button", () => {
 			const subject = (showLeading: boolean) => (
 				<Button appearance="outlined" intent="neutral">
 					{showLeading && <CaretDownIcon />}
+					{/* oxlint-disable-next-line ngrok/jsx-no-conditional-before-text -- the test asserts the crash this rule reports */}
 					Create endpoint
 				</Button>
 			);

--- a/packages/mantle/src/components/sidebar/sidebar.test.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.test.tsx
@@ -226,7 +226,7 @@ describe("Sidebar.Nav (desktop)", () => {
 		render(
 			<Sidebar.Root>
 				<Sidebar.Nav />
-				<Sidebar.Trigger shortcut={<kbd>B</kbd>} />
+				<Sidebar.Trigger shortcut={<kbd translate="no">B</kbd>} />
 			</Sidebar.Root>,
 		);
 
@@ -242,7 +242,7 @@ describe("Sidebar.Nav (desktop)", () => {
 		render(
 			<Sidebar.Root keyboardShortcut={false}>
 				<Sidebar.Nav />
-				<Sidebar.Trigger shortcut={<kbd>B</kbd>} />
+				<Sidebar.Trigger shortcut={<kbd translate="no">B</kbd>} />
 			</Sidebar.Root>,
 		);
 
@@ -1116,7 +1116,7 @@ describe("Sidebar.SearchTrigger", () => {
 		// The chord is announced by the `aria-keyshortcuts` that
 		// `Command.SearchTrigger` adds, so the visible chips must not repeat it.
 		render(
-			<Sidebar.SearchTrigger shortcut={<kbd>K</kbd>}>
+			<Sidebar.SearchTrigger shortcut={<kbd translate="no">K</kbd>}>
 				<MagnifyingGlassIcon />
 				<span>Search</span>
 			</Sidebar.SearchTrigger>,
@@ -1151,7 +1151,7 @@ describe("Sidebar.SearchTrigger", () => {
 				<Sidebar.Root defaultOpen={false}>
 					<Sidebar.Nav>
 						<Command.DialogRoot keyboardShortcut={false}>
-							<Sidebar.Tooltip label="Search" shortcut={<kbd>K</kbd>}>
+							<Sidebar.Tooltip label="Search" shortcut={<kbd translate="no">K</kbd>}>
 								<Command.SearchTrigger>
 									<Sidebar.SearchTrigger>
 										<MagnifyingGlassIcon />

--- a/packages/oxlint-plugin/README.md
+++ b/packages/oxlint-plugin/README.md
@@ -1,0 +1,151 @@
+# @ngrok/oxlint-plugin
+
+ngrok's house [oxlint](https://oxc.rs) rules, under the `ngrok` namespace.
+
+The three rules it ships read a JSX tree for the shapes a browser translation engine turns into a blank page.
+The mechanism, the update-by-update table of what breaks, and the rejected alternatives are in
+[`decisions/2026-08-04-translation-safe-label-wrappers.md`](https://github.com/ngrok/mantle/blob/main/decisions/2026-08-04-translation-safe-label-wrappers.md).
+[CONVENTIONS.md § Browser Translation](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md#browser-translation)
+states the rules the code follows.
+
+## Requirements
+
+- Node.js 24+
+- oxlint 1.77+
+
+oxlint's JS plugin support is in alpha and not subject to semver, so an oxlint bump can break the plugin. The
+`oxlint` peer dependency records the floor.
+
+## Installation
+
+```sh
+pnpm add -D -E @ngrok/oxlint-plugin
+```
+
+## Usage
+
+```json
+{
+	"jsPlugins": ["@ngrok/oxlint-plugin"],
+	"rules": {
+		"ngrok/jsx-no-conditional-before-text": "error",
+		"ngrok/jsx-no-conditional-text-with-siblings": "error",
+		"ngrok/jsx-require-translate-no": "error"
+	}
+}
+```
+
+The mantle repo names the source entry instead — `./packages/oxlint-plugin/src/index.ts`. Its CI lints right
+after install with no build step, so a `dist` import would break `pnpm lint`. Node strips the types.
+
+## Rules
+
+### `ngrok/jsx-no-conditional-before-text`
+
+Reports a conditional element that renders immediately before a bare text child.
+
+Google Translate wraps each text node in a `<font>` and reparents the original node. When the condition turns
+on, React calls `parent.insertBefore(element, textNode)` against a node the parent no longer owns, the DOM
+raises `NotFoundError`, and React re-throws it — so the root tears down and the page goes blank. `Button` hit
+this on the first click of every submit button, because `isLoading` synthesizes the icon.
+
+```tsx
+// ❌
+<button>
+	{icon && <Icon svg={icon} />}
+	{children}
+</button>
+
+// ✅ the icon inserts before an element sibling
+<button>
+	{icon && <Icon svg={icon} />}
+	<span data-slot="button-label">{children}</span>
+</button>
+```
+
+Two other fixes work. Move the conditional element after the text, which turns the mount into an
+`appendChild`. Or mount the element unconditionally and write text into it, which is safe and self-healing.
+
+A child whose every branch renders an element or nothing is not text, so `{footer == null ? null : <div />}`
+is not reported. A branch this rule cannot read statically counts as text, because the crash costs a blank
+page and the fix costs a `<span>`.
+
+### `ngrok/jsx-no-conditional-text-with-siblings`
+
+Reports a conditional text child that can unmount, or change into an element, while a sibling stays mounted.
+React's `removeChild` then names a node the translation engine reparented.
+
+```tsx
+// ❌ the text unmounts while the icon remains
+<button>
+	{label && "Submit"}
+	<Icon svg={caret} />
+</button>
+
+// ✅ every update is a text write
+<button>
+	<span data-slot="button-label">{label}</span>
+	<Icon svg={caret} />
+</button>
+```
+
+Three shapes stay quiet on purpose:
+
+- **Every branch renders text** — `{open ? "Show less" : "Show more"}`. React writes the new value through
+  `commitTextUpdate`, and the translation reverts.
+- **A lone expression child** — React updates it through `setTextContent`. The failure needs a sibling.
+- **A branch this rule cannot read statically** — `{expanded && belowTheFold}`. That identifier holds an
+  element far more often than a string, so the rule trades the recall for precision.
+
+A nested conditional recurses, so `{wide && (full ? <Full /> : <Compact />)}` reads as element-or-nothing.
+
+### `ngrok/jsx-require-translate-no`
+
+Reports an element that holds untranslatable content but carries no `translate="no"`.
+
+A reader copies or retypes a shortcut key, a CLI flag, an env var, a YAML key, a filename, an ID, or a
+one-time passcode. A translated one is wrong, and the reader uses it anyway. The attribute also keeps the
+engine out of the subtree, so it doubles as the second fix for the crash the other two rules report.
+
+```tsx
+// ❌
+<kbd>{shortcut}</kbd>
+
+// ✅
+<kbd translate="no">{shortcut}</kbd>
+```
+
+The rule stays quiet when the element carries any `translate` attribute, and when an enclosing element already
+carries `translate="no"` — descendants inherit it.
+
+#### Options
+
+| Option     | Type       | Default           | Meaning                                         |
+| ---------- | ---------- | ----------------- | ----------------------------------------------- |
+| `elements` | `string[]` | `["kbd", "samp"]` | The tag names to check. An empty list opts out. |
+
+Name a component the way the JSX spells it, including its object:
+
+```json
+{
+	"rules": {
+		"ngrok/jsx-require-translate-no": ["error", { "elements": ["kbd", "samp", "CodeBlock.Code"] }]
+	}
+}
+```
+
+`code` stays off the default list on purpose — mantle's `Code` also styles terms that are not code, so the
+attribute is a default there rather than a lock.
+
+## Suppressing a report
+
+An inline directive must precede the **reported** line, which for the first two rules is the text child
+rather than the conditional above it:
+
+```tsx
+<button>
+	{showLeading && <CaretDownIcon />}
+	{/* oxlint-disable-next-line ngrok/jsx-no-conditional-before-text -- the test asserts the crash this rule reports */}
+	Create endpoint
+</button>
+```

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@ngrok/oxlint-plugin",
+  "version": "0.0.0",
+  "description": "ngrok's house oxlint rules, including the browser-translation crash rules for JSX.",
+  "keywords": [
+    "jsx",
+    "oxlint",
+    "oxlint-plugin",
+    "react",
+    "translation"
+  ],
+  "homepage": "https://mantle.ngrok.com",
+  "license": "MIT",
+  "author": "ngrok",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ngrok/mantle"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "@ngrok/src-live-types": "./src/index.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "node ../../scripts/clean-publish-manifest.js clean",
+    "postpack": "node ../../scripts/clean-publish-manifest.js restore",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc"
+  },
+  "devDependencies": {
+    "@cfg/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "oxlint": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "oxlint": "^1.77.0"
+  },
+  "engines": {
+    "node": "^24.0.0"
+  }
+}

--- a/packages/oxlint-plugin/src/ast.ts
+++ b/packages/oxlint-plugin/src/ast.ts
@@ -1,0 +1,183 @@
+import type { JsxChild, JsxExpression, ReportTarget } from "./types.ts";
+
+/**
+ * What a JSX child can put in the DOM. Every field can be true at once, because one conditional
+ * reaches several outcomes.
+ *
+ * The rules in this package all turn on the difference between a text node and an element node,
+ * since a browser translation engine reparents only text nodes. See
+ * `decisions/2026-08-04-translation-safe-label-wrappers.md` in the mantle repo.
+ */
+export type RenderKinds = {
+	/** Renders a text node. */
+	text: boolean;
+	/** Renders an element node. */
+	element: boolean;
+	/** Renders no node, so the child mounts and unmounts as the condition flips. */
+	nothing: boolean;
+	/** Renders something this package cannot read statically. */
+	unknown: boolean;
+};
+
+const NOTHING: RenderKinds = { text: false, element: false, nothing: true, unknown: false };
+const TEXT: RenderKinds = { text: true, element: false, nothing: false, unknown: false };
+const ELEMENT: RenderKinds = { text: false, element: true, nothing: false, unknown: false };
+const UNKNOWN: RenderKinds = { text: false, element: false, nothing: false, unknown: true };
+
+function union(...kinds: RenderKinds[]): RenderKinds {
+	return {
+		text: kinds.some((kind) => kind.text),
+		element: kinds.some((kind) => kind.element),
+		nothing: kinds.some((kind) => kind.nothing),
+		unknown: kinds.some((kind) => kind.unknown),
+	};
+}
+
+/**
+ * Reads everything an expression can put in the DOM.
+ *
+ * A conditional recurses, so `cond && (wide ? <Full /> : <Compact />)` reports an element and
+ * nothing — never text. An expression this function cannot read statically reports `unknown`,
+ * never a guess, and each rule decides for itself what to do with that.
+ *
+ * @example
+ * // `<Icon />` → { element: true }
+ * // `"Show more"` → { text: true }
+ * // `icon && <Icon />` → { element: true, nothing: true }
+ * // `open ? "Less" : "More"` → { text: true }
+ * // `children` → { unknown: true }
+ * const kinds = renderKinds(container.expression);
+ */
+export function renderKinds(expression: JsxExpression): RenderKinds {
+	switch (expression.type) {
+		case "JSXElement":
+		case "JSXFragment":
+			return ELEMENT;
+		case "TemplateLiteral":
+			return TEXT;
+		case "Literal": {
+			const { value } = expression;
+			if (value == null || typeof value === "boolean") {
+				return NOTHING;
+			}
+			if (typeof value === "string" || typeof value === "number") {
+				return TEXT;
+			}
+			return UNKNOWN;
+		}
+		case "Identifier":
+			return expression.name === "undefined" ? NOTHING : UNKNOWN;
+		case "ConditionalExpression":
+			return union(renderKinds(expression.consequent), renderKinds(expression.alternate));
+		case "LogicalExpression":
+			// Why `NOTHING` for `&&`: a falsy test renders no node. `||` and `??` fall through to
+			// their left value instead, so both sides can reach the DOM.
+			return expression.operator === "&&"
+				? union(renderKinds(expression.right), NOTHING)
+				: union(renderKinds(expression.left), renderKinds(expression.right));
+		default:
+			return UNKNOWN;
+	}
+}
+
+/** Whether an expression branches at its top level, which is what makes a child mount or unmount. */
+export function isConditional(expression: JsxExpression): boolean {
+	return expression.type === "ConditionalExpression" || expression.type === "LogicalExpression";
+}
+
+/**
+ * Whether React puts this child in the DOM at all.
+ *
+ * Whitespace-only JSX text between two lines renders nothing, and so does a JSX comment
+ * container. Neither one separates the siblings around it.
+ */
+export function isRendered(child: JsxChild): boolean {
+	if (child.type === "JSXText") {
+		return child.value.trim() !== "";
+	}
+	if (child.type === "JSXExpressionContainer") {
+		return child.expression.type !== "JSXEmptyExpression";
+	}
+	return true;
+}
+
+/**
+ * The children React renders, in source order, with the whitespace and comments dropped.
+ *
+ * @example
+ * // <button>⏎⇥{icon && <Icon />}⏎⇥{children}⏎</button>
+ * // → [{icon && <Icon />}, {children}]
+ * const rendered = renderedChildren(node.children);
+ */
+export function renderedChildren(children: readonly JsxChild[]): JsxChild[] {
+	return children.filter((child) => isRendered(child));
+}
+
+/**
+ * Whether this child mounts, unmounts, or swaps an element as a condition flips.
+ *
+ * Any of the three inserts before whatever sibling follows. When that sibling is a text node the
+ * translation engine reparented, the insert names a node the parent no longer owns and the DOM
+ * raises `NotFoundError`.
+ *
+ * @example
+ * // `{icon && <Icon />}` → true
+ * // `{open ? "Less" : "More"}` → false, because neither branch is an element
+ * const mountsElement = isConditionalElement(child);
+ */
+export function isConditionalElement(child: JsxChild): boolean {
+	if (child.type !== "JSXExpressionContainer") {
+		return false;
+	}
+	const { expression } = child;
+	return isConditional(expression) && renderKinds(expression).element;
+}
+
+/**
+ * Whether React can render this child as a bare text node.
+ *
+ * An expression this package cannot read statically counts as text, because the crash costs a
+ * blank page and the fix costs a `<span>`. A child that only ever holds an element or no node does
+ * not count — an element is never reparented, and no node is not a text node.
+ *
+ * @example
+ * // `Submit` → true
+ * // `{children}` → true, because the type is unknown here
+ * // `{icon && <Icon />}` → false
+ * // `{footer == null ? null : <div />}` → false
+ * const rendersText = isTextChild(child);
+ */
+export function isTextChild(child: JsxChild): boolean {
+	if (child.type === "JSXText") {
+		return child.value.trim() !== "";
+	}
+	if (child.type !== "JSXExpressionContainer") {
+		return false;
+	}
+	const kinds = renderKinds(child.expression);
+	return kinds.text || kinds.unknown;
+}
+
+/**
+ * The range to underline for a text child, with the JSX whitespace around it trimmed off.
+ *
+ * A `JSXText` span runs from the end of the previous child to the start of the next one, so it
+ * swallows the newline and the indent. Reporting it whole starts the underline on the line above
+ * the text. Every other child already has a tight span.
+ *
+ * @example
+ * // <button>⏎⇥{icon && <Icon />}⏎⇥Submit⏎</button>
+ * // → the range of `Submit`, not the range that starts after `/>}`
+ * context.report({ node: textRange(child), messageId: "conditionalBeforeText" });
+ */
+export function textRange(child: JsxChild): ReportTarget {
+	if (child.type !== "JSXText") {
+		return child;
+	}
+	// Why `raw`: an entity such as `&amp;` is one character in `value` and five in the source, so
+	// only the raw text measures the same units as the span.
+	const text = child.raw ?? child.value;
+	const start = child.range[0] + (text.length - text.trimStart().length);
+	const end = child.range[1] - (text.length - text.trimEnd().length);
+	return end > start ? { range: [start, end] } : child;
+}

--- a/packages/oxlint-plugin/src/index.ts
+++ b/packages/oxlint-plugin/src/index.ts
@@ -1,0 +1,34 @@
+import { jsxNoConditionalBeforeText } from "./jsx-no-conditional-before-text.ts";
+import { jsxNoConditionalTextWithSiblings } from "./jsx-no-conditional-text-with-siblings.ts";
+import { jsxRequireTranslateNo } from "./jsx-require-translate-no.ts";
+import type { Rule } from "./types.ts";
+
+/**
+ * ngrok's house oxlint rules, under the `ngrok` namespace.
+ *
+ * The three rules here read a JSX tree for the shapes a browser translation engine turns into a
+ * blank page. The mechanism, the update-by-update table of what breaks, and the rejected
+ * alternatives are in `decisions/2026-08-04-translation-safe-label-wrappers.md` in the mantle
+ * repo. `CONVENTIONS.md § Browser Translation` states the rules the code follows.
+ *
+ * @example
+ * // .oxlintrc.json
+ * {
+ *   "jsPlugins": ["@ngrok/oxlint-plugin"],
+ *   "rules": {
+ *     "ngrok/jsx-no-conditional-before-text": "error",
+ *     "ngrok/jsx-no-conditional-text-with-siblings": "error",
+ *     "ngrok/jsx-require-translate-no": "error"
+ *   }
+ * }
+ */
+const plugin: { meta: { name: string }; rules: Record<string, Rule> } = {
+	meta: { name: "ngrok" },
+	rules: {
+		"jsx-no-conditional-before-text": jsxNoConditionalBeforeText,
+		"jsx-no-conditional-text-with-siblings": jsxNoConditionalTextWithSiblings,
+		"jsx-require-translate-no": jsxRequireTranslateNo,
+	},
+};
+
+export default plugin;

--- a/packages/oxlint-plugin/src/jsx-no-conditional-before-text.test.ts
+++ b/packages/oxlint-plugin/src/jsx-no-conditional-before-text.test.ts
@@ -1,0 +1,95 @@
+import { jsxNoConditionalBeforeText } from "./jsx-no-conditional-before-text.ts";
+import { ruleTester } from "./rule-tester.ts";
+
+ruleTester.run("jsx-no-conditional-before-text", jsxNoConditionalBeforeText, {
+	valid: [
+		// The documented fix: the icon now inserts before an element sibling.
+		'<button>{icon && <Icon svg={icon} />}<span data-slot="button-label">{children}</span></button>',
+		// Moving the element after the text turns the mount into an `appendChild`.
+		"<button>{children}{icon && <Icon svg={icon} />}</button>",
+		// A lone expression child goes through `setTextContent`, which repairs the subtree.
+		"<button>{children}</button>",
+		"<button>{label && label}</button>",
+		// An unconditional element never mounts, so nothing inserts before the text.
+		"<button><Icon svg={icon} />{children}</button>",
+		// A conditional element before another conditional element inserts before an element.
+		"<button>{icon && <Icon svg={icon} />}{badge && <Badge />}</button>",
+		// A container holding a plain element is an element, not text.
+		"<button>{icon && <Icon svg={icon} />}{<Label />}</button>",
+		// A branch that renders nothing is not a text node, so the following child holds either an
+		// element or no node — `chart/primitive.tsx` is full of this shape.
+		"<button>{icon && <Icon svg={icon} />}{footer == null ? null : <div>{footer}</div>}</button>",
+		"<button>{icon && <Icon svg={icon} />}{open ? <Panel /> : null}</button>",
+		// Text before the conditional element is the safe order.
+		"<button>Submit{icon && <Icon svg={icon} />}</button>",
+	],
+	invalid: [
+		{
+			// The `Button` crash that opened the decision doc, and the case the public
+			// eslint-plugin-react-google-translate cannot see without type information.
+			code: "<button>{icon && <Icon svg={icon} />}{children}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			// Whitespace-only JSX text between the two children does not separate them.
+			code: ["<button>", "\t{icon && <Icon svg={icon} />}", "\t{children}", "</button>"].join("\n"),
+			errors: [{ messageId: "conditionalBeforeText", line: 3 }],
+		},
+		{
+			// A JSX comment renders nothing, so it does not separate them either.
+			code: "<button>{icon && <Icon svg={icon} />}{/* the label */}{children}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			code: "<button>{icon && <Icon svg={icon} />}Submit</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			// The report underlines the text itself, not the newline and indent the `JSXText` span
+			// swallows. Without the trim this lands on line 2, at the column just past `/>}`. The
+			// columns are zero-based, so 1 to 7 spans `Submit` past the leading tab.
+			code: ["<button>", "\t{icon && <Icon svg={icon} />}", "\tSubmit", "</button>"].join("\n"),
+			errors: [
+				{ messageId: "conditionalBeforeText", line: 3, column: 1, endLine: 3, endColumn: 7 },
+			],
+		},
+		{
+			code: "<button>{icon && <Icon svg={icon} />}{item.label}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			code: "<button>{icon && <Icon svg={icon} />}{translate('submit')}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			code: "<button>{icon && <Icon svg={icon} />}{`Hi ${name}`}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			// A ternary with one element branch still mounts and unmounts an element.
+			code: "<button>{open ? <CaretUp /> : null}{children}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			// Swapping one element for another is still an insert. React places the new fiber with
+			// `insertBefore(next, hostSibling)`, and that sibling is the reparented text node.
+			code: "<button>{open ? <CaretUp /> : <CaretDown />}{children}</button>",
+			errors: [{ messageId: "conditionalBeforeText", column: 44 }],
+		},
+		{
+			// A fragment reparents its children into the same host element.
+			code: "<>{icon && <Icon svg={icon} />}{children}</>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			// A conditional whose branches mix an element and text can insert before the text.
+			code: "<button>{open ? <CaretUp /> : 'closed'}{children}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }],
+		},
+		{
+			// Each offending pair reports once, so a three-child run reports twice.
+			code: "<button>{icon && <Icon />}{label}{badge && <Badge />}{count}</button>",
+			errors: [{ messageId: "conditionalBeforeText" }, { messageId: "conditionalBeforeText" }],
+		},
+	],
+});

--- a/packages/oxlint-plugin/src/jsx-no-conditional-before-text.ts
+++ b/packages/oxlint-plugin/src/jsx-no-conditional-before-text.ts
@@ -1,0 +1,58 @@
+import { isConditionalElement, isTextChild, renderedChildren, textRange } from "./ast.ts";
+import type { JsxElement, JsxFragment, Rule } from "./types.ts";
+
+/**
+ * Reports a conditional element that renders immediately before a bare text child.
+ *
+ * Google Translate wraps each text node in a `<font>` and reparents the original node. When the
+ * condition turns on, React calls `parent.insertBefore(element, textNode)` against a node the
+ * parent no longer owns, the DOM raises `NotFoundError`, and React re-throws it — so the root
+ * tears down and the page goes blank.
+ *
+ * Three fixes work. Wrap the text in an element that carries its own `data-slot`, move the
+ * conditional element after the text so the mount becomes an `appendChild`, or mount the element
+ * unconditionally and write text into it.
+ *
+ * @example
+ * // ❌ the icon inserts before a reparented text node
+ * <button>
+ *   {icon && <Icon svg={icon} />}
+ *   {children}
+ * </button>
+ *
+ * // ✅ the icon inserts before an element sibling
+ * <button>
+ *   {icon && <Icon svg={icon} />}
+ *   <span data-slot="button-label">{children}</span>
+ * </button>
+ */
+export const jsxNoConditionalBeforeText: Rule = {
+	meta: {
+		type: "problem",
+		docs: {
+			description: "Disallow a conditional element immediately before bare text children.",
+			url: "https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md#browser-translation",
+		},
+		messages: {
+			conditionalBeforeText:
+				"A conditional element renders immediately before this text. Once a browser translation engine reparents the text node, the element's insert raises `NotFoundError` and the page goes blank. Wrap the text in an element with its own `data-slot`, move the conditional element after the text, or mount it unconditionally.",
+		},
+	},
+	create(context) {
+		function check(node: JsxElement | JsxFragment) {
+			const children = renderedChildren(node.children);
+			for (const [index, child] of children.entries()) {
+				if (!isConditionalElement(child)) {
+					continue;
+				}
+				const next = children[index + 1];
+				if (next == null || !isTextChild(next)) {
+					continue;
+				}
+				context.report({ node: textRange(next), messageId: "conditionalBeforeText" });
+			}
+		}
+
+		return { JSXElement: check, JSXFragment: check };
+	},
+};

--- a/packages/oxlint-plugin/src/jsx-no-conditional-text-with-siblings.test.ts
+++ b/packages/oxlint-plugin/src/jsx-no-conditional-text-with-siblings.test.ts
@@ -1,0 +1,87 @@
+import { jsxNoConditionalTextWithSiblings } from "./jsx-no-conditional-text-with-siblings.ts";
+import { ruleTester } from "./rule-tester.ts";
+
+ruleTester.run("jsx-no-conditional-text-with-siblings", jsxNoConditionalTextWithSiblings, {
+	valid: [
+		// Both branches render text, so React writes the new value through `commitTextUpdate` and
+		// the translation reverts. This is the row the decision doc marks safe.
+		'<button>{open ? "Show less" : "Show more"}<Icon svg={caret} /></button>',
+		'<span>Turn password visibility {showPassword ? "off" : "on"}</span>',
+		// A lone expression child goes through `setTextContent`, which repairs the subtree.
+		'<button>{open ? "Show less" : "Show more"}</button>',
+		"<button>{label && label}</button>",
+		// An unknown branch reads as text on both sides far more often than not.
+		'<button>{error ? error.message : "All good"}<Icon svg={caret} /></button>',
+		"<button>{count ?? total}<Icon svg={caret} /></button>",
+		// A branch this package cannot read statically holds an element far more often than a
+		// string, so the rule trades this recall for precision. All four shapes are common in
+		// `ngrok-private/frontend`, and every one of them renders elements.
+		"<button>{expanded && belowTheFold}<Icon svg={caret} /></button>",
+		"<button>{touched && errors.map((error) => <p>{error}</p>)}<Icon svg={caret} /></button>",
+		"<button>{done && (() => renderSummary())()}<Icon svg={caret} /></button>",
+		// A nested conditional recurses, so this reads as element-or-nothing rather than unknown.
+		"<button>{wide && (full ? <Full /> : <Compact />)}<Icon svg={caret} /></button>",
+		// Every branch is an element, so no text node is ever removed.
+		"<button>{open ? <CaretUp /> : <CaretDown />}<Label /></button>",
+		"<button>{icon && <Icon svg={icon} />}<Label /></button>",
+		// The text is wrapped, so the span unmounts and the span is an element.
+		"<button>{label && <span>{label}</span>}<Icon svg={caret} /></button>",
+		// Not a conditional at all.
+		"<button>{label}<Icon svg={caret} /></button>",
+	],
+	invalid: [
+		{
+			// `&&` renders nothing when the test is falsy, so the text unmounts beside the icon.
+			code: '<button>{label && "Submit"}<Icon svg={caret} /></button>',
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			// A nested conditional recurses down to the text, so this still reports.
+			code: '<button>{wide && (full ? "Show less" : <Compact />)}<Icon svg={caret} /></button>',
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			// A ternary with a `null` branch removes the text node the same way.
+			code: '<button>{open ? "Show less" : null}<Icon svg={caret} /></button>',
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			code: '<button>{open ? "Show less" : undefined}<Icon svg={caret} /></button>',
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			// A text sibling is a sibling too — the decision doc's "siblings remain" row.
+			code: '<span>Turn password visibility {showPassword && "off"}</span>',
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			// The text changes type to an element, which React commits as a replace.
+			code: '<button>{open ? "Show less" : <CaretDown />}<Label /></button>',
+			errors: [{ messageId: "textBecomesElement" }],
+		},
+		{
+			code: "<button>{count ? 3 : <Badge />}<Label /></button>",
+			errors: [{ messageId: "textBecomesElement" }],
+		},
+		{
+			// A template literal is text.
+			code: "<button>{name && `Hi ${name}`}<Icon svg={caret} /></button>",
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			// Whitespace between children does not make the conditional a lone child.
+			code: ["<button>", '\t{label && "Submit"}', "\t<Icon svg={caret} />", "</button>"].join("\n"),
+			errors: [{ messageId: "textCanUnmount", line: 2 }],
+		},
+		{
+			// A fragment hosts the same sibling relationship.
+			code: '<>{label && "Submit"}<Icon svg={caret} /></>',
+			errors: [{ messageId: "textCanUnmount" }],
+		},
+		{
+			// Two offending children report twice.
+			code: '<button>{label && "Submit"}{hint && "now"}</button>',
+			errors: [{ messageId: "textCanUnmount" }, { messageId: "textCanUnmount" }],
+		},
+	],
+});

--- a/packages/oxlint-plugin/src/jsx-no-conditional-text-with-siblings.ts
+++ b/packages/oxlint-plugin/src/jsx-no-conditional-text-with-siblings.ts
@@ -1,0 +1,84 @@
+import { isConditional, renderedChildren, renderKinds } from "./ast.ts";
+import type { JsxElement, JsxFragment, Rule } from "./types.ts";
+
+/**
+ * Reports a conditional text child that can unmount, or change into an element, while a sibling
+ * stays mounted.
+ *
+ * This is the other half of the translation crash. A browser translation engine reparents the text
+ * node, so React's `removeChild` names a node the parent no longer owns and the DOM raises
+ * `NotFoundError`.
+ *
+ * Three shapes stay quiet on purpose. A conditional whose every branch renders text is safe, since
+ * React writes the new value through `commitTextUpdate` and the translation reverts. So is a lone
+ * expression child, which React updates through `setTextContent` — the failure needs a sibling. And
+ * so is a branch this package cannot read statically: `{expanded && belowTheFold}` reads as
+ * unknown, and that identifier holds an element far more often than a string.
+ *
+ * @example
+ * // ❌ the text unmounts while the icon remains
+ * <button>
+ *   {label && "Submit"}
+ *   <Icon svg={caret} />
+ * </button>
+ *
+ * // ✅ every update is a text write
+ * <button>
+ *   <span data-slot="button-label">{label}</span>
+ *   <Icon svg={caret} />
+ * </button>
+ *
+ * // ✅ not reported — both branches render text, so the value changes in place
+ * <button>
+ *   {open ? "Show less" : "Show more"}
+ *   <Icon svg={caret} />
+ * </button>
+ */
+export const jsxNoConditionalTextWithSiblings: Rule = {
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow a conditional text child that can unmount or change type beside a sibling.",
+			url: "https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md#browser-translation",
+		},
+		messages: {
+			textCanUnmount:
+				"This conditional renders text in one branch and nothing in another. When the text unmounts while a sibling remains, React removes a text node that a browser translation engine reparented, the DOM raises `NotFoundError`, and the page goes blank. Wrap the text in an element that stays mounted, or render an empty string instead of nothing so every update is a text write.",
+			textBecomesElement:
+				"This conditional renders text in one branch and an element in another. When the text changes type, React replaces a text node that a browser translation engine reparented, the DOM raises `NotFoundError`, and the page goes blank. Render an element in both branches.",
+		},
+	},
+	create(context) {
+		function check(node: JsxElement | JsxFragment) {
+			const children = renderedChildren(node.children);
+			// A lone expression child is safe, and self-healing. The failure needs a sibling.
+			if (children.length < 2) {
+				return;
+			}
+			for (const child of children) {
+				if (child.type !== "JSXExpressionContainer") {
+					continue;
+				}
+				const { expression } = child;
+				if (!isConditional(expression)) {
+					continue;
+				}
+				const kinds = renderKinds(expression);
+				if (!kinds.text) {
+					continue;
+				}
+				if (kinds.nothing) {
+					context.report({ node: child, messageId: "textCanUnmount" });
+					continue;
+				}
+				// Both branches render something, so the only hazard left is a change of type.
+				if (kinds.element) {
+					context.report({ node: child, messageId: "textBecomesElement" });
+				}
+			}
+		}
+
+		return { JSXElement: check, JSXFragment: check };
+	},
+};

--- a/packages/oxlint-plugin/src/jsx-require-translate-no.test.ts
+++ b/packages/oxlint-plugin/src/jsx-require-translate-no.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+import { configuredElements, jsxRequireTranslateNo } from "./jsx-require-translate-no.ts";
+import { ruleTester } from "./rule-tester.ts";
+
+describe("configuredElements", () => {
+	test("falls back to the default list when the options name none", () => {
+		expect(configuredElements([])).toEqual(new Set(["kbd", "samp"]));
+	});
+
+	test("replaces the default list rather than extending it", () => {
+		expect(configuredElements([{ elements: ["CodeBlock.Code"] }])).toEqual(
+			new Set(["CodeBlock.Code"]),
+		);
+	});
+
+	test("reads an empty list as an opt-out", () => {
+		expect(configuredElements([{ elements: [] }])).toEqual(new Set());
+	});
+
+	test("drops the entries that are not strings", () => {
+		expect(configuredElements([{ elements: ["kbd", 7, null, "samp"] }])).toEqual(
+			new Set(["kbd", "samp"]),
+		);
+	});
+
+	test.each([
+		["a null option", [null]],
+		["an option that is not an object", ["kbd"]],
+		["an option missing the key", [{ other: true }]],
+		["a non-array element list", [{ elements: "kbd" }]],
+	])("falls back to the default list for %s", (_label, options) => {
+		expect(configuredElements(options)).toEqual(new Set(["kbd", "samp"]));
+	});
+});
+
+ruleTester.run("jsx-require-translate-no", jsxRequireTranslateNo, {
+	valid: [
+		'<kbd translate="no">{shortcut}</kbd>',
+		'<samp translate="no">{output}</samp>',
+		// A bare or dynamic `translate` says the author decided, so the rule stays quiet.
+		"<kbd translate>{shortcut}</kbd>",
+		"<kbd translate={translate}>{shortcut}</kbd>",
+		// Descendants inherit the attribute, so an enclosing lock is enough.
+		'<div translate="no"><kbd>{shortcut}</kbd></div>',
+		'<div translate="no"><p><kbd>{shortcut}</kbd></p></div>',
+		// An element outside the configured list is not this rule's business.
+		"<code>{snippet}</code>",
+		"<span>{shortcut}</span>",
+		// The default list holds tag names, not the components that already lock the attribute.
+		"<Kbd>{shortcut}</Kbd>",
+		{
+			// An empty list turns the rule off.
+			code: "<kbd>{shortcut}</kbd>",
+			options: [{ elements: [] }],
+		},
+		{
+			code: "<code>{snippet}</code>",
+			options: [{ elements: ["kbd"] }],
+		},
+		{
+			// A configured component name matches, and this one carries the attribute.
+			code: '<CodeBlock.Code translate="no">{snippet}</CodeBlock.Code>',
+			options: [{ elements: ["CodeBlock.Code"] }],
+		},
+	],
+	invalid: [
+		{
+			code: "<kbd>{shortcut}</kbd>",
+			errors: [{ messageId: "missingTranslateNo", data: { name: "kbd" } }],
+		},
+		{
+			code: "<samp>{output}</samp>",
+			errors: [{ messageId: "missingTranslateNo", data: { name: "samp" } }],
+		},
+		{
+			// `translate="yes"` on an ancestor does not lock the subtree.
+			code: '<div translate="yes"><kbd>{shortcut}</kbd></div>',
+			errors: [{ messageId: "missingTranslateNo", data: { name: "kbd" } }],
+		},
+		{
+			// The ancestor walk must read the attribute value, not just the attribute name.
+			code: "<div translate><kbd>{shortcut}</kbd></div>",
+			errors: [{ messageId: "missingTranslateNo", data: { name: "kbd" } }],
+		},
+		{
+			code: "<Kbd>{shortcut}</Kbd>",
+			options: [{ elements: ["Kbd"] }],
+			errors: [{ messageId: "missingTranslateNo", data: { name: "Kbd" } }],
+		},
+		{
+			// A member-expression tag name is spelled with its object.
+			code: "<CodeBlock.Code>{snippet}</CodeBlock.Code>",
+			options: [{ elements: ["CodeBlock.Code"] }],
+			errors: [{ messageId: "missingTranslateNo", data: { name: "CodeBlock.Code" } }],
+		},
+		{
+			// Each offending element reports once.
+			code: "<div><kbd>{a}</kbd><samp>{b}</samp></div>",
+			errors: [
+				{ messageId: "missingTranslateNo", data: { name: "kbd" } },
+				{ messageId: "missingTranslateNo", data: { name: "samp" } },
+			],
+		},
+	],
+});

--- a/packages/oxlint-plugin/src/jsx-require-translate-no.ts
+++ b/packages/oxlint-plugin/src/jsx-require-translate-no.ts
@@ -1,0 +1,155 @@
+import type { JsxElement, JsxElementName, Rule, RuleContext } from "./types.ts";
+
+/**
+ * The elements the rule checks when the config names none.
+ *
+ * Both hold a string a reader copies or retypes, and neither can hold prose. `code` stays off the
+ * list on purpose — mantle's `Code` also styles terms that are not code, so the attribute is a
+ * default there rather than a lock.
+ */
+const DEFAULT_ELEMENTS = ["kbd", "samp"];
+
+/** Spells a JSX tag name the way the config names it — `kbd`, `Kbd`, or `CodeBlock.Code`. */
+function elementName(name: JsxElementName): string {
+	switch (name.type) {
+		case "JSXIdentifier":
+			return name.name;
+		case "JSXNamespacedName":
+			return `${name.namespace.name}:${name.name.name}`;
+		case "JSXMemberExpression":
+			return `${elementName(name.object)}.${name.property.name}`;
+	}
+}
+
+/**
+ * Reads an element's `translate` attribute: its string value, `""` when the value is dynamic or
+ * the attribute stands bare, and `null` when the attribute is absent.
+ */
+function translateValue(node: JsxElement): string | null {
+	for (const attribute of node.openingElement.attributes) {
+		if (attribute.type !== "JSXAttribute") {
+			continue;
+		}
+		if (attribute.name.type !== "JSXIdentifier" || attribute.name.name !== "translate") {
+			continue;
+		}
+		const { value } = attribute;
+		if (value != null && value.type === "Literal" && typeof value.value === "string") {
+			return value.value;
+		}
+		// A bare or dynamic `translate` still says the author decided, so the rule stays quiet.
+		return "";
+	}
+	return null;
+}
+
+/** Whether an enclosing element already carries `translate="no"`, which descendants inherit. */
+function hasTranslateNoAncestor(node: JsxElement): boolean {
+	let current: JsxElement["parent"] | null = node.parent;
+	while (current != null) {
+		if (current.type === "JSXElement" && translateValue(current) === "no") {
+			return true;
+		}
+		current = "parent" in current ? current.parent : null;
+	}
+	return false;
+}
+
+/**
+ * Reads the element list out of the rule options, falling back to [DEFAULT_ELEMENTS].
+ *
+ * A config that names an empty list turns the rule off, which is the documented way to opt out of
+ * it for one directory.
+ *
+ * @example
+ * configuredElements([{ elements: ["kbd", "CodeBlock.Code"] }]); // Set { "kbd", "CodeBlock.Code" }
+ * configuredElements([]); // Set { "kbd", "samp" }
+ */
+export function configuredElements(options: RuleContext["options"]): Set<string> {
+	const [first] = options;
+	if (
+		first == null ||
+		typeof first !== "object" ||
+		Array.isArray(first) ||
+		!("elements" in first)
+	) {
+		return new Set(DEFAULT_ELEMENTS);
+	}
+	const { elements } = first;
+	if (!Array.isArray(elements)) {
+		return new Set(DEFAULT_ELEMENTS);
+	}
+	return new Set(elements.filter((element) => typeof element === "string"));
+}
+
+/**
+ * Reports an element that holds untranslatable content but carries no `translate="no"`.
+ *
+ * A reader copies or retypes a shortcut key, a CLI flag, an env var, a YAML key, a filename, an
+ * ID, or a one-time passcode. A translated one is wrong, and the reader uses it anyway. The
+ * attribute also keeps the engine out of the subtree, so it doubles as the second fix for the
+ * translation crash the other two rules report.
+ *
+ * The rule checks the tag names in `elements`, which default to `kbd` and `samp`. It stays quiet
+ * when the element carries any `translate` attribute, and when an enclosing element already
+ * carries `translate="no"` — descendants inherit it.
+ *
+ * @example
+ * // ❌ a translated shortcut key names the wrong key
+ * <kbd>{shortcut}</kbd>
+ *
+ * // ✅
+ * <kbd translate="no">{shortcut}</kbd>
+ *
+ * // .oxlintrc.json — add the components that wrap an untranslatable string
+ * // "ngrok/jsx-require-translate-no": ["error", { "elements": ["kbd", "samp", "CodeBlock.Code"] }]
+ */
+export const jsxRequireTranslateNo: Rule = {
+	meta: {
+		type: "problem",
+		docs: {
+			description: 'Require `translate="no"` on elements that hold untranslatable content.',
+			url: "https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md#browser-translation",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					elements: {
+						type: "array",
+						items: { type: "string" },
+						uniqueItems: true,
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+		messages: {
+			missingTranslateNo:
+				'`<{{name}}>` holds a string a reader copies or retypes, and a translated one is wrong. Set `translate="no"` on it. When the element can never hold prose, also omit `translate` from its props type and stamp the attribute after the props spread.',
+		},
+	},
+	create(context) {
+		const elements = configuredElements(context.options);
+		if (elements.size === 0) {
+			return {};
+		}
+
+		return {
+			JSXElement(node: JsxElement) {
+				const name = elementName(node.openingElement.name);
+				if (!elements.has(name)) {
+					return;
+				}
+				if (translateValue(node) != null || hasTranslateNoAncestor(node)) {
+					return;
+				}
+				context.report({
+					node: node.openingElement,
+					messageId: "missingTranslateNo",
+					data: { name },
+				});
+			},
+		};
+	},
+};

--- a/packages/oxlint-plugin/src/rule-tester.ts
+++ b/packages/oxlint-plugin/src/rule-tester.ts
@@ -1,0 +1,15 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+
+// RuleTester declares its own suites, so it needs Vitest's `describe` and `it` injected.
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+/**
+ * A `RuleTester` that parses every case as TSX, which is the only shape the rules in this package
+ * read. Each case states its code as source text, so the assertions run against the real oxlint
+ * parser rather than a hand-built tree.
+ */
+export const ruleTester = new RuleTester({
+	languageOptions: { parserOptions: { lang: "tsx" } },
+});

--- a/packages/oxlint-plugin/src/types.ts
+++ b/packages/oxlint-plugin/src/types.ts
@@ -1,0 +1,34 @@
+import type { RuleTester } from "oxlint/plugins-dev";
+
+/**
+ * oxlint declares its plugin types but exports only `RuleTester`, so every type below reaches
+ * them through `RuleTester.run`'s signature. The reach-through lives in this one file, and it
+ * breaks the build if oxlint reshapes the API — which is alpha and not subject to semver.
+ */
+type AnyRule = Parameters<RuleTester["run"]>[1];
+
+/** A rule that builds a fresh visitor object for each file. */
+export type Rule = Extract<AnyRule, { create: (context: never) => unknown }>;
+
+/** The per-file context oxlint passes to a rule's `create`. */
+export type RuleContext = Parameters<Rule["create"]>[0];
+
+/** Anything `context.report` accepts as the source range to underline. */
+export type ReportTarget = NonNullable<Parameters<RuleContext["report"]>[0]["node"]>;
+
+type Visitors = ReturnType<Rule["create"]>;
+
+type VisitedNode<Key extends keyof Visitors> = Parameters<NonNullable<Visitors[Key]>>[0];
+
+export type JsxElement = VisitedNode<"JSXElement">;
+export type JsxFragment = VisitedNode<"JSXFragment">;
+export type JsxExpressionContainer = VisitedNode<"JSXExpressionContainer">;
+
+/** The tag name of a JSX element — `kbd`, `Kbd`, `CodeBlock.Code`, or `svg:title`. */
+export type JsxElementName = JsxElement["openingElement"]["name"];
+
+/** One entry of a JSX element's or fragment's `children` array. */
+export type JsxChild = JsxElement["children"][number];
+
+/** Any expression that can sit inside a `{…}` container. */
+export type JsxExpression = JsxExpressionContainer["expression"];

--- a/packages/oxlint-plugin/tsconfig.json
+++ b/packages/oxlint-plugin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@cfg/tsconfig/tsconfig.client-package.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"],
+    // Why `.ts` specifiers here, and nowhere else in the monorepo: oxlint loads this plugin from
+    // source, and Node's type stripping resolves the specifier as written rather than mapping
+    // `.js` back to `.ts`. CI lints right after install with no build, so a `dist` import would
+    // break `pnpm lint`. tsdown rewrites the extensions when it bundles.
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/oxlint-plugin/tsdown.config.ts
+++ b/packages/oxlint-plugin/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	dts: true,
+	clean: true,
+	minify: false,
+	sourcemap: true,
+	target: "ES2025",
+	tsconfig: "tsconfig.json",
+	fixedExtension: false,
+	format: "esm",
+	entry: {
+		index: "./src/index.ts",
+	},
+});

--- a/packages/oxlint-plugin/vitest.config.ts
+++ b/packages/oxlint-plugin/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+		// See `packages/mantle/vitest.config.ts` — an un-torn-down spy leaks into every later
+		// test in the file, so restoring centrally keeps an inline `mockRestore()` from being
+		// load-bearing. CONVENTIONS.md § Testing documents this as repo-wide.
+		restoreMocks: true,
+		unstubEnvs: true,
+		unstubGlobals: true,
+		// The timezone pin lives here rather than in the `test` script so it survives a
+		// single-file run and an editor-driven run, per CONVENTIONS.md § Determinism.
+		env: {
+			TZ: "UTC",
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     oxc-parser:
       specifier: 0.142.0
       version: 0.142.0
+    oxlint:
+      specifier: 1.77.0
+      version: 1.77.0
     react:
       specifier: 19.2.8
       version: 19.2.8
@@ -98,7 +101,7 @@ importers:
         specifier: 0.62.0
         version: 0.62.0
       oxlint:
-        specifier: 1.77.0
+        specifier: 'catalog:'
         version: 1.77.0
       tsx:
         specifier: 'catalog:'
@@ -473,6 +476,24 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+
+  packages/oxlint-plugin:
+    devDependencies:
+      '@cfg/tsconfig':
+        specifier: workspace:*
+        version: link:../../config/tsconfig
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.77.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(@tsdown/css@0.22.14)(tsx@4.23.5)(typescript@7.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   "@vitest/browser-playwright": "4.1.10"
   "happy-dom": "20.11.1"
   "oxc-parser": "0.142.0"
+  "oxlint": "1.77.0"
   "playwright-core": "1.62.1"
   "playwright": "1.62.1"
   "react-dom": "19.2.8"


### PR DESCRIPTION
## Why

[CONVENTIONS.md § Browser Translation](../blob/main/CONVENTIONS.md#browser-translation) states three shapes that a browser translation engine turns into a blank page. Review carried the whole burden of finding them, and the `Button` crash still reached a release. `ngrok-private/frontend` needs the same check, so the rules ship as a package rather than as a config in this repo.

## How

`@ngrok/oxlint-plugin` adds three rules under the `ngrok` namespace, each derived from the update-by-update table in [`decisions/2026-08-04-translation-safe-label-wrappers.md`](../blob/main/decisions/2026-08-04-translation-safe-label-wrappers.md):

| Rule | Reports |
| --- | --- |
| `jsx-no-conditional-before-text` | The `insertBefore` half — a conditional element immediately before a bare text child, including the `{children}` spelling |
| `jsx-no-conditional-text-with-siblings` | The `removeChild` half — a conditional text child that can unmount or change type beside a sibling |
| `jsx-require-translate-no` | An element holding untranslatable content with no `translate="no"`; `elements` defaults to `kbd` and `samp` |

Each rule follows the decision doc's table rather than flagging every conditional. An all-text conditional is safe, because React writes the new value through `commitTextUpdate` and the translation reverts. A lone expression child is safe, because React updates it through `setTextContent`. A branch the rule cannot read statically counts as text in the first rule, where the fix costs a `<span>`, and does not count in the second, where `{expanded && belowTheFold}` almost always holds an element.

The test job also gains a step. It passes `--shard=N/4` to every non-mantle package, and vitest rejects a shard count that is not below the number of test files — this package has three, so all four shards failed on it. The package now runs unsharded in its own step.

This repo names the source entry in `.oxlintrc.json`. CI lints right after install with no build step, so a `dist` import would break `pnpm lint` — the package therefore uses `.ts` import specifiers with `rewriteRelativeImportExtensions`, which its `tsconfig.json` explains. Another repo installs from npm and names `@ngrok/oxlint-plugin`.

## Validation

- Tuning cut 31 false positives from an initial 91 across `packages/mantle`, `apps/www`, and a read-only `ngrok-private/frontend` dry run. The remaining 60 frontend reports are that repo's to triage.
- Shipped mantle source and `apps/www` report nothing. `button.test.tsx` keeps one targeted disable, because that test asserts the crash the rule reports.
- Two defects surfaced in the rules during the measurement pass and both have regression tests: a branch that renders nothing counted as text, so `{footer == null ? null : <div />}` false-fired; and nested conditionals did not recurse, so `{wide && (full ? <Full /> : <Compact />)}` read as unknown.
- Whole-repo lint goes from 0.06s to about 0.36s. That is the JS plugin bridge starting up.
- 75 rule tests run through `RuleTester` from `oxlint/plugins-dev`, against the real parser, in about 200ms.
- The sharding failure was reproduced locally with the job's own turbo invocation, then confirmed fixed the same way. All twelve checks pass on the second push.

## Notes for review

- oxlint's JS plugin support is alpha and not subject to semver, so an oxlint bump can break the plugin. The `oxlint` peer dependency records the 1.77 floor, and `oxlint` moved into the workspace catalog now that two packages use it.
- No autofix yet. Inserting `translate="no"` is mechanical and worth a follow-up.
- An inline disable must precede the reported line, which for the first two rules is the text child rather than the conditional above it. The README documents this.
