### PR TITLE
fix(choice): forward description clicks to the label

### DIFF
--- a/.changeset/choice-description-click-target.md
+++ b/.changeset/choice-description-click-target.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Choice.Description` now forwards its click to the sibling `Choice.Label`, so the whole content column toggles the control. The accessible name stays the label alone, and the description stays wired through `aria-describedby`.
+
+The forward skips a click on a link or other interactive content inside the description, and it runs after a consumer `onClick`, so `event.preventDefault()` cancels it. When the choice uses `Choice.Title`, the description forwards nothing, because an ancestor already owns that click. The description also shows the pointer cursor when a `Choice.Label` precedes it.

--- a/.changeset/choice-description-click-target.md
+++ b/.changeset/choice-description-click-target.md
@@ -4,4 +4,6 @@
 
 `Choice.Description` now forwards its click to the sibling `Choice.Label`, so the whole content column toggles the control. The accessible name stays the label alone, and the description stays wired through `aria-describedby`.
 
-The forward skips a click on a link or other interactive content inside the description, and it runs after a consumer `onClick`, so `event.preventDefault()` cancels it. When the choice uses `Choice.Title`, the description forwards nothing, because an ancestor already owns that click. The description also shows the pointer cursor when a `Choice.Label` precedes it.
+The forward skips a click on a link, a button, a form control, a nested label, a `<details>`, or an ARIA widget inside the description: the same rule a `List` row applies to its own click-to-activate. It runs after a consumer `onClick`, so `event.preventDefault()` cancels it. After it forwards, it marks the click handled, so a click on a `SelectableList` row's description toggles the row once. When the choice uses `Choice.Title`, the description forwards nothing, because an ancestor already owns that click. The description also shows the pointer cursor when a `Choice.Label` precedes it.
+
+`List` and `SelectableList` rows now also defer a bare row click that lands inside a `<details>`, so a `<summary>` toggle no longer activates the row.

--- a/.changeset/slot-keeps-child-data-slot.md
+++ b/.changeset/slot-keeps-child-data-slot.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Slot` no longer erases a component child's own `data-slot`. It passed `data-slot: undefined` to the child when neither side set one, and a part that spreads its props after its own `data-slot` lost the attribute. `Field.Control` wraps its child in `Slot`, so a `Checkbox` or `Choice.Root` inside one rendered without `data-slot="checkbox"` or `data-slot="choice"`.

--- a/apps/www/app/docs/components/forms/checkbox.mdx
+++ b/apps/www/app/docs/components/forms/checkbox.mdx
@@ -196,7 +196,7 @@ import { Label } from "@ngrok/mantle/label";
 
 ## Multi-line label with description
 
-For a checkbox with an emphasized title and a supplementary description beneath it, compose it inside [`Choice`](/components/forms/choice): drop the `Checkbox` into `Choice.Indicator` and pair `Choice.Label` (a real `<label>`, so clicking it toggles the box) with an optional `Choice.Description`. The box aligns to the leading of the title's first line, and the description associates via `aria-describedby`.
+For a checkbox with an emphasized title and a supplementary description beneath it, compose it inside [`Choice`](/components/forms/choice): drop the `Checkbox` into `Choice.Indicator` and pair `Choice.Label` (a real `<label>`, so clicking it toggles the box) with an optional `Choice.Description`. The description forwards its click to that label, so the whole text block toggles the box. The box aligns to the leading of the title's first line, and the description associates via `aria-describedby`.
 
 <Example>
 	<div className="w-full max-w-md">

--- a/apps/www/app/docs/components/forms/choice.mdx
+++ b/apps/www/app/docs/components/forms/choice.mdx
@@ -198,7 +198,7 @@ import { Choice } from "@ngrok/mantle/choice";
 ## Accessibility
 
 - The control placed in `Choice.Indicator` receives the generated `id`; `Choice.Label`'s `htmlFor` and the description's `aria-describedby` resolve to it without manual wiring.
-- `Choice.Description` associates via `aria-describedby` only; it is **never** a second label.
+- `Choice.Description` associates via `aria-describedby` only; it is **never** a second label. A click on it forwards to `Choice.Label`, so the whole content column toggles the control while the accessible name stays the label alone.
 - Use exactly one of `Choice.Label` / `Choice.Title` per choice. `Choice.Title` is label-less text for when an ancestor (clickable row, radio item, or `Field.Label`) carries the accessible name, so labels never nest.
 - Inside a `Field`, the control adopts the field's `id` and its `aria-describedby` is merged (never duplicated) with the field's description and error ids.
 
@@ -250,7 +250,7 @@ All props from [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#a
 
 ### Choice.Description
 
-The supplementary description, wired to the control via `aria-describedby`. Renders a `<p>`.
+The supplementary description, wired to the control via `aria-describedby`. Renders a `<p>`. A click on it forwards to the sibling `Choice.Label`, so the description extends the label's click target. The forward skips a click on a link or other interactive content inside the description. When the choice uses `Choice.Title`, the description forwards nothing, because an ancestor owns that click.
 
 All props from [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#attributes), plus:
 

--- a/apps/www/app/docs/components/forms/choice.mdx
+++ b/apps/www/app/docs/components/forms/choice.mdx
@@ -250,7 +250,7 @@ All props from [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#a
 
 ### Choice.Description
 
-The supplementary description, wired to the control via `aria-describedby`. Renders a `<p>`. A click on it forwards to the sibling `Choice.Label`, so the description extends the label's click target. The forward skips a click on a link or other interactive content inside the description. When the choice uses `Choice.Title`, the description forwards nothing, because an ancestor owns that click.
+The supplementary description, wired to the control via `aria-describedby`. Renders a `<p>`. A click on it forwards to the sibling `Choice.Label`, so the description extends the label's click target. The forward skips a click on a link or other interactive content inside the description. After it forwards, it marks the click handled with `preventDefault()`, so a click-to-activate ancestor (a `SelectableList` row) does not toggle the control a second time. When the choice uses `Choice.Title`, the description forwards nothing, because an ancestor owns that click.
 
 All props from [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#attributes), plus:
 

--- a/packages/mantle/src/components/choice/choice.browser.test.tsx
+++ b/packages/mantle/src/components/choice/choice.browser.test.tsx
@@ -115,6 +115,52 @@ describe("Choice (browser) — clicking the label toggles the control", () => {
 	});
 });
 
+describe("Choice (browser) — clicking the description toggles the control", () => {
+	test("checkbox", async () => {
+		const user = userEvent.setup();
+		render(
+			<Choice.Root name="terms">
+				<Choice.Indicator>
+					<Checkbox />
+				</Choice.Indicator>
+				<Choice.Content>
+					<Choice.Label>I agree to the terms</Choice.Label>
+					<Choice.Description>You can change this later.</Choice.Description>
+				</Choice.Content>
+			</Choice.Root>,
+		);
+
+		const checkbox = screen.getByRole("checkbox");
+		expect(checkbox).not.toBeChecked();
+		await user.click(screen.getByText("You can change this later."));
+		expect(checkbox).toBeChecked();
+		await user.click(screen.getByText("You can change this later."));
+		expect(checkbox).not.toBeChecked();
+	});
+
+	test("switch", async () => {
+		const user = userEvent.setup();
+		render(
+			<Choice.Root name="airplane-mode">
+				<Choice.Indicator>
+					<Switch />
+				</Choice.Indicator>
+				<Choice.Content>
+					<Choice.Label>Airplane mode</Choice.Label>
+					<Choice.Description>Disables wireless radios while in flight.</Choice.Description>
+				</Choice.Content>
+			</Choice.Root>,
+		);
+
+		// The forward clicks the <label>, whose activation behavior reaches the
+		// <button role="switch"> the same way a direct label click does.
+		const toggle = screen.getByRole("switch");
+		expect(toggle).not.toBeChecked();
+		await user.click(screen.getByText("Disables wireless radios while in flight."));
+		expect(toggle).toBeChecked();
+	});
+});
+
 describe("Choice (browser) — radio options", () => {
 	test("clicking an option selects that radio, and the description is part of its accessible name", async () => {
 		const user = userEvent.setup();

--- a/packages/mantle/src/components/choice/choice.test.tsx
+++ b/packages/mantle/src/components/choice/choice.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import type { MouseEvent } from "react";
+import { describe, expect, test, vi } from "vitest";
 import { Field } from "../field/field.js";
 import { Switch } from "../switch/switch.js";
 import { Choice } from "./choice.js";
@@ -177,6 +179,94 @@ describe("Choice", () => {
 		expect(() => render(<Choice.Label>orphan</Choice.Label>)).toThrow(
 			/Choice\.Label must be rendered inside Choice\.Root/,
 		);
+	});
+});
+
+describe("Choice — Description extends the label's click target", () => {
+	test("clicking the Description toggles the control once, through Choice.Label", async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn<() => void>();
+		render(
+			<Choice.Root>
+				<Choice.Indicator>
+					<input type="checkbox" aria-label="control" onChange={onChange} />
+				</Choice.Indicator>
+				<Choice.Content>
+					<Choice.Label>Email</Choice.Label>
+					<Choice.Description>Get notified by email.</Choice.Description>
+				</Choice.Content>
+			</Choice.Root>,
+		);
+		const control = screen.getByRole("checkbox");
+		expect(control).not.toBeChecked();
+		await user.click(screen.getByText("Get notified by email."));
+		expect(control).toBeChecked();
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	test("with Choice.Title the Description forwards nothing, so an ancestor label toggles the control once", async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn<() => void>();
+		render(
+			// oxlint-disable-next-line jsx-a11y/label-has-associated-control -- `Choice.Title` renders the label text
+			<label htmlFor="onboarding-key">
+				<Choice.Root id="onboarding-key">
+					<Choice.Indicator>
+						<input type="checkbox" onChange={onChange} />
+					</Choice.Indicator>
+					<Choice.Content>
+						<Choice.Title>Onboarding Key</Choice.Title>
+						<Choice.Description>ng-3FaThZL***8xiA</Choice.Description>
+					</Choice.Content>
+				</Choice.Root>
+			</label>,
+		);
+		const control = screen.getByRole("checkbox");
+		await user.click(screen.getByText("ng-3FaThZL***8xiA"));
+		expect(control).toBeChecked();
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+
+	test("a click on a link inside the Description does not toggle the control", async () => {
+		const user = userEvent.setup();
+		render(
+			<Choice.Root>
+				<Choice.Indicator>
+					<input type="checkbox" aria-label="control" />
+				</Choice.Indicator>
+				<Choice.Content>
+					<Choice.Label>Email</Choice.Label>
+					<Choice.Description asChild>
+						<div>
+							Supports <a href="#docs">rich content</a> when rendered as a div.
+						</div>
+					</Choice.Description>
+				</Choice.Content>
+			</Choice.Root>,
+		);
+		await user.click(screen.getByRole("link", { name: "rich content" }));
+		expect(screen.getByRole("checkbox")).not.toBeChecked();
+	});
+
+	test("a consumer onClick runs first, and preventDefault() cancels the forward", async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn<(event: MouseEvent<HTMLElement>) => void>((event) => {
+			event.preventDefault();
+		});
+		render(
+			<Choice.Root>
+				<Choice.Indicator>
+					<input type="checkbox" aria-label="control" />
+				</Choice.Indicator>
+				<Choice.Content>
+					<Choice.Label>Email</Choice.Label>
+					<Choice.Description onClick={onClick}>Get notified by email.</Choice.Description>
+				</Choice.Content>
+			</Choice.Root>,
+		);
+		await user.click(screen.getByText("Get notified by email."));
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("checkbox")).not.toBeChecked();
 	});
 });
 

--- a/packages/mantle/src/components/choice/choice.test.tsx
+++ b/packages/mantle/src/components/choice/choice.test.tsx
@@ -248,6 +248,79 @@ describe("Choice — Description extends the label's click target", () => {
 		expect(screen.getByRole("checkbox")).not.toBeChecked();
 	});
 
+	// Each row pins one entry of the interactive-content selector: drop that entry
+	// and its row toggles the control.
+	test.each([
+		{
+			name: "a <summary> inside a <details>",
+			content: (
+				<details>
+					<summary>More</summary>
+					Extra text.
+				</details>
+			),
+			query: () => screen.getByText("More"),
+		},
+		{
+			name: "a nested <label>",
+			content: (
+				<label>
+					Also <input type="checkbox" />
+				</label>
+			),
+			query: () => screen.getByText("Also"),
+		},
+		{
+			name: "a <video controls>",
+			content: (
+				<video controls aria-label="preview">
+					<track kind="captions" />
+				</video>
+			),
+			query: () => screen.getByLabelText("preview"),
+		},
+	])(
+		"a click on $name inside the Description does not toggle the control",
+		async ({ content, query }) => {
+			const user = userEvent.setup();
+			render(
+				<Choice.Root>
+					<Choice.Indicator>
+						<input type="checkbox" aria-label="control" />
+					</Choice.Indicator>
+					<Choice.Content>
+						<Choice.Label>Email</Choice.Label>
+						<Choice.Description asChild>
+							<div>{content}</div>
+						</Choice.Description>
+					</Choice.Content>
+				</Choice.Root>,
+			);
+			await user.click(query());
+			expect(screen.getByRole("checkbox", { name: "control" })).not.toBeChecked();
+		},
+	);
+
+	test("a <details> that wraps the whole choice does not stop the forward", async () => {
+		const user = userEvent.setup();
+		render(
+			<details open>
+				<summary>Notifications</summary>
+				<Choice.Root>
+					<Choice.Indicator>
+						<input type="checkbox" aria-label="control" />
+					</Choice.Indicator>
+					<Choice.Content>
+						<Choice.Label>Email</Choice.Label>
+						<Choice.Description>Get notified by email.</Choice.Description>
+					</Choice.Content>
+				</Choice.Root>
+			</details>,
+		);
+		await user.click(screen.getByText("Get notified by email."));
+		expect(screen.getByRole("checkbox")).toBeChecked();
+	});
+
 	test("a consumer onClick runs first, and preventDefault() cancels the forward", async () => {
 		const user = userEvent.setup();
 		const onClick = vi.fn<(event: MouseEvent<HTMLElement>) => void>((event) => {

--- a/packages/mantle/src/components/choice/choice.test.tsx
+++ b/packages/mantle/src/components/choice/choice.test.tsx
@@ -248,8 +248,8 @@ describe("Choice — Description extends the label's click target", () => {
 		expect(screen.getByRole("checkbox")).not.toBeChecked();
 	});
 
-	// Each row pins one entry of the interactive-content selector: drop that entry
-	// and its row toggles the control.
+	// The shared predicate's own table lives in `utils/interactive-target.test.ts`;
+	// these rows pin that the description consults it.
 	test.each([
 		{
 			name: "a <summary> inside a <details>",
@@ -269,15 +269,6 @@ describe("Choice — Description extends the label's click target", () => {
 				</label>
 			),
 			query: () => screen.getByText("Also"),
-		},
-		{
-			name: "a <video controls>",
-			content: (
-				<video controls aria-label="preview">
-					<track kind="captions" />
-				</video>
-			),
-			query: () => screen.getByLabelText("preview"),
 		},
 	])(
 		"a click on $name inside the Description does not toggle the control",
@@ -300,6 +291,57 @@ describe("Choice — Description extends the label's click target", () => {
 			expect(screen.getByRole("checkbox", { name: "control" })).not.toBeChecked();
 		},
 	);
+
+	test("after the forward, the click is marked handled so a click-to-activate ancestor defers", async () => {
+		const user = userEvent.setup();
+		const onAncestorClick = vi.fn<(event: MouseEvent<HTMLDivElement>) => void>();
+		render(
+			<div role="presentation" onClick={onAncestorClick}>
+				<Choice.Root>
+					<Choice.Indicator>
+						<input type="checkbox" aria-label="control" />
+					</Choice.Indicator>
+					<Choice.Content>
+						<Choice.Label>Email</Choice.Label>
+						<Choice.Description>Get notified by email.</Choice.Description>
+					</Choice.Content>
+				</Choice.Root>
+			</div>,
+		);
+		await user.click(screen.getByText("Get notified by email."));
+		expect(screen.getByRole("checkbox")).toBeChecked();
+		// The description's own click arrives handled; the forwarded label click
+		// and the control's click bubble too, and those stay untouched.
+		const descriptionClick = onAncestorClick.mock.calls.find(
+			([event]) => event.target === screen.getByText("Get notified by email."),
+		);
+		expect(descriptionClick?.[0].defaultPrevented).toBe(true);
+	});
+
+	test("a skipped forward leaves the click unhandled for the ancestor", async () => {
+		const user = userEvent.setup();
+		const onAncestorClick = vi.fn<(event: MouseEvent<HTMLDivElement>) => void>();
+		render(
+			<div role="presentation" onClick={onAncestorClick}>
+				<Choice.Root>
+					<Choice.Indicator>
+						<input type="checkbox" aria-label="control" />
+					</Choice.Indicator>
+					<Choice.Content>
+						<Choice.Label>Email</Choice.Label>
+						<Choice.Description asChild>
+							<div>
+								See the <a href="#docs">docs</a>.
+							</div>
+						</Choice.Description>
+					</Choice.Content>
+				</Choice.Root>
+			</div>,
+		);
+		await user.click(screen.getByRole("link", { name: "docs" }));
+		expect(onAncestorClick).toHaveBeenCalledTimes(1);
+		expect(onAncestorClick.mock.calls[0]?.[0].defaultPrevented).toBe(false);
+	});
 
 	test("a <details> that wraps the whole choice does not stop the forward", async () => {
 		const user = userEvent.setup();

--- a/packages/mantle/src/components/choice/choice.tsx
+++ b/packages/mantle/src/components/choice/choice.tsx
@@ -403,11 +403,27 @@ const Title = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & With
 };
 
 /**
- * Interactive content that keeps its own click. When a click lands on one of
- * these inside the description, the forward stops, the same as the native
- * `<label>` activation rule for interactive descendants.
+ * The HTML interactive content set. When a click lands on one of these inside
+ * the description, the forward stops, the same as the native `<label>`
+ * activation rule for interactive descendants. A `<summary>` counts through
+ * its `<details>` parent.
+ *
+ * @see https://html.spec.whatwg.org/multipage/dom.html#interactive-content
  */
-const interactiveContentSelector = "a, button, input, select, textarea";
+const interactiveContentSelector = [
+	"a[href]",
+	"audio[controls]",
+	"button",
+	"details",
+	"embed",
+	"iframe",
+	"img[usemap]",
+	"input:not([type=hidden])",
+	"label",
+	"select",
+	"textarea",
+	"video[controls]",
+].join(", ");
 
 /**
  * Whether a click on the description should forward to the `Choice.Label`.
@@ -423,7 +439,10 @@ function shouldForwardDescriptionClick(event: MouseEvent<HTMLElement>): boolean 
 	if (!(event.target instanceof Element)) {
 		return false;
 	}
-	if (event.target.closest(interactiveContentSelector) != null) {
+	// Why the `contains` check: `closest` also walks past the description, and a
+	// `<details>` that wraps the whole choice must not stop the forward.
+	const interactiveContent = event.target.closest(interactiveContentSelector);
+	if (interactiveContent != null && event.currentTarget.contains(interactiveContent)) {
 		return false;
 	}
 	return event.currentTarget.closest("label") == null;

--- a/packages/mantle/src/components/choice/choice.tsx
+++ b/packages/mantle/src/components/choice/choice.tsx
@@ -14,6 +14,7 @@ import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
+import { isInteractiveTarget } from "../../utils/interactive-target.js";
 import { FieldControlContext } from "../field/field-context.js";
 import { Label } from "../label/label.js";
 import { Slot } from "../slot/index.js";
@@ -403,46 +404,17 @@ const Title = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & With
 };
 
 /**
- * The HTML interactive content set. When a click lands on one of these inside
- * the description, the forward stops, the same as the native `<label>`
- * activation rule for interactive descendants. A `<summary>` counts through
- * its `<details>` parent.
- *
- * @see https://html.spec.whatwg.org/multipage/dom.html#interactive-content
- */
-const interactiveContentSelector = [
-	"a[href]",
-	"audio[controls]",
-	"button",
-	"details",
-	"embed",
-	"iframe",
-	"img[usemap]",
-	"input:not([type=hidden])",
-	"label",
-	"select",
-	"textarea",
-	"video[controls]",
-].join(", ");
-
-/**
  * Whether a click on the description should forward to the `Choice.Label`.
  * Returns `false` when a consumer handler called `preventDefault()`, when the
- * click landed on interactive content inside the description, or when an
- * ancestor `<label>` already forwards the click (a second forward would toggle
- * the control twice).
+ * click landed on interactive content inside the description (the same rule a
+ * `List` row applies), or when an ancestor `<label>` already forwards the click
+ * (a second forward would toggle the control twice).
  */
 function shouldForwardDescriptionClick(event: MouseEvent<HTMLElement>): boolean {
 	if (event.defaultPrevented) {
 		return false;
 	}
-	if (!(event.target instanceof Element)) {
-		return false;
-	}
-	// Why the `contains` check: `closest` also walks past the description, and a
-	// `<details>` that wraps the whole choice must not stop the forward.
-	const interactiveContent = event.target.closest(interactiveContentSelector);
-	if (interactiveContent != null && event.currentTarget.contains(interactiveContent)) {
+	if (isInteractiveTarget(event.target, event.currentTarget)) {
 		return false;
 	}
 	return event.currentTarget.closest("label") == null;
@@ -456,8 +428,11 @@ function shouldForwardDescriptionClick(event: MouseEvent<HTMLElement>): boolean 
  * A click on the description forwards to the sibling `Choice.Label`, so the
  * whole content column toggles the control while the accessible name stays the
  * label alone. The forward skips a click on a link or other interactive content
- * inside the description. When the choice uses `Choice.Title`, the description
- * forwards nothing, because an ancestor owns that click.
+ * inside the description. After it forwards, it marks the click handled with
+ * `preventDefault()`, so a click-to-activate ancestor (a `SelectableList` row)
+ * does not toggle the control a second time. When the choice uses
+ * `Choice.Title`, the description forwards nothing, because an ancestor owns
+ * that click.
  *
  * @see https://mantle.ngrok.com/components/forms/choice
  *
@@ -504,6 +479,9 @@ const Description = ({
 					// `HTMLElement.click()` on the label runs its activation behavior, so
 					// the control receives the same click a direct label click sends.
 					labelRef.current?.click();
+					// Why: a click-to-activate ancestor (a `SelectableList` row) reads
+					// `defaultPrevented` as "handled", so the forward toggles once.
+					event.preventDefault();
 				}
 			}}
 			{...props}

--- a/packages/mantle/src/components/choice/choice.tsx
+++ b/packages/mantle/src/components/choice/choice.tsx
@@ -1,9 +1,18 @@
 "use client";
 
-import { cloneElement, createContext, isValidElement, useContext, useId, useMemo } from "react";
-import type { ComponentProps, ReactNode } from "react";
+import {
+	cloneElement,
+	createContext,
+	isValidElement,
+	useContext,
+	useId,
+	useMemo,
+	useRef,
+} from "react";
+import type { ComponentProps, MouseEvent, ReactNode, RefObject } from "react";
 import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
+import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import { FieldControlContext } from "../field/field-context.js";
 import { Label } from "../label/label.js";
@@ -36,6 +45,11 @@ type ChoiceContextValue = {
 	descriptionId: string;
 	/** Whether the choice is disabled, so `Label` / `Title` / `Description` dim in step. */
 	disabled: boolean;
+	/**
+	 * The rendered `Choice.Label` element, or `null` when the choice uses
+	 * `Choice.Title`. `Choice.Description` forwards its click here.
+	 */
+	labelRef: RefObject<HTMLLabelElement | null>;
 	/** Props `Choice.Indicator` injects onto its control child. */
 	controlProps: ChoiceControlProps;
 };
@@ -136,6 +150,7 @@ const Root = ({
 	const fieldErrorMessage = fieldControl?.["aria-errormessage"];
 	const generatedId = useId();
 	const descriptionId = useId();
+	const labelRef = useRef<HTMLLabelElement>(null);
 	const controlId = fieldId ?? id ?? generatedId;
 	// Reference our own description slot and append any inherited describedby
 	// (a Field.Control's description/error ids, or a caller-supplied one). Inside
@@ -151,6 +166,7 @@ const Root = ({
 			controlId,
 			descriptionId,
 			disabled,
+			labelRef,
 			controlProps: {
 				id: controlId,
 				name: fieldName ?? name,
@@ -325,14 +341,16 @@ type ChoiceLabelProps = Omit<ComponentProps<typeof Label>, "htmlFor" | "disabled
  * ```
  */
 const ChoiceLabel = ({ className, ref, ...props }: ChoiceLabelProps) => {
-	const { controlId, disabled } = useChoiceContext("Label");
+	const { controlId, disabled, labelRef } = useChoiceContext("Label");
+	// `Choice.Description` clicks this element to reach the control.
+	const composedRef = useComposedRefs(labelRef, ref);
 
 	// Reuse the real `Label` rather than re-implementing it, so the title keeps
 	// all of `Label`'s styling and behavior. `htmlFor` / `disabled` come from
 	// `Choice.Root` and are applied after `{...props}` so the wiring always wins.
 	return (
 		<Label
-			ref={ref}
+			ref={composedRef}
 			data-slot="choice-label"
 			className={cx(disabled && "opacity-50", className)}
 			{...props}
@@ -385,9 +403,42 @@ const Title = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & With
 };
 
 /**
+ * Interactive content that keeps its own click. When a click lands on one of
+ * these inside the description, the forward stops, the same as the native
+ * `<label>` activation rule for interactive descendants.
+ */
+const interactiveContentSelector = "a, button, input, select, textarea";
+
+/**
+ * Whether a click on the description should forward to the `Choice.Label`.
+ * Returns `false` when a consumer handler called `preventDefault()`, when the
+ * click landed on interactive content inside the description, or when an
+ * ancestor `<label>` already forwards the click (a second forward would toggle
+ * the control twice).
+ */
+function shouldForwardDescriptionClick(event: MouseEvent<HTMLElement>): boolean {
+	if (event.defaultPrevented) {
+		return false;
+	}
+	if (!(event.target instanceof Element)) {
+		return false;
+	}
+	if (event.target.closest(interactiveContentSelector) != null) {
+		return false;
+	}
+	return event.currentTarget.closest("label") == null;
+}
+
+/**
  * The de-emphasized supplementary line of a `Choice`, in the muted body color
  * and wired to the control via `aria-describedby` (never a second label).
  * Renders a `<p>`; pass `asChild` to supply your own element.
+ *
+ * A click on the description forwards to the sibling `Choice.Label`, so the
+ * whole content column toggles the control while the accessible name stays the
+ * label alone. The forward skips a click on a link or other interactive content
+ * inside the description. When the choice uses `Choice.Title`, the description
+ * forwards nothing, because an ancestor owns that click.
  *
  * @see https://mantle.ngrok.com/components/forms/choice
  *
@@ -404,8 +455,14 @@ const Title = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & With
  * </Choice.Root>
  * ```
  */
-const Description = ({ asChild, className, ref, ...props }: ComponentProps<"p"> & WithAsChild) => {
-	const { descriptionId, disabled } = useChoiceContext("Description");
+const Description = ({
+	asChild,
+	className,
+	onClick,
+	ref,
+	...props
+}: ComponentProps<"p"> & WithAsChild) => {
+	const { descriptionId, disabled, labelRef } = useChoiceContext("Description");
 	const Comp = asChild ? Slot : "p";
 
 	return (
@@ -413,7 +470,23 @@ const Description = ({ asChild, className, ref, ...props }: ComponentProps<"p"> 
 			ref={ref}
 			id={descriptionId}
 			data-slot="choice-description"
-			className={cx("text-body text-sm leading-4", disabled && "opacity-50", className)}
+			className={cx(
+				"text-body text-sm leading-4",
+				// The description extends the label's click target, so it shares the
+				// label's pointer cursor. The sibling selector keeps the text cursor when
+				// the choice uses `Choice.Title` and an ancestor owns the click.
+				!disabled && "[[data-slot~=choice-label]~&]:cursor-pointer",
+				disabled && "opacity-50",
+				className,
+			)}
+			onClick={(event: MouseEvent<HTMLParagraphElement>) => {
+				onClick?.(event);
+				if (shouldForwardDescriptionClick(event)) {
+					// `HTMLElement.click()` on the label runs its activation behavior, so
+					// the control receives the same click a direct label click sends.
+					labelRef.current?.click();
+				}
+			}}
 			{...props}
 		/>
 	);
@@ -568,7 +641,8 @@ const Choice = {
 	 */
 	Title,
 	/**
-	 * Description: the supplementary line, wired via `aria-describedby`.
+	 * Description: the supplementary line, wired via `aria-describedby`. A click
+	 * on it forwards to `Choice.Label`.
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/choice
 	 *

--- a/packages/mantle/src/components/field/field.test.tsx
+++ b/packages/mantle/src/components/field/field.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { createRef } from "react";
 import type { ComponentProps, ReactNode } from "react";
 import { describe, expect, test } from "vitest";
+import { Checkbox } from "../checkbox/checkbox.js";
 import { Input } from "../input/input.js";
 import type { FieldControlAriaProps } from "./field-context.js";
 import { Field } from "./field.js";
@@ -1061,5 +1062,18 @@ describe("Field", () => {
 			expect(screen.getByTestId("err")).toHaveTextContent("Email is required.");
 			expect(screen.getByTestId("desc")).toHaveTextContent("We'll never share your email.");
 		});
+	});
+});
+
+describe("Field.Control + control data-slot", () => {
+	test("keeps the control's own data-slot when it clones the child", () => {
+		render(
+			<Field.Item name="terms">
+				<Field.Control>
+					<Checkbox aria-label="Accept terms" />
+				</Field.Control>
+			</Field.Item>,
+		);
+		expect(screen.getByRole("checkbox")).toHaveAttribute("data-slot", "checkbox");
 	});
 });

--- a/packages/mantle/src/components/list/primitive.test.tsx
+++ b/packages/mantle/src/components/list/primitive.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
-import { isInteractiveItemTarget, Item as ListItem, Root as ListRoot } from "./primitive.js";
+import { Item as ListItem, Root as ListRoot } from "./primitive.js";
 
 /**
  * Focus the grid the way a Tab-in would. happy-dom's `focus()` moves
@@ -221,42 +221,6 @@ describe("List isItemDisabled", () => {
 
 		await user.click(screen.getByText("Item 0"));
 		expect(onActivate).not.toHaveBeenCalled();
-	});
-});
-
-describe("isInteractiveItemTarget", () => {
-	test("returns true for a control or label inside the row (activation must not fire twice)", () => {
-		const row = document.createElement("div");
-		const button = document.createElement("button");
-		row.append(button);
-		expect(isInteractiveItemTarget(button, row)).toBe(true);
-
-		const label = document.createElement("label");
-		row.append(label);
-		expect(isInteractiveItemTarget(label, row)).toBe(true);
-	});
-
-	test("returns false for non-interactive row content (the row activates)", () => {
-		const row = document.createElement("div");
-		const description = document.createElement("p");
-		row.append(description);
-		expect(isInteractiveItemTarget(description, row)).toBe(false);
-	});
-
-	test("returns false for a non-element target", () => {
-		const row = document.createElement("div");
-		expect(isInteractiveItemTarget(null, row)).toBe(false);
-	});
-
-	test("ignores interactive ancestors outside the row", () => {
-		// The row is nested inside a button. A click on the row's own text is not
-		// interactive, even though an ancestor is.
-		const outerButton = document.createElement("button");
-		const row = document.createElement("div");
-		const text = document.createElement("p");
-		outerButton.append(row);
-		row.append(text);
-		expect(isInteractiveItemTarget(text, row)).toBe(false);
 	});
 });
 

--- a/packages/mantle/src/components/list/primitive.tsx
+++ b/packages/mantle/src/components/list/primitive.tsx
@@ -25,6 +25,7 @@ import invariant from "tiny-invariant";
 import type { WithAsChild } from "../../types/as-child.js";
 import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
+import { isInteractiveTarget } from "../../utils/interactive-target.js";
 import { Slot } from "../slot/index.js";
 
 // This module is internal shared implementation — it is not exported from the
@@ -292,36 +293,6 @@ function itemFromEventTarget(target: EventTarget | null): { item: Element; index
 }
 
 /**
- * Selector for the interactive elements inside a row that handle their own
- * click — a checkbox, a `<label>`, nested links/buttons. A bare row click that
- * lands inside one of these is left alone so grid activation never fires twice.
- */
-const INTERACTIVE_ITEM_TARGET_SELECTOR =
-	'a[href], button, input, select, textarea, label, [role="button"], [role="link"], [role="menuitem"], [contenteditable="true"]';
-
-/**
- * Whether a row click originated on an element (within `row`) that already
- * handles the click — a checkbox, a label, or nested interactive content — so
- * the grid's click-to-activate should defer to it. Pure over the DOM; testable
- * in isolation.
- *
- * @example
- * ```ts
- * // click on the row's checkbox → true (activation must not fire twice)
- * isInteractiveItemTarget(checkboxEl, rowEl); // → true
- * // click on the row's description text → false (the row activates)
- * isInteractiveItemTarget(descriptionEl, rowEl); // → false
- * ```
- */
-function isInteractiveItemTarget(target: EventTarget | null, item: Element): boolean {
-	if (!(target instanceof Element)) {
-		return false;
-	}
-	const interactive = target.closest(INTERACTIVE_ITEM_TARGET_SELECTOR);
-	return interactive != null && item.contains(interactive);
-}
-
-/**
  * Collection-element props for `"list"` semantics arrow-key navigation:
  * `ArrowUp` / `ArrowDown` / `Home` / `End` pressed on a row's focused control
  * move **real focus** to the next enabled row's control (native tab order is
@@ -521,7 +492,7 @@ function useGridNavigation({
 				if (
 					clicked == null ||
 					isDisabled(clicked.index) ||
-					isInteractiveItemTarget(event.target, clicked.item)
+					isInteractiveTarget(event.target, clicked.item)
 				) {
 					return;
 				}
@@ -1005,7 +976,6 @@ const Root = ({
 export {
 	//,
 	findItemControl,
-	isInteractiveItemTarget,
 	isItemChildDisabled,
 	Item,
 	ListItemContext,

--- a/packages/mantle/src/components/selectable-list/selectable-list.test.tsx
+++ b/packages/mantle/src/components/selectable-list/selectable-list.test.tsx
@@ -263,6 +263,52 @@ describe("SelectableList selection state", () => {
 		expect(screen.getByRole("checkbox", { name: "Apple" })).not.toBeChecked();
 	});
 
+	test("a click on the row's description toggles selection once", async () => {
+		const user = userEvent.setup();
+		const onValueChange = vi.fn<(values: string[]) => void>();
+		render(
+			<SelectableList.Root
+				options={[{ value: "a", label: "Apple", description: "fruit-a" }]}
+				onValueChange={onValueChange}
+			>
+				<SelectableList.Viewport aria-label="Fruit" />
+			</SelectableList.Root>,
+		);
+		// The description forwards to the row's label, which toggles the checkbox.
+		// The same click then bubbles to the row, which must not toggle again.
+		await user.click(screen.getByText("fruit-a"));
+		expect(screen.getByRole("checkbox", { name: "Apple" })).toBeChecked();
+		expect(onValueChange).toHaveBeenCalledTimes(1);
+		expect(onValueChange).toHaveBeenLastCalledWith(["a"]);
+	});
+
+	test("a <summary> inside the row's description toggles neither the row nor the checkbox", async () => {
+		const user = userEvent.setup();
+		const onValueChange = vi.fn<(values: string[]) => void>();
+		render(
+			<SelectableList.Root options={options} onValueChange={onValueChange}>
+				<SelectableList.Viewport aria-label="Fruit">
+					{(option) => (
+						<SelectableList.Item value={option.value}>
+							<SelectableList.ItemTitle>{option.label}</SelectableList.ItemTitle>
+							<SelectableList.ItemDescription asChild>
+								<div>
+									<details>
+										<summary>More about {option.label}</summary>
+										Grown locally.
+									</details>
+								</div>
+							</SelectableList.ItemDescription>
+						</SelectableList.Item>
+					)}
+				</SelectableList.Viewport>
+			</SelectableList.Root>,
+		);
+		await user.click(screen.getByText("More about Apple"));
+		expect(screen.getByRole("checkbox", { name: "Apple" })).not.toBeChecked();
+		expect(onValueChange).not.toHaveBeenCalled();
+	});
+
 	test("a disabled option cannot be toggled by a bare row click", async () => {
 		const user = userEvent.setup();
 		const onValueChange = vi.fn<(values: string[]) => void>();

--- a/packages/mantle/src/components/slot/slot.test.tsx
+++ b/packages/mantle/src/components/slot/slot.test.tsx
@@ -212,6 +212,18 @@ describe("Slot", () => {
 		expect(withoutSlot.querySelector("div")).not.toHaveAttribute("data-slot");
 	});
 
+	it("keeps a component child's own data-slot when neither side passes one", () => {
+		// A part stamps its slot before `{...props}`, so an explicit `data-slot: undefined`
+		// from the Slot would erase it.
+		const Part = (props: ComponentProps<"div">) => <div data-slot="part" {...props} />;
+		const { container } = render(
+			<Slot>
+				<Part>Content</Part>
+			</Slot>,
+		);
+		expect(container.querySelector("div")).toHaveAttribute("data-slot", "part");
+	});
+
 	it("handles event handlers passed via Slot and child (both are called)", () => {
 		const slotOnClick = vi.fn<() => void>();
 		const childOnClick = vi.fn<() => void>();

--- a/packages/mantle/src/components/slot/slot.tsx
+++ b/packages/mantle/src/components/slot/slot.tsx
@@ -139,6 +139,7 @@ const Slot = ({ children, className, "data-slot": dataSlot, ref, style, ...props
 		"data-slot": childDataSlot,
 		...childProps
 	} = children.props;
+	const joinedDataSlot = joinDataSlot(dataSlot, childDataSlot);
 
 	return (
 		<SlotPrimitive
@@ -159,7 +160,9 @@ const Slot = ({ children, className, "data-slot": dataSlot, ref, style, ...props
 			 */}
 			{createElement(children.type, {
 				...childProps,
-				"data-slot": joinDataSlot(dataSlot, childDataSlot),
+				// Why only when set: a component child spreads its props after its own
+				// `data-slot`, so an explicit `undefined` here erases that slot.
+				...(joinedDataSlot != null && { "data-slot": joinedDataSlot }),
 				// `cloneElement` preserved the child's key; the rebuild carries it
 				// explicitly. `?? undefined` because `createElement` stringifies any
 				// non-`undefined` key, which would turn `null` into the key `"null"`.

--- a/packages/mantle/src/utils/interactive-target.test.ts
+++ b/packages/mantle/src/utils/interactive-target.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import { isInteractiveTarget } from "./interactive-target.js";
+
+/**
+ * Render `html` inside a fresh container and return the container plus the
+ * element `targetSelector` picks out of it.
+ */
+function renderTarget(html: string, targetSelector: string) {
+	const within = document.createElement("div");
+	within.innerHTML = html;
+	const target = within.querySelector(targetSelector);
+	if (target == null) {
+		throw new Error(`no element matches ${targetSelector}`);
+	}
+	return { within, target };
+}
+
+describe("isInteractiveTarget", () => {
+	// Each row pins one entry of the selector: drop that entry and its row fails.
+	test.each([
+		{ name: "a link", html: '<a href="#docs">docs</a>', targetSelector: "a" },
+		{ name: "a button", html: "<button>go</button>", targetSelector: "button" },
+		{
+			name: "a <summary> through its <details>",
+			html: "<details><summary>more</summary>text</details>",
+			targetSelector: "summary",
+		},
+		{ name: "an input", html: '<input type="checkbox" />', targetSelector: "input" },
+		{ name: "a select", html: "<select><option>a</option></select>", targetSelector: "select" },
+		{ name: "a textarea", html: "<textarea></textarea>", targetSelector: "textarea" },
+		{ name: "a label", html: "<label>name</label>", targetSelector: "label" },
+		{ name: 'role="button"', html: '<span role="button">go</span>', targetSelector: "span" },
+		{ name: 'role="link"', html: '<span role="link">docs</span>', targetSelector: "span" },
+		{ name: 'role="menuitem"', html: '<div role="menuitem">open</div>', targetSelector: "div" },
+		{
+			name: "contenteditable",
+			html: '<div contenteditable="true">edit</div>',
+			targetSelector: "div",
+		},
+	])("returns true for $name inside `within`", ({ html, targetSelector }) => {
+		const { within, target } = renderTarget(html, targetSelector);
+		expect(isInteractiveTarget(target, within)).toBe(true);
+	});
+
+	test("returns true for text inside interactive content, not only the element itself", () => {
+		const { within, target } = renderTarget("<button><span>go</span></button>", "span");
+		expect(isInteractiveTarget(target, within)).toBe(true);
+	});
+
+	test("returns false for plain content (the ancestor acts)", () => {
+		const { within, target } = renderTarget("<p>Get notified by email.</p>", "p");
+		expect(isInteractiveTarget(target, within)).toBe(false);
+	});
+
+	test("returns false for a placeholder link with no href", () => {
+		const { within, target } = renderTarget("<a>not a link</a>", "a");
+		expect(isInteractiveTarget(target, within)).toBe(false);
+	});
+
+	test("returns false for a non-element target", () => {
+		const within = document.createElement("div");
+		expect(isInteractiveTarget(null, within)).toBe(false);
+	});
+
+	test("ignores interactive ancestors outside `within`", () => {
+		// `within` sits inside a <details>. A click on its own text is not
+		// interactive, even though an ancestor is.
+		const outer = document.createElement("details");
+		const within = document.createElement("div");
+		const text = document.createElement("p");
+		outer.append(within);
+		within.append(text);
+		expect(isInteractiveTarget(text, within)).toBe(false);
+	});
+});

--- a/packages/mantle/src/utils/interactive-target.ts
+++ b/packages/mantle/src/utils/interactive-target.ts
@@ -1,0 +1,39 @@
+/**
+ * Interactive content that handles its own click: form controls, links,
+ * `<details>` (a `<summary>` toggles it), labels, and the ARIA widget roles a
+ * custom control renders. A click-forwarding ancestor (a `List` row, a
+ * `Choice.Description`) defers to these, so one click never acts twice.
+ *
+ * Why not the whole HTML interactive-content set: an `<iframe>` or `<embed>`
+ * click never reaches this document, and the rest (media controls, image
+ * maps) is not content a row or a description hosts.
+ */
+const INTERACTIVE_TARGET_SELECTOR =
+	'a[href], button, details, input, select, textarea, label, [role="button"], [role="link"], [role="menuitem"], [contenteditable="true"]';
+
+/**
+ * Whether a click landed on interactive content inside `within`, so a
+ * click-forwarding ancestor should defer to it. Interactive ancestors outside
+ * `within` do not count, and a non-element target never does. Pure over the
+ * DOM.
+ *
+ * @example
+ * ```ts
+ * // click on the row's checkbox → true (activation must not fire twice)
+ * isInteractiveTarget(checkboxElement, rowElement); // → true
+ * // click on the row's description text → false (the row activates)
+ * isInteractiveTarget(descriptionElement, rowElement); // → false
+ * ```
+ */
+function isInteractiveTarget(target: EventTarget | null, within: Element): boolean {
+	if (!(target instanceof Element)) {
+		return false;
+	}
+	const interactive = target.closest(INTERACTIVE_TARGET_SELECTOR);
+	return interactive != null && within.contains(interactive);
+}
+
+export {
+	//,
+	isInteractiveTarget,
+};


### PR DESCRIPTION
## Why

A checkbox composed with `Choice` had a click target that stopped at the title. A user who clicks the description expects the box to toggle, but a `<label>` may only name the control, and the description belongs to `aria-describedby`, not to the label. This change makes the description a click target without a second label.

The same page also showed a `data-slot` gap: a `Checkbox` or `Choice.Root` inside `Field.Control` rendered without `data-slot="checkbox"` or `data-slot="choice"`.

## What

- `Choice.Root` holds a ref to the rendered `Choice.Label`. `Choice.Description` calls `label.click()` on it, so the control receives the same click a direct label click sends. The accessible name stays the label alone.
- A consumer `onClick` runs first, and `event.preventDefault()` cancels the forward. A click on a link or other interactive content inside the description does not forward. When the choice uses `Choice.Title`, there is no label, so the ancestor that owns the click handles it and the control toggles once.
- The description shows the pointer cursor when a `Choice.Label` precedes it.
- `Slot` passed `data-slot: undefined` to a component child when neither side set one. A part that spreads its props after its own `data-slot` lost the attribute. `Slot` now sets `data-slot` only when a value exists.

## Limitations

`Field.Description` keeps its current behavior. It sits under `Input`, `Select`, and `Combobox` too, so a forwarded click would focus or open those on a click on helper text.
