### PR TITLE
feat(steps): add a read-only ordered step guide

### DIFF
--- a/.changeset/add-steps.md
+++ b/.changeset/add-steps.md
@@ -1,0 +1,18 @@
+---
+"@ngrok/mantle": minor
+---
+
+Add **`Steps`** — a read-only setup guide.
+
+`Steps` renders an ordered list of steps down a page, each marked by a numbered circle in a left gutter, joined by one continuous vertical rail. Every step stays visible and nothing is interactive: this is a guide, not a wizard. For one panel at a time, where a reader clicks a step to reveal it, reach for `Tabs`; for a step that collapses, reach for `Accordion`.
+
+- Compound parts: `Steps.Root` (the `<ol role="list">`), `Steps.Item` (one `<li>`), and `Steps.Title` (an `h3` by default). Every part takes `asChild` and merges a consumer's `className` last
+- **Composition order is the numbering.** The number is a CSS counter and the marker's silhouette comes from `:first-child` / `:last-child` / `:only-child`, so inserting, removing, or conditionally rendering a step renumbers the rest natively. There is no `index`, no `count`, and nothing to keep in sync — and the first server-rendered paint is already correct
+- The rail is each item's `border-inline-start`, so it spans the item however tall its content grows and runs through the gap to the next step. The last item keeps the width and drops the color, so removing a step shifts nothing sideways. Every offset is a logical property, so the whole layout flips for right-to-left
+- Accessible by default: a real `<ol>` of `<li>` with `role="list"` restated, because the design strips `list-style` and WebKit drops list semantics from a list that has none. Step position comes from the list; the markers are one `aria-hidden` unit per step with no text of their own
+- Data attributes: `data-slot` on every part (`steps`, `steps-item`, `steps-title`), plus `steps-marker` on the marker in the gutter, so a consumer can hide the marker column on a narrow surface. Every part joins an incoming chain ahead of its own name, so `asChild` composition accumulates the whole chain
+- CSS variables: `--color-steps-rail` and `--color-steps-number` are design tokens with a value in all four themes. Override them together on any ancestor to re-theme the rail — the number has to stay readable on the fill, and the fill has to stay opaque
+
+Import it: `import { Steps } from "@ngrok/mantle/steps"`.
+
+Docs: https://mantle.ngrok.com/components/structure/steps

--- a/.changeset/vite-plugins-know-steps.md
+++ b/.changeset/vite-plugins-know-steps.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle-vite-plugins": patch
+---
+
+Teach `mantleTwSourcePlugin` about the new `steps` subpath, so a consumer importing
+`@ngrok/mantle/steps` gets its classes scanned by Tailwind instead of an unstyled guide.
+
+`Steps` pulls in only mantle's `Slot`, which emits no utility classes of its own, so it needs no
+extra chunk beyond its own. No behavior change for any other component.

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -109,7 +109,7 @@ export const componentsByCategory = {
 	// Structure: contains, divides, or arranges arbitrary content — vs Data
 	// Display, which presents specific content. Page/viewport structure
 	// belongs to the top-level Layouts section, not here.
-	Structure: ["Card", "Media Object", "Separator", "Well"],
+	Structure: ["Card", "Media Object", "Separator", "Steps", "Well"],
 } as const satisfies Record<ComponentCategory, readonly string[]>;
 
 /** Display name of a production-ready component. */
@@ -194,6 +194,7 @@ export const prodReadyComponentRouteLookup = {
 	Slider: "/components/forms/slider",
 	Slot: "/components/primitives/slot",
 	"Split Button": "/components/actions/split-button",
+	Steps: "/components/structure/steps",
 	Switch: "/components/forms/switch",
 	Table: "/components/data-display/table",
 	Tabs: "/components/navigation/tabs",

--- a/apps/www/app/docs/components/structure/steps.mdx
+++ b/apps/www/app/docs/components/structure/steps.mdx
@@ -1,0 +1,302 @@
+---
+title: Steps
+description: A read-only setup guide — numbered steps down a page, joined by one continuous vertical rail.
+---
+
+import { Card } from "@ngrok/mantle/card";
+import { Code } from "@ngrok/mantle/code";
+import { Steps } from "@ngrok/mantle/steps";
+import { Example } from "~/components/example";
+
+export const needsDomain = true;
+
+# Steps
+
+A read-only setup guide: an ordered list of steps down a page, each marked by a numbered circle in a left gutter, joined by one continuous vertical rail. Every step stays visible, and nothing is interactive.
+
+Composition order is the numbering. The number is a CSS counter and the marker's silhouette comes from `:first-child` / `:last-child` / `:only-child`, so inserting, removing, or conditionally rendering a step renumbers the rest natively — correct on the server-rendered first paint, with no effect, no registration, and no `index` or `count` to keep in sync.
+
+<Example>
+	<div className="w-full max-w-xl">
+		<Steps.Root>
+			<Steps.Item>
+				<Steps.Title>Install the ngrok agent</Steps.Title>
+				<Card.Root>
+					<Card.Body>
+						<p>
+							Download the agent for your platform, or install it with{" "}
+							<Code>brew install ngrok</Code>.
+						</p>
+					</Card.Body>
+				</Card.Root>
+			</Steps.Item>
+			<Steps.Item>
+				<Steps.Title>Add your authtoken</Steps.Title>
+				<Card.Root>
+					<Card.Body>
+						<p>
+							Run <Code>ngrok config add-authtoken $YOUR_AUTHTOKEN</Code> to write the token into
+							your agent config file.
+						</p>
+					</Card.Body>
+				</Card.Root>
+			</Steps.Item>
+			<Steps.Item>
+				<Steps.Title>Get a public URL for your app</Steps.Title>
+				<Card.Root>
+					<Card.Body>
+						<p>
+							Run <Code>ngrok http 8080</Code> against the port your app listens on.
+						</p>
+					</Card.Body>
+				</Card.Root>
+			</Steps.Item>
+		</Steps.Root>
+	</div>
+</Example>
+
+```tsx
+import { Card } from "@ngrok/mantle/card";
+import { Code } from "@ngrok/mantle/code";
+import { Steps } from "@ngrok/mantle/steps";
+
+<Steps.Root>
+	<Steps.Item>
+		<Steps.Title>Install the ngrok agent</Steps.Title>
+		<Card.Root>
+			<Card.Body>
+				<p>
+					Download the agent for your platform, or install it with <Code>brew install ngrok</Code>.
+				</p>
+			</Card.Body>
+		</Card.Root>
+	</Steps.Item>
+	<Steps.Item>
+		<Steps.Title>Add your authtoken</Steps.Title>
+		<Card.Root>
+			<Card.Body>
+				<p>
+					Run <Code>ngrok config add-authtoken $YOUR_AUTHTOKEN</Code> to write the token into your
+					agent config file.
+				</p>
+			</Card.Body>
+		</Card.Root>
+	</Steps.Item>
+	<Steps.Item>
+		<Steps.Title>Get a public URL for your app</Steps.Title>
+		<Card.Root>
+			<Card.Body>
+				<p>
+					Run <Code>ngrok http 8080</Code> against the port your app listens on.
+				</p>
+			</Card.Body>
+		</Card.Root>
+	</Steps.Item>
+</Steps.Root>;
+```
+
+## Composition
+
+```text showLineNumbers=false
+Steps.Root
+└── Steps.Item
+    └── Steps.Title
+```
+
+- **`Root`** renders the `<ol role="list">`, resets the step counter, and opens the gutter the markers sit in.
+- **`Item`** renders one `<li>`. It increments the counter, draws its own segment of the rail, and mounts the numbered marker. Its children after `Title` are free-form.
+- **`Title`** renders the step heading, and is what the marker aligns to.
+
+## The rail is a border, not a line
+
+Each step's rail is that item's `border-inline-start`. A border spans the item however tall its content grows, and the bottom padding sits inside the border box, so the rail also runs through the gap to the next step. The last item keeps the width and drops the color, so removing a step shifts nothing sideways.
+
+The marker is an SVG blob whose stubs land exactly on that border, in the same color. Same color plus exact overlap is what makes the pair read as one stick that swells into each circle instead of butting against it. Two consequences follow, and both are why the geometry is not tunable:
+
+- The gutter, the marker box, the offsets, and the rail width are one locked system. `18px` of gutter is `(40 - 4) / 2`, and the stub only lands on the rail because both are `4px`.
+- The fill has to stay opaque. A translucent one composites the overlap twice and draws the joint the fillets exist to hide.
+
+## Conditional steps
+
+A step that renders conditionally needs nothing else. The numbers come from a CSS counter over the rendered `<li>` elements, so a `false` child, a `Fragment`, or a wrapper component that renders `Steps.Item` as its root all land the same way — the DOM is the source of truth, not the children array.
+
+<Example>
+	<div className="w-full max-w-xl">
+		<Steps.Root>
+			<Steps.Item>
+				<Steps.Title>Install the ngrok agent</Steps.Title>
+			</Steps.Item>
+			<Steps.Item>
+				<Steps.Title>Add your authtoken</Steps.Title>
+			</Steps.Item>
+			{needsDomain && (
+				<Steps.Item>
+					<Steps.Title>Bring your own domain</Steps.Title>
+				</Steps.Item>
+			)}
+		</Steps.Root>
+	</div>
+</Example>
+
+```tsx
+import { Steps } from "@ngrok/mantle/steps";
+
+const needsDomain = true;
+
+<Steps.Root>
+	<Steps.Item>
+		<Steps.Title>Install the ngrok agent</Steps.Title>
+	</Steps.Item>
+	<Steps.Item>
+		<Steps.Title>Add your authtoken</Steps.Title>
+	</Steps.Item>
+	{needsDomain && (
+		<Steps.Item>
+			<Steps.Title>Bring your own domain</Steps.Title>
+		</Steps.Item>
+	)}
+</Steps.Root>;
+```
+
+## Polymorphism
+
+Every `Steps` part accepts an `asChild` prop. When `true`, the part renders its single child instead of its default element, forwarding all class names, `data-*` attributes, and the ref onto that child.
+
+Reach for it on `Steps.Title` to fit the surrounding document outline — the title renders an `h3` by default, and the component deliberately does not dictate the page's heading levels. `Steps.Item` also accepts it, and its child must render an `<li>`: anything else between the `<ol>` and its items is invalid HTML, and `:first-child` and `:last-child` stop describing the step.
+
+<Example>
+	<div className="w-full max-w-xl">
+		<Steps.Root>
+			<Steps.Item>
+				<Steps.Title asChild>
+					<h2>Install the ngrok agent</h2>
+				</Steps.Title>
+			</Steps.Item>
+			<Steps.Item>
+				<Steps.Title asChild>
+					<h2>Add your authtoken</h2>
+				</Steps.Title>
+			</Steps.Item>
+		</Steps.Root>
+	</div>
+</Example>
+
+```tsx
+import { Steps } from "@ngrok/mantle/steps";
+
+<Steps.Root>
+	<Steps.Item>
+		<Steps.Title asChild>
+			<h2>Install the ngrok agent</h2>
+		</Steps.Title>
+	</Steps.Item>
+	<Steps.Item>
+		<Steps.Title asChild>
+			<h2>Add your authtoken</h2>
+		</Steps.Title>
+	</Steps.Item>
+</Steps.Root>;
+```
+
+## Collapsing the marker column
+
+On a narrow surface there is no horizontal room for the gutter, and the titles carry the order on their own. Hide the gutter, the indent, and the marker with the classes below rather than with a prop. The breakpoint belongs to your layout, and a baked-in one is not removable. The marker is `aria-hidden` at every width, so hiding it changes nothing for a screen reader.
+
+```tsx
+import { Steps } from "@ngrok/mantle/steps";
+
+<Steps.Root className="max-md:ps-0">
+	<Steps.Item className="max-md:border-s-0 max-md:ps-0 max-md:[&_[data-slot=steps-marker]]:hidden">
+		<Steps.Title>Install the ngrok agent</Steps.Title>
+	</Steps.Item>
+	<Steps.Item className="max-md:border-s-0 max-md:ps-0 max-md:[&_[data-slot=steps-marker]]:hidden">
+		<Steps.Title>Add your authtoken</Steps.Title>
+	</Steps.Item>
+</Steps.Root>;
+```
+
+## Theming
+
+`Steps` paints with two design tokens, and both resolve per theme. The standard themes take a quiet neutral stop. The high-contrast themes take both poles, because a rail that quiet disappears against a high-contrast surface.
+
+Override them together. The number has to stay readable on the fill it sits in, and the fill has to stay opaque: a translucent one composites the overlap twice and seams where the marker's stubs land on the rail.
+
+Every cell below is a WCAG contrast ratio, and higher is better. The number owes 4.5:1 on the rail in every theme. The rail itself carries no information, so outside high contrast it owes only 1.4:1 against the surface — enough to read as a line. In the two high-contrast themes it owes WCAG 1.4.11's 3:1. `steps/tokens.test.tsx` re-measures all of it.
+
+| Theme               | Number on rail | Rail on page | Rail on card |
+| ------------------- | -------------- | ------------ | ------------ |
+| light               | 12.64          | 1.42         | 1.48         |
+| dark                | 9.93           | 1.81         | 1.73         |
+| light-high-contrast | 21             | 20.12        | 21           |
+| dark-high-contrast  | 21             | 21           | 18.73        |
+
+## Accessibility
+
+The guide is a real `<ol>` of `<li>`, with `role="list"` restated on the list. The design strips `list-style`, and WebKit drops list semantics from a list that has none ([WebKit bug 170179](https://bugs.webkit.org/show_bug.cgi?id=170179), [Scott O'Hara, "Fixing" Lists](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html)) — which would take the "2 of 3" position with it. Two mechanisms hold the role, and both are load-bearing: `Steps.Root` omits `role` from its props type, so nothing can pass one; and under `asChild` the role is cloned onto the child, because a slot's own props lose to its child's.
+
+The markers are one `aria-hidden` unit per step, with no text of their own: the number is CSS generated content, not a text node. Step position comes from the list, and the visible digits are decoration.
+
+Nothing is focusable and there is no keyboard contract — this is static content. For one panel at a time, where a reader clicks a step to reveal it, reach for [Tabs](/components/navigation/tabs); that intent carries tab semantics and a keyboard contract `Steps` has none of. For a step that collapses, reach for [Accordion](/components/data-display/accordion).
+
+## API Reference
+
+### Steps.Root
+
+The ordered list every step hangs off. Renders an `<ol role="list">` that resets the step counter and opens the gutter the markers sit in. The number is a CSS counter, so `start` and `reversed` move the native marker this component hides, not the number a reader sees.
+
+All props from [ol](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                             |
+| ---------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Steps.Root` styling onto alternative element types or your own React components. |
+
+#### CSS variables
+
+Both are design tokens with a per-theme value, not per-instance knobs. Override them on any ancestor to re-theme every guide below it, and override both together.
+
+| CSS Variable           | Default                                                                      | Description                                                                                                 |
+| ---------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `--color-steps-rail`   | `var(--color-neutral-300)`; `var(--color-black)` in the high-contrast themes | The rail and the marker blob. Must stay opaque — a translucent fill seams where the stubs overlay the rail. |
+| `--color-steps-number` | `var(--color-neutral-950)`; `var(--color-white)` in the high-contrast themes | The number painted on the blob.                                                                             |
+
+#### Data attributes
+
+| Data Attribute | Value     | Description                                                                                         |
+| -------------- | --------- | --------------------------------------------------------------------------------------------------- |
+| `data-slot`    | `"steps"` | On the list element. Stable styling hook that survives a `className` override or an `asChild` swap. |
+
+### Steps.Item
+
+One step. Renders an `<li>` that increments the step counter, draws its own segment of the rail, and mounts the numbered marker ahead of its children. Under `asChild` the child must render an `<li>`.
+
+All props from [li](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                             |
+| ---------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Steps.Item` styling onto alternative element types or your own React components. |
+
+#### Data attributes
+
+| Data Attribute | Value                  | Description                                                                                                                                         |
+| -------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-slot`    | `"steps-item"`         | On the list item. Stable styling hook that survives a `className` override or an `asChild` swap.                                                    |
+| `data-slot`    | `"steps-marker"`       | On the `aria-hidden` marker in the gutter. Target it to hide the marker column — see [Collapsing the marker column](#collapsing-the-marker-column). |
+| `data-slot`    | `"steps-item-content"` | On the `display: contents` wrapper the step's own children render into. It lays out nothing, so style your own child instead of this slot.          |
+
+The wrapper is not cosmetic. A browser translation engine reparents each text node, and the marker beside a bare text child is what turns React's next update into a `removeChild` aimed at a node the list no longer owns — a thrown `DOMException` and a blank page. The wrapper puts a lone text child back on its own, where React writes it through `textContent` instead.
+
+### Steps.Title
+
+The heading of one step, and what the marker aligns to. Renders an `h3` by default — pass `asChild` to fit the surrounding document outline. Keep it a heading element (`h1`-`h6`) for accessibility. The marker sits at a fixed offset from the top of the item, so keep the title the item's first child at the default type size.
+
+All props from [h1-h6](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#attributes), plus:
+
+| Prop       | Type      | Default | Description                                                                                                              |
+| ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `asChild?` | `boolean` | `false` | Use the `asChild` prop to compose the `Steps.Title` styling onto alternative element types or your own React components. |
+
+#### Data attributes
+
+| Data Attribute | Value           | Description                                                                                            |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------------ |
+| `data-slot`    | `"steps-title"` | On the heading element. Stable styling hook that survives a `className` override or an `asChild` swap. |

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -152,6 +152,7 @@ export default [
 		...docRoute("components/structure/card"),
 		...docRoute("components/structure/media-object"),
 		...docRoute("components/structure/separator"),
+		...docRoute("components/structure/steps"),
 		...docRoute("components/structure/well"),
 
 		// hooks 🪝

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -847,6 +847,20 @@
     ]
   },
   {
+    "name": "Steps",
+    "slug": "components/structure/steps",
+    "kind": "component",
+    "category": "Structure",
+    "status": "stable",
+    "importPath": "@ngrok/mantle/steps",
+    "summary": "A read-only setup guide — numbered steps down a page, joined by one continuous vertical rail.",
+    "jsdoc": "A read-only setup guide: an ordered list of steps down a page, each marked by a numbered circle in a left gutter, joined by one continuous vertical rail.",
+    "examples": [
+      "Composition:\n```\nSteps.Root\n└── Steps.Item\n    └── Steps.Title\n```",
+      "```tsx\n<Steps.Root>\n  <Steps.Item>\n    <Steps.Title>Install the ngrok agent</Steps.Title>\n    <p>Download the agent for your platform.</p>\n  </Steps.Item>\n  <Steps.Item>\n    <Steps.Title asChild>\n      <h2>Add your authtoken</h2>\n    </Steps.Title>\n    <p>Run ngrok config add-authtoken with the token from your dashboard.</p>\n  </Steps.Item>\n  <Steps.Item>\n    <Steps.Title>Get a public URL for your app</Steps.Title>\n    <p>Start a tunnel to the port your app listens on.</p>\n  </Steps.Item>\n</Steps.Root>\n```"
+    ]
+  },
+  {
     "name": "Switch",
     "slug": "components/forms/switch",
     "kind": "component",

--- a/packages/mantle-vite-plugins/src/mantle-component-name.ts
+++ b/packages/mantle-vite-plugins/src/mantle-component-name.ts
@@ -74,6 +74,7 @@ export const MANTLE_COMPONENT_NAMES = [
 	"slider",
 	"slot",
 	"split-button",
+	"steps",
 	"switch",
 	"table",
 	"tabs",

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -365,6 +365,11 @@
 			"types": "./dist/split-button.d.ts",
 			"import": "./dist/split-button.js"
 		},
+		"./steps": {
+			"@ngrok/src-live-types": "./src/components/steps/index.ts",
+			"types": "./dist/steps.d.ts",
+			"import": "./dist/steps.js"
+		},
 		"./switch": {
 			"@ngrok/src-live-types": "./src/components/switch/index.ts",
 			"types": "./dist/switch.d.ts",

--- a/packages/mantle/src/components/chart/palette-gates.ts
+++ b/packages/mantle/src/components/chart/palette-gates.ts
@@ -3,10 +3,11 @@
  * CSS custom-property resolution that feeds them.
  *
  * This module is internal shared implementation — it is not exported from the
- * package. `tokens.test.ts` is its only consumer: it resolves every
+ * package. Its consumers are all tests: `tokens.test.ts` resolves every
  * `--color-chart-*` slot in every theme down to a concrete color and runs the
  * gates on the result, so a slot that drifts below a threshold fails CI instead
- * of shipping.
+ * of shipping; `decorative-contrast.test.tsx` and `steps/tokens.test.tsx` read
+ * the same resolver and the same WCAG ratio for their own token pairs.
  *
  * The thresholds and the pairlist rules come from the ASD dataviz color formula
  * this repo follows. The sRGB transfer functions, the OKLab matrices, the WCAG

--- a/packages/mantle/src/components/steps/index.ts
+++ b/packages/mantle/src/components/steps/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Re-exports for the Steps component.
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps
+ */
+
+export {
+	//,
+	Steps,
+} from "./steps.js";
+
+export type { StepsItemProps, StepsRootProps, StepsTitleProps } from "./steps.js";

--- a/packages/mantle/src/components/steps/steps.test.tsx
+++ b/packages/mantle/src/components/steps/steps.test.tsx
@@ -1,0 +1,600 @@
+import { render, screen } from "@testing-library/react";
+import { createRef, type PropsWithChildren, type ReactNode } from "react";
+import { renderToString } from "react-dom/server";
+import invariant from "tiny-invariant";
+import { describe, expect, test } from "vitest";
+import { translateTextNodes } from "../../test-utils/translate-text-nodes.js";
+import { Steps } from "./steps.js";
+
+/** Three steps: the shortest composition that has a first, a middle, and a last. */
+const Guide = ({ children }: PropsWithChildren) => (
+	<Steps.Root data-testid="root">
+		<Steps.Item data-testid="step-1">
+			<Steps.Title>Install the ngrok agent</Steps.Title>
+		</Steps.Item>
+		<Steps.Item data-testid="step-2">
+			<Steps.Title>Add your authtoken</Steps.Title>
+		</Steps.Item>
+		<Steps.Item data-testid="step-3">
+			<Steps.Title>Get a public URL for your app</Steps.Title>
+		</Steps.Item>
+		{children}
+	</Steps.Root>
+);
+
+const markerOf = (item: HTMLElement) => {
+	const marker = item.querySelector('[data-slot="steps-marker"]');
+	invariant(marker != null, "the item rendered no marker");
+	return marker;
+};
+
+/**
+ * Rebuild each silhouette's real CSS selector from the class Tailwind compiles
+ * it from, so the exclusivity test below evaluates the shipped condition against
+ * the shipped DOM. Reading the conditions rather than restating them is what
+ * lets it catch a permuted, widened, or unscoped edit — the silhouette choice
+ * emits no data attribute and changes nothing else in the DOM, so the class is
+ * its only observable.
+ *
+ * Tailwind compiles `group-[&<condition>]/steps-item:block` to
+ * `:where(.group/steps-item)<condition> *`, and the group lands on the item.
+ */
+const paintedShapesIn = (marker: Element) =>
+	Array.from(marker.querySelectorAll("svg > *")).filter((shape) => {
+		const condition = shape.getAttribute("class")?.match(/group-\[&(.+?)\]\/steps-item:block/)?.[1];
+		invariant(condition != null, `<${shape.tagName}> carries no position selector`);
+		const selected = document.querySelectorAll(`[data-slot~="steps-item"]${condition} *`);
+		return Array.from(selected).includes(shape);
+	});
+
+/**
+ * Name the shape that paints, by the geometry it draws rather than by the class
+ * that selected it. A silhouette with a top stub starts on the top edge at the
+ * stub's leading edge, `x=18`; one with a bottom stub walks down to `y=50`. The
+ * plain circle has no path at all.
+ */
+const paintedShapeIn = (marker: Element) => {
+	const painted = paintedShapesIn(marker);
+	invariant(painted.length === 1, `${painted.length} silhouettes paint at once`);
+	const [shape] = painted;
+	invariant(shape != null, "no silhouette paints");
+	const path = shape.getAttribute("d");
+	if (path == null) {
+		return "only";
+	}
+	const hasTopStub = path.startsWith("M18 ");
+	const hasBottomStub = path.includes("V50h-4");
+	if (hasTopStub && hasBottomStub) {
+		return "middle";
+	}
+	return hasTopStub ? "last" : "first";
+};
+
+describe("Steps.Root", () => {
+	test("renders an ol that a WebKit reader still hears as a list", () => {
+		render(<Guide />);
+		const root = screen.getByTestId("root");
+		expect(root.tagName).toBe("OL");
+		// `list-style: none` costs WebKit the list semantics, and those semantics
+		// are the only step position a screen reader gets.
+		expect(root).toHaveAttribute("role", "list");
+		expect(screen.getByRole("list")).toBe(root);
+	});
+
+	test("keeps role=list when a consumer forces another role past the type", () => {
+		render(
+			// `StepsRootProps` omits `role`, so this is a compile error as well as a
+			// no-op — `pnpm typecheck` owns the first half, this owns the second.
+			// @ts-expect-error - role is not assignable to StepsRootProps
+			<Steps.Root data-testid="root" role="presentation">
+				<Steps.Item>
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		expect(screen.getByTestId("root")).toHaveAttribute("role", "list");
+	});
+
+	test("a consumer className beats the default it conflicts with", () => {
+		render(
+			<Steps.Root className="ps-0" data-testid="root">
+				<Steps.Item>
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const root = screen.getByTestId("root");
+		// The tailwind-merge contract: the consumer's padding replaces the gutter
+		// rather than racing it in stylesheet order.
+		expect(root.className).toContain("ps-0");
+		expect(root.className).not.toContain("ps-4.5");
+		expect(root.className).toContain("list-none");
+	});
+
+	test("joins an incoming data-slot chain ahead of its own", () => {
+		render(
+			<Steps.Root data-slot="setup-guide" data-testid="root">
+				<Steps.Item>
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		expect(screen.getByTestId("root")).toHaveAttribute("data-slot", "setup-guide steps");
+	});
+
+	test("renders as child element when asChild is true, keeping data-slot and the role", () => {
+		render(
+			<Steps.Root asChild>
+				<ol data-testid="root">
+					<Steps.Item>
+						<Steps.Title>Install the ngrok agent</Steps.Title>
+					</Steps.Item>
+				</ol>
+			</Steps.Root>,
+		);
+		const root = screen.getByTestId("root");
+		expect(root).toHaveAttribute("data-slot", "steps");
+		expect(root).toHaveAttribute("role", "list");
+	});
+
+	test("keeps role=list when the asChild child carries its own role", () => {
+		// `Slot` merges the child's props over the slot's, so a role stamped only
+		// on the slot loses to the child and the list stops being a list.
+		render(
+			<Steps.Root asChild>
+				<ol data-testid="root" role="presentation">
+					<Steps.Item>
+						<Steps.Title>Install the ngrok agent</Steps.Title>
+					</Steps.Item>
+				</ol>
+			</Steps.Root>,
+		);
+		expect(screen.getByTestId("root")).toHaveAttribute("role", "list");
+		expect(screen.getByRole("list")).toBe(screen.getByTestId("root"));
+	});
+
+	test("forwards refs and data-* attributes", () => {
+		const ref = createRef<HTMLOListElement>();
+		render(
+			<Steps.Root data-flavor="setup" data-testid="root" ref={ref}>
+				<Steps.Item>
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const root = screen.getByTestId("root");
+		expect(root).toHaveAttribute("data-flavor", "setup");
+		expect(ref.current).toBe(root);
+	});
+});
+
+describe("Steps.Item", () => {
+	test("renders an li that is a direct child of the list", () => {
+		render(<Guide />);
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(3);
+		for (const item of items) {
+			expect(item.tagName).toBe("LI");
+			expect(item.parentElement).toBe(screen.getByTestId("root"));
+		}
+	});
+
+	test("a consumer className beats the default it conflicts with", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item className="pb-4" data-testid="step">
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const item = screen.getByTestId("step");
+		// The tailwind-merge contract: `pb-4` replaces `pb-10` rather than racing it.
+		expect(item.className).toContain("pb-4");
+		expect(item.className).not.toContain("pb-10");
+		expect(item.className).toContain("relative");
+	});
+
+	test("joins an incoming data-slot chain ahead of its own", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item data-slot="setup-step" data-testid="step">
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		expect(screen.getByTestId("step")).toHaveAttribute("data-slot", "setup-step steps-item");
+	});
+
+	test("under asChild the swap merges the className and forwards the ref", () => {
+		const ref = createRef<HTMLLIElement>();
+		render(
+			<Steps.Root>
+				<Steps.Item asChild className="pb-4" ref={ref}>
+					<li className="scroll-mt-8" data-testid="step">
+						<Steps.Title>Install the ngrok agent</Steps.Title>
+					</li>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const item = screen.getByTestId("step");
+		expect(ref.current).toBe(item);
+		expect(item.className).toContain("scroll-mt-8");
+		expect(item.className).toContain("pb-4");
+		expect(item.className).toContain("relative");
+	});
+
+	test("the rail turns transparent on the last step and stays four pixels wide", () => {
+		render(<Guide />);
+		// A cross-file pin: `last:border-s-transparent` is what lets `:last-child`
+		// own last-ness, and dropping it hangs 40px of rail below the last marker.
+		// happy-dom computes no Tailwind, so the class is the only observable.
+		const classNames = screen.getAllByRole("listitem").map((item) => item.className);
+		expect(classNames.every((className) => className.includes("border-s-[0.25rem]"))).toBe(true);
+		expect(classNames.every((className) => className.includes("last:border-s-transparent"))).toBe(
+			true,
+		);
+	});
+
+	test("renders as child element when asChild is true, keeping data-slot and the marker", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item asChild>
+					<li data-testid="step">
+						<Steps.Title>Install the ngrok agent</Steps.Title>
+					</li>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const item = screen.getByTestId("step");
+		expect(item).toHaveAttribute("data-slot", "steps-item");
+		expect(markerOf(item)).toBeInTheDocument();
+		expect(item).toHaveTextContent("Install the ngrok agent");
+	});
+
+	test("asChild composition accumulates the data-slot chain in DOM order", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item asChild>
+					<li data-slot="setup-step" data-testid="step">
+						<Steps.Title>Install the ngrok agent</Steps.Title>
+					</li>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		expect(screen.getByTestId("step")).toHaveAttribute("data-slot", "steps-item setup-step");
+	});
+
+	test("asChild throws when the child is not a single JSX tag", () => {
+		expect(() =>
+			render(
+				<Steps.Root>
+					<Steps.Item asChild>Install the ngrok agent</Steps.Item>
+				</Steps.Root>,
+			),
+		).toThrow("When using `asChild`, Steps.Item must be passed a single child as a JSX tag.");
+	});
+
+	test("forwards refs and data-* attributes", () => {
+		const ref = createRef<HTMLLIElement>();
+		render(
+			<Steps.Root>
+				<Steps.Item data-state="done" data-testid="step" ref={ref}>
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const item = screen.getByTestId("step");
+		expect(item).toHaveAttribute("data-state", "done");
+		expect(ref.current).toBe(item);
+	});
+});
+
+describe("Steps.Title", () => {
+	test("renders an h3 by default", () => {
+		render(<Guide />);
+		const title = screen.getByRole("heading", { level: 3, name: "Add your authtoken" });
+		expect(title).toHaveAttribute("data-slot", "steps-title");
+	});
+
+	test("renders as child element when asChild is true, keeping data-slot", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item>
+					<Steps.Title asChild>
+						<h2>Add your authtoken</h2>
+					</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const title = screen.getByRole("heading", { level: 2, name: "Add your authtoken" });
+		expect(title).toHaveAttribute("data-slot", "steps-title");
+	});
+
+	test("a consumer className beats the default it conflicts with", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item>
+					<Steps.Title className="text-2xl" data-testid="title">
+						Add your authtoken
+					</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const title = screen.getByTestId("title");
+		// The tailwind-merge contract: `text-2xl` replaces `text-lg`.
+		expect(title.className).toContain("text-2xl");
+		expect(title.className).not.toContain("text-lg");
+		expect(title.className).toContain("font-medium");
+	});
+
+	test("joins an incoming data-slot chain ahead of its own", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item>
+					<Steps.Title data-slot="setup-heading" data-testid="title">
+						Add your authtoken
+					</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		expect(screen.getByTestId("title")).toHaveAttribute("data-slot", "setup-heading steps-title");
+	});
+
+	test("under asChild the swap merges the className and forwards the ref", () => {
+		const ref = createRef<HTMLHeadingElement>();
+		render(
+			<Steps.Root>
+				<Steps.Item>
+					<Steps.Title asChild className="text-2xl" ref={ref}>
+						<h2 className="tracking-tight" data-testid="title">
+							Add your authtoken
+						</h2>
+					</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const title = screen.getByTestId("title");
+		expect(ref.current).toBe(title);
+		expect(title.tagName).toBe("H2");
+		expect(title.className).toContain("tracking-tight");
+		expect(title.className).toContain("text-2xl");
+	});
+
+	test("forwards refs and data-* attributes", () => {
+		const ref = createRef<HTMLHeadingElement>();
+		render(
+			<Steps.Root>
+				<Steps.Item>
+					<Steps.Title data-emphasis="high" data-testid="title" ref={ref}>
+						Add your authtoken
+					</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const title = screen.getByTestId("title");
+		expect(title).toHaveAttribute("data-emphasis", "high");
+		expect(ref.current).toBe(title);
+	});
+});
+
+describe("Steps data-slot", () => {
+	test.each([
+		["root", "steps", "OL"],
+		["step-1", "steps-item", "LI"],
+		["title", "steps-title", "H3"],
+	])("%s stamps data-slot=%s on a %s", (testId, slot, tagName) => {
+		render(
+			<Steps.Root data-testid="root">
+				<Steps.Item data-testid="step-1">
+					<Steps.Title data-testid="title">Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const element = screen.getByTestId(testId);
+		expect(element.tagName).toBe(tagName);
+		expect(element).toHaveAttribute("data-slot", slot);
+	});
+
+	test("the marker carries its own slot so a consumer can hide the gutter", () => {
+		render(<Guide />);
+		expect(markerOf(screen.getByTestId("step-2"))).toHaveAttribute("data-slot", "steps-marker");
+	});
+
+	test("the content wrapper carries its own slot and lays out nothing", () => {
+		render(<Guide />);
+		const content = screen.getByTestId("step-2").querySelector('[data-slot="steps-item-content"]');
+		// A `<div>`, not a `<span>`: a step's children are flow content, and the
+		// box never renders either way, so the element that validates is free.
+		expect(content?.tagName).toBe("DIV");
+		// A cross-file pin: `contents` is what keeps the wrapper out of layout, so
+		// the step's own children still lay out as children of the `<li>`.
+		expect(content?.className).toBe("contents");
+		expect(content).toHaveTextContent("Add your authtoken");
+	});
+});
+
+describe("Steps marker", () => {
+	test("is decoration: hidden from assistive technology, with no text of its own", () => {
+		render(<Guide />);
+		const marker = markerOf(screen.getByTestId("step-2"));
+		expect(marker).toHaveAttribute("aria-hidden", "true");
+		// The dashboard's copy shipped an <svg><title> per marker, so a reader
+		// heard "Number with partial stick above and below" once per step.
+		expect(marker.querySelector("title")).toBeNull();
+		expect(marker.textContent).toBe("");
+	});
+
+	test.each([
+		[1, ["only"]],
+		[2, ["first", "last"]],
+		[3, ["first", "middle", "last"]],
+		[4, ["first", "middle", "middle", "last"]],
+	])("a %i-step guide paints the silhouettes %j, in that order", (length, expected) => {
+		render(
+			<Steps.Root>
+				{Array.from({ length }, (_unused, index) => (
+					<Steps.Item key={index}>
+						<Steps.Title>Step {index + 1}</Steps.Title>
+					</Steps.Item>
+				))}
+			</Steps.Root>,
+		);
+		// Which shape wins, not only that one wins: swapping two `d` values leaves
+		// each step matching exactly one condition while the first step's stub runs
+		// up out of the circle into nothing.
+		expect(screen.getAllByRole("listitem").map((item) => paintedShapeIn(markerOf(item)))).toEqual(
+			expected,
+		);
+	});
+
+	test("a guide nested inside a step reads its own position, not the outer step's", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item data-testid="outer-first">
+					<Steps.Title>Outer one</Steps.Title>
+					<Steps.Root>
+						<Steps.Item data-testid="inner-first">
+							<Steps.Title>Inner one</Steps.Title>
+						</Steps.Item>
+						<Steps.Item data-testid="inner-last">
+							<Steps.Title>Inner two</Steps.Title>
+						</Steps.Item>
+					</Steps.Root>
+				</Steps.Item>
+				<Steps.Item data-testid="outer-last">
+					<Steps.Title>Outer two</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		// A plain group variant is a descendant selector, so the inner markers
+		// would also match the outer step's `:first-child` and paint two shapes.
+		expect({
+			outerFirst: paintedShapeIn(markerOf(screen.getByTestId("outer-first"))),
+			innerFirst: paintedShapeIn(markerOf(screen.getByTestId("inner-first"))),
+			innerLast: paintedShapeIn(markerOf(screen.getByTestId("inner-last"))),
+			outerLast: paintedShapeIn(markerOf(screen.getByTestId("outer-last"))),
+		}).toEqual({
+			outerFirst: "first",
+			innerFirst: "first",
+			innerLast: "last",
+			outerLast: "last",
+		});
+	});
+});
+
+describe("Steps numbering", () => {
+	test("the three counter classes name one counter, so the numbers advance", () => {
+		render(<Guide />);
+		// A cross-element spelling pin: the reset, the increment, and the
+		// `content` that reads them are on three different elements, and a rename
+		// in one leaves every step numbered 0 with nothing else to see it.
+		expect(screen.getByTestId("root").className).toContain("[counter-reset:mantle-steps]");
+		expect(screen.getByTestId("step-2").className).toContain("[counter-increment:mantle-steps]");
+		expect(markerOf(screen.getByTestId("step-2")).getAttribute("class")).toContain(
+			"after:content-[counter(mantle-steps)]",
+		);
+	});
+
+	test("a fragment and a false child leave the DOM flat, so position stays the numbering", () => {
+		const needsDomain = false;
+		render(
+			<Steps.Root data-testid="root">
+				<>
+					<Steps.Item data-testid="grouped-1">
+						<Steps.Title>Install the ngrok agent</Steps.Title>
+					</Steps.Item>
+					<Steps.Item data-testid="grouped-2">
+						<Steps.Title>Add your authtoken</Steps.Title>
+					</Steps.Item>
+				</>
+				{needsDomain && (
+					<Steps.Item>
+						<Steps.Title>Bring your own domain</Steps.Title>
+					</Steps.Item>
+				)}
+				<Steps.Item data-testid="last">
+					<Steps.Title>Get a public URL for your app</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		// Numbering by `Children` index counts the fragment as one step; the DOM
+		// counts three, and the DOM is what the counter and `:last-child` read.
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(3);
+		expect(items.map((item) => item.dataset.testid)).toEqual(["grouped-1", "grouped-2", "last"]);
+		expect(screen.getByTestId("last").matches(":last-child")).toBe(true);
+		expect(screen.getByTestId("grouped-2").matches(":last-child")).toBe(false);
+	});
+
+	test("a wrapper component that renders Steps.Item as its root stays a step", () => {
+		const DomainStep = () => (
+			<Steps.Item data-testid="wrapped">
+				<Steps.Title>Bring your own domain</Steps.Title>
+			</Steps.Item>
+		);
+		render(
+			<Steps.Root>
+				<Steps.Item data-testid="plain">
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+				<DomainStep />
+			</Steps.Root>,
+		);
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(2);
+		expect(screen.getByTestId("wrapped").matches(":last-child")).toBe(true);
+	});
+});
+
+describe("Steps server rendering", () => {
+	test("the first paint is the finished guide, markers and all", () => {
+		// Numbering and the silhouette choice are CSS, so nothing waits for an
+		// effect: the server markup is what a reader sees in the first frame.
+		const html = renderToString(<Guide />);
+		expect(html).toContain('role="list"');
+		expect(html).toContain('data-slot="steps-item"');
+		expect(html.match(/data-slot="steps-marker"/g)).toHaveLength(3);
+		expect(html).toContain("[counter-increment:mantle-steps]");
+		expect(html).not.toContain("<title>");
+	});
+});
+
+describe("Steps under a browser translation engine", () => {
+	test("removing a lone text child from a translated step does not throw", () => {
+		// Regression: the marker used to sit beside the text, which is what turns
+		// React's `setTextContent` write into a per-node `removeChild`. Translation
+		// reparents that node into a `<font>`, so the removal threw a DOMException
+		// and the page went blank. The content wrapper puts the text back on its own.
+		const Guide = ({ label }: { label: ReactNode }) => (
+			<Steps.Root data-testid="root">
+				<Steps.Item data-testid="step">{label}</Steps.Item>
+			</Steps.Root>
+		);
+		const { rerender } = render(<Guide label="Install the ngrok agent" />);
+		translateTextNodes(screen.getByTestId("root"));
+		expect(screen.getByTestId("step")).toHaveTextContent("[Install the ngrok agent-es]");
+
+		expect(() => rerender(<Guide label={null} />)).not.toThrow();
+		expect(screen.getByTestId("step")).toHaveTextContent("");
+	});
+
+	test("adding a step to a translated guide updates the DOM instead of throwing", () => {
+		const { rerender } = render(<Guide />);
+		translateTextNodes(screen.getByTestId("root"));
+		expect(screen.getByTestId("step-1")).toHaveTextContent("[Install the ngrok agent-es]");
+
+		// The marker mounts with its item and never inserts later, so an update
+		// beside the reparented text nodes is an append, not an insert before one.
+		expect(() =>
+			rerender(
+				<Guide>
+					<Steps.Item data-testid="step-4">
+						<Steps.Title>Bring your own domain</Steps.Title>
+					</Steps.Item>
+				</Guide>,
+			),
+		).not.toThrow();
+		expect(screen.getAllByRole("listitem")).toHaveLength(4);
+		expect(screen.getByTestId("step-4")).toHaveTextContent("Bring your own domain");
+	});
+});

--- a/packages/mantle/src/components/steps/steps.tsx
+++ b/packages/mantle/src/components/steps/steps.tsx
@@ -1,0 +1,541 @@
+import { Children, cloneElement, type ComponentProps, isValidElement, type ReactNode } from "react";
+import invariant from "tiny-invariant";
+import type { WithAsChild } from "../../types/index.js";
+import { cx } from "../../utils/cx/cx.js";
+import { joinDataSlot, type WithDataSlot } from "../../utils/data-slot.js";
+import { Slot } from "../slot/index.js";
+
+/**
+ * The stubbed marker silhouettes, in a `0 0 40 50` viewBox: a circle of `r=20`
+ * at `(20,25)`, plus the 4-wide stubs that run to the edges at `x=18..22`. Each
+ * stub flares into the circle through cubic Bézier fillets, so the junction
+ * reads as one liquid shape rather than a butt joint. An only step needs no
+ * stub, and takes the plain `<circle>` below instead.
+ */
+const SILHOUETTE = {
+	/** Circle, with the stub that runs down to the next step. */
+	first:
+		"M26.418 43.948C23.983 44.772 22 46.86 22 49.43V50h-4v-.57c0-2.57-1.983-4.658-4.418-5.482C5.685 41.274 0 33.801 0 25 0 13.954 8.954 5 20 5s20 8.954 20 20c0 8.801-5.685 16.274-13.582 18.948Z",
+	/** Circle, with both stubs. */
+	middle:
+		"M18 .57V0h4v.57c0 2.57 1.983 4.658 4.418 5.482C34.315 8.726 40 16.199 40 25s-5.685 16.274-13.582 18.948C23.983 44.772 22 46.86 22 49.43V50h-4v-.57c0-2.57-1.983-4.658-4.418-5.482C5.685 41.274 0 33.801 0 25S5.685 8.726 13.582 6.052C16.017 5.228 18 3.14 18 .57Z",
+	/** Circle, with the stub that runs up to the step above. */
+	last: "M18 0v.57c0 2.57-1.983 4.658-4.418 5.482C5.685 8.726 0 16.199 0 25c0 11.046 8.954 20 20 20s20-8.954 20-20c0-8.801-5.685-16.274-13.582-18.948C23.983 5.228 22 3.14 22 .57V0h-4Z",
+} as const;
+
+/**
+ * The numbered marker for one step: the blob, and the number the CSS counter
+ * writes into it.
+ *
+ * The `<ol>` already announces the step's position. `aria-hidden` keeps the
+ * visible number out of that announcement, so a reader hears one number rather
+ * than two that can disagree. The number is generated content, so no text node
+ * exists for a translation engine to reach.
+ *
+ * Positioning: the box sits `22px` before the item's padding box, which is
+ * `18px` before its border box — the offset that lands the stubs on the item's
+ * `4px` rail. Same color plus that overlap is what makes the pair read as one
+ * continuous stick. The two are exact at a 16px root font size, and within half
+ * a pixel of each other at every other size, because a border rounds to whole
+ * pixels and the SVG stub does not.
+ */
+const StepMarker = () => (
+	<div
+		aria-hidden="true"
+		data-slot="steps-marker"
+		className={cx(
+			"pointer-events-none absolute -top-1.5 -start-5.5 h-12.5 w-10 select-none",
+			// The number covers the circle, which spans y 5..45 of the 50-tall box.
+			"after:absolute after:inset-x-0 after:top-1.25 after:grid after:h-10 after:place-items-center",
+			// tabular-nums keeps 1 and 8 the same width, so a double-digit step stays
+			// centered in the circle. It sets a font feature, never the family.
+			// The forced-colors pair keeps the number legible once the blob is forced
+			// to CanvasText, which the svg below opts into for the same reason.
+			"after:text-steps-number after:text-lg after:font-medium after:tabular-nums",
+			"forced-colors:after:text-[Canvas]",
+			// The counter is generated content, so it is neither a text node a
+			// translation engine can reach nor a node React ever moves.
+			"after:content-[counter(mantle-steps)]",
+		)}
+	>
+		{/* Why the forced-colors pair: Windows High Contrast forces `border-color`
+		    and `color` but leaves SVG `fill` alone, which would split the rail and
+		    the blob into two colors and put the joint back. */}
+		<svg
+			viewBox="0 0 40 50"
+			className="fill-steps-rail forced-colors:fill-[CanvasText] absolute inset-0 size-full"
+		>
+			{/* Each silhouette states its whole position, so no two ever both match
+			    and no cascade order decides which one paints. Why the `>*>svg` tail:
+			    a plain group variant is a descendant selector, so a guide nested
+			    inside a step would read its position off the outer step too. */}
+			<path
+				className="hidden group-[&:first-child:not(:only-child)>*>svg]/steps-item:block"
+				d={SILHOUETTE.first}
+			/>
+			<path
+				className="hidden group-[&:not(:first-child):not(:last-child)>*>svg]/steps-item:block"
+				d={SILHOUETTE.middle}
+			/>
+			<path
+				className="hidden group-[&:last-child:not(:only-child)>*>svg]/steps-item:block"
+				d={SILHOUETTE.last}
+			/>
+			<circle
+				className="hidden group-[&:only-child>*>svg]/steps-item:block"
+				cx="20"
+				cy="25"
+				r="20"
+			/>
+		</svg>
+	</div>
+);
+
+/**
+ * The wrapper the step's own children render into. It lays out nothing —
+ * `display: contents` hands every child straight back to the item.
+ *
+ * Why it exists: the marker would otherwise be a sibling of a lone text child,
+ * which is what turns React's safe `setTextContent` write into a per-node
+ * `removeChild`. Under a browser translation engine that node has been
+ * reparented into a `<font>`, so the removal throws and the page goes blank.
+ *
+ * Why a `<div>`: a step's children are flow content — a heading, a paragraph, a
+ * `Card` — and a `<span>` takes phrasing content only. The box never renders
+ * either way, so the element that validates is free.
+ *
+ * @see CONVENTIONS.md § Browser Translation
+ */
+const StepContent = ({ children }: { children: ReactNode }) => (
+	<div data-slot="steps-item-content" className="contents">
+		{children}
+	</div>
+);
+
+/**
+ * Props for `Steps.Root`. Every `<ol>` attribute except `role`, which the part
+ * owns: the guide's whole accessible contract is that it stays a list, so a
+ * value here could only take that away.
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps#stepsroot
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root className="max-w-xl">
+ *   <Steps.Item>
+ *     <Steps.Title>Install the ngrok agent</Steps.Title>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+type StepsRootProps = Omit<ComponentProps<"ol">, "role"> & WithAsChild & WithDataSlot;
+
+/**
+ * The ordered list every step hangs off. Renders an `<ol role="list">` that
+ * resets the step counter and opens the gutter the markers sit in.
+ *
+ * It restates `role="list"` because the design strips `list-style`, and WebKit
+ * drops list semantics from a list that has none — which would take the "2 of
+ * 3" position with it. Two mechanisms hold the role, and both are load-bearing:
+ * `StepsRootProps` omits `role`, so nothing can pass one; and under `asChild`
+ * the role is cloned onto the child, because `Slot` merges a child's props over
+ * the slot's own.
+ *
+ * Composition order is the numbering. The number is a CSS counter, so `start`
+ * and `reversed` move the native marker this component hides, not the number a
+ * reader sees.
+ *
+ * `Steps.Root` paints with two design tokens. Both resolve per theme, so
+ * override them only to re-theme the rail, and override both together — the
+ * number has to stay readable on the fill.
+ *
+ * | CSS Variable            | Default                                                                  | Description                                                                                      |
+ * | ----------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+ * | `--color-steps-rail`    | `var(--color-neutral-300)`; `var(--color-black)` in the high-contrast themes | The rail and the marker blob. Must stay opaque — a translucent fill seams where the two overlap. |
+ * | `--color-steps-number`  | `var(--color-neutral-950)`; `var(--color-white)` in the high-contrast themes | The number painted on the blob.                                                                 |
+ *
+ * | Data Attribute | Value     | Description                                                                                    |
+ * | -------------- | --------- | ------------------------------------------------------------------------------------------------ |
+ * | `data-slot`    | `"steps"` | On the list element. Stable styling hook that survives a `className` override or an `asChild` swap. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps#stepsroot
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root>
+ *   <Steps.Item>
+ *     <Steps.Title>Install the ngrok agent</Steps.Title>
+ *     <p>Download the agent for your platform.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title asChild>
+ *       <h2>Add your authtoken</h2>
+ *     </Steps.Title>
+ *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title>Get a public URL for your app</Steps.Title>
+ *     <p>Start a tunnel to the port your app listens on.</p>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+const Root = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: StepsRootProps) => {
+	const Comp = asChild ? Slot : "ol";
+	// Slot merges child props over slot props, so with asChild the role has to
+	// land on the child element itself to stay un-overridable.
+	const content =
+		asChild && isValidElement<ComponentProps<"ol">>(children)
+			? cloneElement(children, { role: "list" })
+			: children;
+
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "steps")}
+			className={cx(
+				// The gutter keeps the marker inside the list box, so an ancestor
+				// that clips overflow cannot cut it off.
+				"list-none ps-4.5 [counter-reset:mantle-steps]",
+				className,
+			)}
+			{...props}
+			// Why stamped, and why after the spread: `list-style: none` costs a
+			// WebKit reader the list semantics, and those semantics are the only
+			// numbering it gets. `StepsRootProps` omits `role`, so the spread cannot
+			// carry one — this holds even when a wider props object does.
+			role="list"
+		>
+			{content}
+		</Comp>
+	);
+};
+
+/**
+ * Props for `Steps.Item`. Every `<li>` attribute, plus `asChild` — whose child
+ * must itself render an `<li>`.
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps#stepsitem
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root>
+ *   <Steps.Item className="pb-6">
+ *     <Steps.Title>Install the ngrok agent</Steps.Title>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+type StepsItemProps = ComponentProps<"li"> & WithAsChild & WithDataSlot;
+
+/**
+ * One step. Renders an `<li>` that increments the step counter, draws its own
+ * segment of the rail, and mounts the numbered marker ahead of its children.
+ *
+ * The rail is this item's `border-inline-start`, not a drawn line: a border
+ * spans the item however tall its content grows, and the bottom padding sits
+ * inside the border box, so the rail runs through the gap to the next step as
+ * well. The last item keeps the width and drops the color, so removing a step
+ * shifts nothing.
+ *
+ * Under `asChild` the child must render an `<li>` — anything else between the
+ * `<ol>` and its items is invalid HTML, and `:first-child` / `:last-child` stop
+ * describing the step.
+ *
+ * | Data Attribute | Value                   | Description                                                                                                     |
+ * | -------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+ * | `data-slot`    | `"steps-item"`          | On the list item. Stable styling hook that survives a `className` override or an `asChild` swap.                |
+ * | `data-slot`    | `"steps-marker"`        | On the `aria-hidden` marker in the gutter. Target it to hide the marker column, as the responsive recipe does.   |
+ * | `data-slot`    | `"steps-item-content"`  | On the `display: contents` wrapper the step's own children render into. It lays out nothing — style your child. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps#stepsitem
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root>
+ *   <Steps.Item>
+ *     <Steps.Title>Install the ngrok agent</Steps.Title>
+ *     <p>Download the agent for your platform.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title asChild>
+ *       <h2>Add your authtoken</h2>
+ *     </Steps.Title>
+ *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title>Get a public URL for your app</Steps.Title>
+ *     <p>Start a tunnel to the port your app listens on.</p>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+const Item = ({
+	asChild,
+	children,
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: StepsItemProps) => {
+	const itemProps = {
+		"data-slot": joinDataSlot(dataSlot, "steps-item"),
+		// Why the rail width is a rem and not `border-s-4`: the marker scales with
+		// the root font size, and a stub wider or narrower than the border it lands
+		// on puts a step in the goo.
+		className: cx(
+			"group/steps-item border-s-steps-rail relative border-s-[0.25rem] pt-1.5 pb-10 ps-8.5",
+			"[counter-increment:mantle-steps]",
+			// The width stays so the content keeps its indent; only the color goes.
+			"last:border-s-transparent",
+			className,
+		),
+		...props,
+	};
+
+	if (asChild) {
+		invariant(
+			isValidElement<{ children?: ReactNode }>(children) && Children.only(children),
+			"When using `asChild`, Steps.Item must be passed a single child as a JSX tag.",
+		);
+
+		return (
+			<Slot ref={ref} {...itemProps}>
+				{cloneElement(
+					children,
+					{},
+					<>
+						<StepMarker />
+						<StepContent>{children.props.children}</StepContent>
+					</>,
+				)}
+			</Slot>
+		);
+	}
+
+	return (
+		<li ref={ref} {...itemProps}>
+			<StepMarker />
+			<StepContent>{children}</StepContent>
+		</li>
+	);
+};
+
+/**
+ * Props for `Steps.Title`. Every heading attribute, plus `asChild` for fitting
+ * the surrounding document outline.
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps#stepstitle
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root>
+ *   <Steps.Item>
+ *     <Steps.Title asChild>
+ *       <h2>Install the ngrok agent</h2>
+ *     </Steps.Title>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+type StepsTitleProps = ComponentProps<"h3"> & WithAsChild & WithDataSlot;
+
+/**
+ * The heading of one step, and what the marker aligns to. Renders an `h3` by
+ * default — pass `asChild` to fit the surrounding document outline. Keep it a
+ * heading element (`h1`-`h6`) for accessibility.
+ *
+ * The marker sits at a fixed offset from the top of the item, so keep the title
+ * the item's first child at the default type size.
+ *
+ * | Data Attribute | Value           | Description                                                                                       |
+ * | -------------- | --------------- | --------------------------------------------------------------------------------------------------- |
+ * | `data-slot`    | `"steps-title"` | On the heading element. Stable styling hook that survives a `className` override or an `asChild` swap. |
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps#stepstitle
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root>
+ *   <Steps.Item>
+ *     <Steps.Title>Install the ngrok agent</Steps.Title>
+ *     <p>Download the agent for your platform.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title asChild>
+ *       <h2>Add your authtoken</h2>
+ *     </Steps.Title>
+ *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title>Get a public URL for your app</Steps.Title>
+ *     <p>Start a tunnel to the port your app listens on.</p>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+const Title = ({ asChild, className, "data-slot": dataSlot, ref, ...props }: StepsTitleProps) => {
+	const Comp = asChild ? Slot : "h3";
+
+	return (
+		<Comp
+			ref={ref}
+			data-slot={joinDataSlot(dataSlot, "steps-title")}
+			className={cx("text-strong mb-3 text-lg font-medium", className)}
+			{...props}
+		/>
+	);
+};
+
+/**
+ * A read-only setup guide: an ordered list of steps down a page, each marked by
+ * a numbered circle in a left gutter, joined by one continuous vertical rail.
+ * Every step stays visible, and nothing is interactive.
+ *
+ * Composition order is the numbering. The number is a CSS counter and the
+ * marker's silhouette comes from `:first-child` / `:last-child` / `:only-child`,
+ * so inserting, removing, or conditionally rendering a step renumbers the rest
+ * natively — correct on the server-rendered first paint, with no effect, no
+ * registration, and no index to keep in sync.
+ *
+ * The markers are `aria-hidden` decoration. Step position comes from the
+ * `<ol>`, which is what a screen reader announces as "2 of 3".
+ *
+ * For one panel at a time, where a reader clicks a step to reveal it, reach for
+ * [Tabs](https://mantle.ngrok.com/components/navigation/tabs) — that intent
+ * carries tab semantics and a keyboard contract this component has none of. For
+ * a step that collapses, reach for
+ * [Accordion](https://mantle.ngrok.com/components/data-display/accordion).
+ *
+ * @see https://mantle.ngrok.com/components/structure/steps
+ *
+ * @example
+ * Composition:
+ * ```
+ * Steps.Root
+ * └── Steps.Item
+ *     └── Steps.Title
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <Steps.Root>
+ *   <Steps.Item>
+ *     <Steps.Title>Install the ngrok agent</Steps.Title>
+ *     <p>Download the agent for your platform.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title asChild>
+ *       <h2>Add your authtoken</h2>
+ *     </Steps.Title>
+ *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+ *   </Steps.Item>
+ *   <Steps.Item>
+ *     <Steps.Title>Get a public URL for your app</Steps.Title>
+ *     <p>Start a tunnel to the port your app listens on.</p>
+ *   </Steps.Item>
+ * </Steps.Root>
+ * ```
+ */
+const Steps = {
+	/**
+	 * The ordered list every step hangs off. Renders an `<ol role="list">` that
+	 * resets the step counter and opens the gutter the markers sit in.
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/steps#stepsroot
+	 *
+	 * @example
+	 * ```tsx
+	 * <Steps.Root>
+	 *   <Steps.Item>
+	 *     <Steps.Title>Install the ngrok agent</Steps.Title>
+	 *     <p>Download the agent for your platform.</p>
+	 *   </Steps.Item>
+	 *   <Steps.Item>
+	 *     <Steps.Title asChild>
+	 *       <h2>Add your authtoken</h2>
+	 *     </Steps.Title>
+	 *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+	 *   </Steps.Item>
+	 *   <Steps.Item>
+	 *     <Steps.Title>Get a public URL for your app</Steps.Title>
+	 *     <p>Start a tunnel to the port your app listens on.</p>
+	 *   </Steps.Item>
+	 * </Steps.Root>
+	 * ```
+	 */
+	Root,
+	/**
+	 * One step. Renders an `<li>` that increments the step counter, draws its own
+	 * segment of the rail, and mounts the numbered marker ahead of its children.
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/steps#stepsitem
+	 *
+	 * @example
+	 * ```tsx
+	 * <Steps.Root>
+	 *   <Steps.Item>
+	 *     <Steps.Title>Install the ngrok agent</Steps.Title>
+	 *     <p>Download the agent for your platform.</p>
+	 *   </Steps.Item>
+	 *   <Steps.Item>
+	 *     <Steps.Title asChild>
+	 *       <h2>Add your authtoken</h2>
+	 *     </Steps.Title>
+	 *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+	 *   </Steps.Item>
+	 *   <Steps.Item>
+	 *     <Steps.Title>Get a public URL for your app</Steps.Title>
+	 *     <p>Start a tunnel to the port your app listens on.</p>
+	 *   </Steps.Item>
+	 * </Steps.Root>
+	 * ```
+	 */
+	Item,
+	/**
+	 * The heading of one step, and what the marker aligns to. Renders an `h3` by
+	 * default — pass `asChild` to fit the surrounding document outline.
+	 *
+	 * @see https://mantle.ngrok.com/components/structure/steps#stepstitle
+	 *
+	 * @example
+	 * ```tsx
+	 * <Steps.Root>
+	 *   <Steps.Item>
+	 *     <Steps.Title>Install the ngrok agent</Steps.Title>
+	 *     <p>Download the agent for your platform.</p>
+	 *   </Steps.Item>
+	 *   <Steps.Item>
+	 *     <Steps.Title asChild>
+	 *       <h2>Add your authtoken</h2>
+	 *     </Steps.Title>
+	 *     <p>Run ngrok config add-authtoken with the token from your dashboard.</p>
+	 *   </Steps.Item>
+	 *   <Steps.Item>
+	 *     <Steps.Title>Get a public URL for your app</Steps.Title>
+	 *     <p>Start a tunnel to the port your app listens on.</p>
+	 *   </Steps.Item>
+	 * </Steps.Root>
+	 * ```
+	 */
+	Title,
+} as const;
+
+export {
+	//,
+	Steps,
+};
+
+export type {
+	//,
+	StepsItemProps,
+	StepsRootProps,
+	StepsTitleProps,
+};

--- a/packages/mantle/src/components/steps/tokens.test.tsx
+++ b/packages/mantle/src/components/steps/tokens.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import twThemeCss from "tailwindcss/theme.css?raw";
+import darkHighContrastCss from "../../mantle-dark-high-contrast.css?raw";
+import darkCss from "../../mantle-dark.css?raw";
+import lightHighContrastCss from "../../mantle-light-high-contrast.css?raw";
+import lightCss from "../../mantle.css?raw";
+import { contrastRatio, hexFromOklch, layer, resolveProperty } from "../chart/palette-gates.js";
+import type { ThemeName } from "../chart/palette-gates.js";
+import { Steps } from "./steps.js";
+
+/**
+ * The rail, the marker blob, and the number on it come from two design tokens,
+ * and this file measures both in every theme a consumer can be in.
+ *
+ * The pair carries three constraints at once, and no verification command sees
+ * any of them. The fill must be **opaque**, because the marker's stubs overlay
+ * the item's rail in the same color and a translucent fill composites twice
+ * there and shows a seam. The number must stay readable **on** that fill. And
+ * the rail must read against the page, which is what the app-local copy this
+ * component replaces got wrong: it painted `gray-200` and then patched every
+ * use site with `high-contrast:` overrides, because a stop that quiet is
+ * invisible against a high-contrast surface.
+ *
+ * When this fails, re-step a token. Never widen a floor.
+ */
+
+/** WCAG AA for normal-size text. The number renders at 18px, under the 14pt-bold large-text threshold. */
+const CONTRAST_FLOOR = 4.5;
+
+/**
+ * A rail this close to the surface paints no line at all. The standard themes
+ * keep it deliberately quiet — this is the line between quiet and absent.
+ */
+const VISIBILITY_FLOOR = 1.4;
+
+/** WCAG 1.4.11 for non-text contrast. The high-contrast themes owe a line, not a hint. */
+const HIGH_CONTRAST_FLOOR = 3;
+
+/** The value and the declaring file, per theme. A re-alias or a dropped override moves one of them. */
+const PROVENANCE: Record<ThemeName, { rail: string; number: string; source: string }> = {
+	light: {
+		rail: "--color-neutral-300",
+		number: "--color-neutral-950",
+		source: "mantle.css",
+	},
+	dark: {
+		rail: "--color-neutral-300",
+		number: "--color-neutral-950",
+		source: "mantle-dark.css",
+	},
+	"light-high-contrast": {
+		rail: "--color-black",
+		number: "--color-white",
+		source: "mantle-light-high-contrast.css",
+	},
+	"dark-high-contrast": {
+		rail: "--color-black",
+		number: "--color-white",
+		source: "mantle-dark-high-contrast.css",
+	},
+};
+
+type Theme = {
+	name: ThemeName;
+	/** Every custom property this theme resolves, in cascade order. */
+	chain: ReturnType<typeof layer>[];
+};
+
+const themeOf = (name: ThemeName, themeCss: string, themeFile: string): Theme => ({
+	name,
+	chain:
+		themeFile === "mantle.css"
+			? [layer("mantle.css", lightCss), layer("tailwindcss/theme.css", twThemeCss)]
+			: [
+					layer(themeFile, themeCss),
+					layer("mantle.css", lightCss),
+					layer("tailwindcss/theme.css", twThemeCss),
+				],
+});
+
+const THEMES: Theme[] = [
+	themeOf("light", lightCss, "mantle.css"),
+	themeOf("dark", darkCss, "mantle-dark.css"),
+	themeOf("light-high-contrast", lightHighContrastCss, "mantle-light-high-contrast.css"),
+	themeOf("dark-high-contrast", darkHighContrastCss, "mantle-dark-high-contrast.css"),
+];
+
+const cases = THEMES.map((theme) => [theme.name, theme] as const);
+
+const hexOf = (theme: Theme, property: string) =>
+	hexFromOklch(resolveProperty(theme.chain, property).literal);
+
+describe("Steps design tokens", () => {
+	test.each(cases)(
+		"%s: each token resolves to the recorded stop in the recorded file",
+		(name, theme) => {
+			const rail = resolveProperty(theme.chain, "--color-steps-rail");
+			const number = resolveProperty(theme.chain, "--color-steps-number");
+			expect({ rail: rail.name, number: number.name, source: rail.source }).toEqual(
+				PROVENANCE[name],
+			);
+			expect(number.source).toBe(PROVENANCE[name].source);
+		},
+	);
+
+	test.each(cases)("%s: both tokens are opaque, so the stubs leave no seam", (_name, theme) => {
+		// The stubs overlay the item's rail in the rail's own color. An alpha
+		// there paints the overlap twice and draws the joint the fillets exist to
+		// hide. It would also invalidate every ratio measured below, each of which
+		// reads the token as the color a browser rasterizes.
+		for (const property of ["--color-steps-rail", "--color-steps-number"]) {
+			expect(resolveProperty(theme.chain, property).literal).not.toContain("/");
+		}
+	});
+
+	test.each(cases)("%s: the number clears AA on the blob it sits in", (_name, theme) => {
+		const ratio = contrastRatio(
+			hexOf(theme, "--color-steps-number"),
+			hexOf(theme, "--color-steps-rail"),
+		);
+		expect(ratio).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+	});
+
+	test.each(cases)("%s: the rail reads against the page and against a card", (_name, theme) => {
+		const rail = hexOf(theme, "--color-steps-rail");
+		const floor = theme.name.includes("high-contrast") ? HIGH_CONTRAST_FLOOR : VISIBILITY_FLOOR;
+		expect(contrastRatio(rail, hexOf(theme, "--background-color-base"))).toBeGreaterThanOrEqual(
+			floor,
+		);
+		expect(contrastRatio(rail, hexOf(theme, "--background-color-card"))).toBeGreaterThanOrEqual(
+			floor,
+		);
+	});
+
+	test("every element that paints names the token its theme declares", () => {
+		render(
+			<Steps.Root>
+				<Steps.Item data-testid="step">
+					<Steps.Title>Install the ngrok agent</Steps.Title>
+				</Steps.Item>
+			</Steps.Root>,
+		);
+		const item = screen.getByTestId("step");
+		const marker = item.querySelector('[data-slot="steps-marker"]');
+		const svg = item.querySelector("svg");
+
+		// A cross-file pin, per element rather than per token name. Tailwind turns
+		// each utility's `steps-*` tail into a `--color-*` lookup, so renaming one
+		// side alone leaves the utility resolving to nothing — an unpainted rail
+		// or a default-black blob, with lint, typecheck, build, and every other
+		// test green. Three separate use sites, so three separate assertions.
+		expect(item.className).toContain("border-s-steps-rail");
+		expect(svg?.getAttribute("class")).toContain("fill-steps-rail");
+		expect(marker?.getAttribute("class")).toContain("after:text-steps-number");
+
+		for (const theme of THEMES) {
+			for (const token of ["--color-steps-rail", "--color-steps-number"]) {
+				expect(resolveProperty(theme.chain, token).literal).toMatch(/^oklch\(/);
+			}
+		}
+	});
+
+	test("the ratios the docs page publishes are the ratios the tokens resolve to", () => {
+		// The docs page prints six numbers per theme under Theming. The floors
+		// above cannot see a re-step that still clears them, so the table would go
+		// stale silently — these are the exact values, rounded the way it prints.
+		const measured = Object.fromEntries(
+			THEMES.map((theme) => {
+				const rail = hexOf(theme, "--color-steps-rail");
+				const round = (ratio: number) => Number(ratio.toFixed(2));
+				return [
+					theme.name,
+					{
+						numberOnRail: round(contrastRatio(hexOf(theme, "--color-steps-number"), rail)),
+						railOnPage: round(contrastRatio(rail, hexOf(theme, "--background-color-base"))),
+						railOnCard: round(contrastRatio(rail, hexOf(theme, "--background-color-card"))),
+					},
+				];
+			}),
+		);
+		expect(measured).toEqual({
+			light: { numberOnRail: 12.64, railOnPage: 1.42, railOnCard: 1.48 },
+			dark: { numberOnRail: 9.93, railOnPage: 1.81, railOnCard: 1.73 },
+			"light-high-contrast": { numberOnRail: 21, railOnPage: 20.12, railOnCard: 21 },
+			"dark-high-contrast": { numberOnRail: 21, railOnPage: 21, railOnCard: 18.73 },
+		});
+	});
+});

--- a/packages/mantle/src/mantle-dark-high-contrast.css
+++ b/packages/mantle/src/mantle-dark-high-contrast.css
@@ -291,6 +291,11 @@ mantle.css for the full strategy.
 	--color-card-border-muted: var(--color-neutral-300);
 	--color-separator: var(--color-black);
 
+	/* This theme redefines --color-black and --color-white, so the declaration
+	   light-high-contrast makes resolves to the opposite pair here. */
+	--color-steps-rail: var(--color-black);
+	--color-steps-number: var(--color-white);
+
 	--color-active-menu-item: var(--color-neutral-100);
 	--color-selected-menu-item: var(--color-accent-50);
 	--color-active-selected-menu-item: var(--color-accent-100);

--- a/packages/mantle/src/mantle-dark.css
+++ b/packages/mantle/src/mantle-dark.css
@@ -330,6 +330,12 @@ MARK: INVERT THEME in mantle.css for the full strategy.
 	--color-card-border-muted: var(--color-neutral-200);
 	--color-separator: --alpha(var(--color-gray-600) / 0.2);
 
+	/* Dark inverts the neutral ramp, so the two stops light gives the rail and
+	   the number keep their roles here — a quiet rail, and a number that reads
+	   on it. */
+	--color-steps-rail: var(--color-neutral-300);
+	--color-steps-number: var(--color-neutral-950);
+
 	/* Chart series tokens — dark's eight marks, in slot order: blue, green, pink,
 	   red-orange, teal, magenta, violet, amber. A slot keeps its family across the
 	   themes. Nothing else carries over: this theme re-tunes lightness, chroma, and

--- a/packages/mantle/src/mantle-light-high-contrast.css
+++ b/packages/mantle/src/mantle-light-high-contrast.css
@@ -290,6 +290,11 @@ mantle.css for the full strategy.
 	--color-card-border-muted: var(--color-neutral-300);
 	--color-separator: var(--color-black);
 
+	/* A quiet rail disappears here, so this theme takes both poles, the way
+	   --color-separator above it does. */
+	--color-steps-rail: var(--color-black);
+	--color-steps-number: var(--color-white);
+
 	--color-active-menu-item: var(--color-neutral-100);
 	--color-selected-menu-item: var(--color-accent-50);
 	--color-active-selected-menu-item: var(--color-accent-100);

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -230,6 +230,14 @@ MARK: THEME
 	--color-card-border-muted: var(--color-card-border-muted);
 	--color-separator: var(--color-separator);
 
+	/* Steps tokens — the rail and marker fill, and the number painted on the
+	   marker. Both are opaque in all four themes: the marker's stubs overlay the
+	   rail in the same color, and a translucent fill double-composites there and
+	   shows a seam. The two move together, so a theme that darkens the rail
+	   lightens the number. steps/tokens.test.tsx re-measures both. */
+	--color-steps-rail: var(--color-steps-rail);
+	--color-steps-number: var(--color-steps-number);
+
 	--color-active-menu-item: var(--color-active-menu-item);
 	--color-selected-menu-item: var(--color-selected-menu-item);
 	--color-active-selected-menu-item: var(--color-active-selected-menu-item);
@@ -372,6 +380,12 @@ from `:root` (see MARK: INVERT THEME below).
 	--color-card-border: var(--color-neutral-300);
 	--color-card-border-muted: var(--color-neutral-200);
 	--color-separator: --alpha(var(--color-gray-500) / 0.2);
+
+	/* The rail runs beside the panels a step's content sits in, so it takes the
+	   same step the card borders take. The number rides the far end of the same
+	   neutral ramp, which inverts with the theme. */
+	--color-steps-rail: var(--color-neutral-300);
+	--color-steps-number: var(--color-neutral-950);
 
 	--color-active-menu-item: --alpha(var(--color-neutral-500) / 0.05);
 	--color-selected-menu-item: --alpha(var(--color-accent-500) / 0.1);


### PR DESCRIPTION
Closes #1421.

## Why

The dashboard built a setup guide the design system had no answer for: numbered steps down a page, joined by one continuous vertical rail. Reusing it on another surface meant copying app code, which is the signal it belongs here.

The app copy also carried six defects worth engineering away. It numbered steps by `Children.toArray` position, so a fragment collapsed two steps into one numbered slot. It rendered `<li>` inside a `<div>`. It shipped an `<svg><title>` per marker, so a screen reader heard "Number with partial stick above and below" once per step. Rail on/off was a caller-managed `hasStick` boolean beside an index-derived `isLast`, and the two already disagreed at two call sites. And it painted `gray-200`, then patched every use site with `high-contrast:` overrides.

## What

`Steps.Root` renders the `<ol role="list">`, `Steps.Item` one `<li>`, `Steps.Title` an `h3`. Every part takes `asChild` and merges a consumer `className` last.

**Composition order is the numbering.** The number is a CSS counter and the silhouette comes from `:first-child` / `:last-child` / `:only-child`, so the DOM is the source of truth, not the children array. No `index`, no `count`, no effect, no registration — and the server-rendered first paint is already correct.

**The rail is each item's `border-inline-start`.** A border spans the item however tall its content grows, and the bottom padding sits inside the border box, so the rail runs through the gap to the next step. The last item keeps the width and drops the color. Every offset is a logical property, so the layout mirrors for right-to-left.

**Two new design tokens**, `--color-steps-rail` and `--color-steps-number`, with a value in all four themes. Both are opaque: the marker's stubs overlay the rail in the same color, and a translucent fill composites the overlap twice and draws the joint the fillets exist to hide. The high-contrast themes take both poles, the way `--color-separator` does.

Three things the issue left open, and where they landed:

| Question | Answer |
| --- | --- |
| Rail token | A dedicated opaque pair. `--color-separator` is 20% alpha outside high contrast, and `gray-200` sits at 1.21:1 against the page. `neutral-300` is what mantle's own card borders take, so the rail now matches the panels it runs beside. |
| Responsive collapse | A documented recipe, not a prop. The breakpoint belongs to the consumer's layout, and `data-slot="steps-marker"` is the hook. |
| Custom indicator content | Out of scope. The number is generated content on one pseudo-element, so a later `Steps.Indicator` replaces that and leaves the blob, the rail, and the counter alone. |

## Limitations

- **The rail is quiet outside high contrast** — 1.42:1 in light, 1.81:1 in dark. It carries no information: the number does, at 12.64:1, and the step position comes from the `<ol>`. In the two high-contrast themes it measures above 18:1.
- **The marker geometry is not tunable.** The gutter, the marker box, the offsets, and the rail width are one locked system — 18px of gutter is `(40 - 4) / 2`, and the stub only lands on the rail because both are 4px. A knob on any one of them breaks the goo.
- **No part throws when rendered outside `Steps.Root`.** Adding one costs a context provider and `"use client"` on a component that otherwise ships no JS. This follows `Card` and `CenteredLayout`, which make the same trade.
- **The docs page's example headings are `h3` under the page `h1`.** `card.mdx` has the identical shape, so this is a house-wide docs pattern rather than something to fix here.

## Verification

- All five component-spec commands pass: `lint`, `fmt:check`, `typecheck`, unscoped `test` (2499 in `@ngrok/mantle`, 244 in `@app/www`), and `build -F @ngrok/mantle`.
- Rendered in Chromium in all four themes and in `dir="rtl"`. The stubs land on the rail, each position paints one silhouette, and the last item's rail is transparent.
- Path data diffed character-for-character against the issue.
- At a 20px root font the rail measures 5px and the SVG stub measures 5px, so the two scale together.
- A `Steps` nested inside a step numbers from 1 and reads its own position — the plain group variant is a descendant selector, and the fix is a `>*>svg` tail on each silhouette.
- Mutation-tested: swapping two silhouette paths, dropping `last:border-s-transparent`, renaming either token use site, replacing `joinDataSlot` with a literal, dropping the `asChild` ref, and re-stepping the rail token each turn the suite red.
