### PR TITLE
docs: add the "no X needed" ban to the ngrok-style skill

### DIFF
--- a/.claude/skills/ngrok-style/SKILL.md
+++ b/.claude/skills/ngrok-style/SKILL.md
@@ -218,6 +218,11 @@ ngrok is great for:
 - ✅ ngrok handles TLS termination and authentication automatically.
 - ❌ ngrok is fast, reliable, and secure.
 
+**Cut the "no X needed" tail.** This construction reassures the reader about a problem they didn't ask about, and it pads a claim that should stand on its own. State what happens and stop.
+
+- ✅ ngrok terminates TLS automatically.
+- ❌ ngrok terminates TLS automatically, no extra configuration needed.
+
 ### Bold UI elements, don't italicize
 
 - ✅ Click **+ Cloud Endpoint** to get started.


### PR DESCRIPTION
## Why

The `ngrok-style` skill in the private frontend repo added a new AI-pattern ban: the "no X needed" tail. Mantle's copy of the skill tracks the upstream, so it needs the same ban.

## What

Add the ban and its examples after "Avoid the artificial rule of three." The mantle-specific scope in the frontmatter and "When to Apply" is unchanged.
