### PR TITLE
feat(overlays): stack floating UI in two tiers with layer containers

### DIFF
--- a/.changeset/floating-layer-tiers.md
+++ b/.changeset/floating-layer-tiers.md
@@ -1,0 +1,18 @@
+---
+"@ngrok/mantle": minor
+---
+
+Stack floating UI in two tiers so a background popover can never paint over an open dialog.
+
+Overlays — `Dialog`, `AlertDialog`, `Sheet`, and `Command.DialogRoot` — now render at `z-60`, above the float tier. Floats — `Popover`, `Tooltip`, `Select`, `DropdownMenu`, and `HoverCard` — stay at `z-50` and portal into the nearest overlay's positioner instead of `document.body`. A float composed inside an overlay now always paints above the overlay that owns it. A float outside every overlay always paints below the overlay tier. Before this change every layer shared `z-50` and the most recently mounted one won, so a popover that opened late — an onboarding popover after hydration, for example — painted on top of an open full-bleed dialog.
+
+The positioner is a new styling hook on each overlay: `data-slot="dialog-positioner"`, `data-slot="alert-dialog-positioner"`, and `data-slot="sheet-positioner"`.
+
+An explicit `container` on `Dialog.Portal` or `HoverCard.Portal` now also carries into the parts that portal internally, so the content lands in that container — before, the inner portal ignored it.
+
+Migration, for the rare consumer this breaks:
+
+- Custom fixed chrome at `z-50` that must paint above an open mantle overlay needs `z-60` or higher.
+- CSS that selects a float's portal as a direct `body` child (for example `body > [data-radix-popper-content-wrapper]`) no longer matches when the float is composed inside an overlay. Select the float's `data-slot` instead.
+
+`Combobox.Content` (renders in place), `MultiSelect.Content` (portals into the overlay's `data-mantle-modal-content`), and `Toast` (sonner's own viewport, far above both tiers) keep their placement.

--- a/.changeset/floating-layer-tiers.md
+++ b/.changeset/floating-layer-tiers.md
@@ -1,5 +1,5 @@
 ---
-"@ngrok/mantle": minor
+"@ngrok/mantle": patch
 ---
 
 Stack floating UI in two tiers so a background popover can never paint over an open dialog.
@@ -10,7 +10,7 @@ The positioner is a new styling hook on each overlay: `data-slot="dialog-positio
 
 An explicit `container` on `Dialog.Portal` or `HoverCard.Portal` now also carries into the parts that portal internally, so the content lands in that container — before, the inner portal ignored it.
 
-Migration, for the rare consumer this breaks:
+Notes, for the rare consumer that depended on the old stacking:
 
 - Custom fixed chrome at `z-50` that must paint above an open mantle overlay needs `z-60` or higher.
 - CSS that selects a float's portal as a direct `body` child (for example `body > [data-radix-popper-content-wrapper]`) no longer matches when the float is composed inside an overlay. Select the float's `data-slot` instead.

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -246,6 +246,7 @@ export const basePages = [
 	"Colors",
 	"Scroll Fade",
 	"Shadows",
+	"Stacking Layers",
 	"Tailwind Variants",
 	"Typography",
 ] as const;
@@ -256,6 +257,7 @@ export const baseRoutes = {
 	Colors: "/base/colors",
 	"Scroll Fade": "/base/scroll-fade",
 	Shadows: "/base/shadows",
+	"Stacking Layers": "/base/stacking-layers",
 	"Tailwind Variants": "/base/tailwind-variants",
 	Typography: "/base/typography",
 } as const satisfies Record<(typeof basePages)[number], Route>;

--- a/apps/www/app/docs/base/stacking-layers.mdx
+++ b/apps/www/app/docs/base/stacking-layers.mdx
@@ -64,6 +64,81 @@ The bug shape the overlay tier exists for: an announcement popover opens on its 
 	<LateAnnouncementDemo />
 </Example>
 
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { Popover } from "@ngrok/mantle/popover";
+import { useState } from "react";
+
+export function LateAnnouncementDemo() {
+	const [announcementOpen, setAnnouncementOpen] = useState(false);
+
+	return (
+		<div className="flex flex-wrap items-center gap-4">
+			<Popover.Root open={announcementOpen} onOpenChange={setAnnouncementOpen}>
+				<Popover.Anchor asChild>
+					<Button
+						type="button"
+						appearance="outlined"
+						intent="neutral"
+						onClick={() => setAnnouncementOpen(true)}
+					>
+						Show announcement
+					</Button>
+				</Popover.Anchor>
+				<Popover.Content
+					// A click anywhere else must not dismiss the announcement — only
+					// its own button does, like a real onboarding popover.
+					onInteractOutside={(event) => {
+						event.preventDefault();
+					}}
+					side="bottom"
+					className="flex flex-col gap-2"
+				>
+					<p className="text-strong text-sm font-medium">Your account moved down here</p>
+					<Popover.Close asChild>
+						<Button type="button" appearance="filled" intent="neutral" size="sm">
+							Got it
+						</Button>
+					</Popover.Close>
+				</Popover.Content>
+			</Popover.Root>
+			<Dialog.Root>
+				<Dialog.Trigger asChild>
+					<Button type="button" appearance="filled" intent="neutral">
+						Open takeover
+					</Button>
+				</Dialog.Trigger>
+				<Dialog.Content appearance="full-page">
+					<Dialog.Header>
+						<Dialog.Title>Takeover</Dialog.Title>
+						<Dialog.CloseIconButton />
+					</Dialog.Header>
+					<Dialog.Body className="space-y-4">
+						<p>
+							This button opens the page-level announcement popover while the dialog is on top — the
+							way an onboarding popover opens on its own after hydration.
+						</p>
+						<Button
+							type="button"
+							appearance="outlined"
+							intent="neutral"
+							onClick={() => setAnnouncementOpen(true)}
+						>
+							Trigger the late announcement
+						</Button>
+						<p>
+							The announcement stays under this dialog because it belongs to the page, not to the
+							dialog. Close the dialog to find it waiting where it belongs.
+						</p>
+					</Dialog.Body>
+				</Dialog.Content>
+			</Dialog.Root>
+		</div>
+	);
+}
+```
+
 ### Floats inside a dialog paint above it
 
 Each float composed inside the dialog portals into the dialog's positioner, so it opens on top of the dialog — never behind it, never clipped by it.

--- a/apps/www/app/docs/base/stacking-layers.mdx
+++ b/apps/www/app/docs/base/stacking-layers.mdx
@@ -64,7 +64,7 @@ The bug shape the overlay tier exists for: an announcement popover opens on its 
 	<LateAnnouncementDemo />
 </Example>
 
-```tsx
+```tsx collapsible
 import { Button } from "@ngrok/mantle/button";
 import { Dialog } from "@ngrok/mantle/dialog";
 import { Popover } from "@ngrok/mantle/popover";
@@ -198,7 +198,7 @@ Each float composed inside the dialog portals into the dialog's positioner, so i
 	</Dialog.Root>
 </Example>
 
-```tsx
+```tsx collapsible
 <Dialog.Root>
 	<Dialog.Trigger asChild>
 		<Button type="button" appearance="filled" intent="neutral">
@@ -297,7 +297,7 @@ Each float composed inside the dialog portals into the dialog's positioner, so i
 	</Sheet.Root>
 </Example>
 
-```tsx
+```tsx collapsible
 <Sheet.Root>
 	<Sheet.Trigger asChild>
 		<Button type="button" appearance="filled" intent="neutral">
@@ -363,7 +363,7 @@ A float does not register a layer container, so a select opened from a popover s
 	</Popover.Root>
 </Example>
 
-```tsx
+```tsx collapsible
 <Popover.Root>
 	<Popover.Trigger asChild>
 		<Button type="button" appearance="filled" intent="neutral">
@@ -436,7 +436,7 @@ An overlay opened from inside another overlay portals into the outer overlay's p
 	</Dialog.Root>
 </Example>
 
-```tsx
+```tsx collapsible
 <Dialog.Root>
 	<Dialog.Trigger asChild>
 		<Button type="button" appearance="filled" intent="neutral">
@@ -520,7 +520,7 @@ A toast fired from inside an overlay renders in sonner's viewport, far above bot
 	</Dialog.Root>
 </Example>
 
-```tsx
+```tsx collapsible
 <Dialog.Root>
 	<Dialog.Trigger asChild>
 		<Button type="button" appearance="filled" intent="neutral">

--- a/apps/www/app/docs/base/stacking-layers.mdx
+++ b/apps/www/app/docs/base/stacking-layers.mdx
@@ -1,0 +1,50 @@
+---
+title: Stacking Layers
+description: The z-index tiers mantle's floating UI stacks on, what each tier means, and how to place custom UI on the scale
+---
+
+# Stacking Layers
+
+Every mantle surface that floats above the page stacks on one shared scale. Two rules decide what paints on top:
+
+1. **The tier decides between kinds of layers.** An overlay always paints above a float, no matter which one opened first.
+2. **Ownership decides within a tier.** A float composed inside an overlay portals into that overlay's positioner, so it paints above the overlay that owns it. Sibling layers in the same tier and container paint in mount order — the most recently mounted one wins.
+
+## The tiers
+
+| Tier        | z-index     | Layers                                                                                                                                                                                                                 | Renders into                                                       |
+| ----------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Page chrome | `z-50`      | [Sandbar](/components/feedback/sandbar), [AlertCenter](/components/feedback/alert-center) banners, sticky headers                                                                                                      | In place, in the page's own stacking context                       |
+| Float       | `z-50`      | [Popover](/components/overlays/popover), [Tooltip](/components/overlays/tooltip), [Select](/components/forms/select), [DropdownMenu](/components/overlays/dropdown-menu), [HoverCard](/components/overlays/hover-card) | The nearest overlay's positioner, else `document.body`             |
+| Overlay     | `z-60`      | [Dialog](/components/overlays/dialog), [AlertDialog](/components/overlays/alert-dialog), [Sheet](/components/overlays/sheet), [Command](/components/navigation/command)'s palette                                      | The nearest overlay's positioner, else `document.body`             |
+| Toast       | `999999999` | [Toast](/components/feedback/toast) (sonner's own viewport)                                                                                                                                                            | In place where `<Toaster />` renders; painted above both tiers     |
+| Skip link   | `z-max`     | [SkipToMainLink](/components/navigation/skip-to-main-link)                                                                                                                                                             | In place; `--z-index-max` so nothing covers keyboard escape routes |
+
+Two components place themselves differently on purpose:
+
+- [Combobox](/components/forms/combobox)`.Content` renders in place at `z-50` — it does not portal, so the dialog primitive's Escape handling can see it.
+- [MultiSelect](/components/forms/multi-select)`.Content` portals into the closest `data-mantle-modal-content` element — an enclosing overlay's content — else the nearest overlay's positioner, else `document.body`.
+
+## Layer containers
+
+Each overlay renders a **positioner**: the fixed element that lays out its content. The positioner doubles as the overlay's layer container — floats composed inside the overlay portal into it, after the content, so they paint above the content inside the overlay's own stacking context. The positioner is a styling hook:
+
+| Overlay       | Positioner slot                       |
+| ------------- | ------------------------------------- |
+| `Dialog`      | `data-slot="dialog-positioner"`       |
+| `AlertDialog` | `data-slot="alert-dialog-positioner"` |
+| `Sheet`       | `data-slot="sheet-positioner"`        |
+
+Ownership comes from composition, not timing. A float rendered inside `Dialog.Content` belongs to that dialog and paints above it. A float rendered outside stays at `document.body` and paints below every overlay — even when it opens later. Before this contract, every layer shared `z-50` and mount order alone decided, so a popover that opened late (an onboarding popover after hydration, for example) painted on top of an open full-bleed dialog.
+
+Floats do not register a container of their own. A select opened from inside a popover shares the popover's container and paints above the popover by mount order — the right rule for layers the user opened in sequence.
+
+## Placing custom UI on the scale
+
+- **Chrome that floats above page content but under overlays** — a fixed action bar, a floating panel: use `z-50` in the page, the same tier as page chrome. An open dialog covers it, which is almost always correct.
+- **UI that must paint above open overlays**: use `z-60` and mount it after the overlay, or render it inside the overlay's content so it joins the overlay's layer. Reach for this rarely — above the overlay tier, only toasts and the skip link should live.
+- **Never out-stack toasts.** Toasts announce results of actions taken anywhere, including inside overlays.
+- **Custom portals inside an overlay**: pass the overlay's positioner as the portal target (query the `data-slot` above), or compose a mantle float, which resolves it automatically. `Dialog.Portal` and `HoverCard.Portal` accept a `container` prop when you need explicit control.
+- **Do not select a float's portal as a direct `body` child** (`body > [data-radix-popper-content-wrapper]`). Inside an overlay the float lives in the positioner. Target the float's `data-slot` instead.
+
+The full rationale, the alternatives considered, and the paint-order test matrix live in the repo's decision doc, `decisions/2026-08-11-floating-layer-tiers.md`.

--- a/apps/www/app/docs/base/stacking-layers.mdx
+++ b/apps/www/app/docs/base/stacking-layers.mdx
@@ -3,6 +3,19 @@ title: Stacking Layers
 description: The z-index tiers mantle's floating UI stacks on, what each tier means, and how to place custom UI on the scale
 ---
 
+import { Button } from "@ngrok/mantle/button";
+import { Combobox } from "@ngrok/mantle/combobox";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { DropdownMenu } from "@ngrok/mantle/dropdown-menu";
+import { MultiSelect } from "@ngrok/mantle/multi-select";
+import { Popover } from "@ngrok/mantle/popover";
+import { Select } from "@ngrok/mantle/select";
+import { Sheet } from "@ngrok/mantle/sheet";
+import { Toast, makeToast } from "@ngrok/mantle/toast";
+import { Tooltip } from "@ngrok/mantle/tooltip";
+import { Example } from "~/components/example";
+import { LateAnnouncementDemo } from "~/features/stacking-layers-demos";
+
 # Stacking Layers
 
 Every mantle surface that floats above the page stacks on one shared scale. Two rules decide what paints on top:
@@ -38,6 +51,432 @@ Each overlay renders a **positioner**: the fixed element that lays out its conte
 Ownership comes from composition, not timing. A float rendered inside `Dialog.Content` belongs to that dialog and paints above it. A float rendered outside stays at `document.body` and paints below every overlay — even when it opens later. Before this contract, every layer shared `z-50` and mount order alone decided, so a popover that opened late (an onboarding popover after hydration, for example) painted on top of an open full-bleed dialog.
 
 Floats do not register a container of their own. A select opened from inside a popover shares the popover's container and paints above the popover by mount order — the right rule for layers the user opened in sequence.
+
+## See the contract work
+
+Every rule above has a live permutation below, and each also has an automated twin in mantle's layering test matrix (`layer-container.test.tsx` pins DOM placement; `layer-container.browser.test.tsx` proves paint order with real hit-testing).
+
+### A base float never paints above an overlay
+
+The bug shape the overlay tier exists for: an announcement popover opens on its own while a takeover dialog covers its anchor. Open the takeover, then trigger the late announcement from inside it — the announcement stays under the dialog, and it waits on the page when the dialog closes.
+
+<Example>
+	<LateAnnouncementDemo />
+</Example>
+
+### Floats inside a dialog paint above it
+
+Each float composed inside the dialog portals into the dialog's positioner, so it opens on top of the dialog — never behind it, never clipped by it.
+
+<Example>
+	<Dialog.Root>
+		<Dialog.Trigger asChild>
+			<Button type="button" appearance="filled" intent="neutral">
+				Open dialog
+			</Button>
+		</Dialog.Trigger>
+		<Dialog.Content>
+			<Dialog.Header>
+				<Dialog.Title>Floats in a dialog</Dialog.Title>
+				<Dialog.CloseIconButton />
+			</Dialog.Header>
+			<Dialog.Body className="space-y-4">
+				<Popover.Root>
+					<Popover.Trigger asChild>
+						<Button type="button" appearance="outlined" intent="neutral">
+							Open popover
+						</Button>
+					</Popover.Trigger>
+					<Popover.Content>
+						<p>This popover paints above the dialog that owns it.</p>
+					</Popover.Content>
+				</Popover.Root>
+				<Select.Root>
+					<Select.Trigger className="w-45">
+						<Select.Value placeholder="Open select" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+						<Select.Item value="banana">Banana</Select.Item>
+					</Select.Content>
+				</Select.Root>
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger asChild>
+						<Button type="button" appearance="outlined" intent="neutral">
+							Open menu
+						</Button>
+					</DropdownMenu.Trigger>
+					<DropdownMenu.Content>
+						<DropdownMenu.Item>Menu item</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+				<Tooltip.Root>
+					<Tooltip.Trigger asChild>
+						<Button type="button" appearance="outlined" intent="neutral">
+							Hover for a tooltip
+						</Button>
+					</Tooltip.Trigger>
+					<Tooltip.Content>This tooltip paints above the dialog.</Tooltip.Content>
+				</Tooltip.Root>
+			</Dialog.Body>
+		</Dialog.Content>
+	</Dialog.Root>
+</Example>
+
+```tsx
+<Dialog.Root>
+	<Dialog.Trigger asChild>
+		<Button type="button" appearance="filled" intent="neutral">
+			Open dialog
+		</Button>
+	</Dialog.Trigger>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Floats in a dialog</Dialog.Title>
+			<Dialog.CloseIconButton />
+		</Dialog.Header>
+		<Dialog.Body className="space-y-4">
+			<Popover.Root>
+				<Popover.Trigger asChild>
+					<Button type="button" appearance="outlined" intent="neutral">
+						Open popover
+					</Button>
+				</Popover.Trigger>
+				<Popover.Content>
+					<p>This popover paints above the dialog that owns it.</p>
+				</Popover.Content>
+			</Popover.Root>
+			<Select.Root>
+				<Select.Trigger className="w-45">
+					<Select.Value placeholder="Open select" />
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="apple">Apple</Select.Item>
+					<Select.Item value="banana">Banana</Select.Item>
+				</Select.Content>
+			</Select.Root>
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger asChild>
+					<Button type="button" appearance="outlined" intent="neutral">
+						Open menu
+					</Button>
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content>
+					<DropdownMenu.Item>Menu item</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+			<Tooltip.Root>
+				<Tooltip.Trigger asChild>
+					<Button type="button" appearance="outlined" intent="neutral">
+						Hover for a tooltip
+					</Button>
+				</Tooltip.Trigger>
+				<Tooltip.Content>This tooltip paints above the dialog.</Tooltip.Content>
+			</Tooltip.Root>
+		</Dialog.Body>
+	</Dialog.Content>
+</Dialog.Root>
+```
+
+### Pickers inside a sheet place themselves
+
+`Combobox.Content` renders in place and `MultiSelect.Content` portals into the sheet's content element, so both open above the sheet and scroll with it.
+
+<Example>
+	<Sheet.Root>
+		<Sheet.Trigger asChild>
+			<Button type="button" appearance="filled" intent="neutral">
+				Open sheet
+			</Button>
+		</Sheet.Trigger>
+		<Sheet.Content>
+			<Sheet.Header>
+				<Sheet.TitleGroup>
+					<Sheet.Title>Pickers in a sheet</Sheet.Title>
+					<Sheet.Actions>
+						<Sheet.CloseIconButton />
+					</Sheet.Actions>
+				</Sheet.TitleGroup>
+			</Sheet.Header>
+			<Sheet.Body className="space-y-4">
+				<Combobox.Root>
+					<Combobox.Input placeholder="Search fruits..." />
+					<Combobox.Content>
+						<Combobox.Item value="Apple" />
+						<Combobox.Item value="Banana" />
+						<Combobox.Item value="Cherry" />
+					</Combobox.Content>
+				</Combobox.Root>
+				<MultiSelect.Root>
+					<MultiSelect.Trigger>
+						<MultiSelect.TagValues />
+						<MultiSelect.Input placeholder="Select fruits..." />
+					</MultiSelect.Trigger>
+					<MultiSelect.Content>
+						<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+						<MultiSelect.Item value="banana">Banana</MultiSelect.Item>
+					</MultiSelect.Content>
+				</MultiSelect.Root>
+			</Sheet.Body>
+		</Sheet.Content>
+	</Sheet.Root>
+</Example>
+
+```tsx
+<Sheet.Root>
+	<Sheet.Trigger asChild>
+		<Button type="button" appearance="filled" intent="neutral">
+			Open sheet
+		</Button>
+	</Sheet.Trigger>
+	<Sheet.Content>
+		<Sheet.Header>
+			<Sheet.TitleGroup>
+				<Sheet.Title>Pickers in a sheet</Sheet.Title>
+				<Sheet.Actions>
+					<Sheet.CloseIconButton />
+				</Sheet.Actions>
+			</Sheet.TitleGroup>
+		</Sheet.Header>
+		<Sheet.Body className="space-y-4">
+			<Combobox.Root>
+				<Combobox.Input placeholder="Search fruits..." />
+				<Combobox.Content>
+					<Combobox.Item value="Apple" />
+					<Combobox.Item value="Banana" />
+					<Combobox.Item value="Cherry" />
+				</Combobox.Content>
+			</Combobox.Root>
+			<MultiSelect.Root>
+				<MultiSelect.Trigger>
+					<MultiSelect.TagValues />
+					<MultiSelect.Input placeholder="Select fruits..." />
+				</MultiSelect.Trigger>
+				<MultiSelect.Content>
+					<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+					<MultiSelect.Item value="banana">Banana</MultiSelect.Item>
+				</MultiSelect.Content>
+			</MultiSelect.Root>
+		</Sheet.Body>
+	</Sheet.Content>
+</Sheet.Root>
+```
+
+### Floats inside a float stack by mount order
+
+A float does not register a layer container, so a select opened from a popover shares the popover's container and paints above the popover that spawned it.
+
+<Example>
+	<Popover.Root>
+		<Popover.Trigger asChild>
+			<Button type="button" appearance="filled" intent="neutral">
+				Open popover
+			</Button>
+		</Popover.Trigger>
+		<Popover.Content className="space-y-2">
+			<p>Open the select — it paints above this popover.</p>
+			<Select.Root>
+				<Select.Trigger className="w-45">
+					<Select.Value placeholder="Open select" />
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="apple">Apple</Select.Item>
+					<Select.Item value="banana">Banana</Select.Item>
+				</Select.Content>
+			</Select.Root>
+		</Popover.Content>
+	</Popover.Root>
+</Example>
+
+```tsx
+<Popover.Root>
+	<Popover.Trigger asChild>
+		<Button type="button" appearance="filled" intent="neutral">
+			Open popover
+		</Button>
+	</Popover.Trigger>
+	<Popover.Content className="space-y-2">
+		<p>Open the select — it paints above this popover.</p>
+		<Select.Root>
+			<Select.Trigger className="w-45">
+				<Select.Value placeholder="Open select" />
+			</Select.Trigger>
+			<Select.Content>
+				<Select.Item value="apple">Apple</Select.Item>
+				<Select.Item value="banana">Banana</Select.Item>
+			</Select.Content>
+		</Select.Root>
+	</Popover.Content>
+</Popover.Root>
+```
+
+### Overlays stack in mount order
+
+An overlay opened from inside another overlay portals into the outer overlay's positioner and paints above it, backdrop and all. The popover at the end of the chain paints above both.
+
+<Example>
+	<Dialog.Root>
+		<Dialog.Trigger asChild>
+			<Button type="button" appearance="filled" intent="neutral">
+				Open dialog
+			</Button>
+		</Dialog.Trigger>
+		<Dialog.Content>
+			<Dialog.Header>
+				<Dialog.Title>First overlay</Dialog.Title>
+				<Dialog.CloseIconButton />
+			</Dialog.Header>
+			<Dialog.Body>
+				<Sheet.Root>
+					<Sheet.Trigger asChild>
+						<Button type="button" appearance="outlined" intent="neutral">
+							Open a sheet over this dialog
+						</Button>
+					</Sheet.Trigger>
+					<Sheet.Content>
+						<Sheet.Header>
+							<Sheet.TitleGroup>
+								<Sheet.Title>Second overlay</Sheet.Title>
+								<Sheet.Actions>
+									<Sheet.CloseIconButton />
+								</Sheet.Actions>
+							</Sheet.TitleGroup>
+						</Sheet.Header>
+						<Sheet.Body>
+							<Popover.Root>
+								<Popover.Trigger asChild>
+									<Button type="button" appearance="outlined" intent="neutral">
+										Open a popover over the sheet
+									</Button>
+								</Popover.Trigger>
+								<Popover.Content>
+									<p>Dialog, then sheet, then this popover — each paints above the last.</p>
+								</Popover.Content>
+							</Popover.Root>
+						</Sheet.Body>
+					</Sheet.Content>
+				</Sheet.Root>
+			</Dialog.Body>
+		</Dialog.Content>
+	</Dialog.Root>
+</Example>
+
+```tsx
+<Dialog.Root>
+	<Dialog.Trigger asChild>
+		<Button type="button" appearance="filled" intent="neutral">
+			Open dialog
+		</Button>
+	</Dialog.Trigger>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>First overlay</Dialog.Title>
+			<Dialog.CloseIconButton />
+		</Dialog.Header>
+		<Dialog.Body>
+			<Sheet.Root>
+				<Sheet.Trigger asChild>
+					<Button type="button" appearance="outlined" intent="neutral">
+						Open a sheet over this dialog
+					</Button>
+				</Sheet.Trigger>
+				<Sheet.Content>
+					<Sheet.Header>
+						<Sheet.TitleGroup>
+							<Sheet.Title>Second overlay</Sheet.Title>
+							<Sheet.Actions>
+								<Sheet.CloseIconButton />
+							</Sheet.Actions>
+						</Sheet.TitleGroup>
+					</Sheet.Header>
+					<Sheet.Body>
+						<Popover.Root>
+							<Popover.Trigger asChild>
+								<Button type="button" appearance="outlined" intent="neutral">
+									Open a popover over the sheet
+								</Button>
+							</Popover.Trigger>
+							<Popover.Content>
+								<p>Dialog, then sheet, then this popover — each paints above the last.</p>
+							</Popover.Content>
+						</Popover.Root>
+					</Sheet.Body>
+				</Sheet.Content>
+			</Sheet.Root>
+		</Dialog.Body>
+	</Dialog.Content>
+</Dialog.Root>
+```
+
+### Toasts clear every tier
+
+A toast fired from inside an overlay renders in sonner's viewport, far above both tiers, so results stay visible no matter what is open.
+
+<Example>
+	<Dialog.Root>
+		<Dialog.Trigger asChild>
+			<Button type="button" appearance="filled" intent="neutral">
+				Open dialog
+			</Button>
+		</Dialog.Trigger>
+		<Dialog.Content>
+			<Dialog.Header>
+				<Dialog.Title>Toast from a dialog</Dialog.Title>
+				<Dialog.CloseIconButton />
+			</Dialog.Header>
+			<Dialog.Body>
+				<Button
+					type="button"
+					appearance="outlined"
+					intent="neutral"
+					onClick={() => {
+						makeToast(
+							<Toast.Root intent="success">
+								<Toast.Icon />
+								<Toast.Message>This toast paints above the dialog.</Toast.Message>
+							</Toast.Root>,
+						);
+					}}
+				>
+					Fire a toast
+				</Button>
+			</Dialog.Body>
+		</Dialog.Content>
+	</Dialog.Root>
+</Example>
+
+```tsx
+<Dialog.Root>
+	<Dialog.Trigger asChild>
+		<Button type="button" appearance="filled" intent="neutral">
+			Open dialog
+		</Button>
+	</Dialog.Trigger>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Toast from a dialog</Dialog.Title>
+			<Dialog.CloseIconButton />
+		</Dialog.Header>
+		<Dialog.Body>
+			<Button
+				type="button"
+				appearance="outlined"
+				intent="neutral"
+				onClick={() => {
+					makeToast(
+						<Toast.Root intent="success">
+							<Toast.Icon />
+							<Toast.Message>This toast paints above the dialog.</Toast.Message>
+						</Toast.Root>,
+					);
+				}}
+			>
+				Fire a toast
+			</Button>
+		</Dialog.Body>
+	</Dialog.Content>
+</Dialog.Root>
+```
 
 ## Placing custom UI on the scale
 

--- a/apps/www/app/docs/components/forms/combobox.mdx
+++ b/apps/www/app/docs/components/forms/combobox.mdx
@@ -232,7 +232,7 @@ import { CirclesThreePlusIcon } from "@phosphor-icons/react/CirclesThreePlus";
 
 ## Layering and z-index
 
-`Combobox.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier — it does not portal, so the dialog primitive's Escape guard can see it. Inside an overlay it paints with the overlay's content. Outside one, an open overlay (`z-60`) covers it.
 
 `Combobox` does not render a backdrop. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -366,7 +366,7 @@ The `Combobox` components are built on top of [ariakit Combobox](https://ariakit
 
 The outermost part of a combobox. It owns the ariakit store that holds the query text, the open state, and the selection.
 
-Its floating `Combobox.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier — it does not portal, so the dialog primitive's Escape guard can see it. Inside an overlay it paints with the overlay's content. Outside one, an open overlay (`z-60`) covers it.
 
 All props from ariakit [ComboboxProvider](https://ariakit.org/reference/combobox-provider).
 
@@ -386,7 +386,7 @@ All props from ariakit [Combobox](https://ariakit.org/reference/combobox), plus:
 
 Renders a popover that contains combobox content, e.g. items, groups, and separators.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier — it does not portal, so the dialog primitive's Escape guard can see it. Inside an overlay it paints with the overlay's content. Outside one, an open overlay (`z-60`) covers it.
 
 All props from ariakit [ComboboxPopover](https://ariakit.org/reference/combobox-popover), plus:
 

--- a/apps/www/app/docs/components/forms/multi-select.mdx
+++ b/apps/www/app/docs/components/forms/multi-select.mdx
@@ -433,7 +433,7 @@ function Example() {
 
 ## Layering and z-index
 
-`MultiSelect.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`MultiSelect.Content` renders at Tailwind `z-50` and portals into the closest `data-mantle-modal-content` element — an enclosing overlay's content — else the nearest overlay's positioner, else `document.body`. Inside an overlay it paints above the content that contains it. Outside one, an open overlay (`z-60`) covers it.
 
 `MultiSelect` does not render a backdrop by default. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -1120,7 +1120,7 @@ The `MultiSelect` components are built on top of [ariakit Combobox](https://aria
 
 Root component for a multi-select combobox. Owns the selected values and the typeahead query.
 
-Its floating `MultiSelect.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`MultiSelect.Content` renders at Tailwind `z-50` and portals into the closest `data-mantle-modal-content` element — an enclosing overlay's content — else the nearest overlay's positioner, else `document.body`. Inside an overlay it paints above the content that contains it. Outside one, an open overlay (`z-60`) covers it.
 
 All props from ariakit [ComboboxProvider](https://ariakit.org/reference/combobox-provider) (typed to `string[]` for multi-select), plus:
 
@@ -1188,7 +1188,7 @@ Also accepts all standard `span` element props (except `children`). The `onKeyDo
 
 Renders a popover that contains multi-select content.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`MultiSelect.Content` renders at Tailwind `z-50` and portals into the closest `data-mantle-modal-content` element — an enclosing overlay's content — else the nearest overlay's positioner, else `document.body`. Inside an overlay it paints above the content that contains it. Outside one, an open overlay (`z-60`) covers it.
 
 All props from ariakit [ComboboxPopover](https://ariakit.org/reference/combobox-popover), plus:
 

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -173,7 +173,7 @@ import { Select } from "@ngrok/mantle/select";
 
 ## Layering and z-index
 
-`Select.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `Select` does not render a backdrop. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -411,7 +411,7 @@ The `Select` components are built on top of [Radix Select](https://www.radix-ui.
 
 Displays a list of options for the user to pick from—triggered by a button.
 
-Its floating `Select.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 Set `validation` on `Select.Root` when the whole select has an explicit state; this root-level state is forwarded to the trigger and takes precedence over ambient field-level validation from `Field.Item`.
 
@@ -446,7 +446,7 @@ Radix [Select.Value](https://www.radix-ui.com/primitives/docs/components/select#
 
 The component that pops out when the `Select` is open as a portal adjacent to the `Select.Trigger` button. It contains a scrolling viewport of the select items.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 All props from Radix [Select.Content](https://www.radix-ui.com/primitives/docs/components/select#content), plus:
 

--- a/apps/www/app/docs/components/overlays/alert-dialog.mdx
+++ b/apps/www/app/docs/components/overlays/alert-dialog.mdx
@@ -93,7 +93,7 @@ import { Button } from "@ngrok/mantle/button";
 
 ## Layering and z-index
 
-`AlertDialog.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`AlertDialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="alert-dialog-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
 
 `AlertDialog`, `Dialog`, and `Sheet` each render their own backdrop, so stacking modal layers compounds the dim and blur effect on the layers underneath.
 
@@ -242,7 +242,7 @@ Every part of `AlertDialog` that renders DOM accepts `asChild`, which swaps the 
 
 Holds the open state and the required `intent` that `AlertDialog.Icon` and `AlertDialog.Action` read for their color.
 
-Its floating `AlertDialog.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`AlertDialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="alert-dialog-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
 
 All props from Radix [Dialog.Root](https://www.radix-ui.com/primitives/docs/components/dialog#root), plus:
 
@@ -260,7 +260,9 @@ Radix [Dialog.Trigger](https://www.radix-ui.com/primitives/docs/components/dialo
 
 The popover Alert Dialog container. Renders on top of the overlay and is centered in the viewport.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`AlertDialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="alert-dialog-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
+
+`AlertDialog.Content` renders inside a positioner element (`data-slot="alert-dialog-positioner"`) that lays out the content and receives floats portaled from inside the alert dialog. The full stacking contract lives at [Stacking Layers](/base/stacking-layers).
 
 Radix [Dialog.Content](https://www.radix-ui.com/primitives/docs/components/dialog#content) props, plus:
 

--- a/apps/www/app/docs/components/overlays/dialog.mdx
+++ b/apps/www/app/docs/components/overlays/dialog.mdx
@@ -89,7 +89,7 @@ import { Button } from "@ngrok/mantle/button";
 
 ## Layering and z-index
 
-`Dialog.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`Dialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="dialog-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
 
 `Dialog`, `Sheet`, and `AlertDialog` each render their own backdrop, so stacking modal layers compounds the dim and blur effect on the layers underneath.
 
@@ -337,7 +337,7 @@ import { TrashSimpleIcon } from "@phosphor-icons/react/TrashSimple";
 
 ## Stacking a Sheet over a Dialog
 
-`Dialog` and `Sheet` share the same `z-50` layer, so the most recently mounted layer renders on top. Open the dialog below first, then open the sheet from inside it — the sheet stacks over the dialog rather than disappearing behind it. Each layer renders its own backdrop, so the dialog beneath is dimmed by the sheet's overlay.
+`Dialog` and `Sheet` share the overlay tier (`z-60`), so the most recently mounted overlay renders on top. Open the dialog below first, then open the sheet from inside it — the sheet stacks over the dialog rather than disappearing behind it. Each overlay renders its own backdrop, so the dialog beneath is dimmed by the sheet's overlay.
 
 <Example>
 	<Dialog.Root>
@@ -598,7 +598,7 @@ function Example() {
 
 The root stateful component that manages the open/closed state of the dialog.
 
-Its floating `Dialog.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Dialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="dialog-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
 
 | Prop            | Type                      | Default | Description                                                                                                                                                   |
 | --------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -619,7 +619,9 @@ A button that opens the dialog.
 
 The container for the dialog content. Renders on top of the overlay and is centered in the viewport.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Dialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="dialog-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
+
+`Dialog.Content` renders inside a positioner element (`data-slot="dialog-positioner"`) that lays out the content and receives floats portaled from inside the dialog. The full stacking contract lives at [Stacking Layers](/base/stacking-layers).
 
 | Prop                 | Type                                            | Default      | Description                                                                                                                                                |
 | -------------------- | ----------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/www/app/docs/components/overlays/dropdown-menu.mdx
+++ b/apps/www/app/docs/components/overlays/dropdown-menu.mdx
@@ -195,7 +195,7 @@ function Example() {
 
 ## Layering and z-index
 
-`DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and paint above the overlay that owns them. Outside every overlay, they portal to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `DropdownMenu` does not render a backdrop by default. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -228,7 +228,7 @@ The `DropdownMenu` components are built on top of [Radix Dropdown Menu](https://
 
 The root, stateful component that manages the open/closed state of the dropdown menu.
 
-Its floating `DropdownMenu.Content` and `DropdownMenu.SubContent` layers render at Tailwind `z-50`, Mantle's shared floating z-index.
+`DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and paint above the overlay that owns them. Outside every overlay, they portal to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 | Prop            | Type                      | Default | Description                                                                                                                                                        |
 | :-------------- | :------------------------ | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -250,7 +250,7 @@ The trigger button that opens the dropdown menu.
 
 The container for the dropdown menu content. Appears in a portal with scrolling and animations.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and paint above the overlay that owns them. Outside every overlay, they portal to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 All props from Radix [DropdownMenu.Content](https://www.radix-ui.com/primitives/docs/components/dropdown-menu#content), plus:
 
@@ -347,7 +347,7 @@ The trigger item that opens a submenu when hovered or focused.
 
 The content container for submenu items. Appears in a portal with scrolling and animations.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and paint above the overlay that owns them. Outside every overlay, they portal to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 | Prop    | Type      | Default | Description                                                                         |
 | :------ | :-------- | :------ | :---------------------------------------------------------------------------------- |

--- a/apps/www/app/docs/components/overlays/hover-card.mdx
+++ b/apps/www/app/docs/components/overlays/hover-card.mdx
@@ -119,7 +119,7 @@ import { HoverCard } from "@ngrok/mantle/hover-card";
 
 ## Layering and z-index
 
-`HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `HoverCard` does not render a backdrop. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -142,7 +142,7 @@ The `HoverCard` component is built on top of [Radix UI Hover Card](https://www.r
 
 The root stateful component that manages the open/closed state of the hover card.
 
-Its floating `HoverCard.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 | Prop           | Type                      | Default | Description                                                                                                         |
 | -------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -164,7 +164,7 @@ The trigger element that opens the hover card when hovered.
 
 The content to render inside the hover card. Appears in a portal with rich styling and animations.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `HoverCard.Content` sets `position: relative`, so `HoverCard.Arrow`'s absolutely-positioned wrapper keeps one containing block through the open animation. An absolutely-positioned child of the content therefore anchors to the content.
 

--- a/apps/www/app/docs/components/overlays/popover.mdx
+++ b/apps/www/app/docs/components/overlays/popover.mdx
@@ -146,7 +146,7 @@ import { Popover } from "@ngrok/mantle/popover";
 
 ## Layering and z-index
 
-`Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `Popover` does not render a backdrop by default. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -171,7 +171,7 @@ The `Popover` components are built on top of [Radix Popover](https://www.radix-u
 
 The root, stateful component that manages the open/closed state of the popover.
 
-Its floating `Popover.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 All props from Radix [Popover.Root](https://www.radix-ui.com/primitives/docs/components/popover#root).
 
@@ -196,7 +196,7 @@ All props from Radix [Popover.Trigger](https://www.radix-ui.com/primitives/docs/
 
 The content to render inside the popover. Appears in a portal with styling and animations.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `Popover.Content` sets `position: relative`, so `Popover.Arrow`'s absolutely-positioned wrapper keeps one containing block through the open animation. An absolutely-positioned child of the content therefore anchors to the content.
 

--- a/apps/www/app/docs/components/overlays/sheet.mdx
+++ b/apps/www/app/docs/components/overlays/sheet.mdx
@@ -224,7 +224,7 @@ import { TrashSimpleIcon } from "@phosphor-icons/react/TrashSimple";
 
 ## Layering and z-index
 
-`Sheet.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`Sheet.Content` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="sheet-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
 
 `Sheet`, `Dialog`, and `AlertDialog` each render their own backdrop, so stacking modal layers compounds the dim and blur effect on the layers underneath.
 
@@ -524,7 +524,7 @@ The `Sheet` components are built on top of [Radix Dialog](https://www.radix-ui.c
 
 The root component for a `Sheet`. Should compose the `Sheet.Trigger` and `Sheet.Content`. Acts as a stateful provider for the Sheet's open/closed state.
 
-Its floating `Sheet.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Sheet` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="sheet-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
 
 All props from Radix [Dialog.Root](https://www.radix-ui.com/primitives/docs/components/dialog#root).
 
@@ -544,7 +544,9 @@ Radix [Dialog.Close](https://www.radix-ui.com/primitives/docs/components/dialog#
 
 The main container for a `Sheet`. Should be rendered as a child of the `Sheet` component. Renders on top of the overlay backdrop. Should contain the `Sheet.Header`, `Sheet.Body`, and `Sheet.Footer`.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Sheet.Content` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier, above every float (`z-50`). Floats composed inside the content portal into the positioner (`data-slot="sheet-positioner"`) and paint above the content. When multiple overlays are open, the most recently mounted overlay renders on top.
+
+`Sheet.Content` renders inside a positioner element (`data-slot="sheet-positioner"`) that lays out the content and receives floats portaled from inside the sheet. The full stacking contract lives at [Stacking Layers](/base/stacking-layers).
 
 All props from Radix [Dialog.Content](https://www.radix-ui.com/primitives/docs/components/dialog#content), plus:
 

--- a/apps/www/app/docs/components/overlays/tooltip.mdx
+++ b/apps/www/app/docs/components/overlays/tooltip.mdx
@@ -54,7 +54,7 @@ import { Tooltip } from "@ngrok/mantle/tooltip";
 
 ## Layering and z-index
 
-`Tooltip.Content` renders at Tailwind `z-50`, Mantle's shared floating z-index. The shared layer includes `Dialog`, `Sheet`, `AlertDialog`, `Popover`, `Tooltip`, `HoverCard`, `DropdownMenu`, `Select`, `Combobox`, and `MultiSelect`. When more than one shared layer is open, equal z-index means DOM or portal mount order decides the visual order, so the most recently mounted layer renders on top.
+`Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 `Tooltip` does not render a backdrop. Modal layers such as `Dialog`, `Sheet`, and `AlertDialog` do render backdrops, so stacking those layers compounds the dim and blur effect on the layers underneath.
 
@@ -98,7 +98,7 @@ Wraps your app to set shared global behavior for your tooltips, such as consiste
 
 The root component that manages the open/closed state of the tooltip. Wrap your app in `TooltipProvider` when you want shared app-wide delay and hover settings.
 
-Its floating `Tooltip.Content` layer renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 | Prop                       | Type                      | Default | Description                                                                                                             |
 | -------------------------- | ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
@@ -120,7 +120,7 @@ The button that toggles the tooltip. By default, the `Tooltip.Content` will posi
 
 The component that pops out when the tooltip is open.
 
-Renders at Tailwind `z-50`, Mantle's shared floating z-index.
+`Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
 
 | Prop               | Type                                     | Default    | Description                                                                                                                             |
 | ------------------ | ---------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/www/app/features/stacking-layers-demos.tsx
+++ b/apps/www/app/features/stacking-layers-demos.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Button } from "@ngrok/mantle/button";
+import { Dialog } from "@ngrok/mantle/dialog";
+import { Popover } from "@ngrok/mantle/popover";
+import { useState } from "react";
+
+/**
+ * The bug shape the overlay tier exists for: an announcement popover opens on
+ * its own while a full-page dialog covers its anchor. The dialog stays on top
+ * no matter which layer opened last, and the announcement waits underneath.
+ *
+ * @example
+ * ```tsx
+ * <LateAnnouncementDemo />
+ * ```
+ */
+export function LateAnnouncementDemo() {
+	const [announcementOpen, setAnnouncementOpen] = useState(false);
+
+	return (
+		<div className="flex flex-wrap items-center gap-4">
+			<Popover.Root open={announcementOpen} onOpenChange={setAnnouncementOpen}>
+				<Popover.Anchor asChild>
+					<Button
+						type="button"
+						appearance="outlined"
+						intent="neutral"
+						onClick={() => setAnnouncementOpen(true)}
+					>
+						Show announcement
+					</Button>
+				</Popover.Anchor>
+				<Popover.Content
+					// A click anywhere else must not dismiss the announcement — only
+					// its own button does, like a real onboarding popover.
+					onInteractOutside={(event) => {
+						event.preventDefault();
+					}}
+					side="bottom"
+					className="flex flex-col gap-2"
+				>
+					<p className="text-strong text-sm font-medium">Your account moved down here</p>
+					<Popover.Close asChild>
+						<Button type="button" appearance="filled" intent="neutral" size="sm">
+							Got it
+						</Button>
+					</Popover.Close>
+				</Popover.Content>
+			</Popover.Root>
+			<Dialog.Root>
+				<Dialog.Trigger asChild>
+					<Button type="button" appearance="filled" intent="neutral">
+						Open takeover
+					</Button>
+				</Dialog.Trigger>
+				<Dialog.Content appearance="full-page">
+					<Dialog.Header>
+						<Dialog.Title>Takeover</Dialog.Title>
+						<Dialog.CloseIconButton />
+					</Dialog.Header>
+					<Dialog.Body className="space-y-4">
+						<p>
+							This button opens the page-level announcement popover while the dialog is on top — the
+							way an onboarding popover opens on its own after hydration.
+						</p>
+						<Button
+							type="button"
+							appearance="outlined"
+							intent="neutral"
+							onClick={() => setAnnouncementOpen(true)}
+						>
+							Trigger the late announcement
+						</Button>
+						<p>
+							The announcement stays under this dialog because it belongs to the page, not to the
+							dialog. Close the dialog to find it waiting where it belongs.
+						</p>
+					</Dialog.Body>
+				</Dialog.Content>
+			</Dialog.Root>
+		</div>
+	);
+}

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -66,6 +66,7 @@ export default [
 		...docRoute("base/colors"),
 		...docRoute("base/scroll-fade"),
 		...docRoute("base/shadows"),
+		...docRoute("base/stacking-layers"),
 		...docRoute("base/tailwind-variants"),
 		...docRoute("base/typography"),
 

--- a/decisions/2026-08-11-floating-layer-tiers.md
+++ b/decisions/2026-08-11-floating-layer-tiers.md
@@ -1,0 +1,112 @@
+# Floating layers: two z-index tiers plus per-overlay layer containers
+
+**Date:** 2026-08-11
+**Status:** Accepted
+**Applies to:** `@ngrok/mantle/dialog`, `alert-dialog`, `sheet`, `popover`, `tooltip`, `select`, `dropdown-menu`, `hover-card`, and the layering contract every floating component documents
+
+## Context
+
+Every mantle floating layer rendered at one Tailwind `z-50`, portaled to
+`document.body`, and DOM order broke ties: the most recently mounted layer
+painted on top. That rule is correct for interaction-nested layers — a menu
+opened from inside a dialog mounts after the dialog and paints above it — but
+it encodes "opened later" as "logically above," and those are not the same
+fact.
+
+The counterexample shipped: the dashboard's "moved the cheese" onboarding
+popover opens on its own after hydration. When the user loads a route whose
+content is a full-bleed `Dialog`, the dialog's portal lands during hydration
+and the popover's portal lands one commit later — a later `body` sibling at the
+same `z-50`, painting on top of a takeover that covers its anchor
+(ngrok/FEP-1754). The popover was also inert, because the modal dialog put
+`pointer-events: none` on `body`.
+
+No single z-index scale can express the intent, because the same component
+sits on both sides: the sidebar's popover must paint under the dialog, and the
+dialog's own popovers must paint over it.
+
+## Decisions
+
+### 1. Layer ownership comes from the React tree, not from mount timing
+
+Each overlay's positioner — the fixed, transform-free element that lays out
+its content — doubles as its **layer container**, published through the
+internal `LayerContainerContext`
+(`packages/mantle/src/utils/layer-container/layer-container.tsx`). Every
+portaled float resolves its portal target through `useLayerContainer()`: the
+nearest enclosing overlay's positioner, else `document.body`. A float composed
+inside a dialog therefore lives inside the dialog's own stacking context and
+paints above it by construction; a float composed outside lives at `body` and
+cannot reach into any overlay.
+
+The positioner, not a sibling element, must be the container for two reasons:
+
+- Radix marks the portal's other children `aria-hidden` when a modal overlay
+  opens. The positioner is on the content's ancestor chain, which the marking
+  skips, so floats portaled into it stay readable.
+- A `position: fixed` float inside a transformed ancestor positions against
+  that ancestor, not the viewport. The open/close animations live on the
+  content element; the positioner stays transform-free.
+
+`Sheet.Content` was its own fixed, transformed box, so `Sheet` gained a
+zero-box positioner wrapper. `Dialog` and `AlertDialog` already had one.
+
+### 2. Overlays take a higher tier: floats `z-50`, overlays `z-60`
+
+The container alone cannot fix the shipped bug — a late-opening base popover
+still appends to `body` after the dialog's portal and wins the `z-50` tie. So
+overlays (`Dialog`, `AlertDialog`, `Sheet`, and `Command.DialogRoot` through
+`Dialog`) moved to `z-60`: a base-level float can never out-paint an overlay,
+no matter when it opens. Within one tier and one container, DOM order still
+breaks ties, which is the right rule for peers.
+
+Toasts (sonner's own `z-index: 999999999`) stay above both tiers.
+`skip-to-main-link` keeps `z-max`. Page chrome (`Sandbar`, `AlertCenter`
+banners) stays at `z-50`, so overlays now correctly cover it.
+
+### 3. Layers with their own placement rules keep them
+
+- **`Combobox.Content` does not portal.** The dialog primitive's Escape guard
+  (`dialog/primitive.tsx`) only yields to a popup the dialog content
+  _contains_; portaling the popup would make Escape close the whole dialog.
+- **`MultiSelect.Content` portals into the closest
+  `[data-mantle-modal-content]`** — inside the overlay's content element — for
+  the same Escape reason, resolved by DOM search rather than context.
+- **An explicit `container` prop wins.** `Dialog.Portal` and `HoverCard.Portal`
+  pass the resolved container back down as the layer container, so the parts
+  that re-portal internally honor it — before this change, a `container` on
+  those parts was silently ignored by the inner portal.
+
+## Alternatives considered
+
+- **Bump the popover's z-index (or the page's).** Rejected: the same `Popover`
+  component renders both the base-layer announcement and the floats inside the
+  creation form. Any value that buries one buries the other.
+- **Container context alone, no tier split.** Rejected: a base float that
+  opens after the overlay still appends later at an equal z-index and wins the
+  tie. The shipped bug survives.
+- **Tier split alone, no containers.** Rejected: a `z-50` float portaled to
+  `body` from inside a `z-60` dialog paints under its own dialog.
+- **The native top layer (`<dialog>.showModal()`, the Popover API).** Rejected
+  for now: promotion order in the top layer is still chronological, so it
+  re-encodes mount timing, and Radix/Ariakit do not render into it.
+- **Per-depth dynamic z-index values.** Rejected: containers make nesting
+  compose through DOM containment with two static utility classes; computed
+  z-indexes would need inline styles and a registry.
+
+## Consequences
+
+- Consumer chrome at `z-50` that relied on out-stacking an open dialog by
+  mount order now paints under it. The fix is to move that chrome to `z-60`
+  or above — or, usually, to stop rendering it under a takeover.
+- Consumer CSS that assumed a float's portal is a direct `body` child
+  (`body > [data-radix-popper-content-wrapper]`) breaks when the float is
+  composed inside an overlay. Target the float's `data-slot` instead.
+- Floats inside overlays are no longer `aria-hidden` by timing luck — they sit
+  inside the positioner, which the modal marking skips by construction.
+- The `z-60` tier is two utility classes (`z-50`/`z-60`) documented in every
+  floating component's JSDoc, not a CSS variable; a consumer aligning a custom
+  layer uses the same classes.
+- The paint-order contract is pinned by
+  `packages/mantle/src/utils/layer-container/layer-container.test.tsx`
+  (placement matrix) and `layer-container.browser.test.tsx` (hit-testing).

--- a/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/mantle/src/components/alert-dialog/alert-dialog.tsx
@@ -6,6 +6,7 @@ import { type ComponentProps, type ReactNode, createContext, useContext, useMemo
 import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { cx } from "../../utils/cx/cx.js";
+import { LayerContainer } from "../../utils/layer-container/layer-container.js";
 import { Button, type ButtonAppearance, type ButtonProps } from "../button/button.js";
 import type { ButtonIntent } from "../button/intents.js";
 import * as AlertDialogPrimitive from "../dialog/primitive.js";
@@ -42,9 +43,11 @@ type AlertDialogProps = ComponentProps<typeof AlertDialogPrimitive.Root> & {
  * response. Holds the open state and the `intent` that `AlertDialog.Icon` and
  * `AlertDialog.Action` read.
  *
- * `AlertDialog` renders its floating layer at Tailwind `z-50`, Mantle's
- * shared floating z-index. When multiple shared layers are open, the most
- * recently mounted layer renders on top.
+ * `AlertDialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay
+ * tier, above every float (`z-50`). Floats composed inside the content portal
+ * into the positioner (`data-slot="alert-dialog-positioner"`) and paint above
+ * the content. When multiple overlays are open, the most recently mounted
+ * overlay renders on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/alert-dialog#alertdialogroot
  *
@@ -148,7 +151,7 @@ const AlertDialogOverlay = ({
 	<AlertDialogPrimitive.Overlay
 		data-slot="alert-dialog-overlay"
 		className={cx(
-			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-50 backdrop-blur-xs",
+			"data-state-open:animate-in data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:fade-in-0 bg-overlay fixed inset-0 z-60 backdrop-blur-xs",
 			className,
 		)}
 		{...props}
@@ -173,9 +176,11 @@ type AlertDialogContentProps = ComponentProps<typeof AlertDialogPrimitive.Conten
  *
  * Renders on top of the overlay and is centered in the viewport.
  *
- * `AlertDialog.Content` renders its floating layer at Tailwind `z-50`,
- * Mantle's shared floating z-index. When multiple shared layers are open, the
- * most recently mounted layer renders on top.
+ * `AlertDialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's
+ * overlay tier, above every float (`z-50`). Floats composed inside the content
+ * portal into the positioner (`data-slot="alert-dialog-positioner"`) and paint
+ * above the content. When multiple overlays are open, the most recently mounted
+ * overlay renders on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/alert-dialog#alertdialogcontent
  *
@@ -217,7 +222,15 @@ const Content = ({
 }: AlertDialogContentProps) => (
 	<AlertDialogPortal>
 		<AlertDialogOverlay />
-		<div className="fixed inset-4 z-50 flex items-center justify-center">
+		{/* Why the positioner is the layer container: floats composed inside the
+		    alert dialog portal into it, after the content, so they paint above
+		    the content inside the alert dialog's own stacking context. It stays
+		    free of transforms — the open animation lives on the content — so a
+		    portaled float's `position: fixed` still resolves against the viewport. */}
+		<LayerContainer
+			data-slot="alert-dialog-positioner"
+			className="fixed inset-4 z-60 flex items-center justify-center"
+		>
 			<AlertDialogPrimitive.Content
 				data-slot="alert-dialog-content"
 				data-mantle-modal-content
@@ -233,7 +246,7 @@ const Content = ({
 				)}
 				{...props}
 			/>
-		</div>
+		</LayerContainer>
 	</AlertDialogPortal>
 );
 
@@ -796,9 +809,11 @@ const Close = ({ ref, ...props }: ComponentProps<typeof AlertDialogPrimitive.Clo
  * `Dialog` instead. For side-panel content (filter panels, detail views,
  * navigation drawers), use `Sheet`.
  *
- * `AlertDialog` renders its floating layer at Tailwind `z-50`, Mantle's
- * shared floating z-index. When multiple shared layers are open, the most
- * recently mounted layer renders on top.
+ * `AlertDialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay
+ * tier, above every float (`z-50`). Floats composed inside the content portal
+ * into the positioner (`data-slot="alert-dialog-positioner"`) and paint above
+ * the content. When multiple overlays are open, the most recently mounted
+ * overlay renders on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/alert-dialog
  *
@@ -855,9 +870,11 @@ const AlertDialog = {
 	 * informational confirmations. `AlertDialog.Icon` and `AlertDialog.Action`
 	 * read that intent for their color.
 	 *
-	 * `AlertDialog` renders its floating layer at Tailwind `z-50`, Mantle's
-	 * shared floating z-index. When multiple shared layers are open, the most
-	 * recently mounted layer renders on top.
+	 * `AlertDialog` renders its floating layer at Tailwind `z-60`, Mantle's
+	 * overlay tier, above every float (`z-50`). Floats composed inside the content
+	 * portal into the positioner (`data-slot="alert-dialog-positioner"`) and paint
+	 * above the content. When multiple overlays are open, the most recently
+	 * mounted overlay renders on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/alert-dialog#alertdialogroot
 	 *
@@ -1051,9 +1068,12 @@ const AlertDialog = {
 	 * The popover alert dialog container. Renders on top of the overlay,
 	 * centered in the viewport.
 	 *
-	 * `AlertDialog.Content` renders its floating layer at Tailwind `z-50`,
-	 * Mantle's shared floating z-index. When multiple shared layers are open,
-	 * the most recently mounted layer renders on top.
+	 * `AlertDialog.Content` renders its floating layer at Tailwind `z-60`,
+	 * Mantle's overlay tier, above every float (`z-50`). Floats composed inside
+	 * the content portal into the positioner
+	 * (`data-slot="alert-dialog-positioner"`) and paint above the content. When
+	 * multiple overlays are open, the most recently mounted overlay renders on
+	 * top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/alert-dialog#alertdialogcontent
 	 *

--- a/packages/mantle/src/components/combobox/combobox.tsx
+++ b/packages/mantle/src/components/combobox/combobox.tsx
@@ -18,9 +18,10 @@ type ComboboxProps = Primitive.ComboboxProviderProps;
  * async/server-side data, or any single-select where search is helpful. For very small
  * finite lists with no filtering, prefer Select. For multi-selection, prefer MultiSelect.
  *
- * `Combobox.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier —
+ * it does not portal, so the dialog primitive's Escape guard can see it. Inside
+ * an overlay it paints with the overlay's content. Outside one, an open overlay
+ * (`z-60`) covers it.
  *
  * @see https://mantle.ngrok.com/components/forms/combobox#comboboxroot
  *
@@ -108,9 +109,10 @@ type ComboboxContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & Wit
 /**
  * Renders a popover that contains combobox content, e.g. Combobox.Items, Combobox.Groups, and Combobox.Separators.
  *
- * `Combobox.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier —
+ * it does not portal, so the dialog primitive's Escape guard can see it. Inside
+ * an overlay it paints with the overlay's content. Outside one, an open overlay
+ * (`z-60`) covers it.
  *
  * @see https://mantle.ngrok.com/components/forms/combobox#comboboxcontent
  *
@@ -383,9 +385,10 @@ const ComboboxSeparatorComponent = ({
  * async/server-side data, or any single-select where search is helpful. For very small
  * finite lists with no filtering, prefer Select. For multi-selection, prefer MultiSelect.
  *
- * `Combobox.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier —
+ * it does not portal, so the dialog primitive's Escape guard can see it. Inside
+ * an overlay it paints with the overlay's content. Outside one, an open overlay
+ * (`z-60`) covers it.
  *
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
  * @see https://ariakit.org/components/combobox
@@ -424,9 +427,10 @@ const Combobox = {
 	 * async/server-side data, or any single-select where search is helpful. For very small
 	 * finite lists with no filtering, prefer Select. For multi-selection, prefer MultiSelect.
 	 *
-	 * `Combobox.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier
+	 * — it does not portal, so the dialog primitive's Escape guard can see it.
+	 * Inside an overlay it paints with the overlay's content. Outside one, an open
+	 * overlay (`z-60`) covers it.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/combobox#comboboxroot
 	 *
@@ -445,9 +449,10 @@ const Combobox = {
 	/**
 	 * Renders a popover that contains combobox content, e.g. Combobox.Items, Combobox.Groups, and Combobox.Separators.
 	 *
-	 * `Combobox.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Combobox.Content` renders in place at Tailwind `z-50`, Mantle's float tier
+	 * — it does not portal, so the dialog primitive's Escape guard can see it.
+	 * Inside an overlay it paints with the overlay's content. Outside one, an open
+	 * overlay (`z-60`) covers it.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/combobox#comboboxcontent
 	 *

--- a/packages/mantle/src/components/dialog/dialog.tsx
+++ b/packages/mantle/src/components/dialog/dialog.tsx
@@ -1,6 +1,7 @@
 import { XIcon } from "@phosphor-icons/react/X";
 import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
+import { LayerContainer } from "../../utils/layer-container/layer-container.js";
 import {
 	IconButton,
 	type IconButtonAppearance,
@@ -13,9 +14,11 @@ import * as DialogPrimitive from "./primitive.js";
  * A window overlaid on either the primary window or another dialog window.
  * The root stateful component for the Dialog.
  *
- * `Dialog` renders its floating layer at Tailwind `z-50`, Mantle's shared
- * floating z-index. When multiple shared layers are open, the most recently
- * mounted layer renders on top.
+ * `Dialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay
+ * tier, above every float (`z-50`). Floats composed inside the content portal
+ * into the positioner (`data-slot="dialog-positioner"`) and paint above the
+ * content. When multiple overlays are open, the most recently mounted overlay
+ * renders on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/dialog#dialogroot
  *
@@ -198,7 +201,7 @@ const Overlay = ({ className, ref, ...props }: ComponentProps<typeof DialogPrimi
 		ref={ref}
 		data-slot="dialog-overlay"
 		className={cx(
-			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-50 backdrop-blur-xs",
+			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-60 backdrop-blur-xs",
 			className,
 		)}
 		{...props}
@@ -281,9 +284,11 @@ type ContentProps = ComponentProps<typeof DialogPrimitive.Content> &
  * The container for the dialog content.
  * Renders on top of the overlay and is centered in the viewport.
  *
- * `Dialog.Content` renders its floating layer at Tailwind `z-50`, Mantle's
- * shared floating z-index. When multiple shared layers are open, the most
- * recently mounted layer renders on top.
+ * `Dialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's
+ * overlay tier, above every float (`z-50`). Floats composed inside the content
+ * portal into the positioner (`data-slot="dialog-positioner"`) and paint above
+ * the content. When multiple overlays are open, the most recently mounted
+ * overlay renders on top.
  *
  * `appearance` decides how much of the viewport the dialog claims. `"centered"`
  * caps it at `preferredWidth`, `"full-page"` fills the 16px-inset box, and
@@ -358,8 +363,14 @@ const Content = ({
 		    so a sliver of viewport edge is uncovered for the length of the
 		    animation and would otherwise show the raw page. */}
 		<Overlay />
-		<div
-			className={cx("fixed z-50 flex items-center justify-center", wrapperClassName[appearance])}
+		{/* Why the positioner is the layer container: floats composed inside the
+		    dialog portal into it, after the content, so they paint above the
+		    content inside the dialog's own stacking context. It stays free of
+		    transforms — the open animation lives on the content — so a portaled
+		    float's `position: fixed` still resolves against the viewport. */}
+		<LayerContainer
+			data-slot="dialog-positioner"
+			className={cx("fixed z-60 flex items-center justify-center", wrapperClassName[appearance])}
 		>
 			<DialogPrimitive.Content
 				data-appearance={appearance}
@@ -379,7 +390,7 @@ const Content = ({
 			>
 				{children}
 			</DialogPrimitive.Content>
-		</div>
+		</LayerContainer>
 	</Portal>
 );
 
@@ -673,9 +684,11 @@ const Description = ({
  * For side-panel content that slides in from an edge (filter panels, detail
  * views, navigation drawers), prefer `Sheet`.
  *
- * `Dialog` renders its floating layer at Tailwind `z-50`, Mantle's shared
- * floating z-index. When multiple shared layers are open, the most recently
- * mounted layer renders on top.
+ * `Dialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay
+ * tier, above every float (`z-50`). Floats composed inside the content portal
+ * into the positioner (`data-slot="dialog-positioner"`) and paint above the
+ * content. When multiple overlays are open, the most recently mounted overlay
+ * renders on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/dialog
  *
@@ -724,9 +737,11 @@ const Dialog = {
 	 * A window overlaid on either the primary window or another dialog window.
 	 * The root stateful component for the Dialog.
 	 *
-	 * `Dialog` renders its floating layer at Tailwind `z-50`, Mantle's shared
-	 * floating z-index. When multiple shared layers are open, the most recently
-	 * mounted layer renders on top.
+	 * `Dialog` renders its floating layer at Tailwind `z-60`, Mantle's overlay
+	 * tier, above every float (`z-50`). Floats composed inside the content portal
+	 * into the positioner (`data-slot="dialog-positioner"`) and paint above the
+	 * content. When multiple overlays are open, the most recently mounted overlay
+	 * renders on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/dialog#dialogroot
 	 *
@@ -853,9 +868,11 @@ const Dialog = {
 	 * The container for the dialog content.
 	 * Renders on top of the overlay and is centered in the viewport.
 	 *
-	 * `Dialog.Content` renders its floating layer at Tailwind `z-50`, Mantle's
-	 * shared floating z-index. When multiple shared layers are open, the most
-	 * recently mounted layer renders on top.
+	 * `Dialog.Content` renders its floating layer at Tailwind `z-60`, Mantle's
+	 * overlay tier, above every float (`z-50`). Floats composed inside the content
+	 * portal into the positioner (`data-slot="dialog-positioner"`) and paint above
+	 * the content. When multiple overlays are open, the most recently mounted
+	 * overlay renders on top.
 	 *
 	 * `appearance` decides how much of the viewport the dialog claims. `"centered"`
 	 * caps it at `preferredWidth`, `"full-page"` fills the 16px-inset box, and

--- a/packages/mantle/src/components/dialog/primitive.tsx
+++ b/packages/mantle/src/components/dialog/primitive.tsx
@@ -14,6 +14,10 @@ import {
 import { Slot } from "../slot/index.js";
 import { preventCloseOnPromptInteraction } from "../toast/prevent-close-on-prompt-interaction.js";
 import { parseBooleanish } from "../../types/booleanish.js";
+import {
+	LayerContainerContext,
+	useLayerContainer,
+} from "../../utils/layer-container/layer-container.js";
 
 type DialogPrimitiveContentProps = ComponentProps<typeof DialogPrimitive.Content>;
 
@@ -40,7 +44,24 @@ function Root(props: ComponentPropsWithoutRef<typeof DialogPrimitive.Root>) {
 
 const Trigger = DialogPrimitive.Trigger;
 
-const Portal = DialogPrimitive.Portal;
+/**
+ * Mounts dialog layers into the nearest layer container — an enclosing
+ * overlay's positioner when one is open, else `document.body`. An explicit
+ * `container` prop wins over both.
+ */
+const Portal = ({ container, ...props }: ComponentProps<typeof DialogPrimitive.Portal>) => {
+	const layerContainer = useLayerContainer();
+	const resolvedContainer = container ?? layerContainer;
+
+	// Why the provider: `Dialog.Content` portals again internally, so the
+	// resolved container must also become the layer container for the wrapped
+	// subtree — otherwise the inner portal would ignore an explicit `container`.
+	return (
+		<LayerContainerContext.Provider value={resolvedContainer}>
+			<DialogPrimitive.Portal container={resolvedContainer} {...props} />
+		</LayerContainerContext.Provider>
+	);
+};
 
 const Close = DialogPrimitive.Close;
 

--- a/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/mantle/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import { CaretRightIcon } from "@phosphor-icons/react/CaretRight";
 import { CheckIcon } from "@phosphor-icons/react/Check";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
+import { useLayerContainer } from "../../utils/layer-container/layer-container.js";
 import type { WithDataSlot } from "../../utils/data-slot.js";
 import { joinDataSlot } from "../../utils/data-slot.js";
 import { Icon } from "../icon/icon.js";
@@ -13,8 +16,11 @@ import { Separator } from "../separator/separator.js";
  * This is the root, stateful component that manages the open/closed state of the dropdown menu.
  *
  * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
- * `z-50`, Mantle's shared floating z-index. When multiple shared layers are
- * open, the most recently mounted layer renders on top.
+ * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+ * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+ * paint above the overlay that owns them. Outside every overlay, they portal to
+ * `document.body`, below the overlay tier (`z-60`). When sibling floats share a
+ * container, the most recently mounted float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenuroot
  *
@@ -86,9 +92,14 @@ const Group = ({ className, ...props }: ComponentProps<typeof DropdownMenuPrimit
 );
 
 /**
- * The portal container for rendering dropdown content outside the normal DOM tree.
+ * Mounts dropdown content into the nearest layer container — an enclosing
+ * overlay's positioner when one is open, else `document.body`. An explicit
+ * `container` prop wins over both.
  */
-const Portal = DropdownMenuPrimitive.Portal;
+const Portal = ({ container, ...props }: ComponentProps<typeof DropdownMenuPrimitive.Portal>) => {
+	const layerContainer = useLayerContainer();
+	return <DropdownMenuPrimitive.Portal container={container ?? layerContainer} {...props} />;
+};
 
 /**
  * A submenu container for creating nested dropdown menus.
@@ -192,9 +203,12 @@ const SubTrigger = ({
 /**
  * The content container for a dropdown menu sub-menu.
  *
- * `DropdownMenu.SubContent` renders at Tailwind `z-50`, Mantle's shared
- * floating z-index. When multiple shared layers are open, the most recently
- * mounted layer renders on top.
+ * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
+ * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+ * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+ * paint above the overlay that owns them. Outside every overlay, they portal to
+ * `document.body`, below the overlay tier (`z-60`). When sibling floats share a
+ * container, the most recently mounted float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenusubcontent
  *
@@ -245,9 +259,12 @@ type DropdownMenuContentProps = ComponentProps<typeof DropdownMenuPrimitive.Cont
 /**
  * The container for the dropdown menu content.
  *
- * `DropdownMenu.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
+ * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+ * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+ * paint above the overlay that owns them. Outside every overlay, they portal to
+ * `document.body`, below the overlay tier (`z-60`). When sibling floats share a
+ * container, the most recently mounted float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenucontent
  *
@@ -523,8 +540,11 @@ const Shortcut = ({ className, ...props }: ComponentProps<"span">) => {
  * A menu of options or actions, triggered by a button.
  *
  * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
- * `z-50`, Mantle's shared floating z-index. When multiple shared layers are
- * open, the most recently mounted layer renders on top.
+ * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+ * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+ * paint above the overlay that owns them. Outside every overlay, they portal to
+ * `document.body`, below the overlay tier (`z-60`). When sibling floats share a
+ * container, the most recently mounted float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/dropdown-menu
  *
@@ -567,8 +587,11 @@ const DropdownMenu = {
 	 * The root, stateful component that manages the open/closed state of the dropdown menu.
 	 *
 	 * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
-	 * `z-50`, Mantle's shared floating z-index. When multiple shared layers are
-	 * open, the most recently mounted layer renders on top.
+	 * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+	 * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+	 * paint above the overlay that owns them. Outside every overlay, they portal
+	 * to `document.body`, below the overlay tier (`z-60`). When sibling floats
+	 * share a container, the most recently mounted float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenuroot
 	 *
@@ -608,9 +631,12 @@ const DropdownMenu = {
 	/**
 	 * The container for the dropdown menu content. Appears in a portal with scrolling and animations.
 	 *
-	 * `DropdownMenu.Content` renders at Tailwind `z-50`, Mantle's shared
-	 * floating z-index. When multiple shared layers are open, the most recently
-	 * mounted layer renders on top.
+	 * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
+	 * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+	 * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+	 * paint above the overlay that owns them. Outside every overlay, they portal
+	 * to `document.body`, below the overlay tier (`z-60`). When sibling floats
+	 * share a container, the most recently mounted float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenucontent
 	 *
@@ -787,9 +813,12 @@ const DropdownMenu = {
 	/**
 	 * The content container for submenu items.
 	 *
-	 * `DropdownMenu.SubContent` renders at Tailwind `z-50`, Mantle's shared
-	 * floating z-index. When multiple shared layers are open, the most recently
-	 * mounted layer renders on top.
+	 * `DropdownMenu.Content` and `DropdownMenu.SubContent` render at Tailwind
+	 * `z-50`, Mantle's float tier. When composed inside an open `Dialog`,
+	 * `AlertDialog`, or `Sheet`, they portal into that overlay's positioner and
+	 * paint above the overlay that owns them. Outside every overlay, they portal
+	 * to `document.body`, below the overlay tier (`z-60`). When sibling floats
+	 * share a container, the most recently mounted float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/dropdown-menu#dropdownmenusubcontent
 	 *

--- a/packages/mantle/src/components/hover-card/hover-card.tsx
+++ b/packages/mantle/src/components/hover-card/hover-card.tsx
@@ -3,14 +3,21 @@
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
+import {
+	LayerContainerContext,
+	useLayerContainer,
+} from "../../utils/layer-container/layer-container.js";
 
 /**
  * A floating card that appears when a user hovers over a trigger element.
  * This is the root, stateful component that manages the open/closed state of the hover card.
  *
- * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardroot
  *
@@ -66,6 +73,9 @@ const Trigger = (props: ComponentProps<typeof HoverCardPrimitive.Trigger>) => (
  * customize portal placement (e.g., pass a `container` prop) or wrap multiple
  * `HoverCard.Content` instances in a shared portal.
  *
+ * When `container` is omitted, content mounts into the nearest layer container —
+ * an enclosing overlay's positioner when one is open, else `document.body`.
+ *
  * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardportal
  *
  * @example
@@ -84,14 +94,29 @@ const Trigger = (props: ComponentProps<typeof HoverCardPrimitive.Trigger>) => (
  * </HoverCard.Root>
  * ```
  */
-const Portal = HoverCardPrimitive.Portal;
+const Portal = ({ container, ...props }: ComponentProps<typeof HoverCardPrimitive.Portal>) => {
+	const layerContainer = useLayerContainer();
+	const resolvedContainer = container ?? layerContainer;
+
+	// Why the provider: `HoverCard.Content` portals again internally, so the
+	// resolved container must also become the layer container for the wrapped
+	// subtree — otherwise the inner portal would ignore an explicit `container`.
+	return (
+		<LayerContainerContext.Provider value={resolvedContainer}>
+			<HoverCardPrimitive.Portal container={resolvedContainer} {...props} />
+		</LayerContainerContext.Provider>
+	);
+};
 
 /**
  * The content to render inside the hover card.
  *
- * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * It sets `position: relative`, so `HoverCard.Arrow`'s absolutely-positioned
  * wrapper keeps one containing block through the open animation. An
@@ -235,9 +260,12 @@ const Arrow = ({ className, height = 7, width = 14, ...props }: HoverCardArrowPr
  * For short, non-interactive labels or hints, use `Tooltip`. For
  * interactive overlays the user opens deliberately, use `Popover`.
  *
- * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/hover-card
  *
@@ -268,9 +296,12 @@ const HoverCard = {
 	/**
 	 * The root, stateful component that manages the open/closed state of the hover card.
 	 *
-	 * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardroot
 	 *
@@ -316,9 +347,12 @@ const HoverCard = {
 	/**
 	 * The content to render inside the hover card. Appears in a portal with rich styling and animations.
 	 *
-	 * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `HoverCard.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/hover-card#hovercardcontent
 	 *

--- a/packages/mantle/src/components/multi-select/multi-select.tsx
+++ b/packages/mantle/src/components/multi-select/multi-select.tsx
@@ -1207,8 +1207,9 @@ const MultiSelect = {
 	 *
 	 * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the
 	 * closest `data-mantle-modal-content` element — an enclosing overlay's content
-	 * — else `document.body`. Inside an overlay it paints above the content that
-	 * contains it. Outside one, an open overlay (`z-60`) covers it.
+	 * — else the nearest overlay's positioner, else `document.body`. Inside an
+	 * overlay it paints above the content that contains it. Outside one, an open
+	 * overlay (`z-60`) covers it.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/multi-select#multiselectroot
 	 *
@@ -1332,8 +1333,9 @@ const MultiSelect = {
 	 *
 	 * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the
 	 * closest `data-mantle-modal-content` element — an enclosing overlay's content
-	 * — else `document.body`. Inside an overlay it paints above the content that
-	 * contains it. Outside one, an open overlay (`z-60`) covers it.
+	 * — else the nearest overlay's positioner, else `document.body`. Inside an
+	 * overlay it paints above the content that contains it. Outside one, an open
+	 * overlay (`z-60`) covers it.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/multi-select#multiselectcontent
 	 *

--- a/packages/mantle/src/components/multi-select/multi-select.tsx
+++ b/packages/mantle/src/components/multi-select/multi-select.tsx
@@ -18,6 +18,7 @@ import type { WithAsChild } from "../../types/as-child.js";
 import { getPrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
+import { useLayerContainer } from "../../utils/layer-container/layer-container.js";
 import { FieldControlContext } from "../field/field-context.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
 import type { WithValidation } from "../field/validation.js";
@@ -76,9 +77,11 @@ type MultiSelectProps = Primitive.ComboboxProviderProps<string[]>;
  * combobox input — so a native form submit sends the selected values, not the
  * typeahead filter text.
  *
- * `MultiSelect.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the closest
+ * `data-mantle-modal-content` element — an enclosing overlay's content — else
+ * the nearest overlay's positioner, else `document.body`. Inside an overlay it
+ * paints above the content that contains
+ * it. Outside one, an open overlay (`z-60`) covers it.
  *
  * @see https://mantle.ngrok.com/components/forms/multi-select#multiselectroot
  *
@@ -712,9 +715,11 @@ type MultiSelectContentProps = Omit<Primitive.ComboboxPopoverProps, "render"> & 
  * Renders a popover that contains multi-select content, such as items, groups,
  * and separators. Opens below the trigger.
  *
- * `MultiSelect.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the closest
+ * `data-mantle-modal-content` element — an enclosing overlay's content — else
+ * the nearest overlay's positioner, else `document.body`. Inside an overlay it
+ * paints above the content that contains
+ * it. Outside one, an open overlay (`z-60`) covers it.
  *
  * By default, mantle disables Ariakit's body scroll lock when the trigger is
  * inside a mantle modal (`Dialog`, `Sheet`, `AlertDialog`) — the modal already
@@ -751,6 +756,7 @@ const Content = ({
 	...props
 }: MultiSelectContentProps) => {
 	const triggerRef = useContext(TriggerRefContext);
+	const layerContainer = useLayerContainer();
 
 	// When the trigger lives inside a mantle modal (Dialog/Sheet), the modal
 	// already scroll-locks the body. Ariakit's own body scroll lock must stay
@@ -758,10 +764,14 @@ const Content = ({
 	// modal's transient `pointer-events: none`) and re-applies that stale
 	// snapshot on an animation frame after unmount, permanently freezing the
 	// page (see multi-select.browser.test.tsx regression test).
-	const [isInsideModal, setIsInsideModal] = useState(false);
+	// A non-null layer container also means an overlay encloses the trigger —
+	// `closest` alone misses that when the trigger sits in a float portaled
+	// into the overlay's positioner.
+	const [isInsideModalContent, setIsInsideModalContent] = useState(false);
 	useEffect(() => {
-		setIsInsideModal(triggerRef.current?.closest("[data-mantle-modal-content]") != null);
+		setIsInsideModalContent(triggerRef.current?.closest("[data-mantle-modal-content]") != null);
 	}, [triggerRef]);
+	const isInsideModal = isInsideModalContent || layerContainer != null;
 
 	const getAnchorRect = useCallback(() => {
 		return triggerRef.current?.getBoundingClientRect() ?? null;
@@ -773,13 +783,18 @@ const Content = ({
 				return portalElement(element);
 			}
 
+			// Why the layer-container fallback: when the trigger sits in a float
+			// portaled into an overlay's positioner, `closest` cannot reach the
+			// overlay's content element — the popup would land on `document.body`
+			// at `z-50`, under the overlay tier.
 			return (
 				portalElement ??
 				triggerRef.current?.closest<HTMLElement>("[data-mantle-modal-content]") ??
+				(layerContainer instanceof HTMLElement ? layerContainer : null) ??
 				element.ownerDocument.body
 			);
 		},
-		[portalElement, triggerRef],
+		[layerContainer, portalElement, triggerRef],
 	);
 
 	const hideOnInteractOutside = useCallback(
@@ -1139,9 +1154,11 @@ const ContentFooter = ({ className, children, ref, ...props }: MultiSelectConten
  * items rendered as removable tags/chips. For single selection, use Combobox (with search)
  * or Select (without).
  *
- * `MultiSelect.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the closest
+ * `data-mantle-modal-content` element — an enclosing overlay's content — else
+ * the nearest overlay's positioner, else `document.body`. Inside an overlay it
+ * paints above the content that contains
+ * it. Outside one, an open overlay (`z-60`) covers it.
  *
  * @see https://mantle.ngrok.com/components/forms/multi-select
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
@@ -1188,9 +1205,10 @@ const MultiSelect = {
 	 * items rendered as removable tags/chips. For single selection, use Combobox (with search)
 	 * or Select (without).
 	 *
-	 * `MultiSelect.Content` renders at Tailwind `z-50`, Mantle's shared
-	 * floating z-index. When multiple shared layers are open, the most recently
-	 * mounted layer renders on top.
+	 * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the
+	 * closest `data-mantle-modal-content` element — an enclosing overlay's content
+	 * — else `document.body`. Inside an overlay it paints above the content that
+	 * contains it. Outside one, an open overlay (`z-60`) covers it.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/multi-select#multiselectroot
 	 *
@@ -1312,9 +1330,10 @@ const MultiSelect = {
 	/**
 	 * Renders a popover that contains multi-select content.
 	 *
-	 * `MultiSelect.Content` renders at Tailwind `z-50`, Mantle's shared
-	 * floating z-index. When multiple shared layers are open, the most recently
-	 * mounted layer renders on top.
+	 * `MultiSelect.Content` renders at Tailwind `z-50` and portals into the
+	 * closest `data-mantle-modal-content` element — an enclosing overlay's content
+	 * — else `document.body`. Inside an overlay it paints above the content that
+	 * contains it. Outside one, an open overlay (`z-60`) covers it.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/multi-select#multiselectcontent
 	 *

--- a/packages/mantle/src/components/popover/popover.tsx
+++ b/packages/mantle/src/components/popover/popover.tsx
@@ -1,14 +1,20 @@
+"use client";
+
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type { ComponentProps } from "react";
 import { cx } from "../../utils/cx/cx.js";
+import { useLayerContainer } from "../../utils/layer-container/layer-container.js";
 
 /**
  * A floating overlay that displays rich content in a portal, triggered by a button.
  * This is the root, stateful component that manages the open/closed state of the popover.
  *
- * `Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/popover#popoverroot
  *
@@ -112,9 +118,12 @@ type PopoverContentProps = ComponentProps<typeof PopoverPrimitive.Content> & {
 /**
  * The content to render inside the popover.
  *
- * `Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * It sets `position: relative`, so `Popover.Arrow`'s absolutely-positioned
  * wrapper keeps one containing block through the open animation. An
@@ -145,35 +154,39 @@ const Content = ({
 	ref,
 	sideOffset = 4,
 	...props
-}: PopoverContentProps) => (
-	<PopoverPrimitive.Portal>
-		<PopoverPrimitive.Content
-			align={align}
-			data-slot="popover-content"
-			className={cx(
-				// Why relative: `Popover.Arrow`'s wrapper is absolutely positioned, and the
-				// open animation's `scale` makes this element its containing block for one
-				// frame — then drops it, moving the arrow 1px. Positioning this element
-				// keeps that containing block the same before, during, and after.
-				"relative",
-				"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
-				preferredWidth,
-				className,
-			)}
-			onClick={(event) => {
-				/**
-				 * Prevent the click event from propagating up to parent/containing elements
-				 * of the PopoverContent
-				 */
-				event.stopPropagation();
-				onClick?.(event);
-			}}
-			ref={ref}
-			sideOffset={sideOffset}
-			{...props}
-		/>
-	</PopoverPrimitive.Portal>
-);
+}: PopoverContentProps) => {
+	const layerContainer = useLayerContainer();
+
+	return (
+		<PopoverPrimitive.Portal container={layerContainer}>
+			<PopoverPrimitive.Content
+				align={align}
+				data-slot="popover-content"
+				className={cx(
+					// Why relative: `Popover.Arrow`'s wrapper is absolutely positioned, and the
+					// open animation's `scale` makes this element its containing block for one
+					// frame — then drops it, moving the arrow 1px. Positioning this element
+					// keeps that containing block the same before, during, and after.
+					"relative",
+					"text-popover-foreground border-popover bg-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 z-50 rounded-md border p-4 shadow-md outline-hidden",
+					preferredWidth,
+					className,
+				)}
+				onClick={(event) => {
+					/**
+					 * Prevent the click event from propagating up to parent/containing elements
+					 * of the PopoverContent
+					 */
+					event.stopPropagation();
+					onClick?.(event);
+				}}
+				ref={ref}
+				sideOffset={sideOffset}
+				{...props}
+			/>
+		</PopoverPrimitive.Portal>
+	);
+};
 
 type PopoverArrowProps = Omit<
 	ComponentProps<typeof PopoverPrimitive.Arrow>,
@@ -270,9 +283,12 @@ const Arrow = ({ className, height = 7, width = 14, ...props }: PopoverArrowProp
  * the content, block interaction with the rest of the page, and lock body
  * scroll while the popover is open.
  *
- * `Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/popover
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
@@ -306,9 +322,12 @@ const Popover = {
 	/**
 	 * The root, stateful component that manages the open/closed state of the popover.
 	 *
-	 * `Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/popover#popoverroot
 	 *
@@ -403,9 +422,12 @@ const Popover = {
 	/**
 	 * The content to render inside the popover. Appears in a portal with rich styling and animations.
 	 *
-	 * `Popover.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Popover.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/popover#popovercontent
 	 *

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -15,6 +15,7 @@ import type {
 import { createContext, useContext, useMemo } from "react";
 import { composeRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
+import { useLayerContainer } from "../../utils/layer-container/layer-container.js";
 import { FieldControlContext } from "../field/field-context.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
 import type { WithValidation } from "../field/validation.js";
@@ -83,9 +84,12 @@ type SelectProps = PropsWithChildren & {
  * state — suppress the inferred error by passing `validation` on `Field.Item`
  * if a non-error `Select.Root` state needs to win in that case.
  *
- * `Select.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/forms/select#selectroot
  *
@@ -362,9 +366,12 @@ type SelectContentProps = ComponentProps<typeof SelectPrimitive.Content> & {
  * The component that pops out when the select is open as a portal adjacent to the trigger button.
  * It contains a scrolling viewport of the select items.
  *
- * `Select.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/forms/select#selectcontent
  *
@@ -398,35 +405,39 @@ const Content = ({
 	ref,
 	width = "trigger",
 	...props
-}: SelectContentProps) => (
-	<SelectPrimitive.Portal>
-		<SelectPrimitive.Content
-			ref={ref}
-			data-slot="select-content"
-			className={cx(
-				"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
-				"bg-popover font-sans",
-				position === "popper" &&
-					"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)",
-				width === "trigger" && "w-(--radix-select-trigger-width)",
-				className,
-			)}
-			position={position}
-			{...props}
-		>
-			<SelectScrollUpButton />
-			<SelectPrimitive.Viewport
+}: SelectContentProps) => {
+	const layerContainer = useLayerContainer();
+
+	return (
+		<SelectPrimitive.Portal container={layerContainer}>
+			<SelectPrimitive.Content
+				ref={ref}
+				data-slot="select-content"
 				className={cx(
-					"p-1 space-y-px",
-					position === "popper" && "h-(--radix-select-trigger-height) w-full",
+					"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
+					"bg-popover font-sans",
+					position === "popper" &&
+						"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)",
+					width === "trigger" && "w-(--radix-select-trigger-width)",
+					className,
 				)}
+				position={position}
+				{...props}
 			>
-				{children}
-			</SelectPrimitive.Viewport>
-			<SelectScrollDownButton />
-		</SelectPrimitive.Content>
-	</SelectPrimitive.Portal>
-);
+				<SelectScrollUpButton />
+				<SelectPrimitive.Viewport
+					className={cx(
+						"p-1 space-y-px",
+						position === "popper" && "h-(--radix-select-trigger-height) w-full",
+					)}
+				>
+					{children}
+				</SelectPrimitive.Viewport>
+				<SelectScrollDownButton />
+			</SelectPrimitive.Content>
+		</SelectPrimitive.Portal>
+	);
+};
 
 /**
  * Used to render the label of a group. It won't be focusable using arrow keys.
@@ -570,9 +581,12 @@ const SelectSeparatorComponent = ({
  * and search/filtering is unnecessary. For larger lists or async/searchable data, use
  * Combobox. For picking multiple options, use MultiSelect.
  *
- * `Select.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/forms/select
  *
@@ -620,9 +634,12 @@ const Select = {
 	 * and search/filtering is unnecessary. For larger lists or async/searchable data, use
 	 * Combobox. For picking multiple options, use MultiSelect.
 	 *
-	 * `Select.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectroot
 	 *
@@ -654,9 +671,12 @@ const Select = {
 	 * The component that pops out when the select is open as a portal adjacent to the trigger button.
 	 * It contains a scrolling viewport of the select items.
 	 *
-	 * `Select.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectcontent
 	 *

--- a/packages/mantle/src/components/sheet/sheet.tsx
+++ b/packages/mantle/src/components/sheet/sheet.tsx
@@ -2,6 +2,7 @@ import { XIcon } from "@phosphor-icons/react/X";
 import { type VariantProps, cva } from "class-variance-authority";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { cx } from "../../utils/cx/cx.js";
+import { LayerContainer } from "../../utils/layer-container/layer-container.js";
 import {
 	IconButton,
 	type IconButtonAppearance,
@@ -14,9 +15,11 @@ import * as SheetPrimitive from "../dialog/primitive.js";
  * The root component for a `Sheet`. Should compose the `Sheet.Trigger` and `Sheet.Content`.
  * Acts as a stateful provider for the Sheet's open/closed state.
  *
- * `Sheet` renders its floating layer at Tailwind `z-50`, Mantle's shared
- * floating z-index. When multiple shared layers are open, the most recently
- * mounted layer renders on top.
+ * `Sheet` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier,
+ * above every float (`z-50`). Floats composed inside the content portal into
+ * the positioner (`data-slot="sheet-positioner"`) and paint above the content.
+ * When multiple overlays are open, the most recently mounted overlay renders on
+ * top.
  *
  * @see https://mantle.ngrok.com/components/overlays/sheet#sheetroot
  *
@@ -216,7 +219,7 @@ const SheetOverlay = ({
 	<SheetPrimitive.Overlay
 		data-slot="sheet-overlay"
 		className={cx(
-			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-50 backdrop-blur-xs",
+			"bg-overlay data-state-closed:animate-out data-state-closed:fade-out-0 data-state-open:animate-in data-state-open:fade-in-0 fixed inset-0 z-60 backdrop-blur-xs",
 			className,
 		)}
 		{...props}
@@ -225,7 +228,7 @@ const SheetOverlay = ({
 );
 
 const SheetVariants = cva(
-	"bg-dialog border-dialog inset-y-0 h-full w-full fixed z-50 flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in",
+	"bg-dialog border-dialog inset-y-0 h-full w-full fixed flex flex-col shadow-lg outline-hidden transition ease-in-out focus-within:outline-hidden data-state-closed:duration-100 data-state-closed:animate-out data-state-open:duration-100 data-state-open:animate-in",
 	{
 		variants: {
 			/**
@@ -262,9 +265,11 @@ type SheetContentProps = ComponentProps<typeof SheetPrimitive.Content> &
  * Renders on top of the overlay backdrop.
  * Should contain the `Sheet.Header`, `Sheet.Body`, and `Sheet.Footer`.
  *
- * `Sheet.Content` renders its floating layer at Tailwind `z-50`, Mantle's
- * shared floating z-index. When multiple shared layers are open, the most
- * recently mounted layer renders on top.
+ * `Sheet.Content` renders its floating layer at Tailwind `z-60`, Mantle's
+ * overlay tier, above every float (`z-50`). Floats composed inside the content
+ * portal into the positioner (`data-slot="sheet-positioner"`) and paint above
+ * the content. When multiple overlays are open, the most recently mounted
+ * overlay renders on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/sheet#sheetcontent
  *
@@ -322,15 +327,24 @@ const Content = ({
 }: SheetContentProps) => (
 	<SheetPortal>
 		<SheetOverlay />
-		<SheetPrimitive.Content
-			data-slot="sheet-content"
-			data-mantle-modal-content
-			className={cx(SheetVariants({ side }), preferredWidth, className)}
-			ref={ref}
-			{...props}
-		>
-			{children}
-		</SheetPrimitive.Content>
+		{/* Why the positioner is the layer container: floats composed inside the
+		    sheet portal into it, after the content, so they paint above the
+		    content inside the sheet's own stacking context. The content cannot be
+		    the container itself — its slide animation carries a transform, which
+		    would turn a portaled float's `position: fixed` into a position
+		    relative to the content. The positioner has no box of its own; the
+		    content keeps its own fixed positioning. */}
+		<LayerContainer data-slot="sheet-positioner" className="fixed z-60">
+			<SheetPrimitive.Content
+				data-slot="sheet-content"
+				data-mantle-modal-content
+				className={cx(SheetVariants({ side }), preferredWidth, className)}
+				ref={ref}
+				{...props}
+			>
+				{children}
+			</SheetPrimitive.Content>
+		</LayerContainer>
 	</SheetPortal>
 );
 
@@ -864,9 +878,11 @@ const Actions = ({ children, className, ref, ...props }: ComponentProps<"div">) 
  * interrupts the user, use `Dialog` (or `AlertDialog` for destructive
  * confirmations).
  *
- * `Sheet` renders its floating layer at Tailwind `z-50`, Mantle's shared
- * floating z-index. When multiple shared layers are open, the most recently
- * mounted layer renders on top.
+ * `Sheet` renders its floating layer at Tailwind `z-60`, Mantle's overlay tier,
+ * above every float (`z-50`). Floats composed inside the content portal into
+ * the positioner (`data-slot="sheet-positioner"`) and paint above the content.
+ * When multiple overlays are open, the most recently mounted overlay renders on
+ * top.
  *
  * @see https://mantle.ngrok.com/components/overlays/sheet
  *
@@ -984,9 +1000,11 @@ const Sheet = {
 	 * The root component for a `Sheet`. Should compose the `Sheet.Trigger` and `Sheet.Content`.
 	 * Acts as a stateful provider for the Sheet's open/closed state.
 	 *
-	 * `Sheet` renders its floating layer at Tailwind `z-50`, Mantle's shared
-	 * floating z-index. When multiple shared layers are open, the most recently
-	 * mounted layer renders on top.
+	 * `Sheet` renders its floating layer at Tailwind `z-60`, Mantle's overlay
+	 * tier, above every float (`z-50`). Floats composed inside the content portal
+	 * into the positioner (`data-slot="sheet-positioner"`) and paint above the
+	 * content. When multiple overlays are open, the most recently mounted overlay
+	 * renders on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/sheet#sheetroot
 	 *
@@ -1182,9 +1200,11 @@ const Sheet = {
 	 * Renders on top of the overlay backdrop.
 	 * Should contain the `Sheet.Header`, `Sheet.Body`, and `Sheet.Footer`.
 	 *
-	 * `Sheet.Content` renders its floating layer at Tailwind `z-50`, Mantle's
-	 * shared floating z-index. When multiple shared layers are open, the most
-	 * recently mounted layer renders on top.
+	 * `Sheet.Content` renders its floating layer at Tailwind `z-60`, Mantle's
+	 * overlay tier, above every float (`z-50`). Floats composed inside the content
+	 * portal into the positioner (`data-slot="sheet-positioner"`) and paint above
+	 * the content. When multiple overlays are open, the most recently mounted
+	 * overlay renders on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/sheet#sheetcontent
 	 *

--- a/packages/mantle/src/components/tooltip/tooltip.tsx
+++ b/packages/mantle/src/components/tooltip/tooltip.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import type { ComponentProps, ComponentPropsWithoutRef } from "react";
 import { cx } from "../../utils/cx/cx.js";
+import { useLayerContainer } from "../../utils/layer-container/layer-container.js";
 
 /**
  * Wraps your app to set shared global behavior for your tooltips, such
@@ -45,9 +48,12 @@ const TooltipProvider = ({
  * the tooltip. Wrap your app in `TooltipProvider` when you want shared
  * app-wide delay and hover settings.
  *
- * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/tooltip#tooltiproot
  *
@@ -95,9 +101,12 @@ function Trigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) {
 /**
  * The content to render inside the tooltip.
  *
- * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/tooltip#tooltipcontent
  *
@@ -121,25 +130,29 @@ const Content = ({
 	ref,
 	sideOffset = 4,
 	...props
-}: ComponentProps<typeof TooltipPrimitive.Content>) => (
-	<TooltipPrimitive.Portal>
-		<TooltipPrimitive.Content
-			className={cx(
-				"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow",
-				className,
-			)}
-			data-slot="tooltip-content"
-			ref={ref}
-			sideOffset={sideOffset}
-			{...props}
-		>
-			{children}
-			<TooltipPrimitive.Arrow asChild>
-				<div className="bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs" />
-			</TooltipPrimitive.Arrow>
-		</TooltipPrimitive.Content>
-	</TooltipPrimitive.Portal>
-);
+}: ComponentProps<typeof TooltipPrimitive.Content>) => {
+	const layerContainer = useLayerContainer();
+
+	return (
+		<TooltipPrimitive.Portal container={layerContainer}>
+			<TooltipPrimitive.Content
+				className={cx(
+					"bg-tooltip text-tooltip animate-in fade-in-0 zoom-in-95 data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 z-50 max-w-72 overflow-visible wrap-break-word rounded-md px-3 py-1.5 text-sm font-sans shadow",
+					className,
+				)}
+				data-slot="tooltip-content"
+				ref={ref}
+				sideOffset={sideOffset}
+				{...props}
+			>
+				{children}
+				<TooltipPrimitive.Arrow asChild>
+					<div className="bg-tooltip z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-xs" />
+				</TooltipPrimitive.Arrow>
+			</TooltipPrimitive.Content>
+		</TooltipPrimitive.Portal>
+	);
+};
 
 /**
  * A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
@@ -156,9 +169,12 @@ const Content = ({
  * Mount a `<TooltipProvider>` once at the app root when you want shared
  * tooltip behavior such as consistent delay and hover settings.
  *
- * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's shared floating
- * z-index. When multiple shared layers are open, the most recently mounted
- * layer renders on top.
+ * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+ * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+ * that overlay's positioner and paints above the overlay that owns it. Outside
+ * every overlay, it portals to `document.body`, below the overlay tier
+ * (`z-60`). When sibling floats share a container, the most recently mounted
+ * float paints on top.
  *
  * @see https://mantle.ngrok.com/components/overlays/tooltip
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
@@ -192,9 +208,12 @@ const Tooltip = {
 	 * the tooltip. Wrap your app in `TooltipProvider` when you want shared
 	 * app-wide delay and hover settings.
 	 *
-	 * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/tooltip#tooltiproot
 	 *
@@ -216,9 +235,12 @@ const Tooltip = {
 	/**
 	 * The content to render inside the tooltip.
 	 *
-	 * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's shared floating
-	 * z-index. When multiple shared layers are open, the most recently mounted
-	 * layer renders on top.
+	 * `Tooltip.Content` renders at Tailwind `z-50`, Mantle's float tier. When
+	 * composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into
+	 * that overlay's positioner and paints above the overlay that owns it. Outside
+	 * every overlay, it portals to `document.body`, below the overlay tier
+	 * (`z-60`). When sibling floats share a container, the most recently mounted
+	 * float paints on top.
 	 *
 	 * @see https://mantle.ngrok.com/components/overlays/tooltip#tooltipcontent
 	 *

--- a/packages/mantle/src/utils/layer-container/index.ts
+++ b/packages/mantle/src/utils/layer-container/index.ts
@@ -1,0 +1,6 @@
+export {
+	//,
+	LayerContainer,
+	LayerContainerContext,
+	useLayerContainer,
+} from "./layer-container.js";

--- a/packages/mantle/src/utils/layer-container/layer-container.browser.test.tsx
+++ b/packages/mantle/src/utils/layer-container/layer-container.browser.test.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Dialog } from "../../components/dialog/dialog.js";
+import { Popover } from "../../components/popover/popover.js";
+import { Sheet } from "../../components/sheet/sheet.js";
+import { makeToast, Toaster } from "../../components/toast/toast.js";
+
+/**
+ * Browser mode proves the paint order the layer tiers produce — happy-dom can
+ * pin DOM placement (`layer-container.test.tsx`) but not hit-testing. Needs
+ * real layout, `getBoundingClientRect`, `getComputedStyle`, and
+ * `document.elementFromPoint`.
+ *
+ * Cross-file spelling pin: browser tests load no Tailwind, so this restates
+ * the CSS the layering utilities emit (`fixed`, `z-50`, `z-60`, insets).
+ * Radix mirrors each float content's computed z-index onto its popper wrapper,
+ * so `.z-50` here engages the real stacking mechanism. If a component's tier
+ * class changes, `layer-container.test.tsx`'s tier test catches the class; if
+ * these pinned values stop matching Tailwind's output, the paint-order
+ * assertions here go stale together — change both deliberately.
+ */
+const STYLE = `
+.fixed { position: fixed; }
+.z-50 { z-index: 50; }
+.z-60 { z-index: 60; }
+.inset-0 { inset: 0px; }
+.inset-4 { inset: 16px; }
+.inset-y-0 { top: 0px; bottom: 0px; }
+.h-full { height: 100%; }
+.w-full { width: 100%; }
+`;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+/** The center point of an element's border box, for hit-testing. */
+function centerOf(element: Element): { x: number; y: number } {
+	const rect = element.getBoundingClientRect();
+	return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+/** The topmost element painted at the center of `element`. */
+function topElementAt(element: Element): Element | null {
+	const { x, y } = centerOf(element);
+	return document.elementFromPoint(x, y);
+}
+
+/**
+ * A dialog plus a base-level popover that opens only after the dialog is
+ * already open — the FEP-1754 shape, where mount order used to put the
+ * popover on top of the takeover.
+ *
+ * Why `modal={false}`: a modal dialog sets `pointer-events: none` on `body`,
+ * and `elementFromPoint` skips pointer-events-none elements — the assertion
+ * would pass with any z-index. Non-modal keeps hit-testing honest; the tiers
+ * under test are identical either way.
+ */
+function LateBasePopoverScenario() {
+	const [popoverOpen, setPopoverOpen] = useState(false);
+
+	return (
+		<div>
+			<button type="button" onClick={() => setPopoverOpen(true)}>
+				Announce
+			</button>
+			<Popover.Root open={popoverOpen}>
+				<Popover.Anchor>
+					<span>anchor</span>
+				</Popover.Anchor>
+				<Popover.Content>base popover content</Popover.Content>
+			</Popover.Root>
+			<Dialog.Root open modal={false}>
+				<Dialog.Content appearance="full-bleed">
+					<Dialog.Title>Takeover</Dialog.Title>
+				</Dialog.Content>
+			</Dialog.Root>
+		</div>
+	);
+}
+
+describe("paint order across layer tiers", () => {
+	test("a base popover that opens over an already-open dialog paints under it", async () => {
+		const user = userEvent.setup();
+		render(<LateBasePopoverScenario />);
+
+		// The popover opens after the dialog mounted — later in DOM order, which
+		// used to win the tie at a shared z-50.
+		await user.click(screen.getByRole("button", { name: "Announce" }));
+		const popoverContent = await screen.findByText("base popover content");
+
+		const positioner = document.querySelector("[data-slot='dialog-positioner']");
+		expect(positioner).not.toBeNull();
+
+		await waitFor(() => {
+			const topElement = topElementAt(popoverContent);
+			expect(topElement).not.toBeNull();
+			expect(positioner?.contains(topElement)).toBe(true);
+			expect(popoverContent.contains(topElement)).toBe(false);
+		});
+	});
+
+	test("a popover opened from inside a dialog paints above the dialog", async () => {
+		const user = userEvent.setup();
+		render(
+			<Dialog.Root open modal={false}>
+				<Dialog.Content appearance="full-bleed">
+					<Dialog.Title>Takeover</Dialog.Title>
+					<Dialog.Body>
+						<Popover.Root>
+							<Popover.Trigger>Open float</Popover.Trigger>
+							<Popover.Content>float content</Popover.Content>
+						</Popover.Root>
+					</Dialog.Body>
+				</Dialog.Content>
+			</Dialog.Root>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Open float" }));
+		const floatContent = await screen.findByText("float content");
+
+		await waitFor(() => {
+			const topElement = topElementAt(floatContent);
+			expect(topElement).not.toBeNull();
+			expect(floatContent.closest("[data-slot='popover-content']")?.contains(topElement)).toBe(
+				true,
+			);
+		});
+	});
+
+	test("a dialog opened from inside a dialog paints above the outer dialog's open popover", async () => {
+		const user = userEvent.setup();
+		render(
+			<Dialog.Root open modal={false}>
+				<Dialog.Content appearance="full-bleed">
+					<Dialog.Title>Outer</Dialog.Title>
+					<Dialog.Body>
+						<Popover.Root defaultOpen>
+							<Popover.Trigger>Open float</Popover.Trigger>
+							<Popover.Content>float content</Popover.Content>
+						</Popover.Root>
+						<Dialog.Root modal={false}>
+							<Dialog.Trigger>Open inner</Dialog.Trigger>
+							<Dialog.Content appearance="full-bleed">
+								<Dialog.Title>Inner</Dialog.Title>
+							</Dialog.Content>
+						</Dialog.Root>
+					</Dialog.Body>
+				</Dialog.Content>
+			</Dialog.Root>,
+		);
+
+		const floatContent = await screen.findByText("float content");
+		await user.click(screen.getByRole("button", { name: "Open inner" }));
+		await screen.findByText("Inner");
+
+		const positioners = document.querySelectorAll("[data-slot='dialog-positioner']");
+		expect(positioners).toHaveLength(2);
+		const inner = positioners[1];
+
+		await waitFor(() => {
+			const topElement = topElementAt(floatContent);
+			expect(topElement).not.toBeNull();
+			expect(inner != null && inner.contains(topElement)).toBe(true);
+			expect(floatContent.contains(topElement)).toBe(false);
+		});
+	});
+
+	test("a popover inside a sheet positions against its trigger even when the sheet content is transformed", async () => {
+		// Sheet.Content carries a transform while its slide animation runs, and a
+		// transformed element is the containing block for fixed descendants. The
+		// popover portals into the positioner — a sibling of the content — so its
+		// `position: fixed` must keep resolving against the viewport. The identity
+		// transform below is visually nothing but still creates a containing
+		// block: portaling the float into the content instead turns this red.
+		const contentTransform = document.createElement("style");
+		contentTransform.textContent = `[data-slot="sheet-content"] { transform: translateX(0px); }`;
+		document.head.appendChild(contentTransform);
+
+		try {
+			const user = userEvent.setup();
+			render(
+				<Sheet.Root open>
+					<Sheet.Content>
+						<Sheet.Header>
+							<Sheet.TitleGroup>
+								<Sheet.Title>Sheet</Sheet.Title>
+							</Sheet.TitleGroup>
+						</Sheet.Header>
+						<Sheet.Body>
+							<Popover.Root>
+								<Popover.Trigger>Open float</Popover.Trigger>
+								<Popover.Content>float content</Popover.Content>
+							</Popover.Root>
+						</Sheet.Body>
+					</Sheet.Content>
+				</Sheet.Root>,
+			);
+
+			const trigger = screen.getByRole("button", { name: "Open float" });
+			await user.click(trigger);
+			const floatContent = await screen.findByText("float content");
+
+			await waitFor(() => {
+				const contentRect = (
+					floatContent.closest("[data-slot='popover-content']") ?? floatContent
+				).getBoundingClientRect();
+				const triggerRect = trigger.getBoundingClientRect();
+				// Radix places the content below the trigger with `sideOffset` 4.
+				// A broken containing block lands it far away (typically at the
+				// viewport origin, offset by the content's own height).
+				expect(Math.abs(contentRect.top - triggerRect.bottom)).toBeLessThan(24);
+			});
+		} finally {
+			contentTransform.remove();
+		}
+	});
+
+	test("toasts paint above the overlay tier", async () => {
+		render(
+			<div>
+				<Toaster />
+				<Dialog.Root open modal={false}>
+					<Dialog.Content appearance="full-bleed">
+						<Dialog.Title>Takeover</Dialog.Title>
+					</Dialog.Content>
+				</Dialog.Root>
+			</div>,
+		);
+
+		makeToast(<p>toast content</p>);
+		await screen.findByText("toast content");
+
+		// Sonner injects its own stylesheet at runtime, so the viewport's
+		// computed z-index is real. It must clear the overlay tier.
+		const viewport = document.querySelector("[data-sonner-toaster]");
+		expect(viewport).not.toBeNull();
+		const viewportZ = Number(getComputedStyle(viewport as Element).zIndex);
+		expect(viewportZ).toBeGreaterThan(60);
+	});
+});

--- a/packages/mantle/src/utils/layer-container/layer-container.test.tsx
+++ b/packages/mantle/src/utils/layer-container/layer-container.test.tsx
@@ -1,0 +1,832 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { AlertDialog } from "../../components/alert-dialog/alert-dialog.js";
+import { Combobox } from "../../components/combobox/combobox.js";
+import { Command } from "../../components/command/command.js";
+import { Dialog } from "../../components/dialog/dialog.js";
+import { DropdownMenu } from "../../components/dropdown-menu/dropdown-menu.js";
+import { HoverCard } from "../../components/hover-card/hover-card.js";
+import { MultiSelect } from "../../components/multi-select/multi-select.js";
+import { Popover } from "../../components/popover/popover.js";
+import { Select } from "../../components/select/select.js";
+import { Sheet } from "../../components/sheet/sheet.js";
+import { makeToast, Toaster } from "../../components/toast/toast.js";
+import { Tooltip, TooltipProvider } from "../../components/tooltip/tooltip.js";
+
+/**
+ * The layering contract these tests pin:
+ *
+ * - Overlays (`Dialog`, `AlertDialog`, `Sheet`) render at `z-60` and expose a
+ *   positioner element that doubles as the layer container.
+ * - Floats (`Popover`, `Tooltip`, `Select`, `DropdownMenu`, `HoverCard`) render
+ *   at `z-50` and portal into the nearest layer container — the positioner when
+ *   composed inside an overlay, else `document.body`.
+ * - A float inside the positioner follows the overlay content in document
+ *   order, so it paints above the content inside the overlay's stacking
+ *   context. A float outside every overlay stays at `z-50`, below the overlay
+ *   tier, no matter when it opens.
+ *
+ * `layer-container.browser.test.tsx` proves the paint order these placements
+ * produce with real CSS; this file pins the DOM placement itself.
+ */
+
+/** Each overlay under test, its positioner slot, and its content slot. */
+const overlays = [
+	{
+		name: "Dialog",
+		positionerSlot: "dialog-positioner",
+		contentSlot: "dialog-content",
+		renderOpen: (children: React.ReactNode) => (
+			<Dialog.Root open>
+				<Dialog.Content>
+					<Dialog.Title>Overlay</Dialog.Title>
+					<Dialog.Body>{children}</Dialog.Body>
+				</Dialog.Content>
+			</Dialog.Root>
+		),
+	},
+	{
+		name: "AlertDialog",
+		positionerSlot: "alert-dialog-positioner",
+		contentSlot: "alert-dialog-content",
+		renderOpen: (children: React.ReactNode) => (
+			<AlertDialog.Root intent="info" open>
+				<AlertDialog.Content>
+					<AlertDialog.Body>
+						<AlertDialog.Title>Overlay</AlertDialog.Title>
+						{children}
+					</AlertDialog.Body>
+				</AlertDialog.Content>
+			</AlertDialog.Root>
+		),
+	},
+	{
+		name: "Sheet",
+		positionerSlot: "sheet-positioner",
+		contentSlot: "sheet-content",
+		renderOpen: (children: React.ReactNode) => (
+			<Sheet.Root open>
+				<Sheet.Content>
+					<Sheet.Header>
+						<Sheet.TitleGroup>
+							<Sheet.Title>Overlay</Sheet.Title>
+						</Sheet.TitleGroup>
+					</Sheet.Header>
+					<Sheet.Body>{children}</Sheet.Body>
+				</Sheet.Content>
+			</Sheet.Root>
+		),
+	},
+] as const;
+
+/**
+ * Each float under test. `renderClosed` mounts it shut so a real event (or the
+ * controlled-open flip for the hover-driven floats, whose pointer timing
+ * happy-dom cannot reproduce) opens it after the overlay already exists —
+ * the mount order that used to lose.
+ */
+const floats = [
+	{
+		name: "Popover",
+		render: () => (
+			<Popover.Root>
+				<Popover.Trigger>Open float</Popover.Trigger>
+				<Popover.Content>float content</Popover.Content>
+			</Popover.Root>
+		),
+		open: async (user: ReturnType<typeof userEvent.setup>) => {
+			await user.click(screen.getByRole("button", { name: "Open float" }));
+		},
+		findContent: () => screen.findByText("float content"),
+		contentSlot: "popover-content",
+	},
+	{
+		name: "DropdownMenu",
+		render: () => (
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>Open float</DropdownMenu.Trigger>
+				<DropdownMenu.Content>
+					<DropdownMenu.Item>float content</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		),
+		open: async (user: ReturnType<typeof userEvent.setup>) => {
+			await user.click(screen.getByRole("button", { name: "Open float" }));
+		},
+		findContent: () => screen.findByRole("menu"),
+		contentSlot: "dropdown-menu-content",
+	},
+	{
+		name: "Select",
+		render: () => (
+			<Select.Root>
+				<Select.Trigger aria-label="Open float" />
+				<Select.Content>
+					<Select.Item value="a">float content</Select.Item>
+				</Select.Content>
+			</Select.Root>
+		),
+		open: async (user: ReturnType<typeof userEvent.setup>) => {
+			await user.click(screen.getByRole("combobox", { name: "Open float" }));
+		},
+		findContent: () => screen.findByRole("listbox"),
+		contentSlot: "select-content",
+	},
+	{
+		name: "Tooltip",
+		render: () => (
+			<TooltipProvider>
+				<Tooltip.Root open>
+					<Tooltip.Trigger>anchor</Tooltip.Trigger>
+					<Tooltip.Content>float content</Tooltip.Content>
+				</Tooltip.Root>
+			</TooltipProvider>
+		),
+		open: async () => {},
+		findContent: async () => {
+			const contents = await screen.findAllByText("float content");
+			const slotted = contents.find((element) => element.closest("[data-slot='tooltip-content']"));
+			if (slotted == null) {
+				throw new Error("no tooltip content with data-slot rendered");
+			}
+			return slotted;
+		},
+		contentSlot: "tooltip-content",
+	},
+	{
+		name: "HoverCard",
+		render: () => (
+			<HoverCard.Root open>
+				<HoverCard.Trigger>anchor</HoverCard.Trigger>
+				<HoverCard.Content>float content</HoverCard.Content>
+			</HoverCard.Root>
+		),
+		open: async () => {},
+		findContent: () => screen.findByText("float content"),
+		contentSlot: "hover-card-content",
+	},
+] as const;
+
+function getPositioner(slot: string): HTMLElement {
+	const positioner = document.querySelector<HTMLElement>(`[data-slot='${slot}']`);
+	if (positioner == null) {
+		throw new Error(`no [data-slot='${slot}'] rendered`);
+	}
+	return positioner;
+}
+
+describe("layer containers", () => {
+	for (const overlay of overlays) {
+		describe(`float inside ${overlay.name}`, () => {
+			for (const float of floats) {
+				test(`${float.name} portals into the ${overlay.name} positioner, after its content`, async () => {
+					const user = userEvent.setup();
+					render(overlay.renderOpen(float.render()));
+
+					await float.open(user);
+					const floatContent = await float.findContent();
+
+					const positioner = getPositioner(overlay.positionerSlot);
+					const overlayContent = getPositioner(overlay.contentSlot);
+					expect(positioner.contains(floatContent)).toBe(true);
+					// Document order decides paint order inside the positioner's
+					// stacking context: the float must follow the overlay content.
+					expect(
+						overlayContent.compareDocumentPosition(floatContent) & Node.DOCUMENT_POSITION_FOLLOWING,
+					).toBeTruthy();
+					// The modal overlay marks the portal's other children
+					// `aria-hidden` on open. The positioner is on the content's
+					// ancestor chain, so a float portaled into it stays readable —
+					// portaling into a sibling element instead would hide it.
+					expect(floatContent.closest("[aria-hidden='true']")).toBeNull();
+				});
+			}
+		});
+	}
+
+	describe("float outside every overlay", () => {
+		test("a popover that opens after a dialog mounts stays out of the dialog's positioner", async () => {
+			// The FEP-1754 shape: the overlay is already open when a base-level
+			// popover opens later. Mount order used to put the popover on top.
+			const user = userEvent.setup();
+			render(
+				<div>
+					<Popover.Root>
+						<Popover.Trigger>Open base popover</Popover.Trigger>
+						<Popover.Content>base popover content</Popover.Content>
+					</Popover.Root>
+					<Dialog.Root open modal={false}>
+						<Dialog.Content appearance="full-bleed">
+							<Dialog.Title>Takeover</Dialog.Title>
+						</Dialog.Content>
+					</Dialog.Root>
+				</div>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open base popover" }));
+			const popoverContent = await screen.findByText("base popover content");
+
+			const positioner = getPositioner("dialog-positioner");
+			expect(positioner.contains(popoverContent)).toBe(false);
+			// It portals to document.body, where the overlay tier out-stacks it.
+			expect(popoverContent.closest("[data-slot='dialog-positioner']")).toBeNull();
+		});
+	});
+
+	describe("nested overlays", () => {
+		test("a dialog opened from inside a dialog portals into the outer positioner", async () => {
+			const user = userEvent.setup();
+			render(
+				<Dialog.Root open>
+					<Dialog.Content>
+						<Dialog.Title>Outer</Dialog.Title>
+						<Dialog.Body>
+							<Dialog.Root>
+								<Dialog.Trigger>Open inner</Dialog.Trigger>
+								<Dialog.Content>
+									<Dialog.Title>Inner</Dialog.Title>
+								</Dialog.Content>
+							</Dialog.Root>
+						</Dialog.Body>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open inner" }));
+			await screen.findByText("Inner");
+
+			const positioners = document.querySelectorAll("[data-slot='dialog-positioner']");
+			expect(positioners).toHaveLength(2);
+			const [outer, inner] = positioners;
+			expect(outer != null && inner != null && outer.contains(inner)).toBe(true);
+		});
+
+		test("a sheet opened from inside a dialog portals into the dialog's positioner", async () => {
+			const user = userEvent.setup();
+			render(
+				<Dialog.Root open>
+					<Dialog.Content>
+						<Dialog.Title>Outer</Dialog.Title>
+						<Dialog.Body>
+							<Sheet.Root>
+								<Sheet.Trigger>Open sheet</Sheet.Trigger>
+								<Sheet.Content>
+									<Sheet.Header>
+										<Sheet.TitleGroup>
+											<Sheet.Title>Inner sheet</Sheet.Title>
+										</Sheet.TitleGroup>
+									</Sheet.Header>
+								</Sheet.Content>
+							</Sheet.Root>
+						</Dialog.Body>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open sheet" }));
+			await screen.findByText("Inner sheet");
+
+			const dialogPositioner = getPositioner("dialog-positioner");
+			const sheetPositioner = getPositioner("sheet-positioner");
+			expect(dialogPositioner.contains(sheetPositioner)).toBe(true);
+		});
+
+		test("a popover inside the inner dialog portals into the inner positioner, not the outer one", async () => {
+			const user = userEvent.setup();
+			render(
+				<Dialog.Root open>
+					<Dialog.Content>
+						<Dialog.Title>Outer</Dialog.Title>
+						<Dialog.Body>
+							<Dialog.Root open>
+								<Dialog.Content>
+									<Dialog.Title>Inner</Dialog.Title>
+									<Dialog.Body>
+										<Popover.Root>
+											<Popover.Trigger>Open float</Popover.Trigger>
+											<Popover.Content>float content</Popover.Content>
+										</Popover.Root>
+									</Dialog.Body>
+								</Dialog.Content>
+							</Dialog.Root>
+						</Dialog.Body>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open float" }));
+			const floatContent = await screen.findByText("float content");
+
+			const positioners = document.querySelectorAll<HTMLElement>("[data-slot='dialog-positioner']");
+			expect(positioners).toHaveLength(2);
+			const inner = positioners[1];
+			expect(inner != null && inner.contains(floatContent)).toBe(true);
+		});
+
+		test("DropdownMenu.SubContent portals into the same positioner as its menu", async () => {
+			const user = userEvent.setup();
+			render(
+				overlays[0].renderOpen(
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger>Open float</DropdownMenu.Trigger>
+						<DropdownMenu.Content>
+							<DropdownMenu.Sub>
+								<DropdownMenu.SubTrigger>More</DropdownMenu.SubTrigger>
+								<DropdownMenu.SubContent>
+									<DropdownMenu.Item>sub item</DropdownMenu.Item>
+								</DropdownMenu.SubContent>
+							</DropdownMenu.Sub>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>,
+				),
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open float" }));
+			await user.hover(await screen.findByText("More"));
+			const subItem = await screen.findByText("sub item");
+
+			const positioner = getPositioner("dialog-positioner");
+			expect(positioner.contains(subItem)).toBe(true);
+		});
+	});
+
+	describe("explicit container escape hatches", () => {
+		test("HoverCard.Portal's container prop wins over the layer container", async () => {
+			const external = document.createElement("div");
+			external.dataset.testid = "external";
+			document.body.appendChild(external);
+
+			render(
+				<Dialog.Root open>
+					<Dialog.Content>
+						<Dialog.Title>Overlay</Dialog.Title>
+						<Dialog.Body>
+							<HoverCard.Root open>
+								<HoverCard.Trigger>anchor</HoverCard.Trigger>
+								<HoverCard.Portal container={external}>
+									<HoverCard.Content>float content</HoverCard.Content>
+								</HoverCard.Portal>
+							</HoverCard.Root>
+						</Dialog.Body>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			const floatContent = await screen.findByText("float content");
+			expect(external.contains(floatContent)).toBe(true);
+
+			external.remove();
+		});
+
+		test("Dialog.Portal's container prop wins over the layer container", async () => {
+			const external = document.createElement("div");
+			document.body.appendChild(external);
+
+			render(
+				<Dialog.Root open>
+					<Dialog.Portal container={external}>
+						<p>portaled content</p>
+					</Dialog.Portal>
+				</Dialog.Root>,
+			);
+
+			const content = await screen.findByText("portaled content");
+			expect(external.contains(content)).toBe(true);
+
+			external.remove();
+		});
+	});
+
+	describe("floats inside a Popover", () => {
+		// Floats do not register a layer container of their own, so a float
+		// composed inside a popover shares the popover's container. It mounts
+		// later, so within that shared container it paints above the popover.
+
+		test("a Select inside a base popover shares the popover's container and follows it", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open host</Popover.Trigger>
+					<Popover.Content>
+						<Select.Root>
+							<Select.Trigger aria-label="Open float" />
+							<Select.Content>
+								<Select.Item value="a">float content</Select.Item>
+							</Select.Content>
+						</Select.Root>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByRole("combobox", { name: "Open float" }));
+			const listbox = await screen.findByRole("listbox");
+
+			const popoverContent = getPositioner("popover-content");
+			expect(popoverContent.contains(listbox)).toBe(false);
+			expect(listbox.closest("[data-slot='dialog-positioner']")).toBeNull();
+			// Later body sibling at the same tier: the select paints above the
+			// popover that spawned it.
+			expect(
+				popoverContent.compareDocumentPosition(listbox) & Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
+		test("a DropdownMenu inside a base popover shares the popover's container and follows it", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open host</Popover.Trigger>
+					<Popover.Content>
+						<DropdownMenu.Root>
+							<DropdownMenu.Trigger>Open float</DropdownMenu.Trigger>
+							<DropdownMenu.Content>
+								<DropdownMenu.Item>float content</DropdownMenu.Item>
+							</DropdownMenu.Content>
+						</DropdownMenu.Root>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByRole("button", { name: "Open float" }));
+			const menu = await screen.findByRole("menu");
+
+			const popoverContent = getPositioner("popover-content");
+			expect(popoverContent.contains(menu)).toBe(false);
+			expect(
+				popoverContent.compareDocumentPosition(menu) & Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
+		test("a Tooltip inside a base popover shares the popover's container and follows it", async () => {
+			const user = userEvent.setup();
+			render(
+				<TooltipProvider>
+					<Popover.Root>
+						<Popover.Trigger>Open host</Popover.Trigger>
+						<Popover.Content>
+							<Tooltip.Root open>
+								<Tooltip.Trigger>anchor</Tooltip.Trigger>
+								<Tooltip.Content>float content</Tooltip.Content>
+							</Tooltip.Root>
+						</Popover.Content>
+					</Popover.Root>
+				</TooltipProvider>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			const contents = await screen.findAllByText("float content");
+			const tooltipContent = contents.find((element) =>
+				element.closest("[data-slot='tooltip-content']"),
+			);
+			if (tooltipContent == null) {
+				throw new Error("no tooltip content with data-slot rendered");
+			}
+
+			const popoverContent = getPositioner("popover-content");
+			expect(popoverContent.contains(tooltipContent)).toBe(false);
+			expect(
+				popoverContent.compareDocumentPosition(tooltipContent) & Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
+		test("a Popover inside a popover shares the outer popover's container and follows it", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open host</Popover.Trigger>
+					<Popover.Content>
+						<Popover.Root>
+							<Popover.Trigger>Open float</Popover.Trigger>
+							<Popover.Content>float content</Popover.Content>
+						</Popover.Root>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByRole("button", { name: "Open float" }));
+			const innerContent = await screen.findByText("float content");
+
+			const contents = document.querySelectorAll("[data-slot='popover-content']");
+			expect(contents).toHaveLength(2);
+			const outer = contents[0];
+			expect(outer != null && outer.contains(innerContent)).toBe(false);
+			expect(
+				outer != null &&
+					(outer.compareDocumentPosition(innerContent) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+			).toBe(true);
+		});
+
+		test("a Combobox inside a base popover renders its popup in place, inside the popover content", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open host</Popover.Trigger>
+					<Popover.Content>
+						<Combobox.Root>
+							<Combobox.Input aria-label="Fruit" />
+							<Combobox.Content>
+								<Combobox.Item value="Apple" />
+							</Combobox.Content>
+						</Combobox.Root>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByRole("combobox", { name: "Fruit" }));
+			await user.keyboard("App");
+			const popup = await screen.findByRole("listbox");
+
+			expect(getPositioner("popover-content").contains(popup)).toBe(true);
+		});
+
+		test("a Select inside a popover inside a dialog portals into the dialog's positioner", async () => {
+			const user = userEvent.setup();
+			render(
+				overlays[0].renderOpen(
+					<Popover.Root>
+						<Popover.Trigger>Open host</Popover.Trigger>
+						<Popover.Content>
+							<Select.Root>
+								<Select.Trigger aria-label="Open float" />
+								<Select.Content>
+									<Select.Item value="a">float content</Select.Item>
+								</Select.Content>
+							</Select.Root>
+						</Popover.Content>
+					</Popover.Root>,
+				),
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByRole("combobox", { name: "Open float" }));
+			const listbox = await screen.findByRole("listbox");
+
+			const positioner = getPositioner("dialog-positioner");
+			const popoverContent = getPositioner("popover-content");
+			expect(positioner.contains(listbox)).toBe(true);
+			expect(
+				popoverContent.compareDocumentPosition(listbox) & Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
+		test("a MultiSelect inside a base popover portals to document.body", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open host</Popover.Trigger>
+					<Popover.Content>
+						<MultiSelect.Root>
+							<MultiSelect.Trigger>
+								<MultiSelect.TagValues />
+								<MultiSelect.Input placeholder="Select items..." />
+							</MultiSelect.Trigger>
+							<MultiSelect.Content>
+								<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+							</MultiSelect.Content>
+						</MultiSelect.Root>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByPlaceholderText("Select items..."));
+			const popup = await screen.findByRole("listbox");
+
+			expect(getPositioner("popover-content").contains(popup)).toBe(false);
+			expect(popup.closest("[data-slot='dialog-positioner']")).toBeNull();
+		});
+
+		test("a MultiSelect inside a popover inside a dialog portals into the dialog's positioner", async () => {
+			// The trigger sits in a float portaled into the positioner, so
+			// `closest("[data-mantle-modal-content]")` cannot reach the dialog
+			// content — without the layer-container fallback the popup lands on
+			// `document.body` at `z-50`, under the `z-60` dialog.
+			const user = userEvent.setup();
+			render(
+				overlays[0].renderOpen(
+					<Popover.Root>
+						<Popover.Trigger>Open host</Popover.Trigger>
+						<Popover.Content>
+							<MultiSelect.Root>
+								<MultiSelect.Trigger>
+									<MultiSelect.TagValues />
+									<MultiSelect.Input placeholder="Select items..." />
+								</MultiSelect.Trigger>
+								<MultiSelect.Content>
+									<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+								</MultiSelect.Content>
+							</MultiSelect.Root>
+						</Popover.Content>
+					</Popover.Root>,
+				),
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			await user.click(await screen.findByPlaceholderText("Select items..."));
+			const popup = await screen.findByRole("listbox");
+
+			expect(getPositioner("dialog-positioner").contains(popup)).toBe(true);
+		});
+	});
+
+	describe("layers with their own placement rules", () => {
+		test("Combobox renders its popup in place, inside the dialog content element", async () => {
+			// The dialog primitive's Escape guard requires the popup to be a DOM
+			// descendant of the dialog content (`currentTarget.contains(popup)`),
+			// so `Combobox.Content` must never portal. Adding Ariakit's `portal`
+			// prop to it turns this red — and breaks Escape inside dialogs.
+			const user = userEvent.setup();
+			render(
+				overlays[0].renderOpen(
+					<Combobox.Root>
+						<Combobox.Input aria-label="Fruit" />
+						<Combobox.Content>
+							<Combobox.Item value="Apple" />
+						</Combobox.Content>
+					</Combobox.Root>,
+				),
+			);
+
+			await user.click(screen.getByRole("combobox", { name: "Fruit" }));
+			await user.keyboard("App");
+			const popup = await screen.findByRole("listbox");
+
+			const dialogContent = getPositioner("dialog-content");
+			expect(dialogContent.contains(popup)).toBe(true);
+		});
+
+		test("MultiSelect portals its popup into the dialog's `data-mantle-modal-content` element", async () => {
+			// Both sides of the cross-file contract in one render: the dialog
+			// stamps `data-mantle-modal-content` on its content, and
+			// `MultiSelect.Content` resolves its Ariakit `portalElement` to the
+			// closest one so the Escape guard still contains the popup.
+			const user = userEvent.setup();
+			render(
+				overlays[0].renderOpen(
+					<MultiSelect.Root>
+						<MultiSelect.Trigger>
+							<MultiSelect.TagValues />
+							<MultiSelect.Input placeholder="Select items..." />
+						</MultiSelect.Trigger>
+						<MultiSelect.Content>
+							<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+						</MultiSelect.Content>
+					</MultiSelect.Root>,
+				),
+			);
+
+			await user.click(screen.getByPlaceholderText("Select items..."));
+			const popup = await screen.findByRole("listbox");
+
+			const dialogContent = getPositioner("dialog-content");
+			expect(dialogContent.hasAttribute("data-mantle-modal-content")).toBe(true);
+			expect(dialogContent.contains(popup)).toBe(true);
+		});
+
+		test("Combobox renders its popup in place inside the sheet content element", async () => {
+			const user = userEvent.setup();
+			render(
+				overlays[2].renderOpen(
+					<Combobox.Root>
+						<Combobox.Input aria-label="Fruit" />
+						<Combobox.Content>
+							<Combobox.Item value="Apple" />
+						</Combobox.Content>
+					</Combobox.Root>,
+				),
+			);
+
+			await user.click(screen.getByRole("combobox", { name: "Fruit" }));
+			await user.keyboard("App");
+			const popup = await screen.findByRole("listbox");
+
+			expect(getPositioner("sheet-content").contains(popup)).toBe(true);
+		});
+
+		test("MultiSelect portals its popup into the sheet's `data-mantle-modal-content` element", async () => {
+			const user = userEvent.setup();
+			render(
+				overlays[2].renderOpen(
+					<MultiSelect.Root>
+						<MultiSelect.Trigger>
+							<MultiSelect.TagValues />
+							<MultiSelect.Input placeholder="Select items..." />
+						</MultiSelect.Trigger>
+						<MultiSelect.Content>
+							<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+						</MultiSelect.Content>
+					</MultiSelect.Root>,
+				),
+			);
+
+			await user.click(screen.getByPlaceholderText("Select items..."));
+			const popup = await screen.findByRole("listbox");
+
+			const sheetContent = getPositioner("sheet-content");
+			expect(sheetContent.hasAttribute("data-mantle-modal-content")).toBe(true);
+			expect(sheetContent.contains(popup)).toBe(true);
+		});
+
+		test("a toast fired while a dialog is open renders in sonner's viewport, not the positioner", async () => {
+			render(
+				<div>
+					<Toaster />
+					{overlays[0].renderOpen(<p>body</p>)}
+				</div>,
+			);
+
+			makeToast(<p>toast content</p>);
+			const toastContent = await screen.findByText("toast content");
+
+			const viewport = document.querySelector("[data-sonner-toaster]");
+			expect(viewport != null && viewport.contains(toastContent)).toBe(true);
+			expect(getPositioner("dialog-positioner").contains(toastContent)).toBe(false);
+		});
+
+		test("Command.DialogRoot renders its palette inside a dialog positioner", async () => {
+			render(
+				<Command.DialogRoot open>
+					<Command.DialogContent title="Command palette">
+						<Command.Input placeholder="Search…" />
+						<Command.List>
+							<Command.Item>palette item</Command.Item>
+						</Command.List>
+					</Command.DialogContent>
+				</Command.DialogRoot>,
+			);
+
+			const item = await screen.findByText("palette item");
+			expect(getPositioner("dialog-positioner").contains(item)).toBe(true);
+		});
+	});
+
+	describe("server render", () => {
+		test("an open dialog with a default-open popover renders on the server without portals", () => {
+			// Portals cannot render during SSR; the trigger markup still must.
+			const html = renderToString(
+				<Dialog.Root open>
+					<Dialog.Content>
+						<Dialog.Title>Overlay</Dialog.Title>
+						<Dialog.Body>
+							<Popover.Root defaultOpen>
+								<Popover.Trigger>Open float</Popover.Trigger>
+								<Popover.Content>float content</Popover.Content>
+							</Popover.Root>
+						</Dialog.Body>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			expect(html).not.toContain("float content");
+			expect(html).not.toContain('data-slot="dialog-positioner"');
+		});
+	});
+});
+
+describe("layer tiers", () => {
+	// Why class assertions: the z-index tier is the only observable
+	// implementation of the layering contract in happy-dom — no stylesheet
+	// loads, so there is no computed style to read. Each class below is pinned
+	// against the selector-free contract the JSDoc documents (floats `z-50`,
+	// overlays `z-60`); `layer-container.browser.test.tsx` asserts the paint
+	// order these classes produce. A permuted tier (overlay at `z-50`, float at
+	// `z-60`) turns exactly this test red.
+	test("overlay elements carry the overlay tier and floats carry the float tier", async () => {
+		const user = userEvent.setup();
+		render(
+			<div>
+				{overlays[0].renderOpen(
+					<Popover.Root>
+						<Popover.Trigger>Open float</Popover.Trigger>
+						<Popover.Content>float content</Popover.Content>
+					</Popover.Root>,
+				)}
+			</div>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Open float" }));
+		const floatContent = await screen.findByText("float content");
+
+		expect(getPositioner("dialog-positioner")).toHaveClass("z-60");
+		expect(getPositioner("dialog-overlay")).toHaveClass("z-60");
+		expect(floatContent.closest("[data-slot='popover-content']")).toHaveClass("z-50");
+	});
+
+	test("sheet positioner and overlay carry the overlay tier", async () => {
+		render(overlays[2].renderOpen(<p>body</p>));
+
+		await waitFor(() => {
+			expect(getPositioner("sheet-positioner")).toHaveClass("z-60");
+		});
+		expect(getPositioner("sheet-overlay")).toHaveClass("z-60");
+		// The tier lives on the positioner; the content must not carry a stale
+		// tier of its own.
+		expect(getPositioner("sheet-content")).not.toHaveClass("z-50");
+	});
+});

--- a/packages/mantle/src/utils/layer-container/layer-container.test.tsx
+++ b/packages/mantle/src/utils/layer-container/layer-container.test.tsx
@@ -325,6 +325,34 @@ describe("layer containers", () => {
 			expect(inner != null && inner.contains(floatContent)).toBe(true);
 		});
 
+		test("an alert dialog opened from inside a dialog portals into the dialog's positioner", async () => {
+			const user = userEvent.setup();
+			render(
+				<Dialog.Root open>
+					<Dialog.Content>
+						<Dialog.Title>Outer</Dialog.Title>
+						<Dialog.Body>
+							<AlertDialog.Root intent="danger">
+								<AlertDialog.Trigger>Open alert</AlertDialog.Trigger>
+								<AlertDialog.Content>
+									<AlertDialog.Body>
+										<AlertDialog.Title>Inner alert</AlertDialog.Title>
+									</AlertDialog.Body>
+								</AlertDialog.Content>
+							</AlertDialog.Root>
+						</Dialog.Body>
+					</Dialog.Content>
+				</Dialog.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open alert" }));
+			await screen.findByText("Inner alert");
+
+			const dialogPositioner = getPositioner("dialog-positioner");
+			const alertDialogPositioner = getPositioner("alert-dialog-positioner");
+			expect(dialogPositioner.contains(alertDialogPositioner)).toBe(true);
+		});
+
 		test("DropdownMenu.SubContent portals into the same positioner as its menu", async () => {
 			const user = userEvent.setup();
 			render(
@@ -575,6 +603,30 @@ describe("layer containers", () => {
 			).toBeTruthy();
 		});
 
+		test("a HoverCard inside a base popover shares the popover's container and follows it", async () => {
+			const user = userEvent.setup();
+			render(
+				<Popover.Root>
+					<Popover.Trigger>Open host</Popover.Trigger>
+					<Popover.Content>
+						<HoverCard.Root open>
+							<HoverCard.Trigger>anchor</HoverCard.Trigger>
+							<HoverCard.Content>float content</HoverCard.Content>
+						</HoverCard.Root>
+					</Popover.Content>
+				</Popover.Root>,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Open host" }));
+			const hoverCardContent = await screen.findByText("float content");
+
+			const popoverContent = getPositioner("popover-content");
+			expect(popoverContent.contains(hoverCardContent)).toBe(false);
+			expect(
+				popoverContent.compareDocumentPosition(hoverCardContent) & Node.DOCUMENT_POSITION_FOLLOWING,
+			).toBeTruthy();
+		});
+
 		test("a MultiSelect inside a base popover portals to document.body", async () => {
 			const user = userEvent.setup();
 			render(
@@ -687,6 +739,50 @@ describe("layer containers", () => {
 			const dialogContent = getPositioner("dialog-content");
 			expect(dialogContent.hasAttribute("data-mantle-modal-content")).toBe(true);
 			expect(dialogContent.contains(popup)).toBe(true);
+		});
+
+		test("Combobox renders its popup in place inside the alert dialog content element", async () => {
+			const user = userEvent.setup();
+			render(
+				overlays[1].renderOpen(
+					<Combobox.Root>
+						<Combobox.Input aria-label="Fruit" />
+						<Combobox.Content>
+							<Combobox.Item value="Apple" />
+						</Combobox.Content>
+					</Combobox.Root>,
+				),
+			);
+
+			await user.click(screen.getByRole("combobox", { name: "Fruit" }));
+			await user.keyboard("App");
+			const popup = await screen.findByRole("listbox");
+
+			expect(getPositioner("alert-dialog-content").contains(popup)).toBe(true);
+		});
+
+		test("MultiSelect portals its popup into the alert dialog's `data-mantle-modal-content` element", async () => {
+			const user = userEvent.setup();
+			render(
+				overlays[1].renderOpen(
+					<MultiSelect.Root>
+						<MultiSelect.Trigger>
+							<MultiSelect.TagValues />
+							<MultiSelect.Input placeholder="Select items..." />
+						</MultiSelect.Trigger>
+						<MultiSelect.Content>
+							<MultiSelect.Item value="apple">Apple</MultiSelect.Item>
+						</MultiSelect.Content>
+					</MultiSelect.Root>,
+				),
+			);
+
+			await user.click(screen.getByPlaceholderText("Select items..."));
+			const popup = await screen.findByRole("listbox");
+
+			const alertDialogContent = getPositioner("alert-dialog-content");
+			expect(alertDialogContent.hasAttribute("data-mantle-modal-content")).toBe(true);
+			expect(alertDialogContent.contains(popup)).toBe(true);
 		});
 
 		test("Combobox renders its popup in place inside the sheet content element", async () => {

--- a/packages/mantle/src/utils/layer-container/layer-container.tsx
+++ b/packages/mantle/src/utils/layer-container/layer-container.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { createContext, type ComponentProps, useContext, useState } from "react";
+import { composeRefs } from "../compose-refs/compose-refs.js";
+
+/**
+ * The portal target for floating layers composed inside an overlay.
+ *
+ * Mantle stacks floating UI in two tiers: overlays (`Dialog`, `AlertDialog`,
+ * `Sheet`) render at `z-60`, floats (`Popover`, `Tooltip`, `Select`,
+ * `DropdownMenu`, `HoverCard`) at `z-50`. An overlay's content provides its
+ * positioner element through this context. A float composed inside the overlay
+ * portals into that positioner instead of `document.body`, so it paints above
+ * the overlay that owns it. A float outside every overlay reads `null`,
+ * portals to `document.body`, and stays below the overlay tier no matter when
+ * it opens.
+ *
+ * Why the positioner and not a sibling element: Radix marks the portal's
+ * other children `aria-hidden` when a modal overlay opens, so a float portaled
+ * into a sibling would be hidden from screen readers. The positioner is on the
+ * overlay content's ancestor chain, which the marking skips.
+ */
+const LayerContainerContext = createContext<Element | DocumentFragment | null>(null);
+
+/**
+ * The nearest overlay's layer container, or `null` outside every overlay.
+ * Pass the result to a portal's `container` prop — `null` falls back to
+ * `document.body`.
+ *
+ * @example
+ * ```tsx
+ * const layerContainer = useLayerContainer();
+ * return (
+ *   <PopoverPrimitive.Portal container={layerContainer}>
+ *     <PopoverPrimitive.Content>…</PopoverPrimitive.Content>
+ *   </PopoverPrimitive.Portal>
+ * );
+ * ```
+ */
+function useLayerContainer(): Element | DocumentFragment | null {
+	return useContext(LayerContainerContext);
+}
+
+/**
+ * The provider half of {@link LayerContainerContext}: a `div` that registers
+ * itself as the layer container for every float composed inside it. An overlay
+ * renders it as its positioner — the fixed element that lays out its content —
+ * so floats portaled into it later land on the content's ancestor chain and
+ * paint above the content. The caller passes the positioning classes and the
+ * `data-slot`; this component carries none of its own.
+ *
+ * @example
+ * ```tsx
+ * <Portal>
+ *   <Overlay />
+ *   <LayerContainer data-slot="dialog-positioner" className="fixed inset-4 z-60 flex items-center justify-center">
+ *     <DialogPrimitive.Content>…</DialogPrimitive.Content>
+ *   </LayerContainer>
+ * </Portal>
+ * ```
+ */
+function LayerContainer({ children, ref, ...props }: ComponentProps<"div">) {
+	const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+	return (
+		<div ref={composeRefs(ref, setElement)} {...props}>
+			<LayerContainerContext.Provider value={element}>{children}</LayerContainerContext.Provider>
+		</div>
+	);
+}
+
+export {
+	//,
+	LayerContainer,
+	LayerContainerContext,
+	useLayerContainer,
+};


### PR DESCRIPTION
## Why

The dashboard's onboarding popover opens on its own after hydration, and it painted on top of the open full-bleed endpoint-creation dialog (ngrok/FEP-1754). Every mantle floating layer rendered at `z-50`, and DOM order broke ties. "Opened later" meant "paints on top", which is wrong for a base-layer popover under a route takeover. No single z-index fixes it: the same `Popover` renders both the buried announcement and the floats inside the dialog.

## What

Two mechanisms, and each needs the other:

- **Overlay tier.** `Dialog`, `AlertDialog`, and `Sheet` (and `Command`'s palette through `Dialog`) move to `z-60`. Floats (`Popover`, `Tooltip`, `Select`, `DropdownMenu`, `HoverCard`) stay at `z-50`, so a base-level float can never out-paint an overlay.
- **Layer containers.** Each overlay's positioner — the fixed, transform-free element that lays out its content — registers itself through an internal context. Floats portal into the nearest one, else `document.body`, so a float composed inside an overlay paints above the overlay that owns it. The positioner must be the container: Radix marks the portal's other children `aria-hidden` when a modal opens, and the positioner is on the content's ancestor chain. New styling hooks: `data-slot="dialog-positioner"`, `"sheet-positioner"`, `"alert-dialog-positioner"`.

Deliberate exceptions, each pinned by a test: `Combobox.Content` keeps rendering in place — the dialog primitive's Escape guard needs `contains()` to see the popup. `MultiSelect.Content` keeps portaling into `data-mantle-modal-content`, with a new layer-container fallback for a trigger inside a float, where `closest` cannot reach the overlay content. Toasts stay in sonner's viewport, above both tiers.

Also fixed: `container` on `Dialog.Portal` and `HoverCard.Portal` was silently ignored, because the content parts portal again internally. The resolved container now carries into the wrapped subtree.

New docs page at `/base/stacking-layers` explains the tiers and how to place custom UI on the scale. `decisions/2026-08-11-floating-layer-tiers.md` records the alternatives (z-index bumps, container-only, tier-only, the native top layer) and the consequences.

## Verification

- 39 happy-dom placement tests plus 5 Chromium hit-testing tests (`document.elementFromPoint`) cover every float × every overlay, floats inside popovers (base and inside a dialog), nested overlays, the combobox/multi-select/toast exceptions, SSR, and the explicit `container` escape hatches.
- Falsified the load-bearing tests: a tier revert, a container revert, and a multi-select fallback revert each turn exactly one test red.
- `z-60` probe-compiled against the repo's pinned Tailwind 4 → `z-index: 60`.
- `lint`, `fmt:check`, `typecheck`, unscoped `test` (mantle 2502, www 241), and `build -F @ngrok/mantle` all pass; `components-surface.json` needed no regeneration (summaries and examples unchanged).
