### PR TITLE
feat(www): add recipes to the ⌘K command palette

### DIFF
--- a/apps/www/app/components/command-palette-search.test.ts
+++ b/apps/www/app/components/command-palette-search.test.ts
@@ -10,6 +10,7 @@ import {
 	componentsByCategory,
 	layoutPages,
 	previewComponents,
+	recipePages,
 	utilsPages,
 	welcomePages,
 } from "./navigation-data";
@@ -39,6 +40,7 @@ describe("buildPaletteCommands", () => {
 			utilsPages.length +
 			componentCount +
 			layoutPages.length +
+			recipePages.length +
 			previewComponents.length +
 			5; // theme commands
 
@@ -73,6 +75,16 @@ describe("buildPaletteCommands", () => {
 		});
 	});
 
+	test("recipe commands carry their docs route as both target and subtitle", () => {
+		const routeAnnouncer = commands.find((command) => command.title === "Route Announcer");
+		expect(routeAnnouncer).toMatchObject({
+			kind: "route",
+			group: "Recipes",
+			to: "/recipes/route-announcer",
+			subtitle: "/recipes/route-announcer",
+		});
+	});
+
 	test("preview components are flagged so search results can badge them", () => {
 		const calendar = commands.find((command) => command.title === "Calendar");
 		expect(calendar).toMatchObject({
@@ -94,6 +106,7 @@ describe("groupPaletteCommands", () => {
 			"Utils",
 			...componentCategories.map((category) => `Components: ${category}`),
 			"Layouts",
+			"Recipes",
 			"Preview Components",
 			"Theme",
 		]);
@@ -163,6 +176,16 @@ describe("searchPaletteCommands", () => {
 		expect(titles("bsf")).not.toContain("Scroll Fade");
 		// positive control: a real route substring still finds the page
 		expect(titles("scroll-fade")).toContain("Scroll Fade");
+	});
+
+	test("finds recipes by title and by route-path substring", () => {
+		expect(titles("announcer")[0]).toBe("Route Announcer");
+		expect(titles("async")).toContain("Overlays + Async Data");
+
+		const results = titles("/recipes/");
+		for (const page of recipePages) {
+			expect(results).toContain(page);
+		}
 	});
 
 	test("finds external links by their subtitle", () => {

--- a/apps/www/app/components/command-palette-search.ts
+++ b/apps/www/app/components/command-palette-search.ts
@@ -119,8 +119,16 @@ function routeCommand({
 
 /**
  * Builds every command the docs palette offers, in browse display order:
- * Welcome (docs pages plus the GitHub links), Base, Hooks, Utils, one group
- * per component category, Layouts, Recipes, Preview Components, and Theme.
+ *
+ * - Welcome (docs pages plus the GitHub links)
+ * - Base
+ * - Hooks
+ * - Utils
+ * - one group per component category
+ * - Layouts
+ * - Recipes
+ * - Preview Components
+ * - Theme
  *
  * Pure: derives everything from `navigation-data` and the given version, so
  * a page missing here means it is missing from `navigation-data` itself.

--- a/apps/www/app/components/command-palette-search.ts
+++ b/apps/www/app/components/command-palette-search.ts
@@ -13,6 +13,8 @@ import {
 	previewComponents,
 	previewComponentsRouteLookup,
 	prodReadyComponentRouteLookup,
+	recipePages,
+	recipeRoutes,
 	utilsPages,
 	utilsRoutes,
 	welcomePages,
@@ -118,7 +120,7 @@ function routeCommand({
 /**
  * Builds every command the docs palette offers, in browse display order:
  * Welcome (docs pages plus the GitHub links), Base, Hooks, Utils, one group
- * per component category, Layouts, Preview Components, and Theme.
+ * per component category, Layouts, Recipes, Preview Components, and Theme.
  *
  * Pure: derives everything from `navigation-data` and the given version, so
  * a page missing here means it is missing from `navigation-data` itself.
@@ -190,6 +192,14 @@ export function buildPaletteCommands(mantleVersion: string): PaletteCommand[] {
 				to: layoutRoutes[page],
 				group: "Layouts",
 				subtitle: layoutRoutes[page],
+			}),
+		),
+		...recipePages.map((page) =>
+			routeCommand({
+				title: page,
+				to: recipeRoutes[page],
+				group: "Recipes",
+				subtitle: recipeRoutes[page],
 			}),
 		),
 		...previewComponents.map((component) =>

--- a/apps/www/app/components/command-palette.test.tsx
+++ b/apps/www/app/components/command-palette.test.tsx
@@ -46,7 +46,11 @@ describe("CommandPalette", () => {
 
 		expect(screen.getByText("Welcome")).toBeTruthy();
 		expect(screen.getByText("Components: Navigation")).toBeTruthy();
+		expect(screen.getByText("Recipes")).toBeTruthy();
 		expect(screen.getByRole("option", { name: /Overview & Setup/ })).toBeTruthy();
+		expect(screen.getByRole("option", { name: /Route Announcer/ }).getAttribute("href")).toBe(
+			"/recipes/route-announcer",
+		);
 	});
 
 	// Regression: with cmdk's built-in filtering, searching "tabs" surfaced


### PR DESCRIPTION
## Why

The ⌘K palette built its commands from every `navigation-data` section except recipes. A reader had to know a recipe existed and open the Recipes tab to reach it.

## What

The palette now lists the recipe pages in a Recipes group after Layouts. A recipe is found by its title and by its `/recipes/…` route, the same way a component or layout page is.
