### PR TITLE
fix(www): render headings in the body font, not Family

### DIFF
--- a/apps/www/app/components/error-page.tsx
+++ b/apps/www/app/components/error-page.tsx
@@ -20,12 +20,12 @@ export function ErrorPage({ status }: ErrorPageProps) {
 	return (
 		<section className="relative flex min-h-[70vh] flex-col items-center justify-center px-4 py-12 text-center md:py-20">
 			<div className="relative flex flex-col items-center gap-8">
-				<p className="font-family text-strong text-8xl leading-none md:text-9xl">
+				<p className="font-medium text-strong text-8xl leading-none md:text-9xl">
 					<span className="bg-[linear-gradient(98deg,var(--color-amber-700)_1.35%,var(--color-lime-700)_18.48%,var(--color-emerald-700)_38.35%,var(--color-sky-700)_58.63%,var(--color-purple-700)_79.7%,var(--color-rose-700)_100%)] bg-clip-text text-transparent">
 						{status}
 					</span>
 				</p>
-				<h1 className="font-family text-strong max-w-xl text-5xl leading-none md:text-6xl">
+				<h1 className="font-medium text-strong max-w-xl text-5xl leading-none md:text-6xl">
 					{isNotFound ? (
 						<>
 							We haven’t shrimped that page yet.{" "}

--- a/apps/www/app/components/hash-link-heading.tsx
+++ b/apps/www/app/components/hash-link-heading.tsx
@@ -64,7 +64,7 @@ function HashLinkHeading({ id, className, children, ...props }: Props) {
 						// where the absolutely-positioned link icon slides in, WITHOUT
 						// shifting the heading box (a pl/-ml gutter breaks on pages that
 						// center MDX children with mx-auto, which clobbers negative margins)
-						"group relative w-fit font-family scroll-mt-24 before:absolute before:top-0 before:-left-9 before:h-full before:w-9 [@media(hover:hover)]:w-auto",
+						"group relative w-fit scroll-mt-24 before:absolute before:top-0 before:-left-9 before:h-full before:w-9 [@media(hover:hover)]:w-auto",
 						className,
 						singleChild.props.className,
 					),

--- a/apps/www/app/components/page-header.tsx
+++ b/apps/www/app/components/page-header.tsx
@@ -40,7 +40,7 @@ export function PageHeader({
 	return (
 		<div className="flex flex-wrap items-center gap-3 mb-6">
 			<HashLinkHeading id={id}>
-				<h1 className={cx("text-4xl font-medium sm:text-5xl font-family", className)} {...props}>
+				<h1 className={cx("text-4xl font-medium sm:text-5xl", className)} {...props}>
 					{children}
 				</h1>
 			</HashLinkHeading>

--- a/apps/www/app/docs/base/typography.mdx
+++ b/apps/www/app/docs/base/typography.mdx
@@ -13,21 +13,24 @@ Mantle ships typography tokens for consistency and readability.
 
 Mantle ships a general type scale for the headers throughout our products. Text styling is independent of the actual markup, so a Heading 1 can be styled as a Heading 2 or Heading 5 as appropriate.
 
-<p className="mt-4 text-5xl font-medium font-family">Heading 1</p>
-<p className="mt-4 text-3xl font-medium font-family">Heading 2</p>
-<p className="mt-4 text-2xl font-medium font-family">Heading 3</p>
-<p className="mt-4 text-xl font-medium font-family">Heading 4</p>
+Headings do not set a font family. They inherit the body font, so keep `font-sans`, `font-family`, and
+`font-mono` off them.
+
+<p className="mt-4 text-5xl font-medium">Heading 1</p>
+<p className="mt-4 text-3xl font-medium">Heading 2</p>
+<p className="mt-4 text-2xl font-medium">Heading 3</p>
+<p className="mt-4 text-xl font-medium">Heading 4</p>
 <p className="mt-4 text-base font-medium">Heading 5</p>
 <p className="mt-4 text-xs font-medium uppercase tracking-widest">Heading 6</p>
 
-| Level     | Class                  | Size        | Weight        | Additional                  |
-| --------- | ---------------------- | ----------- | ------------- | --------------------------- |
-| Heading 1 | `text-5xl font-family` | `text-5xl`  | `font-medium` | `font-family`               |
-| Heading 2 | `text-3xl font-family` | `text-3xl`  | `font-medium` | `font-family`               |
-| Heading 3 | `text-2xl font-family` | `text-2xl`  | `font-medium` | `font-family`               |
-| Heading 4 | `text-xl font-family`  | `text-xl`   | `font-medium` | `font-family`               |
-| Heading 5 | `text-base`            | `text-base` | `font-medium` | `-`                         |
-| Heading 6 | `text-xs`              | `text-xs`   | `font-medium` | `uppercase tracking-widest` |
+| Level     | Class       | Size        | Weight        | Additional                  |
+| --------- | ----------- | ----------- | ------------- | --------------------------- |
+| Heading 1 | `text-5xl`  | `text-5xl`  | `font-medium` | `-`                         |
+| Heading 2 | `text-3xl`  | `text-3xl`  | `font-medium` | `-`                         |
+| Heading 3 | `text-2xl`  | `text-2xl`  | `font-medium` | `-`                         |
+| Heading 4 | `text-xl`   | `text-xl`   | `font-medium` | `-`                         |
+| Heading 5 | `text-base` | `text-base` | `font-medium` | `-`                         |
+| Heading 6 | `text-xs`   | `text-xs`   | `font-medium` | `uppercase tracking-widest` |
 
 ## Colors
 
@@ -44,10 +47,10 @@ When possible, render text with the following tokens. They add hierarchy outside
 
 ## Fonts
 
-Mantle specifies Roobert as the default font for UI and headings. We also use JetBrains Mono as a monospace typeface, and Family for longform prose and h1s.
+Mantle specifies Roobert as the default font for UI and headings. We also use JetBrains Mono as a monospace typeface, and Family for longform prose.
 
 | Class         | Font Family                                                                                      | Description                                                                       |
 | ------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
 | `font-sans`   | `"Roobert"`, `ui-sans-serif`, `system-ui`, `sans-serif`                                          | The default font for rendering UI and headings. Also applied by `default`.        |
-| `font-family` | `"Family"`, `"Georgia"`, `serif`                                                                 | Best when used in longform writing like prose documentation or h1 headings.       |
+| `font-family` | `"Family"`, `"Georgia"`, `serif`                                                                 | Best when used in longform writing like prose documentation. Not for headings.    |
 | `font-mono`   | `"JetBrains Mono"`, `ui-monospace`, `SFMono-Regular`, `Menlo`, `Monaco`, `Consolas`, `monospace` | Used to render code and tokens. Adjust the size a step down in most applications. |

--- a/apps/www/app/routes/layouts.tsx
+++ b/apps/www/app/routes/layouts.tsx
@@ -14,7 +14,7 @@ export const meta = () => {
 export default function LayoutsPage() {
 	return (
 		<div>
-			<h1 className="text-4xl font-medium text-strong sm:text-5xl font-family mb-4">Layouts</h1>
+			<h1 className="text-4xl font-medium text-strong sm:text-5xl mb-4">Layouts</h1>
 			<p className="mb-4 leading-relaxed text-pretty text-body">
 				Published <code>@ngrok/mantle</code> primitives that own page and viewport structure: region
 				skeletons, landmark wiring, and scroll architecture. A layout is the frame you put

--- a/apps/www/app/routes/migrations.tsx
+++ b/apps/www/app/routes/migrations.tsx
@@ -18,7 +18,7 @@ export const meta = () => {
 export default function MigrationsPage() {
 	return (
 		<div>
-			<h1 className="text-4xl font-medium text-strong sm:text-5xl font-family mb-4">Migrations</h1>
+			<h1 className="text-4xl font-medium text-strong sm:text-5xl mb-4">Migrations</h1>
 			<p className="mb-4 leading-relaxed text-pretty text-body">
 				Step-by-step guides for migrating existing code to new <code>@ngrok/mantle</code> APIs and
 				behaviors. Each guide is written to be handed directly to a coding agent — append{" "}

--- a/apps/www/app/routes/recipes.tsx
+++ b/apps/www/app/routes/recipes.tsx
@@ -14,7 +14,7 @@ export const meta = () => {
 export default function RecipesPage() {
 	return (
 		<div>
-			<h1 className="text-4xl font-medium text-strong sm:text-5xl font-family mb-4">Recipes</h1>
+			<h1 className="text-4xl font-medium text-strong sm:text-5xl mb-4">Recipes</h1>
 			<p className="mb-4 leading-relaxed text-pretty text-body">
 				Compositional how-tos that wire multiple mantle primitives together with state, data, or
 				routing. Use these when a component page is too small and a full app flow is too much. Each


### PR DESCRIPTION
## Why

Headings across the docs site set the Family serif face, so every page mixed a serif heading with Roobert body copy. Headings should not specify a font family at all.

## What changed

Headings now set no font family and inherit the body font. They keep `font-medium` for weight.

`HashLinkHeading` wraps every MDX heading, so one edit there covers `h1` through `h6` on every docs page. The explicit `font-family` also comes off the component-page `h1`, the Recipes, Layouts, and Migrations index headings, and the 404 page.

The 404 status number and its heading relied on Family's single regular weight. Both now take `font-medium` to match the rest of the scale.

The typography page documents the new recipe. Its scale table drops the `font-family` entries, and the Fonts table no longer offers Family for headings.

The `.font-family` utility stays in `mantle.css` as a published token for longform prose. No published package changed, so this carries no changeset.

## Test plan

- [x] `pnpm -w run lint`, `fmt:check`, and `typecheck` report 0 errors
- [x] `pnpm -w run test` passes
- [x] Verified in the browser: the typography page, a component page, and the 404 page all render headings in Roobert at medium weight

No test covers the change. It is styling with no logic, and the repo bans Tailwind utility-string assertions.

Made with [Cursor](https://cursor.com)