### PR TITLE
perf(table): defer the first overflow read past the commit

### DIFF
--- a/.changeset/table-defer-overflow-read.md
+++ b/.changeset/table-defer-overflow-read.md
@@ -1,0 +1,10 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Table.Root` no longer forces a layout inside React's commit. Its overflow observer used to read `scrollWidth`
+in a layout effect on mount, which laid out the whole table before React could finish the commit. The first
+read now runs in the `ResizeObserver` callback, after the browser's own layout, and a `flushSync` there keeps
+`data-x-overflow`, `data-x-scroll-end`, and `data-sticky-active` on the first painted frame. On a 1,000-row
+`DataTable` the mount commit drops from about 31 ms to 14 ms, and from about 344 ms to 142 ms at 10,000 rows.
+Time to first paint is unchanged, because the browser lays out the table either way.

--- a/packages/mantle/src/components/table/table.browser.test.tsx
+++ b/packages/mantle/src/components/table/table.browser.test.tsx
@@ -54,6 +54,26 @@ describe("Table.Root overflow observer", () => {
 		});
 	});
 
+	test("the overflow attributes update before the first frame paints", async () => {
+		// Why a second observer: the browser broadcasts every ResizeObserver's
+		// notifications in creation order, all before paint. This one is created
+		// after `Table.Root`'s, so it reads what the first painted frame will show.
+		// The regression it pins is a `setState` without `flushSync`, which would
+		// leave the attributes at their initial `"false"` until the next React task.
+		renderTable({ rootWidth: 200, tableWidth: 800 });
+		const root = screen.getByTestId("root");
+
+		const seenBeforePaint = await new Promise<string | null>((resolve) => {
+			const observer = new ResizeObserver(() => {
+				observer.disconnect();
+				resolve(root.getAttribute("data-x-overflow"));
+			});
+			observer.observe(root);
+		});
+
+		expect(seenBeforePaint).toBe("true");
+	});
+
 	test("an overflowing table flags overflow and the sticky column, then clears them at the end", async () => {
 		renderTable({ rootWidth: 200, tableWidth: 800 });
 		const root = screen.getByTestId("root");

--- a/packages/mantle/src/components/table/table.browser.test.tsx
+++ b/packages/mantle/src/components/table/table.browser.test.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { Table } from "./table.js";
+
+// Why inline CSS: the browser project loads no stylesheet, and the overflow
+// state needs a scroller that clips its table. This mirrors the `overflow-x-auto`
+// utility on `Table.Root`'s inner scroller.
+const STYLE = `
+[data-slot="table"] > div { overflow-x: auto; }
+`;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+function renderTable({ rootWidth, tableWidth }: { rootWidth: number; tableWidth: number }) {
+	return render(
+		<Table.Root data-testid="root" style={{ width: rootWidth }}>
+			<Table.Element style={{ width: tableWidth }}>
+				<Table.Body>
+					<Table.Row>
+						<Table.Cell>INV001</Table.Cell>
+						<Table.Cell>$250.00</Table.Cell>
+					</Table.Row>
+				</Table.Body>
+			</Table.Element>
+		</Table.Root>,
+	);
+}
+
+describe("Table.Root overflow observer", () => {
+	test("the first layout read waits for the browser, not React's commit", async () => {
+		// Why the getter spy: a `scrollWidth` read forces a layout. The regression
+		// this pins is a synchronous read inside the layout effect, which would run
+		// before `render` returns.
+		const scrollWidth = vi.spyOn(Element.prototype, "scrollWidth", "get");
+
+		renderTable({ rootWidth: 200, tableWidth: 800 });
+		expect(scrollWidth).not.toHaveBeenCalled();
+
+		const root = screen.getByTestId("root");
+		await waitFor(() => {
+			expect(root).toHaveAttribute("data-x-overflow", "true");
+		});
+	});
+
+	test("an overflowing table flags overflow and the sticky column, then clears them at the end", async () => {
+		renderTable({ rootWidth: 200, tableWidth: 800 });
+		const root = screen.getByTestId("root");
+		const scroller = screen.getByRole("table").parentElement;
+		if (scroller == null) {
+			throw new Error("the table has no scroller");
+		}
+
+		await waitFor(() => {
+			expect(root).toHaveAttribute("data-x-overflow", "true");
+		});
+		expect(root).toHaveAttribute("data-x-scroll-end", "false");
+		expect(root).toHaveAttribute("data-sticky-active", "true");
+
+		scroller.scrollLeft = scroller.scrollWidth;
+
+		await waitFor(() => {
+			expect(root).toHaveAttribute("data-x-scroll-end", "true");
+		});
+		expect(root).toHaveAttribute("data-x-overflow", "true");
+		expect(root).not.toHaveAttribute("data-sticky-active");
+	});
+
+	test("a table that fits reports no overflow after the first read", async () => {
+		const scrollWidth = vi.spyOn(Element.prototype, "scrollWidth", "get");
+		renderTable({ rootWidth: 800, tableWidth: 200 });
+		const root = screen.getByTestId("root");
+
+		// The observer's first notification is the readiness signal; the
+		// assertions below are about the values it produced.
+		await waitFor(() => {
+			expect(scrollWidth).toHaveBeenCalled();
+		});
+		expect(root).toHaveAttribute("data-x-overflow", "false");
+		expect(root).toHaveAttribute("data-x-scroll-end", "false");
+		expect(root).not.toHaveAttribute("data-sticky-active");
+	});
+});

--- a/packages/mantle/src/components/table/table.tsx
+++ b/packages/mantle/src/components/table/table.tsx
@@ -2,6 +2,7 @@
 
 import type { ComponentProps, ComponentRef } from "react";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
 
@@ -1070,7 +1071,7 @@ function useHorizontalOverflowObserver<T extends HTMLElement>() {
 			});
 		};
 
-		// Coalesce rapid-fire events (scroll, mutation, resize) into a single
+		// Coalesce rapid-fire events (scroll, mutation) into a single
 		// layout read per animation frame to avoid redundant work.
 		const scheduleCheck = () => {
 			if (frameId === 0) {
@@ -1081,15 +1082,20 @@ function useHorizontalOverflowObserver<T extends HTMLElement>() {
 			}
 		};
 
-		const resizeObserver = new ResizeObserver(scheduleCheck);
+		// Why the observer does the first read: inside this effect, a `scrollWidth`
+		// read forces a layout of the whole table during React's commit. `observe()`
+		// delivers one notification after the browser's own layout, so the same read
+		// there costs nothing. Observer callbacks run before paint, so `flushSync`
+		// lands the new attributes in the first painted frame.
+		const resizeObserver = new ResizeObserver(() => {
+			flushSync(checkState);
+		});
 		resizeObserver.observe(element);
 
 		const mutationObserver = new MutationObserver(scheduleCheck);
 		mutationObserver.observe(element, { childList: true, subtree: true });
 
 		element.addEventListener("scroll", scheduleCheck, { passive: true });
-
-		checkState();
 
 		return () => {
 			cancelAnimationFrame(frameId);


### PR DESCRIPTION
## Why

`Table.Root` measures horizontal overflow to stamp `data-x-overflow`, `data-x-scroll-end`, and `data-sticky-active`. Its hook read `scrollWidth` synchronously in a `useLayoutEffect`, which forces a layout of the whole table inside React's commit. A CPU profile of a 1,000-row `DataTable` mount put that one read at about 55% of the commit (`local/handoffs/tanstack-v8-v9-benchmark`, frame `table-*.js:1:2717`), on both TanStack v8 and v9.

## How

The layout effect no longer reads layout. `ResizeObserver.observe()` delivers one notification after the browser's own layout, so the first read moves into the observer callback, where it costs nothing. Observer callbacks run before paint, so the callback wraps `setState` in `flushSync`; the attributes still land in the first painted frame. Scroll and mutation events keep the rAF coalescing. Patch changeset.

## Validation

- New `table.browser.test.tsx` (real Chromium): a `scrollWidth` getter spy proves no layout read happens before `render` returns; an overflowing table flags `data-x-overflow` and `data-sticky-active` after mount and clears the sticky flag once scrolled to the end; a table that fits stays `"false"`. Re-adding the synchronous read fails the first test.
- Headless Chromium, production React 19.2.8, 6-column `DataTable`, median of 2 rounds:

| Rows | Metric | before | after |
|---|---|---|---|
| 1,000 | React commit (`flushSync`) | 30.6 ms | 14.3 ms (−53%) |
| 1,000 | mount to first paint | 35.9 ms | 34.2 ms (−5%) |
| 10,000 | React commit (`flushSync`) | 344 ms | 142 ms (−59%) |
| 10,000 | mount to first paint | 355 ms | 360 ms (0%) |

Time to first paint does not move, because the browser lays out the table before paint either way. The change removes the layout from the commit, not from the frame.
