### PR TITLE
fix(alert): move focus to a neighbor when dismissal unmounts the alert

### DIFF
--- a/.changeset/alert-dismiss-focus.md
+++ b/.changeset/alert-dismiss-focus.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Alert.DismissIconButton` now moves keyboard focus to a neighbor when its dismissal unmounts the alert. Before, the unmount removed the focused button and focus fell to `<body>`. The next Tab restarted at the top of the page, and a screen reader user got no confirmation that the alert left. Now, when the alert unmounts while the dismiss button holds focus, focus moves to the nearest tabbable element outside the alert: the next one in document order, or the previous one when nothing follows. If your `onClick` handler or a layout effect places focus first, that choice stands. `AlertCenter.DismissIconButton` is unchanged: the center still lands focus on the next alert's control, or on the main landmark when no alert is left. The docs page shows the pattern under [Dismissal](https://mantle.ngrok.com/components/feedback/alert#dismissal).

--- a/apps/www/app/docs/components/feedback/alert.mdx
+++ b/apps/www/app/docs/components/feedback/alert.mdx
@@ -8,7 +8,7 @@ import { Card } from "@ngrok/mantle/card";
 import { $cssProperties } from "@ngrok/mantle/types";
 import { ShrimpIcon } from "@phosphor-icons/react/Shrimp";
 import { Example } from "~/components/example";
-import { DynamicAlertDemo } from "~/features/alert-demos";
+import { DismissibleAlertDemo, DynamicAlertDemo } from "~/features/alert-demos";
 
 # Alert
 
@@ -271,6 +271,51 @@ import { Alert } from "@ngrok/mantle/alert";
 		<Alert.Title>This is an info Alert as a page banner</Alert.Title>
 	</Alert.Content>
 </Alert.Root>;
+```
+
+## Dismissal
+
+`Alert.DismissIconButton` removes nothing on its own. Your state does: stop rendering the alert in its `onClick` handler. When that unmount happens while the dismiss button holds focus, focus moves to the nearest tabbable element outside the alert: the next one in document order, or the previous one when nothing follows. Without that move, focus falls to `<body>` and the next Tab restarts at the top of the page. A screen reader user also gets no confirmation that the alert left. If your handler or a layout effect places focus first, the alert keeps that choice.
+
+In the demo below, Tab to the dismiss button and press Enter. Focus lands on the button that follows the alert.
+
+<Example className="w-full">
+	<DismissibleAlertDemo />
+</Example>
+
+```tsx
+import { Alert } from "@ngrok/mantle/alert";
+import { Button } from "@ngrok/mantle/button";
+import { useState } from "react";
+
+export function TrialAlert() {
+	const [dismissed, setDismissed] = useState(false);
+
+	return (
+		<div className="flex w-full flex-col gap-4">
+			{!dismissed && (
+				<Alert.Root intent="info">
+					<Alert.Icon />
+					<Alert.Content>
+						<Alert.Title>Your trial ends in 3 days</Alert.Title>
+						<Alert.Description>
+							Add a payment method to keep your endpoints online.
+						</Alert.Description>
+						<Alert.DismissIconButton onClick={() => setDismissed(true)} />
+					</Alert.Content>
+				</Alert.Root>
+			)}
+			<Button
+				type="button"
+				appearance="outlined"
+				intent="neutral"
+				onClick={() => setDismissed(false)}
+			>
+				Show the alert again
+			</Button>
+		</div>
+	);
+}
 ```
 
 ## Expand button
@@ -552,7 +597,7 @@ All props from [h5](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/He
 
 ### Alert.DismissIconButton
 
-A dismiss icon button that closes the alert when clicked. It shares the root-level trailing-control CSS variables with `Alert.ExpandButton`.
+A dismiss icon button. Your `onClick` handler removes the alert. When that unmount happens while the button holds focus, focus moves to the nearest tabbable element outside the alert; see [Dismissal](#dismissal). It shares the root-level trailing-control CSS variables with `Alert.ExpandButton`.
 
 All props from [IconButton](/components/actions/icon-button#api-reference), with the following overridden defaults:
 

--- a/apps/www/app/features/alert-demos.test.tsx
+++ b/apps/www/app/features/alert-demos.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
-import { DynamicAlertDemo } from "./alert-demos";
+import { DismissibleAlertDemo, DynamicAlertDemo } from "./alert-demos";
 
 afterEach(() => {
 	cleanup();
@@ -38,5 +38,33 @@ describe("DynamicAlertDemo", () => {
 		const secondAlert = screen.getByRole("alert");
 		expect(secondAlert).not.toBe(firstAlert);
 		expect(document.activeElement).toBe(secondAlert);
+	});
+});
+
+describe("DismissibleAlertDemo", () => {
+	it("unmounts the alert and moves focus to the button after it", async () => {
+		const user = userEvent.setup();
+		render(<DismissibleAlertDemo />);
+
+		await user.tab();
+		expect(document.activeElement).toBe(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+		await user.keyboard("{Enter}");
+
+		expect(screen.queryByRole("button", { name: "Dismiss Alert" })).toBeNull();
+		expect(document.activeElement).toBe(
+			screen.getByRole("button", { name: "Show the alert again" }),
+		);
+	});
+
+	it("shows the alert again from the button that received focus", async () => {
+		const user = userEvent.setup();
+		render(<DismissibleAlertDemo />);
+		await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+		expect(screen.queryByRole("button", { name: "Dismiss Alert" })).toBeNull();
+
+		await user.keyboard("{Enter}");
+
+		expect(screen.queryByRole("button", { name: "Dismiss Alert" })).not.toBeNull();
 	});
 });

--- a/apps/www/app/features/alert-demos.tsx
+++ b/apps/www/app/features/alert-demos.tsx
@@ -29,6 +29,40 @@ function SignInError({ children }: PropsWithChildren) {
 }
 
 /**
+ * An alert whose dismiss button stops rendering it. When the alert leaves, the
+ * button after it receives focus, so a keyboard user's next Tab continues from
+ * where the alert was.
+ */
+export function DismissibleAlertDemo() {
+	const [dismissed, setDismissed] = useState(false);
+
+	return (
+		<div className="flex w-full flex-col gap-4">
+			{!dismissed && (
+				<Alert.Root intent="info">
+					<Alert.Icon />
+					<Alert.Content>
+						<Alert.Title>Your trial ends in 3 days</Alert.Title>
+						<Alert.Description>
+							Add a payment method to keep your endpoints online.
+						</Alert.Description>
+						<Alert.DismissIconButton onClick={() => setDismissed(true)} />
+					</Alert.Content>
+				</Alert.Root>
+			)}
+			<Button
+				type="button"
+				appearance="outlined"
+				intent="neutral"
+				onClick={() => setDismissed(false)}
+			>
+				Show the alert again
+			</Button>
+		</div>
+	);
+}
+
+/**
  * Sign-in form that rejects every submit, so the alert mounts after the action.
  * The `key` remounts the alert on a repeated attempt, so it announces again.
  */

--- a/packages/mantle/src/components/alert-center/alert-center.test.tsx
+++ b/packages/mantle/src/components/alert-center/alert-center.test.tsx
@@ -648,6 +648,32 @@ describe("AlertCenter.Bar", () => {
 		).toHaveFocus();
 	});
 
+	test("moves focus exactly once when the focused top alert is dismissed", async () => {
+		// `Alert.DismissIconButton` moves focus to a tabbable neighbor when its
+		// dismissal unmounts it. Inside the center that would land on the expand
+		// control a tick before the bar's own redirect, so the item opts out.
+		// Every focus landing is recorded: an extra one is the opt-out missing.
+		const user = userEvent.setup();
+		render(<ThreeAlertHarness />);
+		const focusLandings: Array<string | null> = [];
+		const recordLanding = (event: FocusEvent) => {
+			if (event.target instanceof HTMLElement) {
+				focusLandings.push(event.target.getAttribute("aria-label"));
+			}
+		};
+		document.addEventListener("focusin", recordLanding);
+		try {
+			await user.click(screen.getByRole("button", { name: "Dismiss Payment failed" }));
+		} finally {
+			document.removeEventListener("focusin", recordLanding);
+		}
+
+		expect(focusLandings).toEqual([
+			"Dismiss Payment failed",
+			"Dismiss Approaching your data transfer limit",
+		]);
+	});
+
 	test("does not steal focus from a surviving control when a new top alert arrives", async () => {
 		const user = userEvent.setup();
 		const { rerender } = render(

--- a/packages/mantle/src/components/alert-center/alert-center.tsx
+++ b/packages/mantle/src/components/alert-center/alert-center.tsx
@@ -752,8 +752,13 @@ const Item = ({ children, className, id, intent }: AlertCenterItemProps) => {
 	// The chrome `Alert.Root` is only a DOM ancestor of the portaled children —
 	// React context can't cross a portal from the DOM side, so the item
 	// provides the same Alert context (same `intent`) the chrome renders with.
+	// Why `redirectDismissFocus={false}`: the bar's focus redirect owns focus
+	// after a dismissal and lands it on the next alert's control, or on the
+	// main landmark when none is left. `Alert.DismissIconButton`'s own move
+	// would run first and land on the bar's expand control; the focus tracker
+	// would read that as a deliberate move and skip the redirect.
 	return createPortal(
-		<AlertContextProvider intent={intent}>
+		<AlertContextProvider intent={intent} redirectDismissFocus={false}>
 			<AlertCenterItemContext.Provider value={true}>{children}</AlertCenterItemContext.Provider>
 		</AlertContextProvider>,
 		host,

--- a/packages/mantle/src/components/alert/alert.test.tsx
+++ b/packages/mantle/src/components/alert/alert.test.tsx
@@ -1,11 +1,31 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { useLayoutEffect, useRef, useState } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { $cssProperties } from "../../types/index.js";
-import { Alert } from "./alert.js";
+import { Alert, AlertContextProvider } from "./alert.js";
 
 function getAlertRoot(container: HTMLElement) {
 	return container.querySelector('[data-slot="alert"]');
+}
+
+/**
+ * The documented dismissal pattern: the consumer's `onClick` stops rendering
+ * the alert, which unmounts the button that holds focus.
+ */
+function DismissibleAlert() {
+	const [dismissed, setDismissed] = useState(false);
+	if (dismissed) {
+		return null;
+	}
+	return (
+		<Alert.Root intent="info">
+			<Alert.Content>
+				<Alert.Title>Trial ends soon</Alert.Title>
+				<Alert.DismissIconButton onClick={() => setDismissed(true)} />
+			</Alert.Content>
+		</Alert.Root>
+	);
 }
 
 describe("Alert", () => {
@@ -106,6 +126,211 @@ describe("Alert", () => {
 			expect(button).toHaveAttribute("data-intent", "neutral");
 			await userEvent.click(button);
 			expect(onDismiss).toHaveBeenCalledOnce();
+		});
+
+		describe("focus after the dismissal unmounts the alert", () => {
+			test("moves focus to the next tabbable after the alert", async () => {
+				const user = userEvent.setup();
+				render(
+					<>
+						<button type="button">Before</button>
+						<DismissibleAlert />
+						<button type="button">After</button>
+					</>,
+				);
+
+				await user.tab();
+				await user.tab();
+				expect(screen.getByRole("button", { name: "Dismiss Alert" })).toHaveFocus();
+
+				await user.keyboard("{Enter}");
+
+				expect(screen.queryByRole("button", { name: "Dismiss Alert" })).not.toBeInTheDocument();
+				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
+			});
+
+			test("falls back to the previous tabbable when nothing follows the alert", async () => {
+				const user = userEvent.setup();
+				render(
+					<>
+						<button type="button">Before</button>
+						<DismissibleAlert />
+					</>,
+				);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.getByRole("button", { name: "Before" })).toHaveFocus();
+			});
+
+			test("skips a following element a Tab press cannot reach", async () => {
+				const user = userEvent.setup();
+				render(
+					<>
+						<button type="button">Before</button>
+						<DismissibleAlert />
+						<button type="button" disabled>
+							Disabled
+						</button>
+						<div tabIndex={-1}>Programmatic only</div>
+						<button type="button">After</button>
+					</>,
+				);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
+			});
+
+			test("lands on a neighbor that survives when the same unmount removes the nearest one", async () => {
+				function Card() {
+					const [open, setOpen] = useState(true);
+					if (!open) {
+						return null;
+					}
+					return (
+						<section>
+							<Alert.Root intent="info">
+								<Alert.Content>
+									<Alert.Title>Trial ends soon</Alert.Title>
+									<Alert.DismissIconButton onClick={() => setOpen(false)} />
+								</Alert.Content>
+							</Alert.Root>
+							<button type="button">Apply</button>
+						</section>
+					);
+				}
+				const user = userEvent.setup();
+				render(
+					<>
+						<button type="button">Before</button>
+						<Card />
+						<button type="button">After</button>
+					</>,
+				);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
+			});
+
+			test("leaves focus alone when the button does not hold it", () => {
+				render(
+					<>
+						<button type="button">Before</button>
+						<DismissibleAlert />
+						<button type="button">After</button>
+					</>,
+				);
+				const before = screen.getByRole("button", { name: "Before" });
+				before.focus();
+
+				// A synthetic click moves no focus, unlike a pointer or keyboard activation.
+				fireEvent.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.queryByRole("button", { name: "Dismiss Alert" })).not.toBeInTheDocument();
+				expect(before).toHaveFocus();
+			});
+
+			test("keeps focus where the consumer's handler put it", async () => {
+				function Consumer() {
+					const [dismissed, setDismissed] = useState(false);
+					const headingRef = useRef<HTMLHeadingElement>(null);
+					return (
+						<>
+							<h2 ref={headingRef} tabIndex={-1}>
+								Settings
+							</h2>
+							{!dismissed && (
+								<Alert.Root intent="info">
+									<Alert.Content>
+										<Alert.Title>Trial ends soon</Alert.Title>
+										<Alert.DismissIconButton
+											onClick={() => {
+												setDismissed(true);
+												headingRef.current?.focus();
+											}}
+										/>
+									</Alert.Content>
+								</Alert.Root>
+							)}
+							<button type="button">After</button>
+						</>
+					);
+				}
+				const user = userEvent.setup();
+				render(<Consumer />);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.getByRole("heading", { name: "Settings" })).toHaveFocus();
+			});
+
+			test("keeps focus a consumer layout effect places after the unmount", async () => {
+				function Consumer() {
+					const [dismissed, setDismissed] = useState(false);
+					const statusRef = useRef<HTMLParagraphElement>(null);
+					useLayoutEffect(() => {
+						if (dismissed) {
+							statusRef.current?.focus();
+						}
+					}, [dismissed]);
+					return (
+						<>
+							{!dismissed && (
+								<Alert.Root intent="info">
+									<Alert.Content>
+										<Alert.Title>Trial ends soon</Alert.Title>
+										<Alert.DismissIconButton onClick={() => setDismissed(true)} />
+									</Alert.Content>
+								</Alert.Root>
+							)}
+							<p ref={statusRef} tabIndex={-1}>
+								Alert dismissed
+							</p>
+							<button type="button">After</button>
+						</>
+					);
+				}
+				const user = userEvent.setup();
+				render(<Consumer />);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.getByText("Alert dismissed")).toHaveFocus();
+				expect(screen.getByRole("button", { name: "After" })).not.toHaveFocus();
+			});
+
+			test("stays put when the composing context opts out", async () => {
+				// `AlertCenter` projects the button under its own `AlertContextProvider`
+				// and owns focus after a dismissal, so the button must not move it.
+				function Projected() {
+					const [dismissed, setDismissed] = useState(false);
+					if (dismissed) {
+						return null;
+					}
+					return (
+						<AlertContextProvider intent="info" redirectDismissFocus={false}>
+							<div data-slot="alert">
+								<Alert.DismissIconButton onClick={() => setDismissed(true)} />
+							</div>
+						</AlertContextProvider>
+					);
+				}
+				const user = userEvent.setup();
+				render(
+					<>
+						<Projected />
+						<button type="button">After</button>
+					</>,
+				);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.queryByRole("button", { name: "Dismiss Alert" })).not.toBeInTheDocument();
+				expect(document.body).toHaveFocus();
+			});
 		});
 	});
 

--- a/packages/mantle/src/components/alert/alert.test.tsx
+++ b/packages/mantle/src/components/alert/alert.test.tsx
@@ -247,6 +247,27 @@ describe("Alert", () => {
 				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
 			});
 
+			test("tries the next neighbor when the engine refuses to focus the first", async () => {
+				// An engine without `checkVisibility` can pass a CSS-hidden control
+				// that `focus()` then ignores. The refusal is simulated on a plain
+				// button, because happy-dom has no such gap of its own.
+				const user = userEvent.setup();
+				render(
+					<>
+						<DismissibleAlert />
+						<button type="button">Refuses</button>
+						<button type="button">After</button>
+					</>,
+				);
+				const refusing = screen.getByRole("button", { name: "Refuses" });
+				const refusedFocus = vi.spyOn(refusing, "focus").mockImplementation(() => {});
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(refusedFocus).toHaveBeenCalledTimes(1);
+				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
+			});
+
 			test("leaves focus alone when the button does not hold it", () => {
 				render(
 					<>

--- a/packages/mantle/src/components/alert/alert.test.tsx
+++ b/packages/mantle/src/components/alert/alert.test.tsx
@@ -215,6 +215,38 @@ describe("Alert", () => {
 				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
 			});
 
+			test("skips a neighbor the same commit disables", async () => {
+				// The layout cleanup records the neighbors before React commits the
+				// siblings' attribute updates, so a neighbor recorded as enabled can
+				// be disabled by the time the passive cleanup runs.
+				function Consumer() {
+					const [dismissed, setDismissed] = useState(false);
+					return (
+						<>
+							{!dismissed && (
+								<Alert.Root intent="info">
+									<Alert.Content>
+										<Alert.Title>Trial ends soon</Alert.Title>
+										<Alert.DismissIconButton onClick={() => setDismissed(true)} />
+									</Alert.Content>
+								</Alert.Root>
+							)}
+							<button type="button" disabled={dismissed}>
+								Apply
+							</button>
+							<button type="button">After</button>
+						</>
+					);
+				}
+				const user = userEvent.setup();
+				render(<Consumer />);
+
+				await user.click(screen.getByRole("button", { name: "Dismiss Alert" }));
+
+				expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+				expect(screen.getByRole("button", { name: "After" })).toHaveFocus();
+			});
+
 			test("leaves focus alone when the button does not hold it", () => {
 				render(
 					<>

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { CheckCircleIcon } from "@phosphor-icons/react/CheckCircle";
 import { CaretDownIcon } from "@phosphor-icons/react/CaretDown";
 import { InfoIcon } from "@phosphor-icons/react/Info";
@@ -6,11 +8,13 @@ import { WarningIcon } from "@phosphor-icons/react/Warning";
 import { WarningDiamondIcon } from "@phosphor-icons/react/WarningDiamond";
 import { XIcon } from "@phosphor-icons/react/X";
 import { cva } from "class-variance-authority";
-import type { ComponentProps, ReactNode } from "react";
-import { createContext, useContext, useMemo } from "react";
+import type { ComponentProps, ReactNode, RefObject } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef } from "react";
 import invariant from "tiny-invariant";
+import { useIsomorphicLayoutEffect } from "../../hooks/use-isomorphic-layout-effect.js";
 import { $cssProperties } from "../../types/css-properties.js";
 import type { WithAsChild } from "../../types/as-child.js";
+import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 import { Button, type ButtonProps } from "../button/button.js";
 import {
@@ -21,6 +25,7 @@ import {
 import { SvgOnly } from "../icon/svg-only.js";
 import type { SvgAttributes } from "../icon/types.js";
 import { Slot } from "../slot/index.js";
+import { findTabbableNeighbors } from "./tabbable-neighbors.js";
 
 const intents = [
 	//,
@@ -38,6 +43,12 @@ type Appearance = (typeof appearances)[number];
 
 type AlertContextValue = {
 	intent: AlertIntent;
+	/**
+	 * Whether `Alert.DismissIconButton` moves focus to a tabbable neighbor when
+	 * it unmounts while it holds focus. `AlertCenter` sets `false`: its bar
+	 * owns focus after a dismissal and lands it on the next alert's control.
+	 */
+	redirectDismissFocus: boolean;
 };
 
 const AlertContext = createContext<AlertContextValue | null>(null);
@@ -71,11 +82,23 @@ function useAlertContext() {
 const AlertContextProvider = ({
 	children,
 	intent,
+	redirectDismissFocus = true,
 }: {
 	intent: AlertIntent;
 	children?: ReactNode;
+	/**
+	 * Whether `Alert.DismissIconButton` moves focus to a tabbable neighbor when
+	 * it unmounts while it holds focus. Pass `false` when the composing
+	 * component owns focus after a dismissal, as `AlertCenter` does.
+	 *
+	 * @default true
+	 */
+	redirectDismissFocus?: boolean;
 }) => {
-	const context: AlertContextValue = useMemo(() => ({ intent }), [intent]);
+	const context: AlertContextValue = useMemo(
+		() => ({ intent, redirectDismissFocus }),
+		[intent, redirectDismissFocus],
+	);
 	return <AlertContext.Provider value={context}>{children}</AlertContext.Provider>;
 };
 
@@ -378,7 +401,79 @@ type AlertDismissIconButtonProps = Partial<
 };
 
 /**
+ * Moves keyboard focus to the alert's nearest tabbable neighbor when the
+ * dismiss button unmounts while it holds focus. Removing the focused element
+ * fires no blur and silently resets `document.activeElement` to `<body>`, so
+ * the next Tab restarts at the top of the page. A screen reader user also gets
+ * no confirmation that the alert left.
+ *
+ * Two cleanups split the work. The layout cleanup runs while the alert is
+ * still in the document, so it can read which element has focus and collect
+ * the neighbors. The passive cleanup runs after the whole commit, so a
+ * consumer effect that placed focus in the meantime wins. It moves focus only
+ * when focus did fall to `<body>`, and only to a neighbor the same unmount did
+ * not remove.
+ *
+ * @example
+ * ```tsx
+ * const buttonRef = useRef<HTMLButtonElement | null>(null);
+ * useDismissFocusRedirect({ buttonRef, enabled: true });
+ * return <IconButton ref={buttonRef} … />;
+ * ```
+ */
+function useDismissFocusRedirect({
+	buttonRef,
+	enabled,
+}: {
+	buttonRef: RefObject<HTMLButtonElement | null>;
+	/** `false` when the composing component owns focus after a dismissal. */
+	enabled: boolean;
+}): void {
+	const neighborsRef = useRef<HTMLElement[]>([]);
+
+	useIsomorphicLayoutEffect(() => {
+		if (!enabled) {
+			return;
+		}
+		return () => {
+			const button = buttonRef.current;
+			if (button == null || document.activeElement !== button) {
+				return;
+			}
+			// `~=` matches the token inside an `asChild` slot chain.
+			const anchor = button.closest('[data-slot~="alert"]') ?? button;
+			neighborsRef.current = findTabbableNeighbors(anchor);
+		};
+	}, [buttonRef, enabled]);
+
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+		return () => {
+			const neighbors = neighborsRef.current;
+			neighborsRef.current = [];
+			if (neighbors.length === 0) {
+				return;
+			}
+			const { activeElement } = document;
+			if (activeElement != null && activeElement !== document.body) {
+				return;
+			}
+			const target = neighbors.find((element) => element.isConnected);
+			target?.focus();
+		};
+	}, [enabled]);
+}
+
+/**
  * A compact, trailing control for dismissing an alert.
+ *
+ * It removes nothing itself: stop rendering the alert in its `onClick`
+ * handler. When that unmount happens while the button holds focus, focus
+ * moves to the nearest tabbable element outside the alert (the next one in
+ * document order, else the previous one) instead of falling to `<body>`. If
+ * your handler or an effect places focus first, that choice stands.
  *
  * It inherits `--alert-control-color`, `--alert-control-hover-color`, and
  * `--alert-control-hover-bg` from `Alert.Root`, shared with
@@ -405,10 +500,22 @@ const DismissIconButton = ({
 	appearance = "ghost",
 	className,
 	icon = defaultDismissIcon,
+	ref,
 	...props
 }: AlertDismissIconButtonProps) => {
+	// Read without the invariant: the button has no other need for the
+	// context, so a standalone render keeps working and takes the default.
+	const context = useContext(AlertContext);
+	const buttonRef = useRef<HTMLButtonElement | null>(null);
+	const composedRef = useComposedRefs(buttonRef, ref);
+	useDismissFocusRedirect({
+		buttonRef,
+		enabled: context?.redirectDismissFocus ?? true,
+	});
+
 	return (
 		<IconButton
+			ref={composedRef}
 			appearance={appearance}
 			icon={icon}
 			// not a public prop: the dismiss button's visible tone is dictated by
@@ -626,6 +733,9 @@ const Alert = {
 	Description,
 	/**
 	 * An optional, compact, trailing control for dismissing an alert.
+	 * Stop rendering the alert in its `onClick` handler. When that unmount
+	 * happens while the button holds focus, focus moves to the nearest tabbable
+	 * element outside the alert instead of falling to `<body>`.
 	 * It inherits the `--alert-control-color`, `--alert-control-hover-color`, and
 	 * `--alert-control-hover-bg` variables from `Alert.Root`, shared with the
 	 * expand control.

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -25,7 +25,7 @@ import {
 import { SvgOnly } from "../icon/svg-only.js";
 import type { SvgAttributes } from "../icon/types.js";
 import { Slot } from "../slot/index.js";
-import { findTabbableNeighbors } from "./tabbable-neighbors.js";
+import { findTabbableNeighbors, isTabbable } from "./tabbable-neighbors.js";
 
 const intents = [
 	//,
@@ -410,9 +410,10 @@ type AlertDismissIconButtonProps = Partial<
  * Two cleanups split the work. The layout cleanup runs while the alert is
  * still in the document, so it can read which element has focus and collect
  * the neighbors. The passive cleanup runs after the whole commit, so a
- * consumer effect that placed focus in the meantime wins. It moves focus only
- * when focus did fall to `<body>`, and only to a neighbor the same unmount did
- * not remove.
+ * consumer layout effect that placed focus in the meantime wins. A consumer
+ * `useEffect` runs later still and overrides the move. The passive cleanup
+ * moves focus only when focus did fall to `<body>`, and only to a neighbor
+ * that the same commit left connected and tabbable.
  *
  * @example
  * ```tsx
@@ -460,7 +461,8 @@ function useDismissFocusRedirect({
 			if (activeElement != null && activeElement !== document.body) {
 				return;
 			}
-			const target = neighbors.find((element) => element.isConnected);
+			// The same commit can disable, hide, or detach a recorded neighbor.
+			const target = neighbors.find((element) => element.isConnected && isTabbable(element));
 			target?.focus();
 		};
 	}, [enabled]);
@@ -473,7 +475,7 @@ function useDismissFocusRedirect({
  * handler. When that unmount happens while the button holds focus, focus
  * moves to the nearest tabbable element outside the alert (the next one in
  * document order, else the previous one) instead of falling to `<body>`. If
- * your handler or an effect places focus first, that choice stands.
+ * your handler or a layout effect places focus first, that choice stands.
  *
  * It inherits `--alert-control-color`, `--alert-control-hover-color`, and
  * `--alert-control-hover-bg` from `Alert.Root`, shared with

--- a/packages/mantle/src/components/alert/alert.tsx
+++ b/packages/mantle/src/components/alert/alert.tsx
@@ -413,7 +413,8 @@ type AlertDismissIconButtonProps = Partial<
  * consumer layout effect that placed focus in the meantime wins. A consumer
  * `useEffect` runs later still and overrides the move. The passive cleanup
  * moves focus only when focus did fall to `<body>`, and only to a neighbor
- * that the same commit left connected and tabbable.
+ * that the same commit left connected and tabbable. It tries the neighbors
+ * in order until one holds focus.
  *
  * @example
  * ```tsx
@@ -461,9 +462,18 @@ function useDismissFocusRedirect({
 			if (activeElement != null && activeElement !== document.body) {
 				return;
 			}
-			// The same commit can disable, hide, or detach a recorded neighbor.
-			const target = neighbors.find((element) => element.isConnected && isTabbable(element));
-			target?.focus();
+			// The same commit can disable, hide, or detach a recorded neighbor, and
+			// an engine without `checkVisibility` can pass one that `focus()` then
+			// refuses, so each candidate has to confirm the move.
+			for (const element of neighbors) {
+				if (!element.isConnected || !isTabbable(element)) {
+					continue;
+				}
+				element.focus();
+				if (document.activeElement === element) {
+					return;
+				}
+			}
 		};
 	}, [enabled]);
 }

--- a/packages/mantle/src/components/alert/tabbable-neighbors.test.ts
+++ b/packages/mantle/src/components/alert/tabbable-neighbors.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { findTabbableNeighbors } from "./tabbable-neighbors.js";
+
+/**
+ * Writes the fixture into the document and returns the element with
+ * `id="anchor"`, the element the neighbors are computed around.
+ */
+function mount(html: string): HTMLElement {
+	document.body.innerHTML = html;
+	const anchor = document.getElementById("anchor");
+	if (anchor == null) {
+		throw new Error("fixture has no #anchor");
+	}
+	return anchor;
+}
+
+const ids = (elements: HTMLElement[]) => elements.map((element) => element.id);
+
+afterEach(() => {
+	document.body.innerHTML = "";
+});
+
+describe("findTabbableNeighbors", () => {
+	test("orders following tabbables nearest-first, then preceding tabbables nearest-first", () => {
+		const anchor = mount(`
+			<button id="before-far" type="button">1</button>
+			<button id="before-near" type="button">2</button>
+			<div id="anchor"><button id="inside" type="button">x</button></div>
+			<button id="after-near" type="button">3</button>
+			<a id="after-far" href="/next">4</a>
+		`);
+
+		expect(ids(findTabbableNeighbors(anchor))).toEqual([
+			"after-near",
+			"after-far",
+			"before-near",
+			"before-far",
+		]);
+	});
+
+	test("skips elements a Tab press cannot reach", () => {
+		const anchor = mount(`
+			<div id="anchor"></div>
+			<button id="disabled" type="button" disabled>d</button>
+			<div id="negative" tabindex="-1">n</div>
+			<a id="no-href">a</a>
+			<input id="hidden-input" type="hidden" />
+			<div hidden><button id="in-hidden" type="button">h</button></div>
+			<div inert><button id="in-inert" type="button">i</button></div>
+			<div id="positive" tabindex="0">p</div>
+		`);
+
+		expect(ids(findTabbableNeighbors(anchor))).toEqual(["positive"]);
+	});
+
+	test("counts a tabbable ancestor as a preceding neighbor", () => {
+		const anchor = mount(`
+			<div id="scroller" tabindex="0"><div id="anchor"></div></div>
+		`);
+
+		expect(ids(findTabbableNeighbors(anchor))).toEqual(["scroller"]);
+	});
+
+	test("returns an empty array when nothing outside the anchor is tabbable", () => {
+		const anchor = mount(`<div id="anchor"><button type="button">only</button></div>`);
+
+		expect(findTabbableNeighbors(anchor)).toEqual([]);
+	});
+});

--- a/packages/mantle/src/components/alert/tabbable-neighbors.test.ts
+++ b/packages/mantle/src/components/alert/tabbable-neighbors.test.ts
@@ -53,6 +53,50 @@ describe("findTabbableNeighbors", () => {
 		expect(ids(findTabbableNeighbors(anchor))).toEqual(["positive"]);
 	});
 
+	describe("radio groups", () => {
+		test("counts only the checked radio of a named group", () => {
+			const anchor = mount(`
+				<div id="anchor"></div>
+				<input id="plan-free" type="radio" name="plan" />
+				<input id="plan-pro" type="radio" name="plan" checked />
+				<input id="plan-team" type="radio" name="plan" />
+				<button id="after" type="button">Continue</button>
+			`);
+
+			expect(ids(findTabbableNeighbors(anchor))).toEqual(["plan-pro", "after"]);
+		});
+
+		test("counts the first enabled radio when none in the group is checked", () => {
+			const anchor = mount(`
+				<div id="anchor"></div>
+				<input id="plan-free" type="radio" name="plan" disabled />
+				<input id="plan-pro" type="radio" name="plan" />
+				<input id="plan-team" type="radio" name="plan" />
+			`);
+
+			expect(ids(findTabbableNeighbors(anchor))).toEqual(["plan-pro"]);
+		});
+
+		test("keeps separate groups, unnamed radios, and separate forms as their own stops", () => {
+			const anchor = mount(`
+				<div id="anchor"></div>
+				<input id="plan-pro" type="radio" name="plan" checked />
+				<input id="plan-team" type="radio" name="plan" />
+				<input id="region-us" type="radio" name="region" />
+				<input id="region-eu" type="radio" name="region" />
+				<input id="lonely" type="radio" />
+				<form><input id="form-plan" type="radio" name="plan" /></form>
+			`);
+
+			expect(ids(findTabbableNeighbors(anchor))).toEqual([
+				"plan-pro",
+				"region-us",
+				"lonely",
+				"form-plan",
+			]);
+		});
+	});
+
 	test("counts a tabbable ancestor as a preceding neighbor", () => {
 		const anchor = mount(`
 			<div id="scroller" tabindex="0"><div id="anchor"></div></div>

--- a/packages/mantle/src/components/alert/tabbable-neighbors.test.ts
+++ b/packages/mantle/src/components/alert/tabbable-neighbors.test.ts
@@ -42,6 +42,7 @@ describe("findTabbableNeighbors", () => {
 		const anchor = mount(`
 			<div id="anchor"></div>
 			<button id="disabled" type="button" disabled>d</button>
+			<button id="invisible" type="button" style="visibility: hidden">v</button>
 			<div id="negative" tabindex="-1">n</div>
 			<a id="no-href">a</a>
 			<input id="hidden-input" type="hidden" />
@@ -75,6 +76,16 @@ describe("findTabbableNeighbors", () => {
 			`);
 
 			expect(ids(findTabbableNeighbors(anchor))).toEqual(["plan-pro"]);
+		});
+
+		test("groups a radio placed outside its form through the `form` attribute", () => {
+			const anchor = mount(`
+				<div id="anchor"></div>
+				<form id="plan-form"><input id="in-form" type="radio" name="plan" /></form>
+				<input id="via-attribute" type="radio" name="plan" form="plan-form" checked />
+			`);
+
+			expect(ids(findTabbableNeighbors(anchor))).toEqual(["via-attribute"]);
 		});
 
 		test("keeps separate groups, unnamed radios, and separate forms as their own stops", () => {

--- a/packages/mantle/src/components/alert/tabbable-neighbors.ts
+++ b/packages/mantle/src/components/alert/tabbable-neighbors.ts
@@ -10,13 +10,16 @@ const TABBABLE_CANDIDATE_SELECTOR =
  * one stop in sequential navigation: the checked radio, or the first enabled
  * radio when none is checked. A radio with no `name` is its own group. The
  * group is the radios with the same `name` and the same form owner.
+ *
+ * Why the document is the query scope: a `form` attribute can place a radio
+ * outside its owner form's subtree, and the `form` filter still keeps it in
+ * the group.
  */
 function isRadioTabStop(radio: HTMLInputElement): boolean {
 	if (radio.name === "") {
 		return true;
 	}
-	const scope = radio.form ?? radio.ownerDocument;
-	const group = Array.from(scope.querySelectorAll("input")).filter(
+	const group = Array.from(radio.ownerDocument.querySelectorAll("input")).filter(
 		(input) =>
 			input.type === "radio" &&
 			input.name === radio.name &&
@@ -31,10 +34,11 @@ function isRadioTabStop(radio: HTMLInputElement): boolean {
  * Whether a Tab press can reach `element`: it is an `HTMLElement` with a
  * non-negative `tabIndex`, not disabled, not a hidden input, not a radio
  * that its group skips, not inside a `hidden` or `inert` subtree, and
- * rendered.
+ * rendered with a `visibility` other than `hidden`.
  *
  * Why the `checkVisibility` guard: Safari added it in 17.4, so an older engine
- * counts the element as visible instead of throwing.
+ * counts the element as visible instead of throwing. The caller confirms the
+ * move with `document.activeElement`, which covers that gap.
  */
 function isTabbable(element: Element): element is HTMLElement {
 	if (!(element instanceof HTMLElement)) {
@@ -54,7 +58,10 @@ function isTabbable(element: Element): element is HTMLElement {
 	if (element.closest("[hidden], [inert]") != null) {
 		return false;
 	}
-	if (typeof element.checkVisibility === "function" && !element.checkVisibility()) {
+	if (
+		typeof element.checkVisibility === "function" &&
+		!element.checkVisibility({ visibilityProperty: true })
+	) {
 		return false;
 	}
 	return true;
@@ -67,9 +74,9 @@ function isTabbable(element: Element): element is HTMLElement {
  * Elements inside `anchor` leave with it, so they never count. Returns an
  * empty array when the document has no other tabbable.
  *
- * The caller focuses the first element that `isTabbable` still accepts,
- * because the commit that removes `anchor` can remove or disable its nearest
- * neighbor too.
+ * The caller tries each element that `isTabbable` still accepts until one
+ * takes focus, because the commit that removes `anchor` can remove or disable
+ * its nearest neighbor too.
  *
  * @example
  * ```ts

--- a/packages/mantle/src/components/alert/tabbable-neighbors.ts
+++ b/packages/mantle/src/components/alert/tabbable-neighbors.ts
@@ -1,0 +1,72 @@
+/**
+ * Elements the browser puts in the tab order when nothing disables or hides
+ * them. `[tabindex]` also matches negative values; `isTabbable` drops those.
+ */
+const TABBABLE_CANDIDATE_SELECTOR =
+	'a[href], area[href], button, input, select, textarea, iframe, summary, audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]';
+
+/**
+ * Whether a Tab press can reach `element`: it is an `HTMLElement` with a
+ * non-negative `tabIndex`, not disabled, not a hidden input, not inside a
+ * `hidden` or `inert` subtree, and rendered.
+ *
+ * Why the `checkVisibility` guard: Safari added it in 17.4, so an older engine
+ * counts the element as visible instead of throwing.
+ */
+function isTabbable(element: Element): element is HTMLElement {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
+	if (element.tabIndex < 0 || element.matches(":disabled")) {
+		return false;
+	}
+	if (element instanceof HTMLInputElement && element.type === "hidden") {
+		return false;
+	}
+	if (element.closest("[hidden], [inert]") != null) {
+		return false;
+	}
+	if (typeof element.checkVisibility === "function" && !element.checkVisibility()) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * The tabbable elements outside `anchor`, ordered by where keyboard focus
+ * should land when `anchor` leaves the document: every tabbable after it in
+ * document order, nearest first, then every tabbable before it, nearest first.
+ * Elements inside `anchor` leave with it, so they never count. Returns an
+ * empty array when the document has no other tabbable.
+ *
+ * The caller focuses the first element that is still connected, because the
+ * unmount that removes `anchor` can remove its nearest neighbor too.
+ *
+ * @example
+ * ```ts
+ * // <button>Before</button> <div id="alert">…</div> <button>After</button>
+ * findTabbableNeighbors(alert); // → [afterButton, beforeButton]
+ * ```
+ */
+function findTabbableNeighbors(anchor: Element): HTMLElement[] {
+	const following: HTMLElement[] = [];
+	const preceding: HTMLElement[] = [];
+	for (const candidate of anchor.ownerDocument.querySelectorAll(TABBABLE_CANDIDATE_SELECTOR)) {
+		if (anchor.contains(candidate) || !isTabbable(candidate)) {
+			continue;
+		}
+		const position = anchor.compareDocumentPosition(candidate);
+		if ((position & Node.DOCUMENT_POSITION_FOLLOWING) !== 0) {
+			following.push(candidate);
+		} else {
+			preceding.push(candidate);
+		}
+	}
+	preceding.reverse();
+	return [...following, ...preceding];
+}
+
+export {
+	//,
+	findTabbableNeighbors,
+};

--- a/packages/mantle/src/components/alert/tabbable-neighbors.ts
+++ b/packages/mantle/src/components/alert/tabbable-neighbors.ts
@@ -6,9 +6,32 @@ const TABBABLE_CANDIDATE_SELECTOR =
 	'a[href], area[href], button, input, select, textarea, iframe, summary, audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]';
 
 /**
+ * Whether `radio` is the one tab stop of its radio group. A named group takes
+ * one stop in sequential navigation: the checked radio, or the first enabled
+ * radio when none is checked. A radio with no `name` is its own group. The
+ * group is the radios with the same `name` and the same form owner.
+ */
+function isRadioTabStop(radio: HTMLInputElement): boolean {
+	if (radio.name === "") {
+		return true;
+	}
+	const scope = radio.form ?? radio.ownerDocument;
+	const group = Array.from(scope.querySelectorAll("input")).filter(
+		(input) =>
+			input.type === "radio" &&
+			input.name === radio.name &&
+			input.form === radio.form &&
+			!input.disabled,
+	);
+	const checked = group.find((input) => input.checked);
+	return checked == null ? group[0] === radio : checked === radio;
+}
+
+/**
  * Whether a Tab press can reach `element`: it is an `HTMLElement` with a
- * non-negative `tabIndex`, not disabled, not a hidden input, not inside a
- * `hidden` or `inert` subtree, and rendered.
+ * non-negative `tabIndex`, not disabled, not a hidden input, not a radio
+ * that its group skips, not inside a `hidden` or `inert` subtree, and
+ * rendered.
  *
  * Why the `checkVisibility` guard: Safari added it in 17.4, so an older engine
  * counts the element as visible instead of throwing.
@@ -20,8 +43,13 @@ function isTabbable(element: Element): element is HTMLElement {
 	if (element.tabIndex < 0 || element.matches(":disabled")) {
 		return false;
 	}
-	if (element instanceof HTMLInputElement && element.type === "hidden") {
-		return false;
+	if (element instanceof HTMLInputElement) {
+		if (element.type === "hidden") {
+			return false;
+		}
+		if (element.type === "radio" && !isRadioTabStop(element)) {
+			return false;
+		}
 	}
 	if (element.closest("[hidden], [inert]") != null) {
 		return false;
@@ -39,8 +67,9 @@ function isTabbable(element: Element): element is HTMLElement {
  * Elements inside `anchor` leave with it, so they never count. Returns an
  * empty array when the document has no other tabbable.
  *
- * The caller focuses the first element that is still connected, because the
- * unmount that removes `anchor` can remove its nearest neighbor too.
+ * The caller focuses the first element that `isTabbable` still accepts,
+ * because the commit that removes `anchor` can remove or disable its nearest
+ * neighbor too.
  *
  * @example
  * ```ts
@@ -69,4 +98,5 @@ function findTabbableNeighbors(anchor: Element): HTMLElement[] {
 export {
 	//,
 	findTabbableNeighbors,
+	isTabbable,
 };


### PR DESCRIPTION
## Why

The documented usage of `Alert.DismissIconButton` stops rendering the alert in the `onClick` handler. That unmount removes the button that holds focus, so focus falls to `<body>`. The next Tab restarts at the top of the page, and a screen reader user gets no confirmation that the alert left. Every dismissible surface in the dashboard hits this, so the fix belongs in the component.

Resolves MNTL-61.

## What

When the alert unmounts while the dismiss button holds focus, focus moves to the nearest tabbable element outside the alert: the next one in document order, or the previous one when nothing follows.

- The layout cleanup runs while the alert is still in the document. It records the tabbable neighbors, nearest first.
- The passive cleanup runs after the whole commit. It focuses the first neighbor still connected, and only when focus did fall to `<body>`, so a consumer handler or layout effect that placed focus first wins.
- `AlertCenter.Item` opts out through a module-internal flag on the Alert context. The bar's own redirect lands focus on the next alert's control, or on the main landmark.

The docs page gains a Dismissal section with a live demo. The changeset is a `patch`.
