### PR TITLE
fix(text-area): align font sizes with other form controls

### DIFF
--- a/.changeset/text-area-default-font-size.md
+++ b/.changeset/text-area-default-font-size.md
@@ -1,0 +1,17 @@
+---
+"@ngrok/mantle": patch
+---
+
+`TextArea` now renders its default appearance at the same font size as `Input` and `Select`, and its
+`monospaced` appearance a step smaller.
+
+The default (non-monospaced) `TextArea` only set `pointer-coarse:text-base`, so on a fine pointer (desktop) it
+had no font-size class and fell back to the 16px UA/root default — 2px larger than the `text-sm` (14px) that
+`Input` and `Select` use. Adding the missing `text-sm` base brings it in line: 14px on desktop, 16px on touch,
+matching the other form controls.
+
+The `monospaced` appearance drops from the arbitrary `0.8125rem`/`0.9375rem` sizes to `text-xs/5` on desktop
+(12px font with the `text-sm` `1.25rem` line-height, so its rows and baseline stay aligned with the default
+appearance) and `pointer-coarse:text-base` (16px) on touch. The 16px touch size matches the other form
+controls and, crucially, stays at or above the 16px threshold that iOS Safari uses to decide whether to
+auto-zoom into a focused field — so tapping the monospaced textarea on iOS no longer triggers a zoom.

--- a/packages/mantle/src/components/text-area/text-area.tsx
+++ b/packages/mantle/src/components/text-area/text-area.tsx
@@ -61,13 +61,13 @@ const TextArea = ({
 			data-validation={validation || undefined}
 			data-slot="text-area"
 			className={cx(
-				appearance === "monospaced" && "pointer-coarse:text-[0.9375rem] font-mono text-[0.8125rem]",
-				"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
+				"border-input bg-form data-drag-over:border-dashed data-drag-over:ring-4 pointer-coarse:py-[calc(theme(spacing[2.5])-1px)] pointer-coarse:text-base text-sm flex min-h-24 w-full rounded-md border px-3 py-[calc(theme(spacing[2])-1px)] focus-visible:outline-hidden focus-visible:ring-4 disabled:pointer-events-none disabled:opacity-50",
 				"placeholder:text-placeholder data-drag-over:border-dashed",
 				"border-form text-strong ring-focus-accent focus:border-accent-600 data-drag-over:border-accent-600",
 				"data-validation-error:border-danger-600 data-validation-error:ring-focus-danger data-validation-error:focus-visible:border-danger-600 data-validation-error:data-drag-over:border-danger-600",
 				"data-validation-success:border-success-600 data-validation-success:ring-focus-success data-validation-success:focus-visible:border-success-600 data-validation-success:data-drag-over:border-success-600",
 				"data-validation-warning:border-warning-600 data-validation-warning:ring-focus-warning data-validation-warning:focus-visible:border-warning-600 data-validation-warning:data-drag-over:border-warning-600",
+				appearance === "monospaced" && "font-mono pointer-coarse:text-base text-xs/5",
 				className,
 			)}
 			data-drag-over={isDragOver}


### PR DESCRIPTION
Default TextArea was missing a base `text-sm`, so it fell back to 16px on desktop instead of the 14px used by Input/Select. Add `text-sm` so it matches (14px desktop, 16px touch).

Monospaced TextArea now uses `text-xs/5` on desktop (12px with the text-sm 1.25rem line-height, so rows stay aligned with the default appearance) and `pointer-coarse:text-base` (16px) on touch to stay at/above the iOS Safari threshold that would otherwise auto-zoom the focused field. The appearance override is placed last in the cx() call so tailwind-merge keeps it.