### PR TITLE
chore(deps): bump @ariakit/react and @tanstack/react-virtual

### DIFF
--- a/.changeset/bump-ariakit-react-virtual.md
+++ b/.changeset/bump-ariakit-react-virtual.md
@@ -1,0 +1,11 @@
+---
+"@ngrok/mantle": patch
+---
+
+Bump runtime dependencies: `@ariakit/react` to 0.4.39 and `@tanstack/react-virtual` to 3.14.11.
+
+The ariakit bump changes the DOM of `MultiSelect.Content`, which renders a modal popover by default. A modal popover with no dismiss button renders a visually hidden fallback button so assistive technology users who cannot press Escape or click outside are not trapped. That button used to be the first child of the `listbox` element, where a `listbox` may not own a `button`. It now renders next to the `listbox`, still inside the modal context. The button is still hidden and still not reachable with Tab, so only a CSS selector on the popover's first child or a test that queries for a button inside the `listbox` sees the change.
+
+The ariakit bump also fixes a one-frame stale highlight in `Combobox` and `MultiSelect`: with `autoSelect` on, the previously active option no longer stays highlighted for one frame after the filtered list changes.
+
+The `@tanstack/react-virtual` bump reaches `List.VirtualRoot` and `SelectableList.VirtualViewport`. When a row grows while the list is pinned to the end, the virtualizer re-issues the scroll compensation the browser clamped, so the viewport no longer lands short of the last row.

--- a/.changeset/bump-ariakit-react-virtual.md
+++ b/.changeset/bump-ariakit-react-virtual.md
@@ -4,8 +4,8 @@
 
 Bump runtime dependencies: `@ariakit/react` to 0.4.39 and `@tanstack/react-virtual` to 3.14.11.
 
-The ariakit bump changes the DOM of `MultiSelect.Content`, which renders a modal popover by default. A modal popover with no dismiss button renders a visually hidden fallback button so assistive technology users who cannot press Escape or click outside are not trapped. That button used to be the first child of the `listbox` element, where a `listbox` may not own a `button`. It now renders next to the `listbox`, still inside the modal context. The button is still hidden and still not reachable with Tab, so only a CSS selector on the popover's first child or a test that queries for a button inside the `listbox` sees the change.
+The `@ariakit/react` bump changes the DOM of `MultiSelect.Content`, which renders a modal popover by default. A modal popover with no dismiss button renders a visually hidden fallback button so assistive technology users who cannot press Escape or click outside are not trapped. That button used to be the first child of the `listbox` element, where a `listbox` may not own a `button`. It now renders next to the `listbox`, still inside the modal context. The button is still hidden and still not reachable with Tab, so only a CSS selector on the popover's first child or a test that queries for a button inside the `listbox` sees the change.
 
-The ariakit bump also fixes a one-frame stale highlight in `Combobox` and `MultiSelect`: with `autoSelect` on, the previously active option no longer stays highlighted for one frame after the filtered list changes.
+The `@ariakit/react` bump also fixes a one-frame stale highlight in `Combobox` and `MultiSelect`: with `autoSelect` on, the previously active option no longer stays highlighted for one frame after the filtered list changes.
 
 The `@tanstack/react-virtual` bump reaches `List.VirtualRoot` and `SelectableList.VirtualViewport`. When a row grows while the list is pinned to the end, the virtualizer re-issues the scroll compensation the browser clamped, so the viewport no longer lands short of the last row.

--- a/packages/mantle/package.json
+++ b/packages/mantle/package.json
@@ -442,7 +442,7 @@
 		"typecheck": "tsc"
 	},
 	"dependencies": {
-		"@ariakit/react": "0.4.38",
+		"@ariakit/react": "0.4.39",
 		"@headlessui/react": "2.2.10",
 		"@radix-ui/react-dialog": "1.1.23",
 		"@radix-ui/react-dropdown-menu": "2.1.24",
@@ -456,7 +456,7 @@
 		"@radix-ui/react-tabs": "1.1.21",
 		"@radix-ui/react-tooltip": "1.2.16",
 		"@tanstack/react-table": "8.21.3",
-		"@tanstack/react-virtual": "3.14.10",
+		"@tanstack/react-virtual": "3.14.11",
 		"class-variance-authority": "0.7.1",
 		"cmdk": "1.1.1",
 		"d3-scale": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
   packages/mantle:
     dependencies:
       '@ariakit/react':
-        specifier: 0.4.38
-        version: 0.4.38(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 0.4.39
+        version: 0.4.39(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@headlessui/react':
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -314,8 +314,8 @@ importers:
         specifier: 8.21.3
         version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
-        specifier: 3.14.10
-        version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 3.14.11
+        version: 3.14.11(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -472,11 +472,11 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ariakit/components@0.1.11':
-    resolution: {integrity: sha512-hFmfWKkK8jpATf39kNZSMDlG3o+tftfQwyooRhbPl/YCpFur+IGz5ZPA+PGIIfFjfdkAURLNDJPSeWtXO3xssQ==}
+  '@ariakit/components@0.1.12':
+    resolution: {integrity: sha512-50Rg4Fp7W49fEVqa16eX2eYoIDrMGr+NbrQeTy0ujVZ/d12qwNZsdyA+wnbDfaZjoTy717Ohu0YYMAW+8tUusA==}
 
-  '@ariakit/react-components@0.5.0':
-    resolution: {integrity: sha512-NEpptkB3sJZrwTIIzFydyGjLGVLpfDt0X3naLh9x2Z0WyIkJuz6ZbzyWAxMrc9m4oNJgnex4cy5MZYndrJTtKQ==}
+  '@ariakit/react-components@0.6.0':
+    resolution: {integrity: sha512-T+u+8UzJEGbEg9f4yb76MFjaWMY9NYd47Bk8MOMStDuMh+vyn3GKj1m6++7gXUziQ+wD2f+uQkB3n+ay1seKbw==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -491,8 +491,8 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@ariakit/react@0.4.38':
-    resolution: {integrity: sha512-VubItCXqly9GNFxulOYDkFP94jh1M5iHeuo0BDTTiN1ndrGNeZCvsRUWd06BC9yjg+/LKEAnFLeolE1pG1IQBg==}
+  '@ariakit/react@0.4.39':
+    resolution: {integrity: sha512-Urj6knR0+xJzs/xpccl3AKB0OwDlEZvvUI3BFcb7QJge96quy8cub5QLwsE1Suiu1jUBvj4GIbja3jGhuU301w==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2355,8 +2355,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.14.10':
-    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+  '@tanstack/react-virtual@3.14.11':
+    resolution: {integrity: sha512-SStWf8bYdTgAquYqG4Pi2+d1XimQKoCIJ94H3jsm0D6UA0yqffvWuvUzrrQ4idewFWq8BSPpahnmLVosJIAs6g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2368,8 +2368,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@tanstack/virtual-core@3.17.8':
-    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
+  '@tanstack/virtual-core@3.17.9':
+    resolution: {integrity: sha512-M8Bzy7CCMvUjRiuoHVH9mRjyUVczRs8v8RcUEphLFGc445ZP4KQ15Y1sLqhQqJi/HgGJrxfCHnEnIX0x9mVrBg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4733,18 +4733,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -4784,14 +4772,14 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ariakit/components@0.1.11':
+  '@ariakit/components@0.1.12':
     dependencies:
       '@ariakit/store': 0.1.9
       '@ariakit/utils': 0.2.0
 
-  '@ariakit/react-components@0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@ariakit/react-components@0.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@ariakit/components': 0.1.11
+      '@ariakit/components': 0.1.12
       '@ariakit/react-store': 0.1.10(react@19.2.8)
       '@ariakit/react-utils': 0.2.5(react@19.2.8)
       '@ariakit/store': 0.1.9
@@ -4814,9 +4802,9 @@ snapshots:
       '@ariakit/utils': 0.2.0
       react: 19.2.8
 
-  '@ariakit/react@0.4.38(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@ariakit/react@0.4.39(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@ariakit/react-components': 0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@ariakit/react-components': 0.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -5181,7 +5169,7 @@ snapshots:
       '@floating-ui/react': 0.26.28(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/focus': 3.22.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-aria/interactions': 3.28.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-virtual': 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-virtual': 3.14.11(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
@@ -6365,9 +6353,9 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-virtual@3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-virtual@3.14.11(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/virtual-core': 3.17.8
+      '@tanstack/virtual-core': 3.17.9
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -6375,7 +6363,7 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@tanstack/virtual-core@3.17.8': {}
+  '@tanstack/virtual-core@3.17.9': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -7282,7 +7270,7 @@ snapshots:
       buffer-image-size: 0.6.4
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -8978,8 +8966,6 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
-
-  ws@8.21.1: {}
 
   ws@8.21.3: {}
 


### PR DESCRIPTION
## Why

Both runtime bumps are patch releases with a behavior change mantle consumers can see, so each gets a line in the changeset.

## What

`@ariakit/react` 0.4.38 → 0.4.39. A modal popover with no dismiss button renders a visually hidden fallback button so assistive technology users are not trapped. That button used to be the first child of the `listbox`, where a `listbox` may not own a `button`. It now renders next to the `listbox`, still inside the modal context. `MultiSelect.Content` is modal by default, so its DOM changes. The release also fixes a one-frame stale highlight in `Combobox` and `MultiSelect` with `autoSelect` on.

`@tanstack/react-virtual` 3.14.10 → 3.14.11. When a row grows while the list is pinned to the end, the browser clamps the scroll compensation write to the old maximum. The virtualizer now records the clamp and re-issues the write once the sizer grows, so `List.VirtualRoot` and `SelectableList.VirtualViewport` land on the last row.
