### PR TITLE
fix(code-block): pin the gutter, scroll only on real overflow

### DIFF
--- a/.changeset/code-block-overscroll.md
+++ b/.changeset/code-block-overscroll.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`CodeBlock.Code` no longer bounces at the ends of its horizontal scroll range — `overscroll-behavior-x: none` also keeps the scroll from chaining to the page.

--- a/.changeset/code-block-pinned-gutter.md
+++ b/.changeset/code-block-pinned-gutter.md
@@ -4,4 +4,4 @@
 
 `CodeBlock.Code` pins the line-number gutter while the code scrolls horizontally.
 
-The gutter — line numbers and fold toggles — now sticks to the left edge of the scrollport, and an opaque backdrop masks the code sliding under it. In browsers that support scroll-driven animations, a seam in the block's border color fades in as you scroll to separate the pinned gutter from the moving code. Blocks without line numbers scroll as one unit, unchanged.
+The gutter — line numbers and fold toggles — now sticks to the left edge of the scrollport, and an opaque backdrop masks the code sliding under it. Blocks without line numbers scroll as one unit, unchanged.

--- a/.changeset/code-block-pinned-gutter.md
+++ b/.changeset/code-block-pinned-gutter.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+`CodeBlock.Code` pins the line-number gutter while the code scrolls horizontally.
+
+The gutter — line numbers and fold toggles — now sticks to the left edge of the scrollport, and an opaque backdrop masks the code sliding under it. In browsers that support scroll-driven animations, a seam in the block's border color fades in as you scroll to separate the pinned gutter from the moving code. Blocks without line numbers scroll as one unit, unchanged.

--- a/.changeset/code-block-scrollbar-clearance.md
+++ b/.changeset/code-block-scrollbar-clearance.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+`CodeBlock.Code` no longer shows a horizontal scrollbar when every line fits the container.
+
+Every rendered line reserved `3.5rem` of right padding to clear the copy button. That reserve widened the code's intrinsic width, so a block whose longest line fit the container still scrolled sideways. Now only the first two lines — the only lines the copy button overlaps — reserve the clearance, and only when a `CodeBlock.CopyButton` is rendered. A line wider than the container still scrolls, and its first-two-line clearance still keeps text out from under the button at the end of the scroll range.

--- a/.changeset/code-block-scrollbar-clearance.md
+++ b/.changeset/code-block-scrollbar-clearance.md
@@ -4,4 +4,4 @@
 
 `CodeBlock.Code` no longer shows a horizontal scrollbar when every line fits the container.
 
-Every rendered line reserved `3.5rem` of right padding to clear the copy button. That reserve widened the code's intrinsic width, so a block whose longest line fit the container still scrolled sideways. Now only the first two lines — the only lines the copy button overlaps — reserve the clearance, and only when a `CodeBlock.CopyButton` is rendered. A line wider than the container still scrolls, and its first-two-line clearance still keeps text out from under the button at the end of the scroll range.
+Every rendered line reserved `3.5rem` of right padding to clear the copy button. That reserve widened the code's intrinsic width, so a block whose longest line fit the container still scrolled sideways. Now the full clearance sits on the first two lines only — the only lines the copy button overlaps — and only when a `CodeBlock.CopyButton` is rendered. Every line keeps a `1rem` reserve, so a line at the end of the scroll range stays clear of the container's edge.

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -72,7 +72,7 @@ Many code blocks will be single line command line prompts and should be able to 
 
 This example is included to demonstrate that code blocks can scroll horizontally if the content is too wide. Mantle attempts to normalize scrollbar styling across browsers and platforms.
 
-When line numbers are shown, the gutter — numbers and fold toggles — stays pinned to the left edge while the code scrolls under it. In browsers that support scroll-driven animations, a seam in the block's border color fades in as you scroll to separate the pinned gutter from the moving code.
+When line numbers are shown, the gutter — numbers and fold toggles — stays pinned to the left edge while the code scrolls under it.
 
 <HorizontalScrollingDemo />
 

--- a/apps/www/app/docs/components/data-display/code-block.mdx
+++ b/apps/www/app/docs/components/data-display/code-block.mdx
@@ -72,6 +72,8 @@ Many code blocks will be single line command line prompts and should be able to 
 
 This example is included to demonstrate that code blocks can scroll horizontally if the content is too wide. Mantle attempts to normalize scrollbar styling across browsers and platforms.
 
+When line numbers are shown, the gutter — numbers and fold toggles — stays pinned to the left edge while the code scrolls under it. In browsers that support scroll-driven animations, a seam in the block's border color fades in as you scroll to separate the pinned gutter from the moving code.
+
 <HorizontalScrollingDemo />
 
 ```tsx

--- a/packages/mantle/src/components/code-block/code-block.browser.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.browser.test.tsx
@@ -97,15 +97,21 @@ describe("CodeBlock (browser)", () => {
 		"[&:has([data-slot=code-block-copy-button])_.mantle-code-line:nth-child(-n+2)]:pr-14";
 
 	/**
+	 * The end-of-line breathing-room utility on `CodeBlock.Body`: every line
+	 * reserves `1rem`, so the longest line stays clear of the container edge
+	 * at the end of the scroll range. Keyed to the exact class string the same
+	 * way as `CLEARANCE_CLASS`.
+	 */
+	const BREATHING_ROOM_CLASS = "[&_.mantle-code-line]:pr-4";
+
+	/**
 	 * Mirrors the CSS that lays out `CodeBlock.Code`: the Tailwind utilities on
 	 * `CodeBlock.Body`, the `<pre>`, and the `<code>` (`overflow-x-auto`,
 	 * `block min-w-full w-max`), and the `.mantle-code-line` rules from
 	 * `mantle.css`, including the pinned line-number gutter. We inline the rules
 	 * because browser tests load no Tailwind and no mantle stylesheet. Keep the
 	 * selectors and values in sync with their sources — these tests pin both
-	 * sides of the clearance and pinned-gutter contracts. The scroll-driven seam
-	 * animation is omitted: its resting value is transparent and nothing here
-	 * asserts it.
+	 * sides of the clearance and pinned-gutter contracts.
 	 */
 	const LAYOUT_STYLE = `
 		:root {
@@ -131,6 +137,9 @@ describe("CodeBlock (browser)", () => {
 			align-items: flex-start;
 			min-width: 100%;
 			box-sizing: border-box;
+		}
+		.${CSS.escape(BREATHING_ROOM_CLASS)} .mantle-code-line {
+			padding-right: 1rem;
 		}
 		.${CSS.escape(CLEARANCE_CLASS)}:has([data-slot=code-block-copy-button])
 			.mantle-code-line:nth-child(-n + 2) {
@@ -226,6 +235,15 @@ describe("CodeBlock (browser)", () => {
 		});
 	}
 
+	/**
+	 * The root font size in pixels. The `rem` values in `LAYOUT_STYLE` resolve
+	 * against it, so the pixel expectations derive from it instead of assuming
+	 * a 16px browser default.
+	 */
+	function rootFontSizePx(): number {
+		return Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+	}
+
 	function getPre(): HTMLPreElement {
 		const pre = document.querySelector("pre[data-slot='code-block-code']");
 		if (!(pre instanceof HTMLPreElement)) {
@@ -254,7 +272,7 @@ describe("CodeBlock (browser)", () => {
 			expect(pre.scrollWidth).toBe(pre.clientWidth);
 		});
 
-		test("scroll width matches the longest line when a line overflows", () => {
+		test("the scroll range ends one breathing-room reserve past the longest line", () => {
 			render(
 				<div style={{ width: 340 }}>
 					<CodeBlock.Root>
@@ -268,8 +286,9 @@ describe("CodeBlock (browser)", () => {
 
 			const pre = getPre();
 			expect(pre.scrollWidth).toBeGreaterThan(pre.clientWidth);
-			// Why exactly 400: the longest line carries no copy-button clearance.
-			expect(pre.scrollWidth).toBe(400);
+			// Why 400 plus 1rem: the longest line carries no copy-button clearance,
+			// only the end-of-line breathing room.
+			expect(pre.scrollWidth).toBe(400 + rootFontSizePx());
 		});
 
 		test("only the first two lines reserve copy-button clearance, and only when a CopyButton is rendered", () => {
@@ -288,10 +307,10 @@ describe("CodeBlock (browser)", () => {
 			if (first == null || second == null || third == null) {
 				throw new Error("expected three code lines");
 			}
-			// Why 56px: 3.5rem at the default 16px root font size.
-			expect(getComputedStyle(first).paddingRight).toBe("56px");
-			expect(getComputedStyle(second).paddingRight).toBe("56px");
-			expect(getComputedStyle(third).paddingRight).toBe("0px");
+			const remPx = rootFontSizePx();
+			expect(getComputedStyle(first).paddingRight).toBe(`${3.5 * remPx}px`);
+			expect(getComputedStyle(second).paddingRight).toBe(`${3.5 * remPx}px`);
+			expect(getComputedStyle(third).paddingRight).toBe(`${remPx}px`);
 
 			rerender(
 				<div style={{ width: 340 }}>
@@ -303,8 +322,10 @@ describe("CodeBlock (browser)", () => {
 				</div>,
 			);
 
+			// Without a CopyButton the clearance drops, and only the 1rem
+			// breathing room remains.
 			for (const line of document.querySelectorAll(".mantle-code-line")) {
-				expect(getComputedStyle(line).paddingRight).toBe("0px");
+				expect(getComputedStyle(line).paddingRight).toBe(`${rootFontSizePx()}px`);
 			}
 		});
 	});

--- a/packages/mantle/src/components/code-block/code-block.browser.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.browser.test.tsx
@@ -88,12 +88,21 @@ describe("CodeBlock (browser)", () => {
 
 	describe("horizontal overflow", () => {
 		/**
+		 * The copy-button clearance utility on `CodeBlock.Body`. `LAYOUT_STYLE`
+		 * expands it to the CSS Tailwind emits for it, keyed by `CSS.escape` to
+		 * this exact class string — when the component's class drifts from this
+		 * constant, the rule stops matching and the clearance assertions fail.
+		 */
+		const CLEARANCE_CLASS =
+			"[&:has([data-slot=code-block-copy-button])_.mantle-code-line:nth-child(-n+2)]:pr-14";
+
+		/**
 		 * Mirrors the CSS that lays out `CodeBlock.Code`: the Tailwind utilities on
-		 * the `<pre>` and `<code>` (`overflow-x-auto`, `block min-w-full w-max`) and
-		 * the `.mantle-code-line` rules from `mantle.css`. We inline the rules
-		 * because browser tests load no Tailwind and no mantle stylesheet. Keep the
-		 * selectors and values in sync with `mantle.css` — this test pins both
-		 * sides of the copy-button clearance contract.
+		 * `CodeBlock.Body`, the `<pre>`, and the `<code>` (`overflow-x-auto`,
+		 * `block min-w-full w-max`), and the `.mantle-code-line` rules from
+		 * `mantle.css`. We inline the rules because browser tests load no Tailwind
+		 * and no mantle stylesheet. Keep the selectors and values in sync with
+		 * their sources — this test pins both sides of the clearance contract.
 		 */
 		const LAYOUT_STYLE = `
 			pre[data-slot="code-block-code"] {
@@ -113,7 +122,7 @@ describe("CodeBlock (browser)", () => {
 				min-width: 100%;
 				box-sizing: border-box;
 			}
-			[data-slot="code-block-body"]:has([data-slot="code-block-copy-button"])
+			.${CSS.escape(CLEARANCE_CLASS)}:has([data-slot=code-block-copy-button])
 				.mantle-code-line:nth-child(-n + 2) {
 				padding-right: 3.5rem;
 			}

--- a/packages/mantle/src/components/code-block/code-block.browser.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.browser.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { CodeBlock } from "./code-block.js";
+import type { FoldableRange } from "./compute-json-fold-ranges.js";
 import { decorateHighlightedHtml } from "./decorate-highlighted-html.js";
 import { createMantleCodeBlockValue } from "./mantle-code.js";
 
@@ -86,90 +87,154 @@ describe("CodeBlock (browser)", () => {
 		});
 	});
 
+	/**
+	 * The copy-button clearance utility on `CodeBlock.Body`. `LAYOUT_STYLE`
+	 * expands it to the CSS Tailwind emits for it, keyed by `CSS.escape` to
+	 * this exact class string — when the component's class drifts from this
+	 * constant, the rule stops matching and the clearance assertions fail.
+	 */
+	const CLEARANCE_CLASS =
+		"[&:has([data-slot=code-block-copy-button])_.mantle-code-line:nth-child(-n+2)]:pr-14";
+
+	/**
+	 * Mirrors the CSS that lays out `CodeBlock.Code`: the Tailwind utilities on
+	 * `CodeBlock.Body`, the `<pre>`, and the `<code>` (`overflow-x-auto`,
+	 * `block min-w-full w-max`), and the `.mantle-code-line` rules from
+	 * `mantle.css`, including the pinned line-number gutter. We inline the rules
+	 * because browser tests load no Tailwind and no mantle stylesheet. Keep the
+	 * selectors and values in sync with their sources — these tests pin both
+	 * sides of the clearance and pinned-gutter contracts. The scroll-driven seam
+	 * animation is omitted: its resting value is transparent and nothing here
+	 * asserts it.
+	 */
+	const LAYOUT_STYLE = `
+		:root {
+			--background-color-base: rgb(16 16 20);
+			--mantle-code-line-number-width: 2rem;
+			--mantle-code-line-number-gap: 1rem;
+			--mantle-code-fold-gutter-width: 1.125rem;
+			--mantle-code-fold-gutter-gap: 0.25rem;
+		}
+		pre[data-slot="code-block-code"] {
+			margin: 0;
+			padding: 1rem 0;
+			overflow-x: auto;
+			overflow-y: hidden;
+		}
+		pre[data-slot="code-block-code"] > code {
+			display: block;
+			min-width: 100%;
+			width: max-content;
+		}
+		.mantle-code-line {
+			display: flex;
+			align-items: flex-start;
+			min-width: 100%;
+			box-sizing: border-box;
+		}
+		.${CSS.escape(CLEARANCE_CLASS)}:has([data-slot=code-block-copy-button])
+			.mantle-code-line:nth-child(-n + 2) {
+			padding-right: 3.5rem;
+		}
+		.mantle-code-line-content {
+			display: block;
+			min-width: 0;
+			flex: 1 1 auto;
+		}
+		.mantle-code-line-number {
+			position: sticky;
+			left: 0;
+			z-index: 1;
+			display: block;
+			flex-shrink: 0;
+			width: var(--mantle-code-line-number-width);
+			margin-right: var(--mantle-code-line-number-gap);
+		}
+		.mantle-code-line-number::before {
+			content: "";
+			position: absolute;
+			inset: 0 calc(-1 * var(--_gutter-overhang, var(--mantle-code-line-number-gap))) 0 0;
+			z-index: -1;
+			background-color: var(--background-color-base);
+		}
+		pre[data-slot="code-block-code"]:has(.mantle-code-fold-toggle) .mantle-code-line-number::before {
+			--_gutter-overhang: calc(
+				var(--mantle-code-line-number-gap) + var(--mantle-code-fold-gutter-width) +
+					var(--mantle-code-fold-gutter-gap)
+			);
+		}
+		pre[data-mantle-line-numbers="true"] .mantle-code-fold-toggle {
+			position: sticky;
+			left: calc(var(--mantle-code-line-number-width) + var(--mantle-code-line-number-gap));
+			z-index: 1;
+		}
+		.mantle-code-fold-toggle {
+			flex-shrink: 0;
+			display: inline-flex;
+			width: var(--mantle-code-fold-gutter-width);
+			margin-right: var(--mantle-code-fold-gutter-gap);
+			padding: 0;
+			border: 0;
+		}
+		pre[data-slot="code-block-code"]:has(.mantle-code-fold-toggle) .mantle-code-line-content {
+			margin-left: calc(var(--mantle-code-fold-gutter-width) + var(--mantle-code-fold-gutter-gap));
+		}
+		pre[data-slot="code-block-code"]:has(.mantle-code-fold-toggle)
+			.mantle-code-line-opener
+			> .mantle-code-line-content {
+			margin-left: 0;
+		}
+	`;
+
+	let styleElement: HTMLStyleElement;
+
+	beforeAll(() => {
+		styleElement = document.createElement("style");
+		styleElement.textContent = LAYOUT_STYLE;
+		document.head.appendChild(styleElement);
+	});
+
+	afterAll(() => {
+		styleElement.remove();
+	});
+
+	/**
+	 * Builds a pre-rendered value whose lines have exact pixel widths, so the
+	 * geometry assertions do not depend on font metrics.
+	 */
+	function makeFixedWidthValue(
+		lineWidths: number[],
+		options?: { showLineNumbers?: boolean; foldableRanges?: FoldableRange[] },
+	) {
+		const showLineNumbers = options?.showLineNumbers ?? false;
+		const code = lineWidths.map((width) => `line ${width}px`).join("\n");
+		const html = decorateHighlightedHtml({
+			foldableRanges: options?.foldableRanges,
+			html: lineWidths
+				.map(
+					(width) =>
+						`<span class="line"><span style="display:inline-block;width:${width}px"></span></span>`,
+				)
+				.join("\n"),
+			showLineNumbers,
+		});
+		return createMantleCodeBlockValue({
+			language: "typescript",
+			code,
+			preHtml: html,
+			showLineNumbers,
+		});
+	}
+
+	function getPre(): HTMLPreElement {
+		const pre = document.querySelector("pre[data-slot='code-block-code']");
+		if (!(pre instanceof HTMLPreElement)) {
+			throw new Error("expected the code block <pre>");
+		}
+		return pre;
+	}
+
 	describe("horizontal overflow", () => {
-		/**
-		 * The copy-button clearance utility on `CodeBlock.Body`. `LAYOUT_STYLE`
-		 * expands it to the CSS Tailwind emits for it, keyed by `CSS.escape` to
-		 * this exact class string — when the component's class drifts from this
-		 * constant, the rule stops matching and the clearance assertions fail.
-		 */
-		const CLEARANCE_CLASS =
-			"[&:has([data-slot=code-block-copy-button])_.mantle-code-line:nth-child(-n+2)]:pr-14";
-
-		/**
-		 * Mirrors the CSS that lays out `CodeBlock.Code`: the Tailwind utilities on
-		 * `CodeBlock.Body`, the `<pre>`, and the `<code>` (`overflow-x-auto`,
-		 * `block min-w-full w-max`), and the `.mantle-code-line` rules from
-		 * `mantle.css`. We inline the rules because browser tests load no Tailwind
-		 * and no mantle stylesheet. Keep the selectors and values in sync with
-		 * their sources — this test pins both sides of the clearance contract.
-		 */
-		const LAYOUT_STYLE = `
-			pre[data-slot="code-block-code"] {
-				margin: 0;
-				padding: 1rem 0;
-				overflow-x: auto;
-				overflow-y: hidden;
-			}
-			pre[data-slot="code-block-code"] > code {
-				display: block;
-				min-width: 100%;
-				width: max-content;
-			}
-			.mantle-code-line {
-				display: flex;
-				align-items: flex-start;
-				min-width: 100%;
-				box-sizing: border-box;
-			}
-			.${CSS.escape(CLEARANCE_CLASS)}:has([data-slot=code-block-copy-button])
-				.mantle-code-line:nth-child(-n + 2) {
-				padding-right: 3.5rem;
-			}
-			.mantle-code-line-content {
-				display: block;
-				min-width: 0;
-				flex: 1 1 auto;
-			}
-		`;
-
-		let styleElement: HTMLStyleElement;
-
-		beforeAll(() => {
-			styleElement = document.createElement("style");
-			styleElement.textContent = LAYOUT_STYLE;
-			document.head.appendChild(styleElement);
-		});
-
-		afterAll(() => {
-			styleElement.remove();
-		});
-
-		/**
-		 * Builds a pre-rendered value whose lines have exact pixel widths, so the
-		 * geometry assertions do not depend on font metrics.
-		 */
-		function makeFixedWidthValue(lineWidths: number[]) {
-			const code = lineWidths.map((width) => `line ${width}px`).join("\n");
-			const html = decorateHighlightedHtml({
-				html: lineWidths
-					.map(
-						(width) =>
-							`<span class="line"><span style="display:inline-block;width:${width}px"></span></span>`,
-					)
-					.join("\n"),
-			});
-			return createMantleCodeBlockValue({ language: "typescript", code, preHtml: html });
-		}
-
-		function getPre(): HTMLPreElement {
-			const pre = document.querySelector("pre[data-slot='code-block-code']");
-			if (!(pre instanceof HTMLPreElement)) {
-				throw new Error("expected the code block <pre>");
-			}
-			return pre;
-		}
-
 		test("no scrollbar when every line fits the container", () => {
 			// Regression: a blanket per-line `padding-right: 3.5rem` widened the
 			// max-content <code>, so a 300px line in a 340px container scrolled.
@@ -241,6 +306,69 @@ describe("CodeBlock (browser)", () => {
 			for (const line of document.querySelectorAll(".mantle-code-line")) {
 				expect(getComputedStyle(line).paddingRight).toBe("0px");
 			}
+		});
+	});
+
+	describe("pinned line-number gutter", () => {
+		test("line numbers stay pinned while the code scrolls", () => {
+			render(
+				<div style={{ width: 340 }}>
+					<CodeBlock.Root>
+						<CodeBlock.Body>
+							<CodeBlock.Code value={makeFixedWidthValue([100, 400], { showLineNumbers: true })} />
+						</CodeBlock.Body>
+					</CodeBlock.Root>
+				</div>,
+			);
+
+			const pre = getPre();
+			const number = pre.querySelector(".mantle-code-line-number");
+			const content = pre.querySelector(".mantle-code-line-content");
+			if (number == null || content == null) {
+				throw new Error("expected a line number and line content");
+			}
+
+			const preLeft = pre.getBoundingClientRect().left;
+			const contentLeftBefore = content.getBoundingClientRect().left;
+			expect(number.getBoundingClientRect().left - preLeft).toBe(0);
+
+			pre.scrollLeft = 100;
+			expect(pre.scrollLeft).toBe(100);
+
+			expect(number.getBoundingClientRect().left - preLeft).toBe(0);
+			expect(content.getBoundingClientRect().left).toBe(contentLeftBefore - 100);
+		});
+
+		test("fold toggles pin with the numbers and the backdrop masks the gutter", () => {
+			render(
+				<div style={{ width: 340 }}>
+					<CodeBlock.Root>
+						<CodeBlock.Body>
+							<CodeBlock.Code
+								value={makeFixedWidthValue([100, 400, 100], {
+									showLineNumbers: true,
+									foldableRanges: [{ id: "1", startLine: 1, endLine: 3 }],
+								})}
+							/>
+						</CodeBlock.Body>
+					</CodeBlock.Root>
+				</div>,
+			);
+
+			const pre = getPre();
+			const number = pre.querySelector(".mantle-code-line-number");
+			const toggle = pre.querySelector(".mantle-code-fold-toggle");
+			if (number == null || toggle == null) {
+				throw new Error("expected a line number and fold toggle");
+			}
+
+			const preLeft = pre.getBoundingClientRect().left;
+			pre.scrollLeft = 100;
+
+			// Why 48px: the 2rem number column plus its 1rem gap.
+			expect(toggle.getBoundingClientRect().left - preLeft).toBe(48);
+			// The opaque backdrop that masks code scrolling under the gutter.
+			expect(getComputedStyle(number, "::before").backgroundColor).toBe("rgb(16, 16, 20)");
 		});
 	});
 });

--- a/packages/mantle/src/components/code-block/code-block.browser.test.tsx
+++ b/packages/mantle/src/components/code-block/code-block.browser.test.tsx
@@ -2,8 +2,9 @@
 
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { CodeBlock } from "./code-block.js";
+import { decorateHighlightedHtml } from "./decorate-highlighted-html.js";
 import { createMantleCodeBlockValue } from "./mantle-code.js";
 
 function makeValue(code: string, preHtml?: string) {
@@ -82,6 +83,155 @@ describe("CodeBlock (browser)", () => {
 			const iconAfter = button.querySelector("svg")?.innerHTML;
 
 			expect(iconAfter).not.toBe(iconBefore);
+		});
+	});
+
+	describe("horizontal overflow", () => {
+		/**
+		 * Mirrors the CSS that lays out `CodeBlock.Code`: the Tailwind utilities on
+		 * the `<pre>` and `<code>` (`overflow-x-auto`, `block min-w-full w-max`) and
+		 * the `.mantle-code-line` rules from `mantle.css`. We inline the rules
+		 * because browser tests load no Tailwind and no mantle stylesheet. Keep the
+		 * selectors and values in sync with `mantle.css` — this test pins both
+		 * sides of the copy-button clearance contract.
+		 */
+		const LAYOUT_STYLE = `
+			pre[data-slot="code-block-code"] {
+				margin: 0;
+				padding: 1rem 0;
+				overflow-x: auto;
+				overflow-y: hidden;
+			}
+			pre[data-slot="code-block-code"] > code {
+				display: block;
+				min-width: 100%;
+				width: max-content;
+			}
+			.mantle-code-line {
+				display: flex;
+				align-items: flex-start;
+				min-width: 100%;
+				box-sizing: border-box;
+			}
+			[data-slot="code-block-body"]:has([data-slot="code-block-copy-button"])
+				.mantle-code-line:nth-child(-n + 2) {
+				padding-right: 3.5rem;
+			}
+			.mantle-code-line-content {
+				display: block;
+				min-width: 0;
+				flex: 1 1 auto;
+			}
+		`;
+
+		let styleElement: HTMLStyleElement;
+
+		beforeAll(() => {
+			styleElement = document.createElement("style");
+			styleElement.textContent = LAYOUT_STYLE;
+			document.head.appendChild(styleElement);
+		});
+
+		afterAll(() => {
+			styleElement.remove();
+		});
+
+		/**
+		 * Builds a pre-rendered value whose lines have exact pixel widths, so the
+		 * geometry assertions do not depend on font metrics.
+		 */
+		function makeFixedWidthValue(lineWidths: number[]) {
+			const code = lineWidths.map((width) => `line ${width}px`).join("\n");
+			const html = decorateHighlightedHtml({
+				html: lineWidths
+					.map(
+						(width) =>
+							`<span class="line"><span style="display:inline-block;width:${width}px"></span></span>`,
+					)
+					.join("\n"),
+			});
+			return createMantleCodeBlockValue({ language: "typescript", code, preHtml: html });
+		}
+
+		function getPre(): HTMLPreElement {
+			const pre = document.querySelector("pre[data-slot='code-block-code']");
+			if (!(pre instanceof HTMLPreElement)) {
+				throw new Error("expected the code block <pre>");
+			}
+			return pre;
+		}
+
+		test("no scrollbar when every line fits the container", () => {
+			// Regression: a blanket per-line `padding-right: 3.5rem` widened the
+			// max-content <code>, so a 300px line in a 340px container scrolled.
+			render(
+				<div style={{ width: 340 }}>
+					<CodeBlock.Root>
+						<CodeBlock.Body>
+							<CodeBlock.CopyButton />
+							<CodeBlock.Code value={makeFixedWidthValue([100, 100, 300])} />
+						</CodeBlock.Body>
+					</CodeBlock.Root>
+				</div>,
+			);
+
+			const pre = getPre();
+			expect(pre.clientWidth).toBe(340);
+			expect(pre.scrollWidth).toBe(pre.clientWidth);
+		});
+
+		test("scroll width matches the longest line when a line overflows", () => {
+			render(
+				<div style={{ width: 340 }}>
+					<CodeBlock.Root>
+						<CodeBlock.Body>
+							<CodeBlock.CopyButton />
+							<CodeBlock.Code value={makeFixedWidthValue([100, 100, 400])} />
+						</CodeBlock.Body>
+					</CodeBlock.Root>
+				</div>,
+			);
+
+			const pre = getPre();
+			expect(pre.scrollWidth).toBeGreaterThan(pre.clientWidth);
+			// Why exactly 400: the longest line carries no copy-button clearance.
+			expect(pre.scrollWidth).toBe(400);
+		});
+
+		test("only the first two lines reserve copy-button clearance, and only when a CopyButton is rendered", () => {
+			const { rerender } = render(
+				<div style={{ width: 340 }}>
+					<CodeBlock.Root>
+						<CodeBlock.Body>
+							<CodeBlock.CopyButton />
+							<CodeBlock.Code value={makeFixedWidthValue([100, 100, 100])} />
+						</CodeBlock.Body>
+					</CodeBlock.Root>
+				</div>,
+			);
+
+			const [first, second, third] = Array.from(document.querySelectorAll(".mantle-code-line"));
+			if (first == null || second == null || third == null) {
+				throw new Error("expected three code lines");
+			}
+			// Why 56px: 3.5rem at the default 16px root font size.
+			expect(getComputedStyle(first).paddingRight).toBe("56px");
+			expect(getComputedStyle(second).paddingRight).toBe("56px");
+			expect(getComputedStyle(third).paddingRight).toBe("0px");
+
+			rerender(
+				<div style={{ width: 340 }}>
+					<CodeBlock.Root>
+						<CodeBlock.Body>
+							<CodeBlock.Code value={makeFixedWidthValue([100, 100, 100])} />
+						</CodeBlock.Body>
+					</CodeBlock.Root>
+				</div>,
+			);
+
+			for (const line of document.querySelectorAll(".mantle-code-line")) {
+				expect(getComputedStyle(line).paddingRight).toBe("0px");
+			}
 		});
 	});
 });

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -211,12 +211,17 @@ const Body = ({
 			data-slot="code-block-body"
 			className={cx(
 				"relative",
+				// Why per-line breathing room: the scroll range ends at the edge of
+				// the max-content <code>, so without a small reserve the longest
+				// line touches the container edge at the end of the scroll range.
+				"[&_.mantle-code-line]:pr-4",
 				// Why only the first two lines reserve copy-button space: the size-7
 				// button sits at `right-3 top-3`, over the first two text-mono lines
 				// only. Per-line padding adds to the max-content width of the `w-max`
 				// <code>, so a blanket reserve forced a horizontal scrollbar even when
 				// every line fit the container. The `:has()` scope drops the reserve
-				// when no copy button is rendered.
+				// when no copy button is rendered. This rule outranks the breathing
+				// room above on specificity.
 				"[&:has([data-slot=code-block-copy-button])_.mantle-code-line:nth-child(-n+2)]:pr-14",
 				className,
 			)}

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -209,7 +209,17 @@ const Body = ({
 	return (
 		<Component
 			data-slot="code-block-body"
-			className={cx("relative", className)}
+			className={cx(
+				"relative",
+				// Why only the first two lines reserve copy-button space: the size-7
+				// button sits at `right-3 top-3`, over the first two text-mono lines
+				// only. Per-line padding adds to the max-content width of the `w-max`
+				// <code>, so a blanket reserve forced a horizontal scrollbar even when
+				// every line fit the container. The `:has()` scope drops the reserve
+				// when no copy button is rendered.
+				"[&:has([data-slot=code-block-copy-button])_.mantle-code-line:nth-child(-n+2)]:pr-14",
+				className,
+			)}
 			ref={ref}
 			{...props}
 		/>

--- a/packages/mantle/src/components/code-block/code-block.tsx
+++ b/packages/mantle/src/components/code-block/code-block.tsx
@@ -423,7 +423,7 @@ const Code = ({ className, style, value, ref, ...props }: CodeBlockCodeProps) =>
 			data-slot="code-block-code"
 			aria-expanded={hasCodeExpander ? isCodeExpanded : undefined}
 			className={cx(
-				"scrollbar overflow-x-auto overflow-y-hidden py-4",
+				"scrollbar overflow-x-auto overscroll-x-none overflow-y-hidden py-4",
 				!isPreRendered && "pr-14",
 				"data-[mantle-line-numbers~='false']:pl-4",
 				"text-mono m-0 font-mono outline-hidden",

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -1294,7 +1294,54 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
 	background-color: var(--mantle-code-line-highlight-bg);
 }
 
+/*
+ * The pinned-gutter scroll shadow color. Registered as <color> so a
+ * scroll-driven animation can fade it in; `inherits: true` carries the
+ * animated value from the <pre> to the gutter pseudo-element that paints it.
+ * Transparent is the resting value, and the only value wherever
+ * `animation-timeline: scroll()` is unsupported.
+ */
+@property --_code-gutter-shadow {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
+/*
+ * Why `--color-gray-300` over the shadow tokens: the seam must read on both
+ * themes, and a black shadow vanishes on a dark base. The block's own frame
+ * already draws its border in this gray, so the seam matches it.
+ */
+@keyframes code-gutter-shadow {
+	to {
+		--_code-gutter-shadow: var(--color-gray-300);
+	}
+}
+
+@supports (animation-timeline: scroll()) {
+	pre[data-slot="code-block-code"][data-mantle-line-numbers="true"] {
+		animation-name: code-gutter-shadow;
+		animation-fill-mode: both;
+		/* Linear so the fade tracks scroll position 1:1 across the range. */
+		animation-timing-function: linear;
+		/* Fade in across the first 16px of scroll, independent of total scroll width. */
+		animation-range: 0 16px;
+		animation-timeline: scroll(self inline);
+		/* Driven by the scroll timeline; a non-auto duration is required by some engines. */
+		animation-duration: 1ms;
+	}
+}
+
+/*
+ * Why sticky: only the code scrolls; the line numbers stay pinned to the
+ * inline-start edge of the scrollport. `z-index: 1` also scopes the
+ * backdrop pseudo-element below, so its `z-index: -1` stays inside this
+ * stacking context instead of dropping under the code text.
+ */
 .mantle-code-line-number {
+	position: sticky;
+	left: 0;
+	z-index: 1;
 	display: block;
 	flex-shrink: 0;
 	width: var(--mantle-code-line-number-width);
@@ -1302,6 +1349,59 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
 	user-select: none;
 	text-align: right;
 	color: var(--mantle-code-line-number-color);
+}
+
+/*
+ * The opaque gutter backdrop. Scrolled code slides under the pinned numbers,
+ * so this masks it across the whole gutter band — the number column plus its
+ * gap, and the fold gutter on fold-enabled blocks (`--_gutter-overhang`).
+ * The box-shadow is the scrolled-edge seam, driven by the scroll timeline
+ * above; `clip-path` trims it to the band's right edge so adjacent rows tile
+ * without darkened overlaps.
+ */
+.mantle-code-line-number::before {
+	content: "";
+	position: absolute;
+	inset: 0 calc(-1 * var(--_gutter-overhang, var(--mantle-code-line-number-gap))) 0 0;
+	z-index: -1;
+	background-color: var(--background-color-base);
+	/* A hairline plus a soft falloff, both in the animated seam color. */
+	box-shadow:
+		1px 0 0 0 var(--_code-gutter-shadow),
+		6px 0 8px -6px var(--_code-gutter-shadow);
+	clip-path: inset(0 -8px 0 0);
+}
+
+pre[data-slot="code-block-code"]:has(.mantle-code-fold-toggle) .mantle-code-line-number::before {
+	--_gutter-overhang: calc(
+		var(--mantle-code-line-number-gap) + var(--mantle-code-fold-gutter-width) +
+			var(--mantle-code-fold-gutter-gap)
+	);
+}
+
+/*
+ * Re-add the line-highlight tint over the opaque backdrop, so a highlighted
+ * line's gutter matches its content — the same look the translucent line
+ * background painted before the backdrop covered it.
+ */
+.mantle-code-line-highlighted .mantle-code-line-number::before {
+	background-image: linear-gradient(
+		var(--mantle-code-line-highlight-bg),
+		var(--mantle-code-line-highlight-bg)
+	);
+}
+
+/*
+ * Why sticky only with line numbers: the toggle is gutter furniture and pins
+ * with the numbers, whose backdrop masks the code scrolling under it. With
+ * numbers off there is no backdrop, so the toggle scrolls with the code.
+ * `left` matches the toggle's resting offset after the number column, and
+ * `z-index: 1` paints this later sibling above the numbers' backdrop.
+ */
+pre[data-mantle-line-numbers="true"] .mantle-code-fold-toggle {
+	position: sticky;
+	left: calc(var(--mantle-code-line-number-width) + var(--mantle-code-line-number-gap));
+	z-index: 1;
 }
 
 .mantle-code-fold-toggle {

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -1286,19 +1286,6 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
 	box-sizing: border-box;
 }
 
-/*
- * Why only the first two lines reserve copy-button space: the size-7 button
- * sits at `right-3 top-3`, over the first two text-mono lines only. Per-line
- * padding adds to the max-content width of the `w-max` <code>, so a blanket
- * reserve forced a horizontal scrollbar even when every line fit the
- * container. The `:has()` scope drops the reserve when no copy button is
- * rendered.
- */
-[data-slot="code-block-body"]:has([data-slot="code-block-copy-button"])
-	.mantle-code-line:nth-child(-n + 2) {
-	padding-right: 3.5rem;
-}
-
 .mantle-code-line[data-fold-hidden="true"] {
 	display: none;
 }

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -1284,7 +1284,19 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
 	align-items: flex-start;
 	min-width: 100%;
 	box-sizing: border-box;
-	padding-right: 3.5rem; /* space for the copy button overlay */
+}
+
+/*
+ * Why only the first two lines reserve copy-button space: the size-7 button
+ * sits at `right-3 top-3`, over the first two text-mono lines only. Per-line
+ * padding adds to the max-content width of the `w-max` <code>, so a blanket
+ * reserve forced a horizontal scrollbar even when every line fit the
+ * container. The `:has()` scope drops the reserve when no copy button is
+ * rendered.
+ */
+[data-slot="code-block-body"]:has([data-slot="code-block-copy-button"])
+	.mantle-code-line:nth-child(-n + 2) {
+	padding-right: 3.5rem;
 }
 
 .mantle-code-line[data-fold-hidden="true"] {

--- a/packages/mantle/src/mantle.css
+++ b/packages/mantle/src/mantle.css
@@ -1295,44 +1295,6 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
 }
 
 /*
- * The pinned-gutter scroll shadow color. Registered as <color> so a
- * scroll-driven animation can fade it in; `inherits: true` carries the
- * animated value from the <pre> to the gutter pseudo-element that paints it.
- * Transparent is the resting value, and the only value wherever
- * `animation-timeline: scroll()` is unsupported.
- */
-@property --_code-gutter-shadow {
-	syntax: "<color>";
-	inherits: true;
-	initial-value: transparent;
-}
-
-/*
- * Why `--color-gray-300` over the shadow tokens: the seam must read on both
- * themes, and a black shadow vanishes on a dark base. The block's own frame
- * already draws its border in this gray, so the seam matches it.
- */
-@keyframes code-gutter-shadow {
-	to {
-		--_code-gutter-shadow: var(--color-gray-300);
-	}
-}
-
-@supports (animation-timeline: scroll()) {
-	pre[data-slot="code-block-code"][data-mantle-line-numbers="true"] {
-		animation-name: code-gutter-shadow;
-		animation-fill-mode: both;
-		/* Linear so the fade tracks scroll position 1:1 across the range. */
-		animation-timing-function: linear;
-		/* Fade in across the first 16px of scroll, independent of total scroll width. */
-		animation-range: 0 16px;
-		animation-timeline: scroll(self inline);
-		/* Driven by the scroll timeline; a non-auto duration is required by some engines. */
-		animation-duration: 1ms;
-	}
-}
-
-/*
  * Why sticky: only the code scrolls; the line numbers stay pinned to the
  * inline-start edge of the scrollport. `z-index: 1` also scopes the
  * backdrop pseudo-element below, so its `z-index: -1` stays inside this
@@ -1355,9 +1317,6 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
  * The opaque gutter backdrop. Scrolled code slides under the pinned numbers,
  * so this masks it across the whole gutter band — the number column plus its
  * gap, and the fold gutter on fold-enabled blocks (`--_gutter-overhang`).
- * The box-shadow is the scrolled-edge seam, driven by the scroll timeline
- * above; `clip-path` trims it to the band's right edge so adjacent rows tile
- * without darkened overlaps.
  */
 .mantle-code-line-number::before {
 	content: "";
@@ -1365,11 +1324,6 @@ at `:root` (same reason as the palette-alias rule in MARK: INVERT THEME).
 	inset: 0 calc(-1 * var(--_gutter-overhang, var(--mantle-code-line-number-gap))) 0 0;
 	z-index: -1;
 	background-color: var(--background-color-base);
-	/* A hairline plus a soft falloff, both in the animated seam color. */
-	box-shadow:
-		1px 0 0 0 var(--_code-gutter-shadow),
-		6px 0 8px -6px var(--_code-gutter-shadow);
-	clip-path: inset(0 -8px 0 0);
 }
 
 pre[data-slot="code-block-code"]:has(.mantle-code-fold-toggle) .mantle-code-line-number::before {


### PR DESCRIPTION
## Why

A code block whose longest line fit the container still showed a horizontal scrollbar. Every rendered line reserved `3.5rem` of right padding to clear the copy button, so the max-content `<code>` grew wider than its longest line. Review on the preview also flagged that the line numbers scroll away with the code, which leaves no anchor on long lines.

## How

- Only the first two lines — the only lines the copy button overlaps — reserve the full clearance, and only when the block contains a `CodeBlock.CopyButton`. Every line keeps a `1rem` reserve, so the end of the scroll range stays clear of the container's edge.
- The gutter — line numbers and fold toggles — pins to the left edge with `position: sticky`, and an opaque backdrop masks the code sliding under it.
- `overscroll-x-none` on the scroller removes the rubber-band bounce at the ends of the scroll range and keeps the scroll from chaining to the page.

## Validation

- The new browser tests fail against the old blanket padding and against a non-sticky gutter, and pass with the fix.
- The docs-site build emits the CSS for both per-line padding utilities.
