### PR TITLE
fix(sidebar): slim the default expanded panel to 13rem

### DIFF
--- a/.changeset/sidebar-slim-default.md
+++ b/.changeset/sidebar-slim-default.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Sidebar` ships a narrower default expanded panel: `--sidebar-width` is now `13rem` (208px), down from `16rem` (256px). `--sidebar-row-width` follows to `12rem` (192px), so menus floored at that token stay flush with a row.
+
+Override `--sidebar-width` (on `Sidebar.Nav` or at `:root`) if you want the previous width back. See https://mantle.ngrok.com/components/navigation/sidebar#width.

--- a/apps/www/app/docs/components/navigation/sidebar.mdx
+++ b/apps/www/app/docs/components/navigation/sidebar.mdx
@@ -860,12 +860,12 @@ export function PendingAwareRow() {
 ## Width
 
 The panel's width is a CSS variable, not a prop: `Sidebar.Nav` reads each of the three widths with the
-default as its fallback (`w-(--sidebar-width,16rem)`), so there is nothing to thread through your shell
+default as its fallback (`w-(--sidebar-width,13rem)`), so there is nothing to thread through your shell
 and one place to change it.
 
 | CSS Variable             | Default          | What it sizes                                           |
 | ------------------------ | ---------------- | ------------------------------------------------------- |
-| `--sidebar-width`        | `16rem` (256px)  | The expanded desktop panel                              |
+| `--sidebar-width`        | `13rem` (208px)  | The expanded desktop panel                              |
 | `--sidebar-width-icon`   | `3.25rem` (52px) | The [collapsed icon rail](#collapsing-to-the-icon-rail) |
 | `--sidebar-width-mobile` | `18rem` (288px)  | The mobile `Sheet` panel                                |
 
@@ -1059,7 +1059,7 @@ variables either: it renders in a portal on `document.body`, so it inherits noth
 
 | CSS Variable          | Default | Description                                                                                                                                                                 |
 | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--sidebar-row-width` | `15rem` | One row's width inside the expanded panel (240px): `calc(var(--sidebar-width, 16rem) - 1rem)`, the panel width minus the gutter `Sidebar.Header`/`Body`/`Footer` all apply. |
+| `--sidebar-row-width` | `12rem` | One row's width inside the expanded panel (192px): `calc(var(--sidebar-width, 13rem) - 1rem)`, the panel width minus the gutter `Sidebar.Header`/`Body`/`Footer` all apply. |
 
 Keep `width="trigger"` and floor the menu at it. The switcher row below is a collapsed chip; open its menu,
 expand the panel with the trigger, and open it again — the menu is the same width both times:
@@ -1143,7 +1143,7 @@ One static class covers all three presentations at the default widths. Expanded,
 row already measures that wide, so the menu is flush with it. Collapsed, the floor holds the menu at the
 expanded row's width, so it looks identical in the rail. In the mobile `Sheet` the floor is inert because the
 sheet's row is the wider of the two — `--sidebar-width-mobile` − `1.5rem` − the sheet's 1px `border-r` = 263px,
-against 240px — so `width="trigger"` wins.
+against 192px — so `width="trigger"` wins.
 
 That last one is a condition, not a guarantee: **widen `--sidebar-width-mobile` whenever you widen
 `--sidebar-width`**, or the floor outgrows the sheet's row and the menu overhangs the panel it opened from
@@ -1649,10 +1649,10 @@ All props from [div](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/d
 
 | CSS Variable             | Default   | Description                                                                                                                                                                                                                                                                                   |
 | ------------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--sidebar-width`        | `16rem`   | Expanded desktop width (256px). Set it on `Sidebar.Nav` for one sidebar or on any ancestor (`:root`) for every sidebar — see [Width](#width).                                                                                                                                                 |
+| `--sidebar-width`        | `13rem`   | Expanded desktop width (208px). Set it on `Sidebar.Nav` for one sidebar or on any ancestor (`:root`) for every sidebar — see [Width](#width).                                                                                                                                                 |
 | `--sidebar-width-mobile` | `18rem`   | Mobile sheet width (288px). Set it on `Sidebar.Nav` or any ancestor — see [Width](#width).                                                                                                                                                                                                    |
 | `--sidebar-width-icon`   | `3.25rem` | Collapsed icon rail width (52px). Set it on `Sidebar.Nav` or any ancestor — see [Width](#width).                                                                                                                                                                                              |
-| `--sidebar-row-width`    | `15rem`   | Read, not set: one row's width in the expanded panel (240px), derived as `calc(var(--sidebar-width, 16rem) - 1rem)` and declared at `:root` by `mantle.css` so surfaces rendered outside the panel can size to a row — see [Sizing a menu to a sidebar row](#sizing-a-menu-to-a-sidebar-row). |
+| `--sidebar-row-width`    | `12rem`   | Read, not set: one row's width in the expanded panel (192px), derived as `calc(var(--sidebar-width, 13rem) - 1rem)` and declared at `:root` by `mantle.css` so surfaces rendered outside the panel can size to a row — see [Sizing a menu to a sidebar row](#sizing-a-menu-to-a-sidebar-row). |
 
 **Data attributes**
 

--- a/packages/mantle/src/components/sidebar/header-band.browser.test.tsx
+++ b/packages/mantle/src/components/sidebar/header-band.browser.test.tsx
@@ -52,7 +52,7 @@ const STYLE = `
 	.h-14 { height: calc(var(--spacing) * 14); }
 	.h-full { height: 100%; }
 	.min-h-0 { min-height: 0px; }
-	.w-\\(--sidebar-width\\,16rem\\) { width: var(--sidebar-width,16rem); }
+	.w-\\(--sidebar-width\\,13rem\\) { width: var(--sidebar-width,13rem); }
 	.w-full { width: 100%; }
 	.min-w-0 { min-width: 0px; }
 	.flex-1 { flex: 1; }

--- a/packages/mantle/src/components/sidebar/sidebar.test.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.test.tsx
@@ -652,7 +652,7 @@ describe("--sidebar-row-width", () => {
 	// happy-dom loads no stylesheet, so guard the declaration itself.
 	test("mantle.css derives it at :root from the expanded panel width", () => {
 		expect(mantleCss).toMatch(
-			/:root\s*\{[^}]*--sidebar-row-width:\s*calc\(\s*var\(\s*--sidebar-width\s*,\s*16rem\s*\)\s*-\s*1rem\s*\)/,
+			/:root\s*\{[^}]*--sidebar-row-width:\s*calc\(\s*var\(\s*--sidebar-width\s*,\s*13rem\s*\)\s*-\s*1rem\s*\)/,
 		);
 	});
 

--- a/packages/mantle/src/components/sidebar/sidebar.tsx
+++ b/packages/mantle/src/components/sidebar/sidebar.tsx
@@ -509,12 +509,12 @@ type SidebarNavProps = ComponentProps<"div"> & WithDataSlot;
  *
  * | CSS Variable | Default | Description |
  * | --- | --- | --- |
- * | `--sidebar-width` | `16rem` | Expanded desktop panel width (256px). |
+ * | `--sidebar-width` | `13rem` | Expanded desktop panel width (208px). |
  * | `--sidebar-width-mobile` | `18rem` | Mobile sheet width (288px). |
  * | `--sidebar-width-icon` | `3.25rem` | Collapsed icon rail width (52px). |
- * | `--sidebar-row-width` | `15rem` | Derived, not set: one row's width in the expanded panel (240px), for sizing surfaces that render *outside* it. See below and `Sidebar.SwitcherTrigger`. |
+ * | `--sidebar-row-width` | `12rem` | Derived, not set: one row's width in the expanded panel (192px), for sizing surfaces that render *outside* it. See below and `Sidebar.SwitcherTrigger`. |
  *
- * `--sidebar-row-width` is `calc(var(--sidebar-width,16rem) - 1rem)`, declared
+ * `--sidebar-row-width` is `calc(var(--sidebar-width,13rem) - 1rem)`, declared
  * at `:root` by `mantle.css` — the panel width minus the row gutter this
  * component's regions apply.
  *
@@ -646,7 +646,7 @@ const Nav = ({
 			className={cx(
 				// bg lives on this surface (not the inner nav) so consumer
 				// className overrides like `bg-card` take effect on desktop too.
-				"group/sidebar-nav bg-base relative h-full w-(--sidebar-width,16rem) shrink-0 overflow-hidden",
+				"group/sidebar-nav bg-base relative h-full w-(--sidebar-width,13rem) shrink-0 overflow-hidden",
 				// collapsing animates the width down to the skinny icon rail; the
 				// panel content stays interactive and in the accessibility tree.
 				"data-[state=collapsed]:w-(--sidebar-width-icon,3.25rem)",
@@ -2005,7 +2005,7 @@ type SidebarSwitcherTriggerProps = ComponentProps<"button"> & WithAsChild & With
  * no-op while the panel is expanded (the row already measures that wide), and
  * inert in the mobile sheet as long as its row is the wider of the two
  * (`--sidebar-width-mobile` minus `1.5rem` and the sheet's 1px border, vs
- * `--sidebar-width` minus `1rem`; 263px vs 240px at the defaults) — so widen
+ * `--sidebar-width` minus `1rem`; 263px vs 192px at the defaults) — so widen
  * `--sidebar-width-mobile` whenever you widen `--sidebar-width`, or the floor
  * overhangs the sheet.
  *

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -717,7 +717,7 @@ MARK: COMPONENT GEOMETRY
    `--sidebar-width-mobile` with it, or the floor outgrows the sheet's row),
    or set `--sidebar-row-width` on the outside surface itself. */
 :root {
-	--sidebar-row-width: calc(var(--sidebar-width, 16rem) - 1rem);
+	--sidebar-row-width: calc(var(--sidebar-width, 13rem) - 1rem);
 }
 
 /**


### PR DESCRIPTION
The previous 16rem default left more chrome than the nav needed. Drop the fallback to 13rem and keep --sidebar-row-width in sync so floored menus stay flush with a row.