### PR TITLE
fix(mantle): animate the PasswordInput eye on every visibility change

### DIFF
--- a/.changeset/password-input-animate-on-visibility-change.md
+++ b/.changeset/password-input-animate-on-visibility-change.md
@@ -2,4 +2,4 @@
 "@ngrok/mantle": patch
 ---
 
-`PasswordInput` now animates its eye icon on every visibility change, including a change to `showValue` from another control. Before this change, only a click on the built-in toggle animated the icon, so a page that reveals several fields from one control swapped the icons with no motion. The icon no longer animates when a controlled consumer ignores the toggle, because the icon did not change. Reduced motion still turns the animation off.
+`PasswordInput` now animates its eye icon on every visibility change, including a change to `showValue` from another control. Before this change, only a click on the built-in toggle animated the icon, so a page that reveals several fields from one control swapped the icons with no motion. The icon no longer animates when a controlled consumer ignores the toggle, because the icon did not change. Reduced motion still turns the animation off. The docs page shows a controlled example under [Visibility state](https://mantle.ngrok.com/components/forms/password-input#visibility-state).

--- a/.changeset/password-input-animate-on-visibility-change.md
+++ b/.changeset/password-input-animate-on-visibility-change.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`PasswordInput` now animates its eye icon on every visibility change, including a change to `showValue` from another control. Before this change, only a click on the built-in toggle animated the icon, so a page that reveals several fields from one control swapped the icons with no motion. The icon no longer animates when a controlled consumer ignores the toggle, because the icon did not change. Reduced motion still turns the animation off.

--- a/.changeset/password-input-document-data-attributes.md
+++ b/.changeset/password-input-document-data-attributes.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/mantle": patch
+---
+
+`PasswordInput` now documents every data attribute it stamps, in its JSDoc and on its docs page: `data-slot="input-capture"` on the `<input>`, and `data-disabled` and `data-validation` on the chrome, beside the two `data-slot` values it already listed. `PasswordInputProps` gained a JSDoc summary.

--- a/.changeset/password-input-document-data-attributes.md
+++ b/.changeset/password-input-document-data-attributes.md
@@ -2,4 +2,4 @@
 "@ngrok/mantle": patch
 ---
 
-`PasswordInput` now documents every data attribute it stamps, in its JSDoc and on its docs page: `data-slot="input-capture"` on the `<input>`, and `data-disabled` and `data-validation` on the chrome, beside the two `data-slot` values it already listed. `PasswordInputProps` gained a JSDoc summary.
+`PasswordInput` now documents every data attribute it stamps, in its JSDoc and on its docs page: `data-slot="input-capture"` on the `<input>`, and `data-disabled` and `data-validation` on the chrome, beside the two `data-slot` values it already listed. `PasswordInputProps` gained a JSDoc summary. See the [PasswordInput API](https://mantle.ngrok.com/components/forms/password-input#passwordinput).

--- a/apps/www/app/docs/components/forms/password-input.mdx
+++ b/apps/www/app/docs/components/forms/password-input.mdx
@@ -11,43 +11,54 @@ import { useState } from "react";
 import { z } from "zod";
 import { Example } from "~/components/example";
 
-export const ControlledVisibility = (props) => {
+export function ControlledVisibilityExample() {
 	const [showPassword, setShowPassword] = useState(false);
 
     return (
-    	<div className="flex flex-wrap items-center gap-2">
-    		<PasswordInput {...props} showValue={showPassword} onValueVisibilityChange={setShowPassword} />
-    		<Button
-    			type="button"
-    			appearance="outlined"
-    			intent="neutral"
-    			onClick={() => {
-    				setShowPassword((v) => !v);
-    			}}
-    		>
-    			{showPassword ? "Hide" : "Show"} Password
-    		</Button>
-    	</div>
+    	<Field.Item className="max-w-sm" name="password-controlled">
+    		<Field.Label>Controlled Visibility</Field.Label>
+    		<Field.Control>
+    			{(controlProps) => (
+    				<div className="flex flex-wrap items-center gap-2">
+    					<PasswordInput
+    						{...controlProps}
+    						showValue={showPassword}
+    						onValueVisibilityChange={setShowPassword}
+    					/>
+    					<Button
+    						type="button"
+    						appearance="outlined"
+    						intent="neutral"
+    						onClick={() => {
+    							setShowPassword((value) => !value);
+    						}}
+    					>
+    						{showPassword ? "Hide" : "Show"} Password
+    					</Button>
+    				</div>
+    			)}
+    		</Field.Control>
+    	</Field.Item>
     );
 
-};
+}
 
 export const formSchema = z.object({
-password: z.string().min(8, "Use at least 8 characters."),
+	password: z.string().min(8, "Use at least 8 characters."),
 });
 export function TanStackFormExample() {
-const defaultValues = {
-password: "",
-};
-const form = useForm({
-defaultValues,
-validators: {
-onSubmit: formSchema,
-},
-onSubmit: ({ value }) => {
-window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
-},
-});
+	const defaultValues = {
+		password: "",
+	};
+	const form = useForm({
+		defaultValues,
+		validators: {
+			onSubmit: formSchema,
+		},
+		onSubmit: ({ value }) => {
+			window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
+		},
+	});
 
     return (
     	<form
@@ -86,6 +97,53 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
 
 An input optimized for password and other sensitive-value entry. Renders a native `<input type="password">` with a built-in trailing button that toggles between hidden (`••••`) and revealed (`text`) display.
 
+Pair it with `Field.*` for label, description, and error wiring in forms:
+
+<Example className="flex-col gap-4">
+	<Field.Item className="max-w-64" name="password">
+		<Field.Label>Password</Field.Label>
+		<Field.Control>
+			<PasswordInput autoComplete="current-password" />
+		</Field.Control>
+	</Field.Item>
+	<Field.Item className="max-w-64" name="password-error">
+		<Field.Label>Password (error)</Field.Label>
+		<Field.Control>
+			<PasswordInput autoComplete="current-password" validation="error" />
+		</Field.Control>
+	</Field.Item>
+</Example>
+
+```tsx
+import { Field } from "@ngrok/mantle/field";
+import { PasswordInput } from "@ngrok/mantle/input";
+
+<Field.Item className="max-w-64" name="password">
+	<Field.Label>Password</Field.Label>
+	<Field.Control>
+		<PasswordInput autoComplete="current-password" />
+	</Field.Control>
+</Field.Item>
+<Field.Item className="max-w-64" name="password-error">
+	<Field.Label>Password (error)</Field.Label>
+	<Field.Control>
+		<PasswordInput autoComplete="current-password" validation="error" />
+	</Field.Control>
+</Field.Item>
+```
+
+Or render the control on its own:
+
+<Example>
+	<PasswordInput className="max-w-64" aria-label="Password" />
+</Example>
+
+```tsx
+import { PasswordInput } from "@ngrok/mantle/input";
+
+<PasswordInput aria-label="Password" />;
+```
+
 ## When to use
 
 - Password fields on login, signup, and reset flows.
@@ -93,12 +151,54 @@ An input optimized for password and other sensitive-value entry. Renders a nativ
 
 ## When not to use
 
-- For values that are never sensitive — use a plain [`Input`](/components/forms/input).
+- For values that are never sensitive: use a plain [`Input`](/components/forms/input).
 - For controls where the toggle would be confusing (e.g. masked input formatting like phone numbers).
 
 ## Visibility state
 
-The toggle is uncontrolled by default. Pass `showValue` to control the visibility from the outside (useful when one UI control toggles multiple password fields), and `onValueVisibilityChange` to be notified when the user toggles via the built-in button.
+The toggle is uncontrolled by default. Pass `showValue` to control the visibility from the outside, for example when one control reveals several password fields. Pass `onValueVisibilityChange` to receive the next visibility when the user clicks the built-in toggle. The eye icon animates on every visibility change, from the built-in toggle or from `showValue`, unless the user prefers reduced motion.
+
+<Example>
+	<ControlledVisibilityExample />
+</Example>
+
+```tsx
+import { Button } from "@ngrok/mantle/button";
+import { Field } from "@ngrok/mantle/field";
+import { PasswordInput } from "@ngrok/mantle/input";
+import { useState } from "react";
+
+function ControlledVisibilityExample() {
+	const [showPassword, setShowPassword] = useState(false);
+
+	return (
+		<Field.Item className="max-w-sm" name="password-controlled">
+			<Field.Label>Controlled Visibility</Field.Label>
+			<Field.Control>
+				{(controlProps) => (
+					<div className="flex flex-wrap items-center gap-2">
+						<PasswordInput
+							{...controlProps}
+							showValue={showPassword}
+							onValueVisibilityChange={setShowPassword}
+						/>
+						<Button
+							type="button"
+							appearance="outlined"
+							intent="neutral"
+							onClick={() => {
+								setShowPassword((value) => !value);
+							}}
+						>
+							{showPassword ? "Hide" : "Show"} Password
+						</Button>
+					</div>
+				)}
+			</Field.Control>
+		</Field.Item>
+	);
+}
+```
 
 ## Accessibility
 
@@ -126,60 +226,7 @@ Inside a `Field.Item`, pass `id` on `Field.Item` to set the input's `id` yoursel
 
 ## Browser password managers
 
-When revealed, the input switches to `type="text"` — some password managers may pause autofill in this state, which is the intended security tradeoff.
-
-Pair with `Field.*` for label/description/error wiring in forms:
-
-<Example className="flex-col gap-4">
-	<Field.Item className="max-w-64" name="password">
-		<Field.Label>Password</Field.Label>
-		<Field.Control>
-			<PasswordInput />
-		</Field.Control>
-	</Field.Item>
-	<Field.Item className="max-w-64" name="password-error">
-		<Field.Label>Password (error)</Field.Label>
-		<Field.Control>
-			<PasswordInput validation="error" />
-		</Field.Control>
-	</Field.Item>
-	<Field.Item className="max-w-64" name="password-controlled">
-		<Field.Label>Controlled Visibility</Field.Label>
-		<Field.Control>
-			<ControlledVisibility />
-		</Field.Control>
-	</Field.Item>
-</Example>
-
-```tsx
-import { Field } from "@ngrok/mantle/field";
-import { PasswordInput } from "@ngrok/mantle/input";
-
-<Field.Item className="max-w-64" name="password">
-	<Field.Label>Password</Field.Label>
-	<Field.Control>
-		<PasswordInput />
-	</Field.Control>
-</Field.Item>
-<Field.Item className="max-w-64" name="password-error">
-	<Field.Label>Password (error)</Field.Label>
-	<Field.Control>
-		<PasswordInput validation="error" />
-	</Field.Control>
-</Field.Item>
-```
-
-Or render the control on its own:
-
-<Example>
-	<PasswordInput className="max-w-64" aria-label="Password" />
-</Example>
-
-```tsx
-import { PasswordInput } from "@ngrok/mantle/input";
-
-<PasswordInput aria-label="Password" />;
-```
+When revealed, the input switches to `type="text"`. Some password managers may pause autofill in this state, which is the intended security trade-off.
 
 ## Examples
 
@@ -249,7 +296,9 @@ function Example() {
 
 ## API Reference
 
-The `PasswordInput` accepts the following props in addition to the [standard HTML input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+### PasswordInput
+
+The `PasswordInput` accepts the following props in addition to the [standard HTML input attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input), except `type`: the toggle owns it.
 
 | Prop                      | Type                                                                                                     | Default | Description                                                                                                                                                                                                                                                                                                             |
 | ------------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -257,9 +306,14 @@ The `PasswordInput` accepts the following props in addition to the [standard HTM
 | `showValue`               | `boolean`                                                                                                |         | The controlled visibility of the value. When set, the input follows this prop; a click on the toggle only calls `onValueVisibilityChange` with the next value. When omitted, the toggle owns the visibility and starts hidden.                                                                                          |
 | `validation`              | `"error"` \| `"success"` \| `"warning"` \| `false` \| `() => "error" \| "success" \| "warning" \| false` |         | Use the `validation` prop to show if the input has a specific validation status. This will change the border and outline of the input. The `false` type is useful when using short-circuiting logic so that you don't need to use a ternary with `undefined`. Setting `validation` to `error` also sets `aria-invalid`. |
 
-### Data attributes
+One standard attribute is narrowed to a union, so a typo is a type error: `autoComplete` accepts the [HTML autocomplete tokens](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
 
-| Data Attribute | Value                     | Description                   |
-| -------------- | ------------------------- | ----------------------------- |
-| `data-slot`    | `"password-input"`        | The chrome around the input.  |
-| `data-slot`    | `"password-input-toggle"` | The visibility toggle button. |
+#### Data attributes
+
+| Data Attribute    | Value                                   | Description                                          |
+| ----------------- | --------------------------------------- | ---------------------------------------------------- |
+| `data-slot`       | `"password-input"`                      | The chrome around the input.                         |
+| `data-slot`       | `"input-capture"`                       | The `<input>` element.                               |
+| `data-slot`       | `"password-input-toggle"`               | The visibility toggle button.                        |
+| `data-disabled`   | present when disabled                   | On the chrome. Style with `data-disabled:`.          |
+| `data-validation` | `"error"` \| `"success"` \| `"warning"` | On the chrome and the `<input>`. Omitted when unset. |

--- a/packages/mantle/src/components/input/password-input.browser.test.tsx
+++ b/packages/mantle/src/components/input/password-input.browser.test.tsx
@@ -36,16 +36,18 @@ describe("PasswordInput (browser)", () => {
 		const toggle = screen.getByRole("button", { name: "Show value" });
 
 		await user.click(toggle);
-		expect(handleChange).toHaveBeenCalledWith(true);
+		expect(handleChange).toHaveBeenCalledTimes(1);
+		expect(handleChange).toHaveBeenLastCalledWith(true);
 
 		await user.click(toggle);
-		expect(handleChange).toHaveBeenCalledWith(false);
+		expect(handleChange).toHaveBeenCalledTimes(2);
+		expect(handleChange).toHaveBeenLastCalledWith(false);
 	});
 
 	test("does not call Element.animate when prefers-reduced-motion is enabled", async () => {
 		const user = userEvent.setup();
 		// Simulate prefers-reduced-motion: reduce
-		const matchMediaSpy = vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+		vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
 			matches: false, // "(prefers-reduced-motion: no-preference)" → false means reduced motion
 			media: query,
 			onchange: null,
@@ -67,8 +69,5 @@ describe("PasswordInput (browser)", () => {
 
 		expect(screen.getByPlaceholderText("test")).toHaveAttribute("type", "text");
 		expect(animateSpy).not.toHaveBeenCalled();
-
-		matchMediaSpy.mockRestore();
-		animateSpy.mockRestore();
 	});
 });

--- a/packages/mantle/src/components/input/password-input.test.tsx
+++ b/packages/mantle/src/components/input/password-input.test.tsx
@@ -258,6 +258,38 @@ describe("PasswordInput", () => {
 			expect(animateSpy.mock.contexts[1]).toBe(toggle.querySelector("svg"));
 		});
 
+		// Regression: the animation ran inside the toggle's click handler, so a
+		// `showValue` change from another control swapped the icon with no motion.
+		test("a showValue change from outside animates the icon now in the DOM", () => {
+			const animateSpy = vi.spyOn(SVGSVGElement.prototype, "animate");
+			const { rerender } = render(<PasswordInput placeholder="test" showValue={false} />);
+			const toggle = screen.getByRole("button", { name: "Show value" });
+
+			// The first paint is not a change, so it does not animate.
+			expect(animateSpy).not.toHaveBeenCalled();
+
+			rerender(<PasswordInput placeholder="test" showValue />);
+			expect(animateSpy).toHaveBeenCalledTimes(1);
+			expect(animateSpy.mock.contexts[0]).toBe(toggle.querySelector("svg"));
+
+			rerender(<PasswordInput placeholder="test" showValue={false} />);
+			expect(animateSpy).toHaveBeenCalledTimes(2);
+			expect(animateSpy.mock.contexts[1]).toBe(toggle.querySelector("svg"));
+		});
+
+		// The icon did not change, so motion would claim a reveal that did not happen.
+		test("given a consumer that does not echo, a click does not animate the icon", async () => {
+			const user = userEvent.setup();
+			const animateSpy = vi.spyOn(SVGSVGElement.prototype, "animate");
+			render(
+				<PasswordInput placeholder="test" showValue={false} onValueVisibilityChange={() => {}} />,
+			);
+
+			await user.click(screen.getByRole("button", { name: "Show value" }));
+
+			expect(animateSpy).not.toHaveBeenCalled();
+		});
+
 		// `Profiler` counts commits. A mirror effect commits the stale `type`
 		// first and the corrected one second; derivation commits once.
 		test("a showValue change swaps the type and aria-pressed in one commit", () => {

--- a/packages/mantle/src/components/input/password-input.test.tsx
+++ b/packages/mantle/src/components/input/password-input.test.tsx
@@ -325,15 +325,42 @@ describe("PasswordInput", () => {
 		});
 	});
 
-	test("stamps data-slot on the chrome and the toggle", () => {
+	test("forwards className to the chrome, and ref and data-* to the input", () => {
+		const ref = vi.fn<(node: HTMLInputElement | null) => void>();
+		const { container } = render(
+			<PasswordInput className="custom" data-testid="secret" placeholder="test" ref={ref} />,
+		);
+
+		const input = screen.getByPlaceholderText("test");
+		expect(container.querySelector('[data-slot="password-input"]')).toHaveClass("custom");
+		// Why the input: `Input` routes every unclaimed prop to the `<input>`
+		// through context, so `data-*` lands beside `name` and `placeholder`.
+		expect(input).toHaveAttribute("data-testid", "secret");
+		expect(ref).toHaveBeenCalledTimes(1);
+		expect(ref).toHaveBeenLastCalledWith(input);
+	});
+
+	test("stamps data-slot on the chrome, the input, and the toggle", () => {
 		const { container } = render(<PasswordInput placeholder="test" />);
 
-		expect(container.querySelector('[data-slot="password-input"]')).toContainElement(
-			screen.getByPlaceholderText("test"),
-		);
+		const input = screen.getByPlaceholderText("test");
+		expect(container.querySelector('[data-slot="password-input"]')).toContainElement(input);
+		expect(input).toHaveAttribute("data-slot", "input-capture");
 		expect(screen.getByRole("button", { name: "Show value" })).toHaveAttribute(
 			"data-slot",
 			"password-input-toggle",
 		);
+	});
+
+	test("stamps data-disabled and data-validation on the chrome, and omits them when unset", () => {
+		const { container, rerender } = render(<PasswordInput placeholder="test" />);
+		const chrome = container.querySelector('[data-slot="password-input"]');
+
+		expect(chrome).not.toHaveAttribute("data-disabled");
+		expect(chrome).not.toHaveAttribute("data-validation");
+
+		rerender(<PasswordInput placeholder="test" disabled validation="warning" />);
+		expect(chrome).toHaveAttribute("data-disabled");
+		expect(chrome).toHaveAttribute("data-validation", "warning");
 	});
 });

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -11,6 +11,9 @@ import { Icon } from "../icon/icon.js";
 import { Input, InputCapture } from "./input.js";
 import type { InputType, WithAutoComplete } from "./types.js";
 
+/**
+ * The props for the `PasswordInput` component.
+ */
 type PasswordInputProps = Omit<ComponentProps<"input">, "autoComplete" | "type"> &
 	WithValidation &
 	WithAutoComplete & {
@@ -40,16 +43,16 @@ type PasswordInputType = Extract<InputType, "text" | "password">;
  *   accurately and may want to verify visually before submitting.
  *
  * **When not to use**
- * - For values that are never sensitive — use a plain {@link https://mantle.ngrok.com/components/forms/input Input}.
+ * - For values that are never sensitive: use a plain {@link https://mantle.ngrok.com/components/forms/input Input}.
  * - For controls where the toggle would be confusing (e.g. masked input
  *   formatting like phone numbers).
  *
  * **Visibility state.** The toggle is uncontrolled by default. Pass
- * `showValue` to control the visibility from the outside (useful when one
- * UI control toggles multiple password fields), and `onValueVisibilityChange`
- * to be notified when the user toggles via the built-in button. The eye icon
- * animates whenever the visibility changes, from the built-in button or from
- * `showValue`, unless the user prefers reduced motion.
+ * `showValue` to control the visibility from the outside, for example when
+ * one control reveals several password fields. Pass `onValueVisibilityChange`
+ * to receive the next visibility when the user clicks the built-in toggle.
+ * The eye icon animates on every visibility change, from the built-in toggle
+ * or from `showValue`, unless the user prefers reduced motion.
  *
  * **Accessibility.** Always pair with a {@link https://mantle.ngrok.com/components/forms/label Label}.
  * The toggle is a focusable `aria-pressed` button named "Show value". Its
@@ -63,11 +66,14 @@ type PasswordInputType = Extract<InputType, "text" | "password">;
  * | Data Attribute | Value | Description |
  * | --- | --- | --- |
  * | `data-slot` | `"password-input"` | The chrome around the input. |
+ * | `data-slot` | `"input-capture"` | The `<input>` element. |
  * | `data-slot` | `"password-input-toggle"` | The visibility toggle button. |
+ * | `data-disabled` | present when disabled | On the chrome. Style with `data-disabled:`. |
+ * | `data-validation` | `"error"` \| `"success"` \| `"warning"` | On the chrome and the `<input>`. Omitted when unset. |
  *
  * **Browser password managers.** When revealed, the input switches to
- * `type="text"` — some password managers may pause autofill in this state,
- * which is the intended security tradeoff.
+ * `type="text"`. Some password managers may pause autofill in this state,
+ * which is the intended security trade-off.
  *
  * @see https://mantle.ngrok.com/components/forms/password-input
  *
@@ -114,7 +120,6 @@ const PasswordInput = ({
 	const type: PasswordInputType = showPassword ? "text" : "password";
 	const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
 	const iconRef = useRef<SVGSVGElement>(null);
-	const animationRef = useRef<Animation | null>(null);
 	const animatedShowPassword = useRef(showPassword);
 
 	// Why an effect and not the click handler: the visibility can change from
@@ -127,27 +132,18 @@ const PasswordInput = ({
 		}
 		animatedShowPassword.current = showPassword;
 
-		// Cancel any in-flight animation so rapid toggles are never blocked
-		animationRef.current?.cancel();
-		animationRef.current = null;
-
 		const icon = iconRef.current;
 		if (icon == null || getPrefersReducedMotion()) {
 			return;
 		}
 
-		const animation = icon.animate([{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }], {
+		// Why no cancel: every visibility change swaps `EyeIcon` for
+		// `EyeClosedIcon`, so the previous animation runs on a detached `<svg>`
+		// and cannot block or stack with this one.
+		icon.animate([{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }], {
 			duration: 200,
 			easing: "ease-out",
 		});
-		animationRef.current = animation;
-		animation.onfinish = () => {
-			animationRef.current = null;
-		};
-		// Why: `cancel()` rejects `finished` with an AbortError, and nothing
-		// awaits it, so a rapid second toggle would surface an unhandled
-		// rejection.
-		animation.finished.catch(() => {});
 	}, [showPassword]);
 
 	return (

--- a/packages/mantle/src/components/input/password-input.tsx
+++ b/packages/mantle/src/components/input/password-input.tsx
@@ -4,7 +4,7 @@ import { EyeIcon } from "@phosphor-icons/react/Eye";
 import { EyeClosedIcon } from "@phosphor-icons/react/EyeClosed";
 import { useId, useRef, useState } from "react";
 import type { ComponentProps } from "react";
-import { flushSync } from "react-dom";
+import { useIsomorphicLayoutEffect } from "../../hooks/use-isomorphic-layout-effect.js";
 import { getPrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 import type { WithValidation } from "../field/validation.js";
 import { Icon } from "../icon/icon.js";
@@ -47,7 +47,9 @@ type PasswordInputType = Extract<InputType, "text" | "password">;
  * **Visibility state.** The toggle is uncontrolled by default. Pass
  * `showValue` to control the visibility from the outside (useful when one
  * UI control toggles multiple password fields), and `onValueVisibilityChange`
- * to be notified when the user toggles via the built-in button.
+ * to be notified when the user toggles via the built-in button. The eye icon
+ * animates whenever the visibility changes, from the built-in button or from
+ * `showValue`, unless the user prefers reduced motion.
  *
  * **Accessibility.** Always pair with a {@link https://mantle.ngrok.com/components/forms/label Label}.
  * The toggle is a focusable `aria-pressed` button named "Show value". Its
@@ -113,6 +115,40 @@ const PasswordInput = ({
 	const EyeCon = showPassword ? EyeIcon : EyeClosedIcon;
 	const iconRef = useRef<SVGSVGElement>(null);
 	const animationRef = useRef<Animation | null>(null);
+	const animatedShowPassword = useRef(showPassword);
+
+	// Why an effect and not the click handler: the visibility can change from
+	// outside through `showValue`, and the icon must animate the same way for
+	// both. A layout effect runs after the commit that swaps the icon, so it
+	// animates the `<svg>` now in the DOM, before paint.
+	useIsomorphicLayoutEffect(() => {
+		if (animatedShowPassword.current === showPassword) {
+			return;
+		}
+		animatedShowPassword.current = showPassword;
+
+		// Cancel any in-flight animation so rapid toggles are never blocked
+		animationRef.current?.cancel();
+		animationRef.current = null;
+
+		const icon = iconRef.current;
+		if (icon == null || getPrefersReducedMotion()) {
+			return;
+		}
+
+		const animation = icon.animate([{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }], {
+			duration: 200,
+			easing: "ease-out",
+		});
+		animationRef.current = animation;
+		animation.onfinish = () => {
+			animationRef.current = null;
+		};
+		// Why: `cancel()` rejects `finished` with an AbortError, and nothing
+		// awaits it, so a rapid second toggle would surface an unhandled
+		// rejection.
+		animation.finished.catch(() => {});
+	}, [showPassword]);
 
 	return (
 		<Input data-slot="password-input" disabled={disabled} id={id} type={type} ref={ref} {...props}>
@@ -133,37 +169,11 @@ const PasswordInput = ({
 				aria-controls={id}
 				className="text-body hover:text-strong focus-visible:ring-focus-accent ml-1 cursor-pointer rounded-xs bg-inherit p-0 focus-visible:ring-2 focus-visible:outline-hidden"
 				onClick={() => {
-					// Cancel any in-flight animation so rapid clicks are never blocked
-					if (animationRef.current) {
-						animationRef.current.cancel();
-						animationRef.current = null;
-					}
-
 					const nextShowPassword = !showPassword;
-					// Why flushSync around both: `icon.animate` below needs the new icon in
-					// the DOM first. In controlled mode, the parent's setState inside the
-					// callback is the render that swaps it.
-					flushSync(() => {
-						if (!isControlled) {
-							setInternalShowValue(nextShowPassword);
-						}
-						onValueVisibilityChange?.(nextShowPassword);
-					});
-
-					const icon = iconRef.current;
-					if (icon && !getPrefersReducedMotion()) {
-						animationRef.current = icon.animate(
-							[{ transform: "scaleY(0)" }, { transform: "scaleY(1)" }],
-							{ duration: 200, easing: "ease-out" },
-						);
-						animationRef.current.onfinish = () => {
-							animationRef.current = null;
-						};
-						// Why: `cancel()` rejects `finished` with an AbortError, and nothing
-						// awaits it, so a rapid second click would surface an unhandled
-						// rejection.
-						animationRef.current.finished.catch(() => {});
+					if (!isControlled) {
+						setInternalShowValue(nextShowPassword);
 					}
+					onValueVisibilityChange?.(nextShowPassword);
 				}}
 			>
 				<Icon ref={iconRef} svg={<EyeCon aria-hidden />} />


### PR DESCRIPTION
## Why

`PasswordInput` animated its eye icon only from its own toggle. The animation ran inside the button's `onClick`, so a page that reveals several fields from one control (`showValue` driven by a shared "Show value" button) swapped the icon with no motion. The dashboard's Your Authtoken page hit this: the snippet toggles reveal the hero field, and the eye jumped instead of animating.

## What

- A layout effect keyed on the resolved visibility runs the animation after the commit that swaps the icon, so a click and a `showValue` change animate the same way.
- The click handler only writes the state and calls `onValueVisibilityChange`. It no longer needs `flushSync`.
- A controlled consumer that ignores the toggle gets no animation, because the icon did not change.
- Reduced motion still turns the animation off. The first paint does not animate.
- The effect does not cancel or track the previous animation. Every change swaps `EyeIcon` for `EyeClosedIcon`, so React mounts a new `<svg>` and the old animation runs on a detached node.

A COMPONENT_SPEC.md audit of the component rides along:

- The JSDoc and the docs page list every data attribute the component stamps, including the ones it inherits from `Input`.
- The docs page follows the spec's section order and has a live controlled example for the `showValue` animation.
- Tests pin `className`, `ref`, and `data-*` forwarding and the chrome's `data-disabled` and `data-validation`.

Two patch changesets included.
