### PR TITLE
feat: add VisuallyHidden and LiveRegion a11y primitives

### DIFF
--- a/.changeset/live-region-component.md
+++ b/.changeset/live-region-component.md
@@ -2,6 +2,6 @@
 "@ngrok/mantle": minor
 ---
 
-Add `LiveRegion`, a persistent, visually hidden live region that announces its text to screen readers when the text changes. The `politeness` prop picks the urgency: `"polite"` (the default) renders `role="status"` and `aria-live="polite"`, and `"assertive"` renders `role="alert"` and `aria-live="assertive"`. The region stamps `aria-atomic="true"` and `data-slot="live-region"`, takes `asChild`, and treats the derived `role` and `aria-live` as defaults a consumer prop can override. Keep the region mounted from first paint and swap only its children: a region created after the fact announces unreliably.
+Add `LiveRegion`, a persistent, visually hidden live region that announces its text to screen readers when the text changes. The `politeness` prop picks the urgency: `"polite"` (the default) renders `role="status"` and `aria-live="polite"`, and `"assertive"` renders `role="alert"` alone, because a redundant `aria-live` makes VoiceOver on iOS announce the message twice. The region stamps `aria-atomic="true"` and `data-slot="live-region"`, takes `asChild`, and treats the derived `role` and `aria-live` as defaults a consumer prop can override. Keep the region mounted from first paint and swap only its children: a region created after the fact announces unreliably.
 
 Docs: https://mantle.ngrok.com/components/primitives/live-region

--- a/.changeset/live-region-component.md
+++ b/.changeset/live-region-component.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": minor
+---
+
+Add `LiveRegion`, a persistent, visually hidden live region that announces its text to screen readers when the text changes. The `politeness` prop picks the urgency: `"polite"` (the default) renders `role="status"` and `aria-live="polite"`, and `"assertive"` renders `role="alert"` and `aria-live="assertive"`. The region stamps `aria-atomic="true"` and `data-slot="live-region"`, takes `asChild`, and treats the derived `role` and `aria-live` as defaults a consumer prop can override. Keep the region mounted from first paint and swap only its children: a region created after the fact announces unreliably.
+
+Docs: https://mantle.ngrok.com/components/primitives/live-region

--- a/.changeset/visually-hidden-component.md
+++ b/.changeset/visually-hidden-component.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": minor
+---
+
+Add `VisuallyHidden`, a primitive that renders content for screen readers without showing it. It renders a `<span>` clipped to a one-pixel box (never `display: none`), stamps `data-slot="visually-hidden"`, and takes `asChild` to hide a more semantic element (a `<caption>`, a `<legend>`, a heading). Do not use it to name an icon-only control: voice-control software skips a control whose only label is hidden DOM text, so use `aria-label` there instead.
+
+Docs: https://mantle.ngrok.com/components/primitives/visually-hidden

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -105,7 +105,16 @@ export const componentsByCategory = {
 		"Sheet",
 		"Tooltip",
 	],
-	Primitives: ["Browser Only", "Main", "SandboxedOnClick", "Skip to Main Link", "Slot", "Theme"],
+	Primitives: [
+		"Browser Only",
+		"Live Region",
+		"Main",
+		"SandboxedOnClick",
+		"Skip to Main Link",
+		"Slot",
+		"Theme",
+		"Visually Hidden",
+	],
 	// Structure: contains, divides, or arranges arbitrary content — vs Data
 	// Display, which presents specific content. Page/viewport structure
 	// belongs to the top-level Layouts section, not here.
@@ -170,6 +179,7 @@ export const prodReadyComponentRouteLookup = {
 	Label: "/components/forms/label",
 	"Line Chart": "/components/charts/line-chart",
 	List: "/components/data-display/list",
+	"Live Region": "/components/primitives/live-region",
 	Main: "/components/primitives/main",
 	"Media Object": "/components/structure/media-object",
 	"Multi Select": "/components/forms/multi-select",
@@ -202,6 +212,7 @@ export const prodReadyComponentRouteLookup = {
 	"Theme Switcher": "/components/forms/theme-switcher",
 	Toast: "/components/feedback/toast",
 	Tooltip: "/components/overlays/tooltip",
+	"Visually Hidden": "/components/primitives/visually-hidden",
 	Well: "/components/structure/well",
 } as const satisfies Record<ProdReadyComponent, Route>;
 

--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -333,12 +333,14 @@ export const recipePages = [
 	//,
 	"Breadcrumbs from Routes",
 	"Overlays + Async Data",
+	"Route Announcer",
 ] as const;
 
 /** Route lookup for recipe pages. */
 export const recipeRoutes = {
 	"Breadcrumbs from Routes": "/recipes/breadcrumbs-from-routes",
 	"Overlays + Async Data": "/recipes/overlay-async",
+	"Route Announcer": "/recipes/route-announcer",
 } as const satisfies Record<(typeof recipePages)[number], Route>;
 
 /** Short descriptions for recipe index pages. */
@@ -347,6 +349,8 @@ export const recipeDescriptions = {
 		"Derive a breadcrumb trail from the matched route chain with React Router route handles \u2014 derived state, so it is correct on the server and on the first frame, with no context and no effects.",
 	"Overlays + Async Data":
 		"Open a Sheet, Dialog, or Alert Dialog immediately, then swap the body between pending, loaded, 404, and 500 states with TanStack Query.",
+	"Route Announcer":
+		"Announce completed client-side navigations to screen readers by pairing a persistent LiveRegion with React Router's location, with page-name fallbacks and repeat-message handling.",
 } as const satisfies Record<(typeof recipePages)[number], string>;
 
 /** Migration guide pages. */

--- a/apps/www/app/docs/components/primitives/live-region.mdx
+++ b/apps/www/app/docs/components/primitives/live-region.mdx
@@ -130,7 +130,7 @@ function AssertiveExample() {
 
 ## Announcing route changes
 
-A single-page app repaints on navigation without a page load, so screen readers announce nothing. Feed a persistent `LiveRegion` the page name from your router's location, so it announces each completed navigation. The demo swaps pages with local state because the docs site cannot navigate inside an example. In your app, derive `pageName` from the router's location instead.
+A single-page app repaints on navigation without a page load, so screen readers announce nothing. Feed a persistent `LiveRegion` the page name from your router's location, so it announces each completed navigation. The demo swaps pages with local state because the docs site cannot navigate inside an example. In your app, derive `pageName` from the router's location instead. The [Route Announcer recipe](/recipes/route-announcer) is the complete pattern wired to React Router: page-name fallbacks, repeat-message handling, and tests.
 
 export function RouteAnnouncerExample() {
 	const [pageName, setPageName] = useState("Dashboard");

--- a/apps/www/app/docs/components/primitives/live-region.mdx
+++ b/apps/www/app/docs/components/primitives/live-region.mdx
@@ -10,9 +10,9 @@ import { Example } from "~/components/example";
 
 # Live Region
 
-Announces its text to screen readers when the text changes. `LiveRegion` renders a persistent, visually hidden `<span>` live region with `role="status"` and `aria-live="polite"` (or `role="alert"` and `aria-live="assertive"` when `politeness` is `"assertive"`). It stamps both the role and `aria-live` because some screen reader and browser pairs honor only one of the two.
+Announces its text to screen readers when the text changes. `LiveRegion` renders a persistent, visually hidden `<span>` live region with `role="status"` and `aria-live="polite"`. When `politeness` is `"assertive"`, it renders `role="alert"` and `aria-live="assertive"`. It stamps both the role and `aria-live` because some screen reader and browser pairs honor only one of the two.
 
-A live region announces reliably only when it already exists in the accessibility tree before its text changes, so keep `LiveRegion` mounted from first paint and swap only its children. A screen reader does not re-announce a message identical to the previous one; when the same message must repeat, clear the children first.
+A live region announces reliably only when it already exists in the accessibility tree before its text changes. Keep `LiveRegion` mounted from first paint and swap only its children. A screen reader does not re-announce a message identical to the previous one; when the same message must repeat, clear the children first.
 
 **When to use**
 

--- a/apps/www/app/docs/components/primitives/live-region.mdx
+++ b/apps/www/app/docs/components/primitives/live-region.mdx
@@ -10,7 +10,7 @@ import { Example } from "~/components/example";
 
 # Live Region
 
-Announces its text to screen readers when the text changes. `LiveRegion` renders a persistent, visually hidden `<span>` live region with `role="status"` and `aria-live="polite"`. When `politeness` is `"assertive"`, it renders `role="alert"` and `aria-live="assertive"`. It stamps both the role and `aria-live` because some screen reader and browser pairs honor only one of the two.
+Announces its text to screen readers when the text changes. `LiveRegion` renders a persistent, visually hidden `<span>` live region with `role="status"` and `aria-live="polite"`; the redundant `aria-live` covers screen reader and browser pairs that honor only one of the two. When `politeness` is `"assertive"`, it renders `role="alert"` alone: the role already carries assertive live-region semantics, and a redundant `aria-live` makes VoiceOver on iOS announce the message twice.
 
 A live region announces reliably only when it already exists in the accessibility tree before its text changes. Keep `LiveRegion` mounted from first paint and swap only its children. A screen reader does not re-announce a message identical to the previous one; when the same message must repeat, clear the children first.
 
@@ -76,6 +76,25 @@ function ResultsExample() {
 		</div>
 	);
 }
+```
+
+## Polymorphism
+
+`LiveRegion` accepts an `asChild` prop. When `true`, it renders its single child instead of its default `<span>`, forwarding its class names, ARIA attributes, `data-*` attributes, and ref onto that child.
+
+<Example>
+	<LiveRegion asChild>
+		<p>Ready.</p>
+	</LiveRegion>
+	<p className="text-muted text-sm">The live region above is a hidden paragraph element.</p>
+</Example>
+
+```tsx
+import { LiveRegion } from "@ngrok/mantle/live-region";
+
+<LiveRegion asChild>
+	<p>Ready.</p>
+</LiveRegion>;
 ```
 
 ## Politeness
@@ -196,25 +215,6 @@ function RouteAnnouncerExample() {
 		</div>
 	);
 }
-```
-
-## Polymorphism
-
-`LiveRegion` accepts an `asChild` prop. When `true`, it renders its single child instead of its default `<span>`, forwarding its class names, ARIA attributes, `data-*` attributes, and ref onto that child.
-
-<Example>
-	<LiveRegion asChild>
-		<p>Ready.</p>
-	</LiveRegion>
-	<p className="text-muted text-sm">The live region above is a hidden paragraph element.</p>
-</Example>
-
-```tsx
-import { LiveRegion } from "@ngrok/mantle/live-region";
-
-<LiveRegion asChild>
-	<p>Ready.</p>
-</LiveRegion>;
 ```
 
 ## API Reference

--- a/apps/www/app/docs/components/primitives/live-region.mdx
+++ b/apps/www/app/docs/components/primitives/live-region.mdx
@@ -1,0 +1,239 @@
+---
+title: Live Region
+description: A persistent, visually hidden region that announces its text to screen readers when the text changes.
+---
+
+import { Button } from "@ngrok/mantle/button";
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { useState } from "react";
+import { Example } from "~/components/example";
+
+# Live Region
+
+Announces its text to screen readers when the text changes. `LiveRegion` renders a persistent, visually hidden `<span>` live region with `role="status"` and `aria-live="polite"` (or `role="alert"` and `aria-live="assertive"` when `politeness` is `"assertive"`). It stamps both the role and `aria-live` because some screen reader and browser pairs honor only one of the two.
+
+A live region announces reliably only when it already exists in the accessibility tree before its text changes, so keep `LiveRegion` mounted from first paint and swap only its children. A screen reader does not re-announce a message identical to the previous one; when the same message must repeat, clear the children first.
+
+**When to use**
+
+- Announce a completed client-side navigation: the new page name, after a route change.
+- Announce an async result that moves focus nowhere: "3 results found", "Draft saved".
+
+**When not to use**
+
+- For status the user must see. Use [`Alert`](/components/feedback/alert) or [`Toast`](/components/feedback/toast), which pair visible UI with their own announcements.
+- For hidden text that never changes. Use [`VisuallyHidden`](/components/primitives/visually-hidden).
+
+export function ResultsExample() {
+	const [count, setCount] = useState(3);
+	return (
+		<div className="flex flex-col items-start gap-4">
+			<Button
+				type="button"
+				appearance="filled"
+				intent="neutral"
+				onClick={() => setCount((current) => current + 1)}
+			>
+				Add a result
+			</Button>
+			<LiveRegion>{`${count} results found`}</LiveRegion>
+			<ul className="list-disc pl-5 text-sm">
+				{Array.from({ length: count }, (_, index) => (
+					<li key={index}>Result {index + 1}</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+<Example>
+	<ResultsExample />
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { useState } from "react";
+
+function ResultsExample() {
+	const [count, setCount] = useState(3);
+	return (
+		<div className="flex flex-col items-start gap-4">
+			<Button
+				type="button"
+				appearance="filled"
+				intent="neutral"
+				onClick={() => setCount((current) => current + 1)}
+			>
+				Add a result
+			</Button>
+			<LiveRegion>{`${count} results found`}</LiveRegion>
+			<ul className="list-disc pl-5 text-sm">
+				{Array.from({ length: count }, (_, index) => (
+					<li key={index}>Result {index + 1}</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+```
+
+## Politeness
+
+`politeness` defaults to `"polite"`: the announcement waits for the screen reader's current utterance to finish. Pass `"assertive"` only when a delayed announcement would mislead the user (a session about to expire, a failed save). An assertive region interrupts the screen reader's current utterance.
+
+export function AssertiveExample() {
+	const [message, setMessage] = useState("");
+	return (
+		<div className="flex flex-col items-start gap-4">
+			<Button
+				type="button"
+				appearance="outlined"
+				intent="danger"
+				onClick={() => setMessage("Session expired. Sign in again.")}
+			>
+				Expire the session
+			</Button>
+			<LiveRegion politeness="assertive">{message}</LiveRegion>
+			<p className="text-muted text-sm">{message || "The session is active."}</p>
+		</div>
+	);
+}
+
+<Example>
+	<AssertiveExample />
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { useState } from "react";
+
+function AssertiveExample() {
+	const [message, setMessage] = useState("");
+	return (
+		<div className="flex flex-col items-start gap-4">
+			<Button
+				type="button"
+				appearance="outlined"
+				intent="danger"
+				onClick={() => setMessage("Session expired. Sign in again.")}
+			>
+				Expire the session
+			</Button>
+			<LiveRegion politeness="assertive">{message}</LiveRegion>
+			<p className="text-muted text-sm">{message || "The session is active."}</p>
+		</div>
+	);
+}
+```
+
+## Announcing route changes
+
+A single-page app repaints on navigation without a page load, so screen readers announce nothing. Feed a persistent `LiveRegion` the page name from your router's location, so it announces each completed navigation. The demo swaps pages with local state because the docs site cannot navigate inside an example. In your app, derive `pageName` from the router's location instead.
+
+export function RouteAnnouncerExample() {
+	const [pageName, setPageName] = useState("Dashboard");
+	return (
+		<div className="flex flex-col items-start gap-4">
+			<nav className="flex gap-2">
+				<Button
+					type="button"
+					appearance="outlined"
+					intent="neutral"
+					onClick={() => setPageName("Dashboard")}
+				>
+					Dashboard
+				</Button>
+				<Button
+					type="button"
+					appearance="outlined"
+					intent="neutral"
+					onClick={() => setPageName("Settings")}
+				>
+					Settings
+				</Button>
+			</nav>
+			<LiveRegion>{`Navigated to ${pageName}`}</LiveRegion>
+			<h3 className="text-lg font-medium">{pageName}</h3>
+		</div>
+	);
+}
+
+<Example>
+	<RouteAnnouncerExample />
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { useState } from "react";
+
+function RouteAnnouncerExample() {
+	const [pageName, setPageName] = useState("Dashboard");
+	return (
+		<div className="flex flex-col items-start gap-4">
+			<nav className="flex gap-2">
+				<Button
+					type="button"
+					appearance="outlined"
+					intent="neutral"
+					onClick={() => setPageName("Dashboard")}
+				>
+					Dashboard
+				</Button>
+				<Button
+					type="button"
+					appearance="outlined"
+					intent="neutral"
+					onClick={() => setPageName("Settings")}
+				>
+					Settings
+				</Button>
+			</nav>
+			<LiveRegion>{`Navigated to ${pageName}`}</LiveRegion>
+			<h3 className="text-lg font-medium">{pageName}</h3>
+		</div>
+	);
+}
+```
+
+## Polymorphism
+
+`LiveRegion` accepts an `asChild` prop. When `true`, it renders its single child instead of its default `<span>`, forwarding its class names, ARIA attributes, `data-*` attributes, and ref onto that child.
+
+<Example>
+	<LiveRegion asChild>
+		<p>Ready.</p>
+	</LiveRegion>
+	<p className="text-muted text-sm">The live region above is a hidden paragraph element.</p>
+</Example>
+
+```tsx
+import { LiveRegion } from "@ngrok/mantle/live-region";
+
+<LiveRegion asChild>
+	<p>Ready.</p>
+</LiveRegion>;
+```
+
+## API Reference
+
+### LiveRegion
+
+All props from [span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span#attributes), plus:
+
+| Prop          | Type                      | Default    | Description                                                                                                                                                                                |
+| ------------- | ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `asChild?`    | `boolean`                 | `false`    | Use the `asChild` prop to compose the `LiveRegion` behavior onto alternative element types or your own React components.                                                                   |
+| `children?`   | `ReactNode`               |            | The message to announce. Screen readers announce it each time it changes; keep the region mounted and swap only this.                                                                      |
+| `className?`  | `string`                  |            | Additional CSS classes to apply to the region.                                                                                                                                             |
+| `politeness?` | `"polite" \| "assertive"` | `"polite"` | How urgently a screen reader announces a changed message: `"polite"` waits for the current utterance to finish, `"assertive"` interrupts it. Also derives `role`: `"status"` or `"alert"`. |
+
+The derived `role` and `aria-live` read as defaults: a `role` or `aria-live` prop wins. `aria-atomic` defaults to `"true"` so the region re-reads the whole message, not the changed characters.
+
+#### Data attributes
+
+| Data Attribute | Value           | Description                                                               |
+| -------------- | --------------- | ------------------------------------------------------------------------- |
+| `data-slot`    | `"live-region"` | Stamped on the rendered element, and joined onto the child via `asChild`. |

--- a/apps/www/app/docs/components/primitives/visually-hidden.mdx
+++ b/apps/www/app/docs/components/primitives/visually-hidden.mdx
@@ -1,0 +1,121 @@
+---
+title: Visually Hidden
+description: Render content that screen readers announce and sighted users never see.
+---
+
+import { Anchor } from "@ngrok/mantle/anchor";
+import { VisuallyHidden } from "@ngrok/mantle/visually-hidden";
+import { Example } from "~/components/example";
+
+# Visually Hidden
+
+Content for assistive technology only. `VisuallyHidden` renders a native `<span>` clipped to a one-pixel box (the `sr-only` technique, never `display: none`), so screen readers read the content and sighted users never see it. The content also stays in copied and searched text.
+
+**When to use**
+
+- State context the visual design already carries: "(opens in a new tab)" on an external link, a caption on a layout table.
+- Give a screen reader a text alternative for content it cannot read, such as a decorative chart.
+- Style the message of a [`LiveRegion`](/components/primitives/live-region), which builds on the same technique.
+
+**When not to use**
+
+- To name an icon-only control. Voice-control software skips a control whose only label is hidden DOM text, so use `aria-label`, as [`IconButton`](/components/actions/icon-button)'s required `label` prop does.
+- To hide content from assistive technology too. Use the `hidden` attribute or `aria-hidden`.
+- For a link that appears on focus. Use [`SkipToMainLink`](/components/primitives/skip-to-main-link).
+
+<Example>
+	<p>
+		Read the{" "}
+		<Anchor href="https://status.ngrok.com" target="_blank" rel="noreferrer">
+			status page
+			<VisuallyHidden> (opens in a new tab)</VisuallyHidden>
+		</Anchor>{" "}
+		before you file an incident.
+	</p>
+</Example>
+
+```tsx
+import { Anchor } from "@ngrok/mantle/anchor";
+import { VisuallyHidden } from "@ngrok/mantle/visually-hidden";
+
+<p>
+	Read the{" "}
+	<Anchor href="https://status.ngrok.com" target="_blank" rel="noreferrer">
+		status page
+		<VisuallyHidden> (opens in a new tab)</VisuallyHidden>
+	</Anchor>{" "}
+	before you file an incident.
+</p>;
+```
+
+## Polymorphism
+
+`VisuallyHidden` accepts an `asChild` prop. When `true`, it renders its single child instead of its default `<span>`, forwarding its class names, `data-*` attributes, and ref onto that child. When the hidden content should be a more semantic element (a `<caption>`, a `<legend>`, a heading), reach for `asChild`.
+
+<Example>
+	<table className="w-full text-sm">
+		<VisuallyHidden asChild>
+			<caption>Monthly revenue by region</caption>
+		</VisuallyHidden>
+		<thead>
+			<tr>
+				<th className="text-left font-medium">Region</th>
+				<th className="text-right font-medium">Revenue</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>North America</td>
+				<td className="text-right">$1,204</td>
+			</tr>
+			<tr>
+				<td>Europe</td>
+				<td className="text-right">$986</td>
+			</tr>
+		</tbody>
+	</table>
+</Example>
+
+```tsx
+import { VisuallyHidden } from "@ngrok/mantle/visually-hidden";
+
+<table>
+	<VisuallyHidden asChild>
+		<caption>Monthly revenue by region</caption>
+	</VisuallyHidden>
+	<thead>
+		<tr>
+			<th>Region</th>
+			<th>Revenue</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>North America</td>
+			<td>$1,204</td>
+		</tr>
+		<tr>
+			<td>Europe</td>
+			<td>$986</td>
+		</tr>
+	</tbody>
+</table>;
+```
+
+## API Reference
+
+### VisuallyHidden
+
+All props from [span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span#attributes), plus:
+
+| Prop         | Type        | Default | Description                                                                                                                |
+| ------------ | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `asChild?`   | `boolean`   | `false` | Use the `asChild` prop to compose the `VisuallyHidden` hiding onto alternative element types or your own React components. |
+| `children`   | `ReactNode` |         | The content read to screen readers.                                                                                        |
+| `className?` | `string`    |         | Additional CSS classes to apply to the hidden element.                                                                     |
+
+#### Data attributes
+
+| Data Attribute | Value               | Description                                                               |
+| -------------- | ------------------- | ------------------------------------------------------------------------- |
+| `data-slot`    | `"visually-hidden"` | Stamped on the rendered element, and joined onto the child via `asChild`. |

--- a/apps/www/app/docs/components/primitives/visually-hidden.mdx
+++ b/apps/www/app/docs/components/primitives/visually-hidden.mdx
@@ -9,7 +9,7 @@ import { Example } from "~/components/example";
 
 # Visually Hidden
 
-Content for assistive technology only. `VisuallyHidden` renders a native `<span>` clipped to a one-pixel box (the `sr-only` technique, never `display: none`), so screen readers read the content and sighted users never see it. The content also stays in copied and searched text.
+Content for assistive technology only. `VisuallyHidden` renders a native `<span>` clipped to a one-pixel box (the `sr-only` technique, never `display: none`). Screen readers read the content; sighted users never see it. The content also stays in copied and searched text.
 
 **When to use**
 

--- a/apps/www/app/docs/components/primitives/visually-hidden.mdx
+++ b/apps/www/app/docs/components/primitives/visually-hidden.mdx
@@ -111,7 +111,7 @@ All props from [span](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
 | Prop         | Type        | Default | Description                                                                                                                |
 | ------------ | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `asChild?`   | `boolean`   | `false` | Use the `asChild` prop to compose the `VisuallyHidden` hiding onto alternative element types or your own React components. |
-| `children`   | `ReactNode` |         | The content read to screen readers.                                                                                        |
+| `children?`  | `ReactNode` |         | The content read to screen readers.                                                                                        |
 | `className?` | `string`    |         | Additional CSS classes to apply to the hidden element.                                                                     |
 
 #### Data attributes

--- a/apps/www/app/docs/recipes/route-announcer.mdx
+++ b/apps/www/app/docs/recipes/route-announcer.mdx
@@ -16,9 +16,11 @@ This site runs the exact file below. Turn on a screen reader and click through t
 ## Why a recipe, not a component
 
 The announcer needs one thing mantle cannot own: your router. `useLocation` here is React Router's;
-with TanStack Router or Next.js, swap that one import and keep everything else. Mantle ships the
-announcement mechanics as [LiveRegion](/components/primitives/live-region); this file is the router
-glue, and it lives in your app.
+with another router, read the pathname from its own location API. TanStack Router's `useLocation()`
+returns a location object, so the destructure carries over; Next.js's `usePathname()` returns the
+pathname string itself. Mantle ships the announcement mechanics as
+[LiveRegion](/components/primitives/live-region); this file is the router glue, and it lives in your
+app.
 
 ## The message
 
@@ -147,7 +149,7 @@ document order.
 Screen readers queue polite announcements across regions, so a toast that fires during a navigation
 reads back to back with the route announcement instead of clobbering it.
 
-One caveat: a modal [Dialog](/components/overlay/dialog) stamps `aria-hidden` on the other children
+One caveat: a modal [Dialog](/components/overlays/dialog) stamps `aria-hidden` on the other children
 of `<body>` while it is open, which mutes any live region outside it. A navigation normally closes
 the modal first, so this rarely bites, but an announcement raced against a closing modal can go
 unread.

--- a/apps/www/app/docs/recipes/route-announcer.mdx
+++ b/apps/www/app/docs/recipes/route-announcer.mdx
@@ -1,0 +1,352 @@
+---
+title: Route Announcer
+description: Announce completed client-side navigations to screen readers by pairing a persistent LiveRegion with React Router's location, with page-name fallbacks and repeat-message handling.
+---
+
+# Route Announcer
+
+A full page load announces itself: the browser fires a navigation event and the screen reader reads
+the new document title. A client-side navigation does neither. React Router swaps the route, the page
+repaints, and a screen reader user hears nothing. This recipe pairs a persistent
+[LiveRegion](/components/primitives/live-region) with `useLocation()` so every completed navigation
+publishes `Navigated to {page}`.
+
+This site runs the exact file below. Turn on a screen reader and click through the sidebar to hear it.
+
+## Why a recipe, not a component
+
+The announcer needs one thing mantle cannot own: your router. `useLocation` here is React Router's;
+with TanStack Router or Next.js, swap that one import and keep everything else. Mantle ships the
+announcement mechanics as [LiveRegion](/components/primitives/live-region); this file is the router
+glue, and it lives in your app.
+
+## The message
+
+The announcement reads `Navigated to {page}`. The prefix marks the message as a navigation. Without
+it, a bare page name lands mid-stream with no context and reads as unrelated status text.
+
+The page name resolves in order:
+
+1. **The page `<h1>`.** The most accurate name for where the user landed.
+2. **`document.title`.** The fallback when a page renders no heading. It can lag: a route without a
+   `meta` export keeps the previous page's title, which is why the heading wins.
+3. **The pathname.** The last resort, so the announcement never goes out empty.
+
+## Deliberate non-behaviors
+
+Three silences are on purpose:
+
+- **The initial document load stays silent.** The screen reader reads the document title itself on a
+  full load; announcing it again doubles it.
+- **Search-param and hash changes stay silent.** They are in-page state, not a new page. The effect
+  keys on `pathname` alone, so `?tab=examples` and `#api-reference` never announce.
+- **Focus never moves.** A focus move announces on its own, and the two announcements would race.
+  Announcing and moving focus are different recipes; this one only speaks.
+
+## Clearing before publishing
+
+A live region only announces a DOM change, and consecutive pages can resolve to the same text: two
+detail pages titled `Alert`, or two routes sharing a fallback title. Writing the same string again is
+not a change, so the second navigation stays silent. The effect clears the region first, then
+publishes on the next frame, so every navigation mutates the DOM even when the text repeats.
+
+## The component
+
+This is the one file to copy. Render it once, inside the router context in the root layout:
+
+````tsx
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * Announces completed client-side navigations to assistive technology.
+ *
+ * React Router swaps the route without a document load, so screen readers
+ * hear nothing. This component publishes "Navigated to {page}" to a
+ * persistent polite `LiveRegion` after each pathname change. The prefix marks
+ * the message as a navigation, so it does not read as unrelated status text.
+ *
+ * The announcement prefers the page `<h1>` over `document.title` because
+ * routes without a `meta` export keep the previous document title. The
+ * pathname is the last resort.
+ *
+ * Deliberate non-behaviors:
+ * - The initial document load stays silent; assistive technology reads the
+ *   document title itself.
+ * - Search-param and hash changes stay silent; they are in-page state.
+ * - Focus never moves; a focus move announces on its own, and the two
+ *   announcements would race.
+ *
+ * Render it once, inside the router context in the root layout.
+ *
+ * @example
+ * ```tsx
+ * <RouteAnnouncer />
+ * <ScrollRestoration />
+ * <Scripts />
+ * ```
+ */
+function RouteAnnouncer() {
+	const { pathname } = useLocation();
+	const [announcement, setAnnouncement] = useState("");
+	const previousPathname = useRef(pathname);
+
+	useEffect(() => {
+		if (previousPathname.current === pathname) {
+			return;
+		}
+		previousPathname.current = pathname;
+
+		const pageHeading = document.querySelector("h1")?.textContent?.trim();
+		const pageName = pageHeading || document.title || pathname;
+		const message = `Navigated to ${pageName}`;
+
+		// Clear first, then publish on the next frame. Consecutive pages can
+		// resolve to the same text, and a live region only announces a DOM change.
+		setAnnouncement("");
+		const frame = requestAnimationFrame(() => {
+			setAnnouncement(message);
+		});
+		return () => {
+			cancelAnimationFrame(frame);
+		};
+	}, [pathname]);
+
+	return <LiveRegion>{announcement}</LiveRegion>;
+}
+
+export {
+	//,
+	RouteAnnouncer,
+};
+````
+
+## Where it goes
+
+Mount it once per document, in the root layout, inside the router context. A live region announces
+reliably only when it already exists in the accessibility tree before its text changes, so it must
+render from first paint and never unmount. In a React Router app, next to `<ScrollRestoration />`
+works:
+
+```tsx
+<body>
+	<AppShell>{children}</AppShell>
+	<RouteAnnouncer />
+	<ScrollRestoration />
+	<Scripts />
+</body>
+```
+
+DOM position does not matter beyond that: a live region announces on content mutation, not on
+document order.
+
+## Coexisting with toasts
+
+[Toast](/components/feedback/toast) renders its own polite live region, and the two do not conflict.
+Screen readers queue polite announcements across regions, so a toast that fires during a navigation
+reads back to back with the route announcement instead of clobbering it.
+
+One caveat: a modal [Dialog](/components/overlay/dialog) stamps `aria-hidden` on the other children
+of `<body>` while it is open, which mutes any live region outside it. A navigation normally closes
+the modal first, so this rarely bites, but an announcement raced against a closing modal can go
+unread.
+
+## Testing it
+
+This is the component's test file, verbatim, and it runs in this repo. The publish lands one frame
+after the clearing write, so the `flushAnnouncement` helper waits out one `requestAnimationFrame`
+inside `act` before every assertion:
+
+```tsx
+// @vitest-environment happy-dom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { createMemoryRouter, MemoryRouter, Outlet, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { RouteAnnouncer } from "./route-announcer";
+
+afterEach(() => {
+	cleanup();
+});
+
+/**
+ * Renders the announcer in a persistent layout route, the way the app root
+ * hosts it, with leaf routes that cover the heading/no-heading branches.
+ */
+function renderWithRouter(initialPath = "/") {
+	const router = createMemoryRouter(
+		[
+			{
+				element: (
+					<>
+						<RouteAnnouncer />
+						<button type="button">persistent control</button>
+						<Outlet />
+					</>
+				),
+				children: [
+					{ path: "/", element: <h1>Home</h1> },
+					{ path: "/components", element: <h1>Components</h1> },
+					{ path: "/no-heading", element: <p>A page without a heading</p> },
+					{ path: "/components/feedback/alert", element: <h1>Alert</h1> },
+					{ path: "/components/feedback/toast", element: <h1>Alert</h1> },
+				],
+			},
+		],
+		{ initialEntries: [initialPath] },
+	);
+	render(<RouterProvider router={router} />);
+	return router;
+}
+
+/** Runs the announcer's next-frame publish, which follows the clearing write. */
+async function flushAnnouncement() {
+	await act(async () => {
+		await new Promise<void>((resolve) => {
+			requestAnimationFrame(() => {
+				resolve();
+			});
+		});
+	});
+}
+
+describe("RouteAnnouncer", () => {
+	beforeEach(() => {
+		document.title = "";
+	});
+
+	test("server-renders an empty polite live region", () => {
+		const html = renderToString(
+			<MemoryRouter>
+				<RouteAnnouncer />
+			</MemoryRouter>,
+		);
+
+		expect(html).toContain('role="status"');
+		expect(html).toContain('aria-live="polite"');
+	});
+
+	test("does not announce the initial page load", async () => {
+		renderWithRouter();
+
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("");
+	});
+
+	test("announces the new page heading after a navigation", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Components");
+	});
+
+	test("prefers the page heading over the document title", async () => {
+		const router = renderWithRouter();
+		document.title = "Stale title from the previous page";
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Components");
+	});
+
+	test("falls back to the document title when the page has no heading", async () => {
+		const router = renderWithRouter();
+		document.title = "Kbd — @ngrok/mantle";
+
+		await act(() => router.navigate("/no-heading"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Kbd — @ngrok/mantle");
+	});
+
+	test("falls back to the pathname when there is no heading and no title", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/no-heading"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Navigated to /no-heading");
+	});
+
+	test("stays silent when only the search params change", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/?tab=examples"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("");
+	});
+
+	test("stays silent when only the hash changes", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/#api-reference"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("");
+	});
+
+	test("announces again when the user returns to a previous page", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+		await act(() => router.navigate("/"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Home");
+	});
+
+	test("mutates the region even when two pages share the same heading", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/components/feedback/alert"));
+		await flushAnnouncement();
+		const region = screen.getByRole("status");
+		expect(region.textContent).toBe("Navigated to Alert");
+
+		// A live region only announces a DOM change. The clear-then-publish
+		// sequence must mutate the region even when the text is identical.
+		const mutations: MutationRecord[] = [];
+		const observer = new MutationObserver((records) => {
+			mutations.push(...records);
+		});
+		observer.observe(region, { characterData: true, childList: true, subtree: true });
+
+		await act(() => router.navigate("/components/feedback/toast"));
+		await flushAnnouncement();
+		mutations.push(...observer.takeRecords());
+		observer.disconnect();
+
+		expect(region.textContent).toBe("Navigated to Alert");
+		expect(mutations.length).toBeGreaterThan(0);
+	});
+
+	test("does not move focus when it announces", async () => {
+		const router = renderWithRouter();
+		const control = screen.getByRole("button", { name: "persistent control" });
+		control.focus();
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+
+		expect(document.activeElement).toBe(control);
+	});
+});
+```
+
+## Trade-offs
+
+- **`document.querySelector("h1")` takes the document's first `<h1>`.** In a one-`h1`-per-page app
+  (which yours should be), that is the page heading. A page that renders several gets whichever comes
+  first in the DOM.
+- **The heading must exist when the effect runs.** A page whose `<h1>` streams in later (deferred
+  data, a lazy boundary) falls back to `document.title` for that navigation. If that fallback reads
+  wrong, move the name into the route's `meta` export.
+- **English is baked into the prefix.** A localized app should pull `Navigated to` from its i18n
+  layer along with everything else on the page.

--- a/apps/www/app/features/route-announcer-fences.test.ts
+++ b/apps/www/app/features/route-announcer-fences.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The recipe page promises its fences are drop-in: copy the file, it runs. That
+ * only stays true if the fences and the real modules cannot drift, so this asserts
+ * each fence is byte-identical to the file it claims to be.
+ *
+ * If this fails, the fix is to re-copy the file into the fence, never to loosen
+ * the assertion. A recipe whose code does not run is worse than no recipe.
+ */
+const RECIPE = "app/docs/recipes/route-announcer.mdx";
+
+const FENCED_FILES = [
+	"app/features/route-announcer.tsx",
+	"app/features/route-announcer.test.tsx",
+] as const;
+
+/** This file's own location, two directories below the app root. */
+const APP_ROOT = new URL("../../", import.meta.url);
+
+/**
+ * Reads a path written relative to the app root. The paths above stay
+ * app-relative because they are the names the recipe page itself uses and the
+ * names that read best in test output, but they are resolved against this
+ * module's own URL rather than the process's working directory, which is not
+ * the app root under every runner and IDE.
+ */
+function readFromAppRoot(path: string): string {
+	return readFileSync(fileURLToPath(new URL(path, APP_ROOT)), "utf8");
+}
+
+/**
+ * Extracts every fenced `ts`/`tsx` block, allowing any fence length: a block
+ * whose own content contains a ``` fence (JSDoc `@example`) must be delimited by a
+ * longer run, and oxfmt normalizes those to four backticks.
+ */
+function fencedBlocks(markdown: string): ReadonlyArray<string> {
+	const blocks: Array<string> = [];
+	const pattern = /^(`{3,})(?:ts|tsx)\n([\s\S]*?)^\1$/gm;
+	let match = pattern.exec(markdown);
+	while (match != null) {
+		const [, , body] = match;
+		if (body != null) {
+			blocks.push(body.trimEnd());
+		}
+		match = pattern.exec(markdown);
+	}
+	return blocks;
+}
+
+describe("route announcer recipe fences", () => {
+	const markdown = readFromAppRoot(RECIPE);
+	const blocks = fencedBlocks(markdown);
+
+	it("finds fenced code on the recipe page", () => {
+		expect(blocks.length).toBeGreaterThan(0);
+	});
+
+	it.for(FENCED_FILES)("%s appears verbatim in the recipe", (path) => {
+		const source = readFromAppRoot(path).trimEnd();
+		expect(blocks).toContain(source);
+	});
+});

--- a/apps/www/app/features/route-announcer.test.tsx
+++ b/apps/www/app/features/route-announcer.test.tsx
@@ -80,7 +80,7 @@ describe("RouteAnnouncer", () => {
 		await act(() => router.navigate("/components"));
 		await flushAnnouncement();
 
-		expect(screen.getByRole("status").textContent).toBe("Components");
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Components");
 	});
 
 	test("prefers the page heading over the document title", async () => {
@@ -90,7 +90,7 @@ describe("RouteAnnouncer", () => {
 		await act(() => router.navigate("/components"));
 		await flushAnnouncement();
 
-		expect(screen.getByRole("status").textContent).toBe("Components");
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Components");
 	});
 
 	test("falls back to the document title when the page has no heading", async () => {
@@ -100,7 +100,7 @@ describe("RouteAnnouncer", () => {
 		await act(() => router.navigate("/no-heading"));
 		await flushAnnouncement();
 
-		expect(screen.getByRole("status").textContent).toBe("Kbd — @ngrok/mantle");
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Kbd — @ngrok/mantle");
 	});
 
 	test("falls back to the pathname when there is no heading and no title", async () => {
@@ -109,7 +109,7 @@ describe("RouteAnnouncer", () => {
 		await act(() => router.navigate("/no-heading"));
 		await flushAnnouncement();
 
-		expect(screen.getByRole("status").textContent).toBe("/no-heading");
+		expect(screen.getByRole("status").textContent).toBe("Navigated to /no-heading");
 	});
 
 	test("stays silent when only the search params change", async () => {
@@ -138,7 +138,7 @@ describe("RouteAnnouncer", () => {
 		await act(() => router.navigate("/"));
 		await flushAnnouncement();
 
-		expect(screen.getByRole("status").textContent).toBe("Home");
+		expect(screen.getByRole("status").textContent).toBe("Navigated to Home");
 	});
 
 	test("mutates the region even when two pages share the same heading", async () => {
@@ -147,7 +147,7 @@ describe("RouteAnnouncer", () => {
 		await act(() => router.navigate("/components/feedback/alert"));
 		await flushAnnouncement();
 		const region = screen.getByRole("status");
-		expect(region.textContent).toBe("Alert");
+		expect(region.textContent).toBe("Navigated to Alert");
 
 		// A live region only announces a DOM change. The clear-then-publish
 		// sequence must mutate the region even when the text is identical.
@@ -162,7 +162,7 @@ describe("RouteAnnouncer", () => {
 		mutations.push(...observer.takeRecords());
 		observer.disconnect();
 
-		expect(region.textContent).toBe("Alert");
+		expect(region.textContent).toBe("Navigated to Alert");
 		expect(mutations.length).toBeGreaterThan(0);
 	});
 

--- a/apps/www/app/features/route-announcer.test.tsx
+++ b/apps/www/app/features/route-announcer.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { createMemoryRouter, MemoryRouter, Outlet, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { RouteAnnouncer } from "./route-announcer";
+
+afterEach(() => {
+	cleanup();
+});
+
+/**
+ * Renders the announcer in a persistent layout route, the way the app root
+ * hosts it, with leaf routes that cover the heading/no-heading branches.
+ */
+function renderWithRouter(initialPath = "/") {
+	const router = createMemoryRouter(
+		[
+			{
+				element: (
+					<>
+						<RouteAnnouncer />
+						<button type="button">persistent control</button>
+						<Outlet />
+					</>
+				),
+				children: [
+					{ path: "/", element: <h1>Home</h1> },
+					{ path: "/components", element: <h1>Components</h1> },
+					{ path: "/no-heading", element: <p>A page without a heading</p> },
+					{ path: "/components/feedback/alert", element: <h1>Alert</h1> },
+					{ path: "/components/feedback/toast", element: <h1>Alert</h1> },
+				],
+			},
+		],
+		{ initialEntries: [initialPath] },
+	);
+	render(<RouterProvider router={router} />);
+	return router;
+}
+
+/** Runs the announcer's next-frame publish, which follows the clearing write. */
+async function flushAnnouncement() {
+	await act(async () => {
+		await new Promise<void>((resolve) => {
+			requestAnimationFrame(() => {
+				resolve();
+			});
+		});
+	});
+}
+
+describe("RouteAnnouncer", () => {
+	beforeEach(() => {
+		document.title = "";
+	});
+
+	test("server-renders an empty polite live region", () => {
+		const html = renderToString(
+			<MemoryRouter>
+				<RouteAnnouncer />
+			</MemoryRouter>,
+		);
+
+		expect(html).toContain('role="status"');
+		expect(html).toContain('aria-live="polite"');
+	});
+
+	test("does not announce the initial page load", async () => {
+		renderWithRouter();
+
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("");
+	});
+
+	test("announces the new page heading after a navigation", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Components");
+	});
+
+	test("prefers the page heading over the document title", async () => {
+		const router = renderWithRouter();
+		document.title = "Stale title from the previous page";
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Components");
+	});
+
+	test("falls back to the document title when the page has no heading", async () => {
+		const router = renderWithRouter();
+		document.title = "Kbd — @ngrok/mantle";
+
+		await act(() => router.navigate("/no-heading"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Kbd — @ngrok/mantle");
+	});
+
+	test("falls back to the pathname when there is no heading and no title", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/no-heading"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("/no-heading");
+	});
+
+	test("stays silent when only the search params change", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/?tab=examples"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("");
+	});
+
+	test("stays silent when only the hash changes", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/#api-reference"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("");
+	});
+
+	test("announces again when the user returns to a previous page", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+		await act(() => router.navigate("/"));
+		await flushAnnouncement();
+
+		expect(screen.getByRole("status").textContent).toBe("Home");
+	});
+
+	test("mutates the region even when two pages share the same heading", async () => {
+		const router = renderWithRouter();
+
+		await act(() => router.navigate("/components/feedback/alert"));
+		await flushAnnouncement();
+		const region = screen.getByRole("status");
+		expect(region.textContent).toBe("Alert");
+
+		// A live region only announces a DOM change. The clear-then-publish
+		// sequence must mutate the region even when the text is identical.
+		const mutations: MutationRecord[] = [];
+		const observer = new MutationObserver((records) => {
+			mutations.push(...records);
+		});
+		observer.observe(region, { characterData: true, childList: true, subtree: true });
+
+		await act(() => router.navigate("/components/feedback/toast"));
+		await flushAnnouncement();
+		mutations.push(...observer.takeRecords());
+		observer.disconnect();
+
+		expect(region.textContent).toBe("Alert");
+		expect(mutations.length).toBeGreaterThan(0);
+	});
+
+	test("does not move focus when it announces", async () => {
+		const router = renderWithRouter();
+		const control = screen.getByRole("button", { name: "persistent control" });
+		control.focus();
+
+		await act(() => router.navigate("/components"));
+		await flushAnnouncement();
+
+		expect(document.activeElement).toBe(control);
+	});
+});

--- a/apps/www/app/features/route-announcer.tsx
+++ b/apps/www/app/features/route-announcer.tsx
@@ -6,8 +6,9 @@ import { useLocation } from "react-router";
  * Announces completed client-side navigations to assistive technology.
  *
  * React Router swaps the route without a document load, so screen readers
- * hear nothing. This component publishes the new page's name to a persistent
- * polite `LiveRegion` after each pathname change.
+ * hear nothing. This component publishes "Navigated to {page}" to a
+ * persistent polite `LiveRegion` after each pathname change. The prefix marks
+ * the message as a navigation, so it does not read as unrelated status text.
  *
  * The announcement prefers the page `<h1>` over `document.title` because
  * routes without a `meta` export keep the previous document title. The
@@ -41,7 +42,8 @@ function RouteAnnouncer() {
 		previousPathname.current = pathname;
 
 		const pageHeading = document.querySelector("h1")?.textContent?.trim();
-		const message = pageHeading || document.title || pathname;
+		const pageName = pageHeading || document.title || pathname;
+		const message = `Navigated to ${pageName}`;
 
 		// Clear first, then publish on the next frame. Consecutive pages can
 		// resolve to the same text, and a live region only announces a DOM change.

--- a/apps/www/app/features/route-announcer.tsx
+++ b/apps/www/app/features/route-announcer.tsx
@@ -1,0 +1,63 @@
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * Announces completed client-side navigations to assistive technology.
+ *
+ * React Router swaps the route without a document load, so screen readers
+ * hear nothing. This component publishes the new page's name to a persistent
+ * polite `LiveRegion` after each pathname change.
+ *
+ * The announcement prefers the page `<h1>` over `document.title` because
+ * routes without a `meta` export keep the previous document title. The
+ * pathname is the last resort.
+ *
+ * Deliberate non-behaviors:
+ * - The initial document load stays silent; assistive technology reads the
+ *   document title itself.
+ * - Search-param and hash changes stay silent; they are in-page state.
+ * - Focus never moves; a focus move announces on its own, and the two
+ *   announcements would race.
+ *
+ * Render it once, inside the router context in the root layout.
+ *
+ * @example
+ * ```tsx
+ * <RouteAnnouncer />
+ * <ScrollRestoration />
+ * <Scripts />
+ * ```
+ */
+function RouteAnnouncer() {
+	const { pathname } = useLocation();
+	const [announcement, setAnnouncement] = useState("");
+	const previousPathname = useRef(pathname);
+
+	useEffect(() => {
+		if (previousPathname.current === pathname) {
+			return;
+		}
+		previousPathname.current = pathname;
+
+		const pageHeading = document.querySelector("h1")?.textContent?.trim();
+		const message = pageHeading || document.title || pathname;
+
+		// Clear first, then publish on the next frame. Consecutive pages can
+		// resolve to the same text, and a live region only announces a DOM change.
+		setAnnouncement("");
+		const frame = requestAnimationFrame(() => {
+			setAnnouncement(message);
+		});
+		return () => {
+			cancelAnimationFrame(frame);
+		};
+	}, [pathname]);
+
+	return <LiveRegion>{announcement}</LiveRegion>;
+}
+
+export {
+	//,
+	RouteAnnouncer,
+};

--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -34,6 +34,7 @@ import { Header } from "./components/header";
 import { NavigationProvider } from "./components/navigation-context";
 import { PageContainer } from "./components/page-container";
 import { useNonce } from "./components/nonce";
+import { RouteAnnouncer } from "./features/route-announcer";
 import "./global.css";
 import { canonicalDomain, canonicalHref } from "./utilities/canonical-origin";
 import { parseMantleVersion } from "./utilities/mantle-version.server";
@@ -218,6 +219,10 @@ export function Layout({ children }: PropsWithChildren) {
 						</QueryClientProvider>
 					</TooltipProvider>
 				</ThemeProvider>
+				{/* Suppressed inside framed example previews: nothing navigates inside
+				    the preview iframe, and each iframe would add its own status region
+				    to the page. */}
+				{!isFramedPreview && <RouteAnnouncer />}
 				<ScrollRestoration nonce={nonce} />
 				<Scripts nonce={nonce} />
 			</body>

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -143,7 +143,7 @@ const docsPages = [
 const layoutsPages = ["app-layout", "centered-layout"];
 
 // recipes section: compositional how-tos spanning multiple primitives
-const recipesPages = ["breadcrumbs-from-routes", "overlay-async"];
+const recipesPages = ["breadcrumbs-from-routes", "overlay-async", "route-announcer"];
 
 // migrations section
 const migrationsPages = [

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -112,11 +112,13 @@ const docsPages = [
 	"components/preview/calendar",
 	// primitives
 	"components/primitives/browser-only",
+	"components/primitives/live-region",
 	"components/primitives/main",
 	"components/primitives/sandboxed-on-click",
 	"components/primitives/skip-to-main-link",
 	"components/primitives/slot",
 	"components/primitives/theme",
+	"components/primitives/visually-hidden",
 	// structure
 	"components/structure/card",
 	"components/structure/media-object",

--- a/apps/www/app/utilities/__snapshots__/components-surface.json
+++ b/apps/www/app/utilities/__snapshots__/components-surface.json
@@ -519,6 +519,19 @@
     ]
   },
   {
+    "name": "Live Region",
+    "slug": "components/primitives/live-region",
+    "kind": "component",
+    "category": "Primitives",
+    "status": "stable",
+    "importPath": "@ngrok/mantle/live-region",
+    "summary": "A persistent, visually hidden region that announces its text to screen readers when the text changes.",
+    "jsdoc": "Announces its text to screen readers when the text changes.",
+    "examples": [
+      "```tsx\nimport { LiveRegion } from \"@ngrok/mantle/live-region\";\n\n// Mount the region before the first message, then swap the message.\nfunction SearchResults({ results }: { results: string[] }) {\n  return (\n    <>\n      <LiveRegion>{`${results.length} results found`}</LiveRegion>\n      <ul>\n        {results.map((result) => (\n          <li key={result}>{result}</li>\n        ))}\n      </ul>\n    </>\n  );\n}\n```"
+    ]
+  },
+  {
     "name": "Main",
     "slug": "components/primitives/main",
     "kind": "component",
@@ -950,6 +963,19 @@
     "examples": [
       "Composition:\n```\nTooltip.Root\n├── Tooltip.Trigger\n└── Tooltip.Content\n```",
       "```tsx\n<Tooltip.Root>\n  <Tooltip.Trigger asChild>\n    <Button type=\"button\" appearance=\"outlined\" intent=\"neutral\">\n      Hover me\n    </Button>\n  </Tooltip.Trigger>\n  <Tooltip.Content>\n    This is a tooltip\n  </Tooltip.Content>\n</Tooltip.Root>\n```"
+    ]
+  },
+  {
+    "name": "Visually Hidden",
+    "slug": "components/primitives/visually-hidden",
+    "kind": "component",
+    "category": "Primitives",
+    "status": "stable",
+    "importPath": "@ngrok/mantle/visually-hidden",
+    "summary": "Render content that screen readers announce and sighted users never see.",
+    "jsdoc": "Content for assistive technology only.",
+    "examples": [
+      "```tsx\nimport { VisuallyHidden } from \"@ngrok/mantle/visually-hidden\";\n\n<a href=\"https://status.ngrok.com\" target=\"_blank\" rel=\"noreferrer\">\n  ngrok status\n  <VisuallyHidden> (opens in a new tab)</VisuallyHidden>\n</a>\n```"
     ]
   },
   {

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -255,6 +255,11 @@
 			"types": "./dist/list.d.ts",
 			"import": "./dist/list.js"
 		},
+		"./live-region": {
+			"@ngrok/src-live-types": "./src/components/live-region/index.ts",
+			"types": "./dist/live-region.d.ts",
+			"import": "./dist/live-region.js"
+		},
 		"./main": {
 			"@ngrok/src-live-types": "./src/components/main/index.ts",
 			"types": "./dist/main.d.ts",
@@ -414,6 +419,11 @@
 			"@ngrok/src-live-types": "./src/utils/index.ts",
 			"types": "./dist/utils.d.ts",
 			"import": "./dist/utils.js"
+		},
+		"./visually-hidden": {
+			"@ngrok/src-live-types": "./src/components/visually-hidden/index.ts",
+			"types": "./dist/visually-hidden.d.ts",
+			"import": "./dist/visually-hidden.js"
 		},
 		"./well": {
 			"@ngrok/src-live-types": "./src/components/well/index.ts",

--- a/packages/mantle/src/components/live-region/index.ts
+++ b/packages/mantle/src/components/live-region/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Re-exports for the LiveRegion component.
+ *
+ * @see https://mantle.ngrok.com/components/primitives/live-region
+ */
+
+export {
+	//,
+	LiveRegion,
+} from "./live-region.js";

--- a/packages/mantle/src/components/live-region/live-region.test.tsx
+++ b/packages/mantle/src/components/live-region/live-region.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { LiveRegion } from "./live-region.js";
+
+describe("LiveRegion", () => {
+	test("renders a polite status region by default", () => {
+		render(<LiveRegion data-testid="region">Draft saved</LiveRegion>);
+		const region = screen.getByTestId("region");
+		expect(region.tagName).toBe("SPAN");
+		expect(region).toHaveAttribute("data-slot", "live-region");
+		expect(region).toHaveAttribute("role", "status");
+		expect(region).toHaveAttribute("aria-live", "polite");
+		expect(region).toHaveAttribute("aria-atomic", "true");
+		expect(region).toHaveTextContent("Draft saved");
+	});
+
+	test("renders an alert region when politeness is assertive", () => {
+		render(
+			<LiveRegion data-testid="region" politeness="assertive">
+				Session expired
+			</LiveRegion>,
+		);
+		const region = screen.getByTestId("region");
+		expect(region).toHaveAttribute("role", "alert");
+		expect(region).toHaveAttribute("aria-live", "assertive");
+	});
+
+	test("is visually hidden by the sr-only class", () => {
+		render(<LiveRegion data-testid="region">Draft saved</LiveRegion>);
+		// The class is the only observable implementation of the hiding contract:
+		// happy-dom computes no layout, so the clipping itself is not assertable.
+		expect(screen.getByTestId("region").className.split(" ")).toContain("sr-only");
+	});
+
+	test("keeps the same element mounted across message changes", () => {
+		const { rerender } = render(<LiveRegion data-testid="region">3 results found</LiveRegion>);
+		const region = screen.getByTestId("region");
+		rerender(<LiveRegion data-testid="region">5 results found</LiveRegion>);
+		// Same node: screen readers only announce text that changes inside an
+		// existing region, so a remount would silently break the contract.
+		expect(screen.getByTestId("region")).toBe(region);
+		expect(region).toHaveTextContent("5 results found");
+	});
+
+	test("stays mounted and empty before the first message", () => {
+		render(<LiveRegion data-testid="region" />);
+		const region = screen.getByTestId("region");
+		expect(region).toHaveAttribute("role", "status");
+		expect(region.textContent).toBe("");
+	});
+
+	test("server-renders the region so it exists before hydration", () => {
+		const html = renderToString(<LiveRegion />);
+		expect(html).toContain('role="status"');
+		expect(html).toContain('aria-live="polite"');
+	});
+
+	test("lets a consumer's role prop win over the derived role", () => {
+		render(
+			<LiveRegion data-testid="region" role="log">
+				new chat message
+			</LiveRegion>,
+		);
+		expect(screen.getByTestId("region")).toHaveAttribute("role", "log");
+	});
+
+	test("forwards ref to the underlying span", () => {
+		const ref = createRef<HTMLSpanElement>();
+		render(<LiveRegion ref={ref}>Draft saved</LiveRegion>);
+		expect(ref.current).toBe(screen.getByText("Draft saved"));
+	});
+
+	test("forwards arbitrary data-* props", () => {
+		render(
+			<LiveRegion data-testid="region" data-analytics-id="route-announcer">
+				Dashboard
+			</LiveRegion>,
+		);
+		expect(screen.getByTestId("region")).toHaveAttribute("data-analytics-id", "route-announcer");
+	});
+
+	test("asChild renders its child, merging classes, attributes, and the ref onto it", () => {
+		const ref = createRef<HTMLParagraphElement>();
+		render(
+			<LiveRegion asChild className="custom-class" politeness="assertive">
+				<p data-testid="region" ref={ref}>
+					Session expired
+				</p>
+			</LiveRegion>,
+		);
+		const region = screen.getByTestId("region");
+		expect(region.tagName).toBe("P");
+		expect(region).toHaveAttribute("data-slot", "live-region");
+		expect(region).toHaveAttribute("role", "alert");
+		expect(region).toHaveAttribute("aria-live", "assertive");
+		// Split before matching: a substring check would also match `not-sr-only`.
+		const classes = region.className.split(" ");
+		expect(classes).toContain("custom-class");
+		expect(classes).toContain("sr-only");
+		expect(ref.current).toBe(region);
+	});
+});

--- a/packages/mantle/src/components/live-region/live-region.test.tsx
+++ b/packages/mantle/src/components/live-region/live-region.test.tsx
@@ -24,7 +24,9 @@ describe("LiveRegion", () => {
 		);
 		const region = screen.getByTestId("region");
 		expect(region).toHaveAttribute("role", "alert");
-		expect(region).toHaveAttribute("aria-live", "assertive");
+		// role="alert" already carries assertive live-region semantics, and a
+		// redundant aria-live double-speaks in VoiceOver on iOS.
+		expect(region).not.toHaveAttribute("aria-live");
 	});
 
 	test("is visually hidden by the sr-only class", () => {
@@ -57,13 +59,15 @@ describe("LiveRegion", () => {
 		expect(html).toContain('aria-live="polite"');
 	});
 
-	test("lets a consumer's role prop win over the derived role", () => {
+	test("lets a consumer's role and aria-live props win over the derived pair", () => {
 		render(
-			<LiveRegion data-testid="region" role="log">
+			<LiveRegion data-testid="region" role="log" aria-live="off">
 				new chat message
 			</LiveRegion>,
 		);
-		expect(screen.getByTestId("region")).toHaveAttribute("role", "log");
+		const region = screen.getByTestId("region");
+		expect(region).toHaveAttribute("role", "log");
+		expect(region).toHaveAttribute("aria-live", "off");
 	});
 
 	test("forwards ref to the underlying span", () => {
@@ -94,7 +98,7 @@ describe("LiveRegion", () => {
 		expect(region.tagName).toBe("P");
 		expect(region).toHaveAttribute("data-slot", "live-region");
 		expect(region).toHaveAttribute("role", "alert");
-		expect(region).toHaveAttribute("aria-live", "assertive");
+		expect(region).not.toHaveAttribute("aria-live");
 		// Split before matching: a substring check would also match `not-sr-only`.
 		const classes = region.className.split(" ");
 		expect(classes).toContain("custom-class");

--- a/packages/mantle/src/components/live-region/live-region.tsx
+++ b/packages/mantle/src/components/live-region/live-region.tsx
@@ -18,12 +18,12 @@ type LiveRegionProps = ComponentProps<"span"> &
 /**
  * Announces its text to screen readers when the text changes. Renders a
  * persistent, visually hidden `<span>` live region with `role="status"` and
- * `aria-live="polite"` (or `role="alert"` and `aria-live="assertive"` when
- * `politeness` is `"assertive"`).
+ * `aria-live="polite"`. When `politeness` is `"assertive"`, it renders
+ * `role="alert"` and `aria-live="assertive"`.
  *
  * A live region announces reliably only when it already exists in the
- * accessibility tree before its text changes, so keep `LiveRegion` mounted
- * from first paint and swap only its children. A screen reader does not
+ * accessibility tree before its text changes. Keep `LiveRegion` mounted from
+ * first paint and swap only its children. A screen reader does not
  * re-announce a message identical to the previous one; when the same message
  * must repeat, clear the children first. The derived `role` and `aria-live`
  * read as defaults: a `role` or `aria-live` prop wins.
@@ -38,6 +38,10 @@ type LiveRegionProps = ComponentProps<"span"> &
  *
  * **Polymorphism.** Pass `asChild` to render the live region as a different
  * element instead of the default `<span>`.
+ *
+ * | Data Attribute | Value           | Description                                                               |
+ * | -------------- | --------------- | ------------------------------------------------------------------------- |
+ * | `data-slot`    | `"live-region"` | Stamped on the rendered element, and joined onto the child via `asChild`. |
  *
  * @see https://mantle.ngrok.com/components/primitives/live-region
  * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions

--- a/packages/mantle/src/components/live-region/live-region.tsx
+++ b/packages/mantle/src/components/live-region/live-region.tsx
@@ -19,7 +19,9 @@ type LiveRegionProps = ComponentProps<"span"> &
  * Announces its text to screen readers when the text changes. Renders a
  * persistent, visually hidden `<span>` live region with `role="status"` and
  * `aria-live="polite"`. When `politeness` is `"assertive"`, it renders
- * `role="alert"` and `aria-live="assertive"`.
+ * `role="alert"` alone: the role already carries assertive live-region
+ * semantics, and a redundant `aria-live` makes VoiceOver on iOS announce the
+ * message twice.
  *
  * A live region announces reliably only when it already exists in the
  * accessibility tree before its text changes. Keep `LiveRegion` mounted from
@@ -77,10 +79,11 @@ const LiveRegion = ({
 		<Comp
 			ref={ref}
 			data-slot="live-region"
-			// Why both role and aria-live: some screen reader and browser pairs
-			// honor only one of the two, so the region stamps the pair.
+			// Why a redundant aria-live next to role="status" only: some screen
+			// reader and browser pairs honor only one of the two, but the same
+			// pairing with role="alert" double-speaks in VoiceOver on iOS.
 			role={politeness === "assertive" ? "alert" : "status"}
-			aria-live={politeness}
+			aria-live={politeness === "assertive" ? undefined : "polite"}
 			aria-atomic="true"
 			className={cx("sr-only", className)}
 			{...props}

--- a/packages/mantle/src/components/live-region/live-region.tsx
+++ b/packages/mantle/src/components/live-region/live-region.tsx
@@ -1,0 +1,90 @@
+import type { ComponentProps } from "react";
+import type { WithAsChild } from "../../types/as-child.js";
+import { cx } from "../../utils/cx/cx.js";
+import { Slot } from "../slot/index.js";
+
+type LiveRegionProps = ComponentProps<"span"> &
+	WithAsChild & {
+		/**
+		 * How urgently a screen reader announces a changed message: `"polite"`
+		 * waits for the current utterance to finish, `"assertive"` interrupts it.
+		 * `"polite"` renders `role="status"`; `"assertive"` renders `role="alert"`.
+		 *
+		 * @default "polite"
+		 */
+		politeness?: "polite" | "assertive";
+	};
+
+/**
+ * Announces its text to screen readers when the text changes. Renders a
+ * persistent, visually hidden `<span>` live region with `role="status"` and
+ * `aria-live="polite"` (or `role="alert"` and `aria-live="assertive"` when
+ * `politeness` is `"assertive"`).
+ *
+ * A live region announces reliably only when it already exists in the
+ * accessibility tree before its text changes, so keep `LiveRegion` mounted
+ * from first paint and swap only its children. A screen reader does not
+ * re-announce a message identical to the previous one; when the same message
+ * must repeat, clear the children first. The derived `role` and `aria-live`
+ * read as defaults: a `role` or `aria-live` prop wins.
+ *
+ * **When to use**
+ * - Announce a completed client-side navigation: the new page name, after a route change.
+ * - Announce an async result that moves focus nowhere: "3 results found", "Draft saved".
+ *
+ * **When not to use**
+ * - For status the user must see. Use {@link https://mantle.ngrok.com/components/feedback/alert Alert} or {@link https://mantle.ngrok.com/components/feedback/toast Toast}, which pair visible UI with their own announcements.
+ * - For hidden text that never changes. Use {@link https://mantle.ngrok.com/components/primitives/visually-hidden VisuallyHidden}.
+ *
+ * **Polymorphism.** Pass `asChild` to render the live region as a different
+ * element instead of the default `<span>`.
+ *
+ * @see https://mantle.ngrok.com/components/primitives/live-region
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions
+ *
+ * @example
+ * ```tsx
+ * import { LiveRegion } from "@ngrok/mantle/live-region";
+ *
+ * // Mount the region before the first message, then swap the message.
+ * function SearchResults({ results }: { results: string[] }) {
+ *   return (
+ *     <>
+ *       <LiveRegion>{`${results.length} results found`}</LiveRegion>
+ *       <ul>
+ *         {results.map((result) => (
+ *           <li key={result}>{result}</li>
+ *         ))}
+ *       </ul>
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+const LiveRegion = ({
+	asChild,
+	className,
+	politeness = "polite",
+	ref,
+	...props
+}: LiveRegionProps) => {
+	const Comp = asChild ? Slot : "span";
+	return (
+		<Comp
+			ref={ref}
+			data-slot="live-region"
+			// Why both role and aria-live: some screen reader and browser pairs
+			// honor only one of the two, so the region stamps the pair.
+			role={politeness === "assertive" ? "alert" : "status"}
+			aria-live={politeness}
+			aria-atomic="true"
+			className={cx("sr-only", className)}
+			{...props}
+		/>
+	);
+};
+
+export {
+	//,
+	LiveRegion,
+};

--- a/packages/mantle/src/components/visually-hidden/index.ts
+++ b/packages/mantle/src/components/visually-hidden/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Re-exports for the VisuallyHidden component.
+ *
+ * @see https://mantle.ngrok.com/components/primitives/visually-hidden
+ */
+
+export {
+	//,
+	VisuallyHidden,
+} from "./visually-hidden.js";

--- a/packages/mantle/src/components/visually-hidden/visually-hidden.test.tsx
+++ b/packages/mantle/src/components/visually-hidden/visually-hidden.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, test } from "vitest";
+import { VisuallyHidden } from "./visually-hidden.js";
+
+describe("VisuallyHidden", () => {
+	test("renders a span with its data-slot and the sr-only class", () => {
+		render(<VisuallyHidden data-testid="hidden">(opens in a new tab)</VisuallyHidden>);
+		const element = screen.getByTestId("hidden");
+		expect(element.tagName).toBe("SPAN");
+		expect(element).toHaveAttribute("data-slot", "visually-hidden");
+		// The class is the only observable implementation of the hiding contract:
+		// happy-dom computes no layout, so the clipping itself is not assertable.
+		expect(element.className.split(" ")).toContain("sr-only");
+		expect(element).toHaveTextContent("(opens in a new tab)");
+	});
+
+	test("lets the consumer's not-sr-only replace the default sr-only", () => {
+		render(
+			<VisuallyHidden data-testid="hidden" className="not-sr-only">
+				visible after all
+			</VisuallyHidden>,
+		);
+		// A tailwind-merge override contract: `sr-only` and `not-sr-only` share a
+		// merge group, so the consumer's class replaces the default rather than
+		// landing beside it.
+		const classes = screen.getByTestId("hidden").className.split(" ");
+		expect(classes).toContain("not-sr-only");
+		expect(classes).not.toContain("sr-only");
+	});
+
+	test("forwards ref to the underlying span", () => {
+		const ref = createRef<HTMLSpanElement>();
+		render(<VisuallyHidden ref={ref}>screen reader text</VisuallyHidden>);
+		expect(ref.current).toBe(screen.getByText("screen reader text"));
+	});
+
+	test("forwards arbitrary data-* props", () => {
+		render(
+			<VisuallyHidden data-testid="hidden" data-analytics-id="sr-note">
+				note
+			</VisuallyHidden>,
+		);
+		expect(screen.getByTestId("hidden")).toHaveAttribute("data-analytics-id", "sr-note");
+	});
+
+	test("asChild renders its child, merging classes, data-slot, and the ref onto it", () => {
+		const ref = createRef<HTMLTableCaptionElement>();
+		render(
+			<table>
+				<VisuallyHidden asChild className="custom-class">
+					<caption data-testid="caption" ref={ref}>
+						Monthly revenue by region
+					</caption>
+				</VisuallyHidden>
+				<tbody>
+					<tr>
+						<td>North</td>
+					</tr>
+				</tbody>
+			</table>,
+		);
+		const caption = screen.getByTestId("caption");
+		expect(caption.tagName).toBe("CAPTION");
+		expect(caption).toHaveAttribute("data-slot", "visually-hidden");
+		// Split before matching: a substring check would also match `not-sr-only`.
+		const classes = caption.className.split(" ");
+		expect(classes).toContain("custom-class");
+		expect(classes).toContain("sr-only");
+		expect(ref.current).toBe(caption);
+	});
+});

--- a/packages/mantle/src/components/visually-hidden/visually-hidden.tsx
+++ b/packages/mantle/src/components/visually-hidden/visually-hidden.tsx
@@ -5,8 +5,8 @@ import { Slot } from "../slot/index.js";
 
 /**
  * Content for assistive technology only. Renders a native `<span>` clipped to
- * a one-pixel box (the `sr-only` technique, never `display: none`), so screen
- * readers read the content and sighted users never see it.
+ * a one-pixel box (the `sr-only` technique, never `display: none`). Screen
+ * readers read the content; sighted users never see it.
  *
  * **When to use**
  * - State context the visual design already carries: "(opens in a new tab)" on an external link, a caption on a layout table.
@@ -20,6 +20,10 @@ import { Slot } from "../slot/index.js";
  *
  * **Polymorphism.** Pass `asChild` to hide a more semantic element instead of
  * the default `<span>` (a `<caption>`, a `<legend>`, a heading).
+ *
+ * | Data Attribute | Value               | Description                                                               |
+ * | -------------- | ------------------- | ------------------------------------------------------------------------- |
+ * | `data-slot`    | `"visually-hidden"` | Stamped on the rendered element, and joined onto the child via `asChild`. |
  *
  * @see https://mantle.ngrok.com/components/primitives/visually-hidden
  * @see https://webaim.org/techniques/css/invisiblecontent/

--- a/packages/mantle/src/components/visually-hidden/visually-hidden.tsx
+++ b/packages/mantle/src/components/visually-hidden/visually-hidden.tsx
@@ -1,0 +1,52 @@
+import type { ComponentProps } from "react";
+import type { WithAsChild } from "../../types/as-child.js";
+import { cx } from "../../utils/cx/cx.js";
+import { Slot } from "../slot/index.js";
+
+/**
+ * Content for assistive technology only. Renders a native `<span>` clipped to
+ * a one-pixel box (the `sr-only` technique, never `display: none`), so screen
+ * readers read the content and sighted users never see it.
+ *
+ * **When to use**
+ * - State context the visual design already carries: "(opens in a new tab)" on an external link, a caption on a layout table.
+ * - Give a screen reader a text alternative for content it cannot read, such as a decorative chart.
+ * - Style the message of a {@link https://mantle.ngrok.com/components/primitives/live-region LiveRegion}, which builds on the same technique.
+ *
+ * **When not to use**
+ * - To name an icon-only control. Voice-control software skips a control whose only label is hidden DOM text, so use `aria-label`, as {@link https://mantle.ngrok.com/components/actions/icon-button IconButton}'s required `label` prop does.
+ * - To hide content from assistive technology too. Use the `hidden` attribute or `aria-hidden`.
+ * - For a link that appears on focus. Use {@link https://mantle.ngrok.com/components/primitives/skip-to-main-link SkipToMainLink}.
+ *
+ * **Polymorphism.** Pass `asChild` to hide a more semantic element instead of
+ * the default `<span>` (a `<caption>`, a `<legend>`, a heading).
+ *
+ * @see https://mantle.ngrok.com/components/primitives/visually-hidden
+ * @see https://webaim.org/techniques/css/invisiblecontent/
+ *
+ * @example
+ * ```tsx
+ * import { VisuallyHidden } from "@ngrok/mantle/visually-hidden";
+ *
+ * <a href="https://status.ngrok.com" target="_blank" rel="noreferrer">
+ *   ngrok status
+ *   <VisuallyHidden> (opens in a new tab)</VisuallyHidden>
+ * </a>
+ * ```
+ */
+const VisuallyHidden = ({
+	asChild,
+	className,
+	ref,
+	...props
+}: ComponentProps<"span"> & WithAsChild) => {
+	const Comp = asChild ? Slot : "span";
+	return (
+		<Comp ref={ref} data-slot="visually-hidden" className={cx("sr-only", className)} {...props} />
+	);
+};
+
+export {
+	//,
+	VisuallyHidden,
+};


### PR DESCRIPTION
Closes #1462.

## Why

Mantle ships no router-agnostic way to announce a client-side navigation or hide text for assistive technology. Consumers hand-roll `sr-only` spans, and four mantle components each carry a private live region.

## What

- `VisuallyHidden` (Primitives): a `<span>` hidden with the `sr-only` technique, with `asChild` to hide a more semantic element (a `<caption>`, a `<legend>`, a heading). The docs warn against hidden-text labels on icon-only controls, which voice-control software skips.
- `LiveRegion` (Primitives): a persistent, visually hidden live region. The `politeness` prop derives `role="status"` / `aria-live="polite"` or `role="alert"` / `aria-live="assertive"`, plus `aria-atomic="true"`; a consumer's `role` or `aria-live` prop wins.
- The docs site renders a `RouteAnnouncer` built on `LiveRegion`, matching the announcer the frontend monorepo ships in every app root. After each pathname change it announces `Navigated to {page}`: the page `<h1>`, then `document.title`, then the pathname. The prefix marks the message as a navigation. The initial load, search-param changes, and hash changes stay silent, and focus never moves.
- A Route Announcer recipe at `/recipes/route-announcer` explains the pattern and inlines `route-announcer.tsx` and its test file verbatim. A fences test keeps the recipe and the modules byte-identical, the same guard the breadcrumbs recipe uses.

Changesets: one `minor` per component for `@ngrok/mantle`. #1464 removed `mantleTwSourcePlugin`, so the new subpaths need no `@ngrok/mantle-vite-plugins` changeset: `source-all.css` already scans the whole `dist` directory.
