### PR TITLE
fix(hooks): guard storage access in useLocalStorage and useSessionStorage

### DIFF
--- a/.changeset/guard-storage-hooks.md
+++ b/.changeset/guard-storage-hooks.md
@@ -1,0 +1,7 @@
+---
+"@ngrok/mantle": patch
+---
+
+`useLocalStorage` and `useSessionStorage` now guard every storage access. Before, a `setItem` that threw (a full origin, Safari private browsing, blocked site data) skipped the sync event, so the hook's value never advanced and the caller got no signal: a dismissible banner that gates its visibility on the stored value never closed. A storage read that threw during render took down the subtree.
+
+If a write fails, the hook now keeps the value in memory, so every same-key instance still advances until the page reloads. A later write that succeeds restores storage as the source of truth. If the browser denies storage access, the read resolves to the default instead of throwing.

--- a/.changeset/guard-storage-hooks.md
+++ b/.changeset/guard-storage-hooks.md
@@ -4,4 +4,4 @@
 
 `useLocalStorage` and `useSessionStorage` now guard every storage access. Before, a `setItem` that threw (a full origin, Safari private browsing, blocked site data) skipped the sync event, so the hook's value never advanced and the caller got no signal: a dismissible banner that gates its visibility on the stored value never closed. A storage read that threw during render took down the subtree.
 
-If a write fails, the hook now keeps the value in memory, so every same-key instance still advances until the page reloads. A later write that succeeds restores storage as the source of truth. If the browser denies storage access, the read resolves to the default instead of throwing.
+If a write fails, the hook now keeps the value in memory, so every same-key instance still advances until the page reloads. A later write that succeeds, or a `storage` event from another document, restores storage as the source of truth. If the browser denies storage access, the read resolves to the default instead of throwing.

--- a/apps/www/app/docs/hooks.mdx
+++ b/apps/www/app/docs/hooks.mdx
@@ -220,6 +220,8 @@ const [value, setValue] = useLocalStorage("key", "default");
 
 SSR-safe localStorage-backed string state. Server rendering returns the default and never touches localStorage. Values are JSON-encoded on write and decoded on read. The setter keeps every same-key hook instance in the tab in sync, and cross-tab changes arrive via the native `storage` event. Missing or corrupt entries resolve to the default instead of throwing.
 
+Reads and writes never throw. If the browser denies storage access, the value is the default. If a write fails (a full origin, Safari private browsing, blocked site data), the hook keeps the value in memory, so it still advances until the page reloads. A later write that succeeds restores storage as the source of truth.
+
 ```tsx
 import { useLocalStorage } from "@ngrok/mantle/hooks";
 

--- a/apps/www/app/docs/hooks.mdx
+++ b/apps/www/app/docs/hooks.mdx
@@ -220,7 +220,7 @@ const [value, setValue] = useLocalStorage("key", "default");
 
 SSR-safe localStorage-backed string state. Server rendering returns the default and never touches localStorage. Values are JSON-encoded on write and decoded on read. The setter keeps every same-key hook instance in the tab in sync, and cross-tab changes arrive via the native `storage` event. Missing or corrupt entries resolve to the default instead of throwing.
 
-Reads and writes never throw. If the browser denies storage access, the value is the default. If a write fails (a full origin, Safari private browsing, blocked site data), the hook keeps the value in memory, so it still advances until the page reloads. A later write that succeeds restores storage as the source of truth.
+Reads and writes never throw. If the browser denies storage access, the value is the default. If a write fails (a full origin, Safari private browsing, blocked site data), the hook keeps the value in memory, so it still advances until the page reloads. A later write that succeeds, or a `storage` event from another document, restores storage as the source of truth.
 
 ```tsx
 import { useLocalStorage } from "@ngrok/mantle/hooks";

--- a/packages/mantle/src/hooks/use-local-storage.test.tsx
+++ b/packages/mantle/src/hooks/use-local-storage.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { useLocalStorage } from "./use-local-storage.js";
 
 const key = "test-preference";
@@ -9,6 +9,28 @@ const defaultValue = "default-value";
 function Probe() {
 	const [value] = useLocalStorage(key, defaultValue);
 	return <span>{value}</span>;
+}
+
+/**
+ * Wraps `storage` so every `setItem` throws `QuotaExceededError`, the way a
+ * full origin or Safari private browsing behaves. Reads pass through.
+ *
+ * Why a wrapper behind the `window.localStorage` getter: happy-dom binds each
+ * `Storage` method onto the instance on first access. A prototype spy
+ * installed later never reaches the hook's call, and an instance spy leaks
+ * past `restoreMocks`.
+ */
+function refuseWrites(storage: Storage): Storage {
+	return new Proxy(storage, {
+		get(target, property) {
+			if (property === "setItem") {
+				return () => {
+					throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+				};
+			}
+			return Reflect.get(target, property);
+		},
+	});
 }
 
 beforeEach(() => {
@@ -159,6 +181,86 @@ describe("useLocalStorage", () => {
 
 		const [value] = result.current;
 		expect(value).toBe(defaultValue);
+	});
+
+	test("a write that storage refuses still advances every hook instance in the tab", () => {
+		// Why its own key: the memory fallback is module state, and a refused
+		// write must not leak into the tests that share `key`.
+		const quotaKey = "test-preference-quota";
+		const storage = window.localStorage;
+		vi.spyOn(window, "localStorage", "get").mockReturnValue(refuseWrites(storage));
+		const first = renderHook(() => useLocalStorage(quotaKey, defaultValue));
+		const second = renderHook(() => useLocalStorage(quotaKey, defaultValue));
+
+		act(() => {
+			const [, setValue] = first.result.current;
+			setValue("dismissed");
+		});
+
+		expect(first.result.current[0]).toBe("dismissed");
+		expect(second.result.current[0]).toBe("dismissed");
+		expect(storage.getItem(quotaKey)).toBeNull();
+	});
+
+	test("a write that succeeds after a refused one makes storage the source of truth again", () => {
+		const recoveryKey = "test-preference-recovery";
+		const storage = window.localStorage;
+		const getter = vi.spyOn(window, "localStorage", "get").mockReturnValue(refuseWrites(storage));
+		const { result } = renderHook(() => useLocalStorage(recoveryKey, defaultValue));
+
+		act(() => {
+			result.current[1]("held-in-memory");
+		});
+		expect(result.current[0]).toBe("held-in-memory");
+		expect(storage.getItem(recoveryKey)).toBeNull();
+
+		// storage accepts writes again
+		getter.mockRestore();
+		act(() => {
+			result.current[1]("persisted");
+		});
+		expect(result.current[0]).toBe("persisted");
+		expect(storage.getItem(recoveryKey)).toBe(JSON.stringify("persisted"));
+
+		// storage wins from here on: a cross-tab change replaces the value
+		act(() => {
+			storage.setItem(recoveryKey, JSON.stringify("other-tab-value"));
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: recoveryKey,
+					newValue: JSON.stringify("other-tab-value"),
+					storageArea: storage,
+				}),
+			);
+		});
+		expect(result.current[0]).toBe("other-tab-value");
+	});
+
+	test("a denied storage read resolves to the default instead of throwing during render", () => {
+		vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+			throw new DOMException("Access is denied for this document.", "SecurityError");
+		});
+
+		const { result } = renderHook(() => useLocalStorage(key, defaultValue));
+
+		expect(result.current[0]).toBe(defaultValue);
+	});
+
+	test("a denied storage still lets the setter advance every hook instance in the tab", () => {
+		const deniedKey = "test-preference-denied";
+		vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+			throw new DOMException("Access is denied for this document.", "SecurityError");
+		});
+		const first = renderHook(() => useLocalStorage(deniedKey, defaultValue));
+		const second = renderHook(() => useLocalStorage(deniedKey, defaultValue));
+
+		act(() => {
+			const [, setValue] = first.result.current;
+			setValue("dismissed");
+		});
+
+		expect(first.result.current[0]).toBe("dismissed");
+		expect(second.result.current[0]).toBe("dismissed");
 	});
 
 	test("server rendering returns the default and never touches localStorage (SSR regression)", () => {

--- a/packages/mantle/src/hooks/use-local-storage.test.tsx
+++ b/packages/mantle/src/hooks/use-local-storage.test.tsx
@@ -222,7 +222,7 @@ describe("useLocalStorage", () => {
 		expect(result.current[0]).toBe("persisted");
 		expect(storage.getItem(recoveryKey)).toBe(JSON.stringify("persisted"));
 
-		// storage wins from here on: a cross-tab change replaces the value
+		// storage wins from here on: a change from another tab replaces the value
 		act(() => {
 			storage.setItem(recoveryKey, JSON.stringify("other-tab-value"));
 			window.dispatchEvent(
@@ -234,6 +234,48 @@ describe("useLocalStorage", () => {
 			);
 		});
 		expect(result.current[0]).toBe("other-tab-value");
+	});
+
+	test("a storage change from another tab replaces a refused write", () => {
+		const overtakenKey = "test-preference-overtaken";
+		const storage = window.localStorage;
+		vi.spyOn(window, "localStorage", "get").mockReturnValue(refuseWrites(storage));
+		const { result } = renderHook(() => useLocalStorage(overtakenKey, defaultValue));
+
+		act(() => {
+			result.current[1]("held-in-memory");
+		});
+		expect(result.current[0]).toBe("held-in-memory");
+
+		act(() => {
+			storage.setItem(overtakenKey, JSON.stringify("other-document-value"));
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: overtakenKey,
+					newValue: JSON.stringify("other-document-value"),
+					storageArea: window.localStorage,
+				}),
+			);
+		});
+		expect(result.current[0]).toBe("other-document-value");
+	});
+
+	test("a clear-all storage event drops a refused write", () => {
+		const clearedKey = "test-preference-cleared";
+		vi.spyOn(window, "localStorage", "get").mockReturnValue(refuseWrites(window.localStorage));
+		const { result } = renderHook(() => useLocalStorage(clearedKey, defaultValue));
+
+		act(() => {
+			result.current[1]("held-in-memory");
+		});
+		expect(result.current[0]).toBe("held-in-memory");
+
+		act(() => {
+			window.dispatchEvent(
+				new StorageEvent("storage", { key: null, storageArea: window.localStorage }),
+			);
+		});
+		expect(result.current[0]).toBe(defaultValue);
 	});
 
 	test("a denied storage read resolves to the default instead of throwing during render", () => {

--- a/packages/mantle/src/hooks/use-local-storage.tsx
+++ b/packages/mantle/src/hooks/use-local-storage.tsx
@@ -8,6 +8,28 @@ import { useCallback, useMemo, useSyncExternalStore } from "react";
 const memoryFallback = new Map<string, string>();
 
 /**
+ * Lets a matching `storage` event outrank the memory fallback. Another
+ * document changed storage, so the event's `newValue` replaces the refused
+ * write, and a null `newValue` (a remove) deletes it. A clear-all event
+ * (`key` is null) empties the whole fallback. The hook's own echo of a
+ * refused write carries the fallback value, so it changes nothing.
+ */
+function reconcileMemoryFallback(event: StorageEvent): void {
+	if (event.key == null) {
+		memoryFallback.clear();
+		return;
+	}
+	if (!memoryFallback.has(event.key)) {
+		return;
+	}
+	if (event.newValue == null) {
+		memoryFallback.delete(event.key);
+	} else {
+		memoryFallback.set(event.key, event.newValue);
+	}
+}
+
+/**
  * Resolves `window.localStorage`, or null where the browser denies access.
  *
  * Why a guard on the property read: with site data blocked, Chrome throws a
@@ -36,6 +58,7 @@ function subscribeToLocalStorageKey(key: string): (onStoreChange: () => void) =>
 			const matchesStore = event.storageArea == null || event.storageArea === getLocalStorageArea();
 			const matchesKey = event.key == null || event.key === key;
 			if (matchesStore && matchesKey) {
+				reconcileMemoryFallback(event);
 				onStoreChange();
 			}
 		}
@@ -126,8 +149,8 @@ function parseStoredValue(raw: string, defaultValue: string): string {
  *   the value resolves to `defaultValue`. If `setItem` throws (a full
  *   origin, Safari private browsing, blocked site data), the hook keeps
  *   the value in memory, so every same-key instance still advances until
- *   the page reloads. A later write that succeeds restores storage as the
- *   source of truth.
+ *   the page reloads. A later write that succeeds, or a `storage` event
+ *   from another document, restores storage as the source of truth.
  *
  * @param key - The localStorage key to read and write.
  * @param defaultValue - Returned when no valid entry exists for `key` and

--- a/packages/mantle/src/hooks/use-local-storage.tsx
+++ b/packages/mantle/src/hooks/use-local-storage.tsx
@@ -1,6 +1,28 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 
 /**
+ * The JSON-encoded value of the last refused write, per key. A write lands
+ * here when `setItem` throws, so the hook still advances until the page
+ * reloads. A later write that succeeds deletes the entry.
+ */
+const memoryFallback = new Map<string, string>();
+
+/**
+ * Resolves `window.localStorage`, or null where the browser denies access.
+ *
+ * Why a guard on the property read: with site data blocked, Chrome throws a
+ * `SecurityError` from the `localStorage` getter itself, before any method
+ * call.
+ */
+function getLocalStorageArea(): Storage | null {
+	try {
+		return window.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Builds the subscribe function for one localStorage key. It notifies only
  * for `storage` events that could change that key: a matching `key` (or a
  * clear-all event, where `key` is null) in localStorage — or an event whose
@@ -11,7 +33,7 @@ import { useCallback, useMemo, useSyncExternalStore } from "react";
 function subscribeToLocalStorageKey(key: string): (onStoreChange: () => void) => () => void {
 	return function subscribe(onStoreChange: () => void): () => void {
 		function handleStorageEvent(event: StorageEvent): void {
-			const matchesStore = event.storageArea == null || event.storageArea === window.localStorage;
+			const matchesStore = event.storageArea == null || event.storageArea === getLocalStorageArea();
 			const matchesKey = event.key == null || event.key === key;
 			if (matchesStore && matchesKey) {
 				onStoreChange();
@@ -36,6 +58,40 @@ function getLocalStorageServerSnapshot(): null {
 }
 
 /**
+ * Reads the raw entry for `key`. If the memory fallback holds an entry, it
+ * wins: storage refused that write and still returns the older entry. If
+ * storage access throws, the entry resolves to null, so a denied storage
+ * can never crash the render.
+ */
+function readLocalStorageItem(key: string): string | null {
+	const fallback = memoryFallback.get(key);
+	if (fallback != null) {
+		return fallback;
+	}
+
+	try {
+		return window.localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Writes the raw entry for `key`. If `setItem` throws (a full origin,
+ * Safari private browsing, blocked site data), the value lands in the
+ * memory fallback instead, so the hook still advances. A write that
+ * succeeds deletes the fallback, so storage is the source of truth again.
+ */
+function writeLocalStorageItem(key: string, encoded: string): void {
+	try {
+		window.localStorage.setItem(key, encoded);
+		memoryFallback.delete(key);
+	} catch {
+		memoryFallback.set(key, encoded);
+	}
+}
+
+/**
  * Decodes a raw localStorage entry written by this hook. A corrupt or
  * non-string entry resolves to the default instead of throwing, so a bad
  * stored value can never crash the render.
@@ -55,7 +111,7 @@ function parseStoredValue(raw: string, defaultValue: string): string {
  * Contract:
  *
  * - Server rendering returns `defaultValue` and never touches localStorage.
- * - Values are JSON-encoded on write and JSON-decoded on read — the same
+ * - Values are JSON-encoded on write and JSON-decoded on read: the same
  *   wire format popular hooks libraries (e.g. `@uidotdev/usehooks`) use,
  *   so existing stored entries remain readable.
  * - The setter dispatches a synthetic `storage` event (tagged with its
@@ -66,6 +122,12 @@ function parseStoredValue(raw: string, defaultValue: string): string {
  * - Missing, corrupt, or non-string entries resolve to `defaultValue`; the
  *   hook never seeds `defaultValue` into storage on its own (reading is
  *   side-effect free).
+ * - Reads and writes never throw. If the browser denies storage access,
+ *   the value resolves to `defaultValue`. If `setItem` throws (a full
+ *   origin, Safari private browsing, blocked site data), the hook keeps
+ *   the value in memory, so every same-key instance still advances until
+ *   the page reloads. A later write that succeeds restores storage as the
+ *   source of truth.
  *
  * @param key - The localStorage key to read and write.
  * @param defaultValue - Returned when no valid entry exists for `key` and
@@ -88,7 +150,7 @@ function useLocalStorage(
 
 	const rawValue = useSyncExternalStore(
 		subscribe,
-		() => window.localStorage.getItem(key),
+		() => readLocalStorageItem(key),
 		getLocalStorageServerSnapshot,
 	);
 
@@ -97,9 +159,9 @@ function useLocalStorage(
 	const setValue = useCallback(
 		(next: string) => {
 			const encoded = JSON.stringify(next);
-			window.localStorage.setItem(key, encoded);
+			writeLocalStorageItem(key, encoded);
 			window.dispatchEvent(
-				new StorageEvent("storage", { key, newValue: encoded, storageArea: window.localStorage }),
+				new StorageEvent("storage", { key, newValue: encoded, storageArea: getLocalStorageArea() }),
 			);
 		},
 		[key],

--- a/packages/mantle/src/hooks/use-session-storage.test.tsx
+++ b/packages/mantle/src/hooks/use-session-storage.test.tsx
@@ -191,7 +191,8 @@ describe("useSessionStorage", () => {
 		expect(result.current[0]).toBe("persisted");
 		expect(storage.getItem(recoveryKey)).toBe(JSON.stringify("persisted"));
 
-		// storage wins from here on: a cross-tab change replaces the value
+		// storage wins from here on: a change from another document in the tab
+		// (an iframe on the same origin) replaces the value
 		act(() => {
 			storage.setItem(recoveryKey, JSON.stringify("other-tab-value"));
 			window.dispatchEvent(
@@ -203,6 +204,48 @@ describe("useSessionStorage", () => {
 			);
 		});
 		expect(result.current[0]).toBe("other-tab-value");
+	});
+
+	test("a storage change from another document in the tab replaces a refused write", () => {
+		const overtakenKey = "test-session-preference-overtaken";
+		const storage = window.sessionStorage;
+		vi.spyOn(window, "sessionStorage", "get").mockReturnValue(refuseWrites(storage));
+		const { result } = renderHook(() => useSessionStorage(overtakenKey, defaultValue));
+
+		act(() => {
+			result.current[1]("held-in-memory");
+		});
+		expect(result.current[0]).toBe("held-in-memory");
+
+		act(() => {
+			storage.setItem(overtakenKey, JSON.stringify("other-document-value"));
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: overtakenKey,
+					newValue: JSON.stringify("other-document-value"),
+					storageArea: window.sessionStorage,
+				}),
+			);
+		});
+		expect(result.current[0]).toBe("other-document-value");
+	});
+
+	test("a clear-all storage event drops a refused write", () => {
+		const clearedKey = "test-session-preference-cleared";
+		vi.spyOn(window, "sessionStorage", "get").mockReturnValue(refuseWrites(window.sessionStorage));
+		const { result } = renderHook(() => useSessionStorage(clearedKey, defaultValue));
+
+		act(() => {
+			result.current[1]("held-in-memory");
+		});
+		expect(result.current[0]).toBe("held-in-memory");
+
+		act(() => {
+			window.dispatchEvent(
+				new StorageEvent("storage", { key: null, storageArea: window.sessionStorage }),
+			);
+		});
+		expect(result.current[0]).toBe(defaultValue);
 	});
 
 	test("a denied storage read resolves to the default instead of throwing during render", () => {

--- a/packages/mantle/src/hooks/use-session-storage.test.tsx
+++ b/packages/mantle/src/hooks/use-session-storage.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { useSessionStorage } from "./use-session-storage.js";
 
 const key = "test-session-preference";
@@ -9,6 +9,28 @@ const defaultValue = "default-value";
 function Probe() {
 	const [value] = useSessionStorage(key, defaultValue);
 	return <span>{value}</span>;
+}
+
+/**
+ * Wraps `storage` so every `setItem` throws `QuotaExceededError`, the way a
+ * full origin or Safari private browsing behaves. Reads pass through.
+ *
+ * Why a wrapper behind the `window.sessionStorage` getter: happy-dom binds each
+ * `Storage` method onto the instance on first access. A prototype spy
+ * installed later never reaches the hook's call, and an instance spy leaks
+ * past `restoreMocks`.
+ */
+function refuseWrites(storage: Storage): Storage {
+	return new Proxy(storage, {
+		get(target, property) {
+			if (property === "setItem") {
+				return () => {
+					throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+				};
+			}
+			return Reflect.get(target, property);
+		},
+	});
 }
 
 beforeEach(() => {
@@ -128,6 +150,86 @@ describe("useSessionStorage", () => {
 
 		const [value] = result.current;
 		expect(value).toBe(defaultValue);
+	});
+
+	test("a write that storage refuses still advances every hook instance in the tab", () => {
+		// Why its own key: the memory fallback is module state, and a refused
+		// write must not leak into the tests that share `key`.
+		const quotaKey = "test-session-preference-quota";
+		const storage = window.sessionStorage;
+		vi.spyOn(window, "sessionStorage", "get").mockReturnValue(refuseWrites(storage));
+		const first = renderHook(() => useSessionStorage(quotaKey, defaultValue));
+		const second = renderHook(() => useSessionStorage(quotaKey, defaultValue));
+
+		act(() => {
+			const [, setValue] = first.result.current;
+			setValue("dismissed");
+		});
+
+		expect(first.result.current[0]).toBe("dismissed");
+		expect(second.result.current[0]).toBe("dismissed");
+		expect(storage.getItem(quotaKey)).toBeNull();
+	});
+
+	test("a write that succeeds after a refused one makes storage the source of truth again", () => {
+		const recoveryKey = "test-session-preference-recovery";
+		const storage = window.sessionStorage;
+		const getter = vi.spyOn(window, "sessionStorage", "get").mockReturnValue(refuseWrites(storage));
+		const { result } = renderHook(() => useSessionStorage(recoveryKey, defaultValue));
+
+		act(() => {
+			result.current[1]("held-in-memory");
+		});
+		expect(result.current[0]).toBe("held-in-memory");
+		expect(storage.getItem(recoveryKey)).toBeNull();
+
+		// storage accepts writes again
+		getter.mockRestore();
+		act(() => {
+			result.current[1]("persisted");
+		});
+		expect(result.current[0]).toBe("persisted");
+		expect(storage.getItem(recoveryKey)).toBe(JSON.stringify("persisted"));
+
+		// storage wins from here on: a cross-tab change replaces the value
+		act(() => {
+			storage.setItem(recoveryKey, JSON.stringify("other-tab-value"));
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: recoveryKey,
+					newValue: JSON.stringify("other-tab-value"),
+					storageArea: storage,
+				}),
+			);
+		});
+		expect(result.current[0]).toBe("other-tab-value");
+	});
+
+	test("a denied storage read resolves to the default instead of throwing during render", () => {
+		vi.spyOn(window, "sessionStorage", "get").mockImplementation(() => {
+			throw new DOMException("Access is denied for this document.", "SecurityError");
+		});
+
+		const { result } = renderHook(() => useSessionStorage(key, defaultValue));
+
+		expect(result.current[0]).toBe(defaultValue);
+	});
+
+	test("a denied storage still lets the setter advance every hook instance in the tab", () => {
+		const deniedKey = "test-session-preference-denied";
+		vi.spyOn(window, "sessionStorage", "get").mockImplementation(() => {
+			throw new DOMException("Access is denied for this document.", "SecurityError");
+		});
+		const first = renderHook(() => useSessionStorage(deniedKey, defaultValue));
+		const second = renderHook(() => useSessionStorage(deniedKey, defaultValue));
+
+		act(() => {
+			const [, setValue] = first.result.current;
+			setValue("dismissed");
+		});
+
+		expect(first.result.current[0]).toBe("dismissed");
+		expect(second.result.current[0]).toBe("dismissed");
 	});
 
 	test("server rendering returns the default and never touches sessionStorage (SSR regression)", () => {

--- a/packages/mantle/src/hooks/use-session-storage.tsx
+++ b/packages/mantle/src/hooks/use-session-storage.tsx
@@ -8,6 +8,28 @@ import { useCallback, useMemo, useSyncExternalStore } from "react";
 const memoryFallback = new Map<string, string>();
 
 /**
+ * Lets a matching `storage` event outrank the memory fallback. Another
+ * document changed storage, so the event's `newValue` replaces the refused
+ * write, and a null `newValue` (a remove) deletes it. A clear-all event
+ * (`key` is null) empties the whole fallback. The hook's own echo of a
+ * refused write carries the fallback value, so it changes nothing.
+ */
+function reconcileMemoryFallback(event: StorageEvent): void {
+	if (event.key == null) {
+		memoryFallback.clear();
+		return;
+	}
+	if (!memoryFallback.has(event.key)) {
+		return;
+	}
+	if (event.newValue == null) {
+		memoryFallback.delete(event.key);
+	} else {
+		memoryFallback.set(event.key, event.newValue);
+	}
+}
+
+/**
  * Resolves `window.sessionStorage`, or null where the browser denies access.
  *
  * Why a guard on the property read: with site data blocked, Chrome throws a
@@ -37,6 +59,7 @@ function subscribeToSessionStorageKey(key: string): (onStoreChange: () => void) 
 				event.storageArea == null || event.storageArea === getSessionStorageArea();
 			const matchesKey = event.key == null || event.key === key;
 			if (matchesStore && matchesKey) {
+				reconcileMemoryFallback(event);
 				onStoreChange();
 			}
 		}
@@ -123,8 +146,8 @@ function parseStoredValue(raw: string, defaultValue: string): string {
  *   the value resolves to `defaultValue`. If `setItem` throws (a full
  *   origin, Safari private browsing, blocked site data), the hook keeps
  *   the value in memory, so every same-key instance still advances until
- *   the page reloads. A later write that succeeds restores storage as the
- *   source of truth.
+ *   the page reloads. A later write that succeeds, or a `storage` event
+ *   from another document, restores storage as the source of truth.
  *
  * @param key - The sessionStorage key to read and write.
  * @param defaultValue - Returned when no valid entry exists for `key` and

--- a/packages/mantle/src/hooks/use-session-storage.tsx
+++ b/packages/mantle/src/hooks/use-session-storage.tsx
@@ -1,6 +1,28 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 
 /**
+ * The JSON-encoded value of the last refused write, per key. A write lands
+ * here when `setItem` throws, so the hook still advances until the page
+ * reloads. A later write that succeeds deletes the entry.
+ */
+const memoryFallback = new Map<string, string>();
+
+/**
+ * Resolves `window.sessionStorage`, or null where the browser denies access.
+ *
+ * Why a guard on the property read: with site data blocked, Chrome throws a
+ * `SecurityError` from the `sessionStorage` getter itself, before any method
+ * call.
+ */
+function getSessionStorageArea(): Storage | null {
+	try {
+		return window.sessionStorage;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Builds the subscribe function for one sessionStorage key. It notifies only
  * for `storage` events that could change that key: a matching `key` (or a
  * clear-all event, where `key` is null) in sessionStorage — or an event
@@ -11,7 +33,8 @@ import { useCallback, useMemo, useSyncExternalStore } from "react";
 function subscribeToSessionStorageKey(key: string): (onStoreChange: () => void) => () => void {
 	return function subscribe(onStoreChange: () => void): () => void {
 		function handleStorageEvent(event: StorageEvent): void {
-			const matchesStore = event.storageArea == null || event.storageArea === window.sessionStorage;
+			const matchesStore =
+				event.storageArea == null || event.storageArea === getSessionStorageArea();
 			const matchesKey = event.key == null || event.key === key;
 			if (matchesStore && matchesKey) {
 				onStoreChange();
@@ -33,6 +56,40 @@ function subscribeToSessionStorageKey(key: string): (onStoreChange: () => void) 
  */
 function getSessionStorageServerSnapshot(): null {
 	return null;
+}
+
+/**
+ * Reads the raw entry for `key`. If the memory fallback holds an entry, it
+ * wins: storage refused that write and still returns the older entry. If
+ * storage access throws, the entry resolves to null, so a denied storage
+ * can never crash the render.
+ */
+function readSessionStorageItem(key: string): string | null {
+	const fallback = memoryFallback.get(key);
+	if (fallback != null) {
+		return fallback;
+	}
+
+	try {
+		return window.sessionStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Writes the raw entry for `key`. If `setItem` throws (a full origin,
+ * Safari private browsing, blocked site data), the value lands in the
+ * memory fallback instead, so the hook still advances. A write that
+ * succeeds deletes the fallback, so storage is the source of truth again.
+ */
+function writeSessionStorageItem(key: string, encoded: string): void {
+	try {
+		window.sessionStorage.setItem(key, encoded);
+		memoryFallback.delete(key);
+	} catch {
+		memoryFallback.set(key, encoded);
+	}
 }
 
 /**
@@ -62,6 +119,12 @@ function parseStoredValue(raw: string, defaultValue: string): string {
  * - Missing, corrupt, or non-string entries resolve to `defaultValue`; the
  *   hook never seeds `defaultValue` into storage on its own (reading is
  *   side-effect free).
+ * - Reads and writes never throw. If the browser denies storage access,
+ *   the value resolves to `defaultValue`. If `setItem` throws (a full
+ *   origin, Safari private browsing, blocked site data), the hook keeps
+ *   the value in memory, so every same-key instance still advances until
+ *   the page reloads. A later write that succeeds restores storage as the
+ *   source of truth.
  *
  * @param key - The sessionStorage key to read and write.
  * @param defaultValue - Returned when no valid entry exists for `key` and
@@ -84,7 +147,7 @@ function useSessionStorage(
 
 	const rawValue = useSyncExternalStore(
 		subscribe,
-		() => window.sessionStorage.getItem(key),
+		() => readSessionStorageItem(key),
 		getSessionStorageServerSnapshot,
 	);
 
@@ -93,9 +156,13 @@ function useSessionStorage(
 	const setValue = useCallback(
 		(next: string) => {
 			const encoded = JSON.stringify(next);
-			window.sessionStorage.setItem(key, encoded);
+			writeSessionStorageItem(key, encoded);
 			window.dispatchEvent(
-				new StorageEvent("storage", { key, newValue: encoded, storageArea: window.sessionStorage }),
+				new StorageEvent("storage", {
+					key,
+					newValue: encoded,
+					storageArea: getSessionStorageArea(),
+				}),
 			);
 		},
 		[key],


### PR DESCRIPTION
Fixes [MNTL-60](https://linear.app/ngrok/issue/MNTL-60/uselocalstorage-unguarded-storage-access-makes-writes-silently-inert).

## Why

`useLocalStorage` and `useSessionStorage` touched storage with no error handling. If `setItem` threw (a full origin, Safari private browsing, blocked site data), the synthetic `storage` event never fired. The value never advanced, and the caller got no signal: a dismissible banner that gates its visibility on the stored value never closed. If the read threw, it threw during render and took down the subtree.

## How

- Both hooks now guard every storage access, including the `window.localStorage` property read, which throws in Chrome when a policy blocks site data.
- A refused write lands in a per-key in-memory fallback, so every same-key instance still advances until the page reloads. The read prefers the fallback, because storage still returns the entry from before the refused write.
- A later write that succeeds clears the fallback, so storage is the source of truth again.
- A denied read resolves to the default instead of throwing.
- The new tests wrap the real storage behind the `window.localStorage` getter. happy-dom binds `Storage` methods onto the instance on first access, so a prototype or instance spy never reaches the hook.
- Patch changeset for `@ngrok/mantle`.

## Validation

- The eight new tests fail on the original hooks and pass on the fix.
