### PR TITLE
fix(select): wrap the value and item labels for translated pages

### DIFF
--- a/.changeset/select-slot-joins-and-data-attributes.md
+++ b/.changeset/select-slot-joins-and-data-attributes.md
@@ -1,0 +1,9 @@
+---
+"@ngrok/mantle": patch
+---
+
+Every `Select` part now joins a `data-slot` you pass ahead of its own slot instead of replacing it, so `<Select.Trigger data-slot="app-trigger">` renders `data-slot="app-trigger select-trigger"` and both hooks keep working.
+
+The docs page and the JSDoc now list the data attributes each part stamps: `data-state`, `data-placeholder`, `data-disabled`, and `data-validation` on `Select.Trigger`; `data-state`, `data-side`, and `data-align` on `Select.Content`; and `data-state`, `data-highlighted`, and `data-disabled` on `Select.Item`. Every `Select.Root` prop carries a description.
+
+`Select.Content` no longer animates when the user prefers reduced motion.

--- a/.changeset/select-translation-safe-labels.md
+++ b/.changeset/select-translation-safe-labels.md
@@ -1,0 +1,11 @@
+---
+"@ngrok/mantle": patch
+---
+
+`Select` no longer crashes on a page a browser translation engine has translated. Radix portals the selected item's text into `Select.Value` and keys the placeholder, so React removed a bare text node from the trigger whenever the value changed, the placeholder gave way to a first value, or the select unmounted on navigation. Google Translate reparents that text node first, and the `removeChild` threw `NotFoundError`, which tore down the React root and blanked the page.
+
+`Select.Item` now renders `children` inside a `<span data-slot="select-item-label">`. `Select.Value` renders `placeholder` inside a `<span data-slot="select-placeholder">` and your own `children` inside a `<span data-slot="select-value-label">`. React removes those elements instead of a text node, and an element removal cannot throw. Each span is `display: contents`, so it adds no box: your own item or value content stays the direct layout child of the value node, and a trigger override such as `[&>span]:flex-1` keeps working. A lone string child on `Select.Value` also takes React's `textContent` path now, which wipes the translation wrapper, so a swap between text and an element there is safe too.
+
+`Select.Value` also carries `data-slot="select-value"`. All four slots are public API, and the data-attribute tables on the docs page list them. You no longer need to wrap item labels in your own `<span>`.
+
+`translate="no"` on a `Select.Item` now also rides on the label span, so the copy the trigger shows stays untranslated. Set it on an item whose label is an ID, a path, a filename, or a key.

--- a/COMPONENT_SPEC.md
+++ b/COMPONENT_SPEC.md
@@ -497,17 +497,17 @@ A translation engine reparents the text nodes React holds, which turns a routine
 [CONVENTIONS.md → Browser Translation](./CONVENTIONS.md#browser-translation) owns both rules and the mechanism.
 What they mean for a part:
 
-- **No part renders a conditional element immediately before bare text children.** Wrap the text in an element
-  carrying `<component-name>-label`, move the conditional element after the text, or mount that element
-  unconditionally. A wrapper's `data-slot` is public API, so document it like every other one
-  ([§6](#6-data-attributes-are-api)).
+- **No part renders a conditional element immediately before bare text children, and no part portals bare
+  text.** Wrap the text in an element carrying `<component-name>-label`, move the conditional element after the
+  text, or mount that element unconditionally. A wrapper's `data-slot` is public API, so document it like every
+  other one ([§6](#6-data-attributes-are-api)).
 - **A part that renders code, a key, a filename, an ID, or a passcode sets `translate="no"`.** Lock it —
   `Omit<ComponentProps<…>, "translate">`, plus the attribute stamped after the props spread — when the part can
   never hold prose. Keep the prop when it can, and document the default in the JSDoc and the API reference.
 
 `Kbd`, `CodeBlock.Code`, and `OtpInput.Slot` lock the attribute. `Code` and `CodeBlock.Title` default it.
-`Button`, `Badge`, and `Anchor` wrap their label. `DataTable` moves one indicator after its children, and keeps
-its sort announcer mounted at all times.
+`Button`, `Badge`, `Anchor`, and `Select.Item` wrap their label, and `Select.Value` wraps its placeholder and its
+children. `DataTable` moves one indicator after its children, and keeps its sort announcer mounted at all times.
 
 ---
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -235,6 +235,10 @@ Three fixes work, and the conditional element decides which one:
 A lone expression child is already safe: React writes it through `setTextContent`, which repairs the subtree.
 The failure needs a sibling.
 
+A portal is the exception. React removes a portal's children from the container one at a time, so a portal
+whose only child is a bare text node throws on unmount with no sibling in play. Wrap what you portal in an
+element. `Select.Item` wraps the label Radix portals into the trigger for this reason.
+
 ### Mark untranslatable content `translate="no"`
 
 A reader copies or retypes some strings: code, a CLI flag, an env var, a YAML key, a shortcut key, a filename,

--- a/apps/www/app/docs/browser-translation.mdx
+++ b/apps/www/app/docs/browser-translation.mdx
@@ -22,22 +22,24 @@ This is not hypothetical. It shipped in mantle 0.83.2: the first click of any su
 
 The failure needs React to insert before, or remove, a **text** node the engine reparented. Element children are never reparented.
 
-| Update                                          | Result                                  |
-| ----------------------------------------------- | --------------------------------------- |
-| Insert an element before a translated text node | **Throws**                              |
-| Remove a text child while siblings remain       | **Throws**                              |
-| A text child changes type to an element         | **Throws**                              |
-| Change a text child's value                     | Safe. The translation reverts.          |
-| Reorder or remove **element** children          | Safe. Elements are never reparented.    |
-| **Append** after a translated text node         | Safe.                                   |
-| Unmount the whole subtree                       | Safe. React removes the outermost node. |
-| A **lone** expression child                     | Safe, and self-healing.                 |
+| Update                                          | Result                                                                                |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Insert an element before a translated text node | **Throws**                                                                            |
+| Remove a text child while siblings remain       | **Throws**                                                                            |
+| A text child changes type to an element         | **Throws**                                                                            |
+| Change a text child's value                     | Safe. The translation reverts.                                                        |
+| Reorder or remove **element** children          | Safe. Elements are never reparented.                                                  |
+| **Append** after a translated text node         | Safe.                                                                                 |
+| Unmount the whole subtree                       | Safe. React removes the outermost node.                                               |
+| Remove a portal's bare text child               | **Throws**. A portal has no node of its own, so its children are the outermost nodes. |
+| A **lone** expression child                     | Safe, and self-healing.                                                               |
 
 The last row is the one to design toward. When `children` is the only child of a host element, React writes it through `textContent`, which wipes the `<font>` wrapper and repairs the subtree instead of fighting it.
 
 ## What mantle guarantees
 
 - [`Button`](/components/actions/button), [`Badge`](/components/data-display/badge), and [`Anchor`](/components/navigation/anchor) render `children` inside a label slot, so an appearing `icon` or `isLoading` spinner inserts before an **element** sibling. In `Button` and `Badge` that slot is `display: contents`, so it adds no box and changes no layout.
+- [`Select.Item`](/components/forms/select#selectitem) renders `children` inside a label slot, and [`Select.Value`](/components/forms/select#selectvalue) wraps its `placeholder` and your own `children` the same way. Radix portals the selected label into the trigger and removes it on its own when the value changes, so the node it removes has to be an element. All three slots are `display: contents`. `translate="no"` on a `Select.Item` rides on that portaled label too, so an ID or a path stays untranslated in the trigger.
 - `DataTable.HeaderSortButton` renders its label through `Button`'s label slot, and the sort state lives in attributes (`aria-sort` on the header cell, `data-sort-direction` on the button), so a sort change inserts no node before text.
 - `DataTable.ActionHeader` renders its sticky indicator after `children`, which turns the mount into an append.
 - [`Code`](/components/data-display/code), [`Kbd`](/components/data-display/kbd), `CodeBlock.Code`, `CodeBlock.Title`, and `OtpInput.Slot` mark their content [`translate="no"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/translate), so the engine skips those subtrees entirely.

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -540,14 +540,14 @@ Select.Root
 
 ## Polymorphism
 
-`Select.Group`, `Select.Label`, `Select.Value`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior.
-
-`Select.Value asChild` is the useful one: reach for it when the displayed value needs its own element for truncation or badge chrome. `Select.Label asChild` helps when a group heading must be a specific element for the page's outline.
+`Select.Group`, `Select.Label`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior. `Select.Label asChild` helps when a group heading must be a specific element for the page's outline.
 
 `Select.Root` is a state provider that renders no DOM, so it takes no `asChild`.
 
 > [!WARNING]
 > `Select.Trigger`, `Select.Content`, and `Select.Item` currently advertise `asChild` in their prop types but **throw at runtime** (`Primitive.* failed to slot onto its children`). Each one renders its own chrome next to your content (the trigger's caret, the content's scroll buttons and viewport, the item's check indicator), so the underlying Radix `Slot` receives more than the single child it requires. Do not use `asChild` on these three parts. To customize the trigger's content, pass it as `children` instead.
+>
+> `Select.Value asChild` renders your element but **drops every prop**: Radix hands its `Slot` a keyed Fragment, so the value's `data-slot`, `ref`, and `style` never reach your element, and React warns about invalid Fragment props. Do not use it. To render a custom value, pass `children` instead, as the [custom selected value](#custom-selected-value) example does.
 
 ## API Reference
 

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -439,9 +439,19 @@ All props from Radix [Select.Trigger](https://www.radix-ui.com/primitives/docs/c
 
 ### Select.Value
 
-The part that reflects the selected value. Renders the selected item's text by default. For more control, control the select and pass your own children. Do not style this part — under `Select.Content position="item-aligned"`, Radix measures its box to align the open list over the selected item. Pass `placeholder` for the text to show when the select has no value.
+The part that reflects the selected value. Renders the selected item's text by default. For more control, control the select and pass your own children. Do not style this part: under `Select.Content position="item-aligned"`, Radix measures its box to align the open list over the selected item. Pass `placeholder` for the text to show when the select has no value.
+
+`placeholder` renders inside a `<span data-slot="select-placeholder">`, your own `children` inside a `<span data-slot="select-value-label">`, and the selected item's text arrives inside the `select-item-label` span from `Select.Item`. Each span is `display: contents`, so it adds no box and changes no layout. React removes one of those spans whenever the value changes, and an element removal is safe on a translated page. A browser translation engine reparents text nodes, and a removal aimed at a reparented text node throws. [Browser translation](/browser-translation) covers the mechanism.
 
 Radix [Select.Value](https://www.radix-ui.com/primitives/docs/components/select#value) props.
+
+#### Data attributes
+
+| Data Attribute | Value                  | Description                                                                   |
+| -------------- | ---------------------- | ----------------------------------------------------------------------------- |
+| `data-slot`    | `"select-value"`       | On the value element.                                                         |
+| `data-slot`    | `"select-placeholder"` | On the `<span>` wrapping `placeholder`. Present only while there is no value. |
+| `data-slot`    | `"select-value-label"` | On the `<span>` wrapping your `children`. Absent under `asChild`.             |
 
 ### Select.Content
 
@@ -470,11 +480,25 @@ Used to visually separate items in the select. Composed from [Mantle Separator](
 
 An option within a select menu. Similar to an html `option` element. Has a required `value` prop. When a user selects this item, `Select.Root` passes that value to its `onValueChange` handler. Displays the children as the option's text. Pass `icon` to render an icon before the text.
 
+`children` render inside a `<span data-slot="select-item-label">`. Radix portals that span into `Select.Value` while the item is selected and removes it when the selection changes. The span exists so the node React removes is an element: a browser translation engine reparents text nodes, and a removal aimed at one throws. The span is `display: contents`, so it adds no box in the list or in the trigger, and your own item content stays the direct layout child of the value. To style it as a box, set a display of your own on it first. [Browser translation](/browser-translation) covers the mechanism and the rule your own components need.
+
+When the label is an ID, a path, a filename, or a key, set `translate="no"` on the item. The attribute also rides on the label span, so the copy the trigger shows stays untranslated too.
+
 All props from Radix [Select.Item](https://www.radix-ui.com/primitives/docs/components/select#item), plus:
 
 | Prop    | Type        | Default | Description                                     |
 | ------- | ----------- | ------- | ----------------------------------------------- |
 | `icon?` | `ReactNode` |         | An optional icon rendered before the item text. |
+
+#### Data attributes
+
+| Data Attribute     | Value                        | Description                                                          |
+| ------------------ | ---------------------------- | -------------------------------------------------------------------- |
+| `data-slot`        | `"select-item"`              | On the option element.                                               |
+| `data-slot`        | `"select-item-label"`        | On the `<span>` wrapping `children`, in the list and in the trigger. |
+| `data-state`       | `"checked"` \| `"unchecked"` | Whether this item is the selected value.                             |
+| `data-highlighted` | present when highlighted     | Presence-only. The item under the pointer or the keyboard focus.     |
+| `data-disabled`    | present when disabled        | Presence-only. The `disabled` prop.                                  |
 
 ### Select.Label
 

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -632,9 +632,10 @@ When the label is an ID, a path, a filename, or a key, set `translate="no"` on t
 
 All props from Radix [Select.Item](https://www.radix-ui.com/primitives/docs/components/select#item), plus:
 
-| Prop    | Type        | Default | Description                                     |
-| ------- | ----------- | ------- | ----------------------------------------------- |
-| `icon?` | `ReactNode` |         | An optional icon rendered before the item text. |
+| Prop         | Type            | Default | Description                                                                                                                                                       |
+| ------------ | --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `icon?`      | `ReactNode`     |         | An optional icon rendered before the item text.                                                                                                                   |
+| `translate?` | `"yes" \| "no"` |         | The standard HTML attribute, also set on the label span so the copy the trigger shows keeps it. Set `"no"` when the label is an ID, a path, a filename, or a key. |
 
 #### Data attributes
 

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -424,7 +424,7 @@ function Example() {
 
 ### Rich item labels
 
-An item takes any content, and the trigger shows the selected label as-is. When the list needs a second line and the trigger needs one, control the select and render a compact value with `Select.Value` children. Both renders stay safe on a translated page: React removes the label span or the value span, never a bare text node.
+An item takes any content, and the trigger shows the selected label as-is. When the list needs two lines and the trigger must stay on one line, control the select and render a compact value with `Select.Value` children. Both renders stay safe on a translated page: React removes the label span or the value span, never a bare text node.
 
 <Example>
 	<RichItemLabelsExample />

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -5,7 +5,9 @@ description: Displays a list of options for the user to pick from—triggered by
 
 import { Button } from "@ngrok/mantle/button";
 import { Field, toErrorMessages } from "@ngrok/mantle/field";
+import { Icon } from "@ngrok/mantle/icon";
 import { Select } from "@ngrok/mantle/select";
+import { GlobeHemisphereWestIcon } from "@phosphor-icons/react/GlobeHemisphereWest";
 import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
 import { z } from "zod";
@@ -84,6 +86,49 @@ window.alert(`Submitted: ${JSON.stringify(value, null, 2)}`);
     			Submit
     		</Button>
     	</form>
+    );
+
+}
+
+export const regions = [
+	{ value: "us", label: "United States", host: "us.ngrok.com" },
+	{ value: "eu", label: "Europe", host: "eu.ngrok.com" },
+	{ value: "ap", label: "Asia Pacific", host: "ap.ngrok.com" },
+	{ value: "au", label: "Australia", host: "au.ngrok.com" },
+];
+
+export function RichItemLabelsExample() {
+	const [value, setValue] = useState("us");
+	const region = regions.find((candidate) => candidate.value === value);
+
+    return (
+    	<Select.Root value={value} onValueChange={setValue}>
+    		<Select.Trigger className="w-72" aria-label="Region">
+    			<Select.Value placeholder="Select a region">
+    				{region && (
+    					<span className="flex items-center gap-2">
+    						<Icon svg={<GlobeHemisphereWestIcon />} className="size-4" />
+    						<span>{region.label}</span>
+    						<span className="text-muted text-xs" translate="no">
+    							{region.host}
+    						</span>
+    					</span>
+    				)}
+    			</Select.Value>
+    		</Select.Trigger>
+    		<Select.Content width="trigger">
+    			{regions.map((region) => (
+    				<Select.Item key={region.value} value={region.value} icon={<GlobeHemisphereWestIcon />}>
+    					<span className="flex flex-col">
+    						<span>{region.label}</span>
+    						<span className="text-muted text-xs" translate="no">
+    							{region.host}
+    						</span>
+    					</span>
+    				</Select.Item>
+    			))}
+    		</Select.Content>
+    	</Select.Root>
     );
 
 }
@@ -375,6 +420,107 @@ function Example() {
 		</Select.Root>
 	);
 }
+```
+
+### Rich item labels
+
+An item takes any content, and the trigger shows the selected label as-is. When the list needs a second line and the trigger needs one, control the select and render a compact value with `Select.Value` children. Both renders stay safe on a translated page: React removes the label span or the value span, never a bare text node.
+
+<Example>
+	<RichItemLabelsExample />
+</Example>
+
+```tsx
+import { Icon } from "@ngrok/mantle/icon";
+import { Select } from "@ngrok/mantle/select";
+import { GlobeHemisphereWestIcon } from "@phosphor-icons/react/GlobeHemisphereWest";
+import { useState } from "react";
+
+const regions = [
+	{ value: "us", label: "United States", host: "us.ngrok.com" },
+	{ value: "eu", label: "Europe", host: "eu.ngrok.com" },
+	{ value: "ap", label: "Asia Pacific", host: "ap.ngrok.com" },
+	{ value: "au", label: "Australia", host: "au.ngrok.com" },
+];
+
+function Example() {
+	const [value, setValue] = useState("us");
+	const region = regions.find((candidate) => candidate.value === value);
+
+	return (
+		<Select.Root value={value} onValueChange={setValue}>
+			<Select.Trigger className="w-72" aria-label="Region">
+				<Select.Value placeholder="Select a region">
+					{region && (
+						<span className="flex items-center gap-2">
+							<Icon svg={<GlobeHemisphereWestIcon />} className="size-4" />
+							<span>{region.label}</span>
+							<span className="text-muted text-xs" translate="no">
+								{region.host}
+							</span>
+						</span>
+					)}
+				</Select.Value>
+			</Select.Trigger>
+			<Select.Content width="trigger">
+				{regions.map((region) => (
+					<Select.Item key={region.value} value={region.value} icon={<GlobeHemisphereWestIcon />}>
+						<span className="flex flex-col">
+							<span>{region.label}</span>
+							<span className="text-muted text-xs" translate="no">
+								{region.host}
+							</span>
+						</span>
+					</Select.Item>
+				))}
+			</Select.Content>
+		</Select.Root>
+	);
+}
+```
+
+### Untranslatable labels
+
+When a label is an ID, a path, a filename, or a key, set `translate="no"` on the item. A browser translation engine then skips the row and the copy the trigger shows, so the reader copies the right string.
+
+<Example>
+	<Select.Root defaultValue="us-east-1">
+		<Select.Trigger className="w-56" aria-label="AWS region">
+			<Select.Value placeholder="Select a region" />
+		</Select.Trigger>
+		<Select.Content width="trigger">
+			<Select.Item value="us-east-1" translate="no">
+				us-east-1
+			</Select.Item>
+			<Select.Item value="eu-west-1" translate="no">
+				eu-west-1
+			</Select.Item>
+			<Select.Item value="ap-southeast-2" translate="no">
+				ap-southeast-2
+			</Select.Item>
+		</Select.Content>
+	</Select.Root>
+</Example>
+
+```tsx
+import { Select } from "@ngrok/mantle/select";
+
+<Select.Root defaultValue="us-east-1">
+	<Select.Trigger className="w-56" aria-label="AWS region">
+		<Select.Value placeholder="Select a region" />
+	</Select.Trigger>
+	<Select.Content width="trigger">
+		<Select.Item value="us-east-1" translate="no">
+			us-east-1
+		</Select.Item>
+		<Select.Item value="eu-west-1" translate="no">
+			eu-west-1
+		</Select.Item>
+		<Select.Item value="ap-southeast-2" translate="no">
+			ap-southeast-2
+		</Select.Item>
+	</Select.Content>
+</Select.Root>;
 ```
 
 ## Composition

--- a/apps/www/app/docs/components/forms/select.mdx
+++ b/apps/www/app/docs/components/forms/select.mdx
@@ -216,6 +216,32 @@ import { Select } from "@ngrok/mantle/select";
 </Field.Item>;
 ```
 
+## Composition
+
+Compose the parts of a `Select` together to build your own:
+
+```text showLineNumbers=false
+Select.Root
+├── Select.Trigger
+│   └── Select.Value
+└── Select.Content
+    ├── Select.Group
+    │   ├── Select.Label
+    │   └── Select.Item
+    └── Select.Separator
+```
+
+## Polymorphism
+
+`Select.Group`, `Select.Label`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior. `Select.Label asChild` helps when a group heading must be a specific element for the page's outline.
+
+`Select.Root` is a state provider that renders no DOM, so it takes no `asChild`.
+
+> [!WARNING]
+> `Select.Trigger`, `Select.Content`, and `Select.Item` currently advertise `asChild` in their prop types but **throw at runtime** (`Primitive.* failed to slot onto its children`). Each one renders its own chrome next to your content (the trigger's caret, the content's scroll buttons and viewport, the item's check indicator), so the underlying Radix `Slot` receives more than the single child it requires. Do not use `asChild` on these three parts. To customize the trigger's content, pass it as `children` instead.
+>
+> `Select.Value asChild` renders your element but **drops every prop**: Radix hands its `Slot` a keyed Fragment, so the value's `data-slot`, `ref`, and `style` never reach your element, and React warns about invalid Fragment props. Do not use it. To render a custom value, pass `children` instead, as the [custom selected value](#custom-selected-value) example does.
+
 ## Layering and z-index
 
 `Select.Content` renders at Tailwind `z-50`, Mantle's float tier. When composed inside an open `Dialog`, `AlertDialog`, or `Sheet`, it portals into that overlay's positioner and paints above the overlay that owns it. Outside every overlay, it portals to `document.body`, below the overlay tier (`z-60`). When sibling floats share a container, the most recently mounted float paints on top.
@@ -523,32 +549,6 @@ import { Select } from "@ngrok/mantle/select";
 </Select.Root>;
 ```
 
-## Composition
-
-Compose the parts of a `Select` together to build your own:
-
-```text showLineNumbers=false
-Select.Root
-├── Select.Trigger
-│   └── Select.Value
-└── Select.Content
-    ├── Select.Group
-    │   ├── Select.Label
-    │   └── Select.Item
-    └── Select.Separator
-```
-
-## Polymorphism
-
-`Select.Group`, `Select.Label`, and `Select.Separator` accept `asChild`, which swaps the part's default element for your single child while keeping its styling and the select's keyboard and selection behavior. `Select.Label asChild` helps when a group heading must be a specific element for the page's outline.
-
-`Select.Root` is a state provider that renders no DOM, so it takes no `asChild`.
-
-> [!WARNING]
-> `Select.Trigger`, `Select.Content`, and `Select.Item` currently advertise `asChild` in their prop types but **throw at runtime** (`Primitive.* failed to slot onto its children`). Each one renders its own chrome next to your content (the trigger's caret, the content's scroll buttons and viewport, the item's check indicator), so the underlying Radix `Slot` receives more than the single child it requires. Do not use `asChild` on these three parts. To customize the trigger's content, pass it as `children` instead.
->
-> `Select.Value asChild` renders your element but **drops every prop**: Radix hands its `Slot` a keyed Fragment, so the value's `data-slot`, `ref`, and `style` never reach your element, and React warns about invalid Fragment props. Do not use it. To render a custom value, pass `children` instead, as the [custom selected value](#custom-selected-value) example does.
-
 ## API Reference
 
 The `Select` components are built on top of [Radix Select](https://www.radix-ui.com/primitives/docs/components/select).
@@ -575,13 +575,23 @@ All props from Radix [Select.Root](https://www.radix-ui.com/primitives/docs/comp
 
 The button that toggles the `Select`. The `Select.Content` will position itself adjacent to the trigger.
 
-When composing with `Field.Item`, wrap `Select.Root` (not the trigger) in `Field.Control`. The generated `id`, `name`, and `aria-invalid` flow onto `Select.Root` — so the hidden form input picks up the field name — and the trigger reads `aria-describedby` / `aria-errormessage` from `FieldControlContext`. Validation resolves from explicit `Select.Root`, then `Select.Trigger`, then the nearest `Field.Item`.
+When composing with `Field.Item`, wrap `Select.Root` (not the trigger) in `Field.Control`. The generated `id`, `name`, and `aria-invalid` flow onto `Select.Root` (so the hidden form input picks up the field name), and the trigger reads `aria-describedby` / `aria-errormessage` from `FieldControlContext`. Validation resolves from explicit `Select.Root`, then `Select.Trigger`, then the nearest `Field.Item`.
 
 All props from Radix [Select.Trigger](https://www.radix-ui.com/primitives/docs/components/select#trigger), plus:
 
 | Prop          | Type                                                                                               | Default | Description                                                                                                                                                                                                                                                                                                                               |
 | ------------- | -------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `validation?` | `"error" \| "success" \| "warning" \| false \| (() => "error" \| "success" \| "warning" \| false)` |         | Use the `validation` prop to show if the select trigger has a specific validation status. This will change the border and outline of the select trigger. The `false` type is useful when using short-circuiting logic so that you don't need to use a ternary with `undefined`. Setting `validation` to `error` also sets `aria-invalid`. |
+
+#### Data attributes
+
+| Data Attribute     | Value                                   | Description                                                         |
+| ------------------ | --------------------------------------- | ------------------------------------------------------------------- |
+| `data-slot`        | `"select-trigger"`                      | On the trigger button.                                              |
+| `data-state`       | `"open"` \| `"closed"`                  | Whether the list is open.                                           |
+| `data-placeholder` | present when there is no value          | Presence-only. Style the placeholder text with `data-placeholder:`. |
+| `data-disabled`    | present when disabled                   | Presence-only. The `disabled` prop on `Select.Root`.                |
+| `data-validation`  | `"success"` \| `"warning"` \| `"error"` | The resolved `validation` state. Omitted when there is none.        |
 
 ### Select.Value
 
@@ -612,15 +622,36 @@ All props from Radix [Select.Content](https://www.radix-ui.com/primitives/docs/c
 | `position?` | `"popper" \| "item-aligned"` | `"popper"`  | `popper` opens the list below the trigger. `item-aligned` is the Radix default: the list opens over the trigger with the selected item aligned to it.                           |
 | `width?`    | `"trigger" \| "content"`     | `"trigger"` | `trigger` makes the content the same width as the trigger button. `content` makes it the intrinsic size of the content itself; it will be the width of the longest/widest item. |
 
+#### Data attributes
+
+| Data Attribute | Value                                          | Description                                                           |
+| -------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
+| `data-slot`    | `"select-content"`                             | On the content element.                                               |
+| `data-state`   | `"open"` \| `"closed"`                         | Drives the open and close animations.                                 |
+| `data-side`    | `"top"` \| `"right"` \| `"bottom"` \| `"left"` | The side of the trigger the list opened on. `position="popper"` only. |
+| `data-align`   | `"start"` \| `"center"` \| `"end"`             | The alignment against the trigger. `position="popper"` only.          |
+
 ### Select.Group
 
 A group of related options within a select menu. Similar to an html `optgroup` element. Pair it with `Select.Label`, which gives the group its accessible name.
 
 Radix [Select.Group](https://www.radix-ui.com/primitives/docs/components/select#group) props.
 
+#### Data attributes
+
+| Data Attribute | Value            | Description           |
+| -------------- | ---------------- | --------------------- |
+| `data-slot`    | `"select-group"` | On the group element. |
+
 ### Select.Separator
 
 Used to visually separate items in the select. Composed from [Mantle Separator](/components/structure/separator).
+
+#### Data attributes
+
+| Data Attribute | Value                | Description               |
+| -------------- | -------------------- | ------------------------- |
+| `data-slot`    | `"select-separator"` | On the separator element. |
 
 ### Select.Item
 
@@ -652,3 +683,9 @@ All props from Radix [Select.Item](https://www.radix-ui.com/primitives/docs/comp
 Used to render the label of a group. It won't be focusable using arrow keys. Pair it with `Select.Group` — the label gives the group its accessible name.
 
 Radix [Select.Label](https://www.radix-ui.com/primitives/docs/components/select#label) props.
+
+#### Data attributes
+
+| Data Attribute | Value            | Description                 |
+| -------------- | ---------------- | --------------------------- |
+| `data-slot`    | `"select-label"` | On the group label element. |

--- a/decisions/2026-08-04-translation-safe-label-wrappers.md
+++ b/decisions/2026-08-04-translation-safe-label-wrappers.md
@@ -83,7 +83,7 @@ long one with `min-w-0 truncate`. `Select.Item` was already the precedent in the
 library: it has the identical `{icon && …}` shape but wraps children in
 `SelectPrimitive.ItemText`, so it never threw.
 
-**Revised 2026-09-11 — see [the second amendment](#amendment-2026-09-11-a-portals-text-child-is-an-outermost-node).**
+**Revised 2026-09-11: see [the second amendment](#amendment-2026-09-11-a-portals-text-child-is-an-outermost-node).**
 `Select.Item` never threw in the list. It threw in the trigger.
 
 Both the plain and the `asChild` path wrap, because both render the same shape.

--- a/decisions/2026-08-04-translation-safe-label-wrappers.md
+++ b/decisions/2026-08-04-translation-safe-label-wrappers.md
@@ -83,6 +83,9 @@ long one with `min-w-0 truncate`. `Select.Item` was already the precedent in the
 library: it has the identical `{icon && …}` shape but wraps children in
 `SelectPrimitive.ItemText`, so it never threw.
 
+**Revised 2026-09-11 — see [the second amendment](#amendment-2026-09-11-a-portals-text-child-is-an-outermost-node).**
+`Select.Item` never threw in the list. It threw in the trigger.
+
 Both the plain and the `asChild` path wrap, because both render the same shape.
 
 ### 2. The label is one flex item. Pass an icon through `icon`, not as a child
@@ -156,6 +159,41 @@ lays its children out in inline flow and spaces its icons with margins.
 
 Decisions 3 and 4 stand. An always-mounted announcer and a trailing decorative
 sibling are still the right shapes, and neither depends on how the wrapper displays.
+
+## Amendment, 2026-09-11: a portal's text child is an outermost node
+
+Decision 1 cited `Select.Item` as the part that never threw, because
+`SelectPrimitive.ItemText` wraps its children. That held for the list and not for
+the trigger. Radix portals the selected item's raw `children` into the
+`Select.Value` node, and it keys the placeholder fragment so a value change
+remounts it. A portal has no host node of its own, so React removes each portal
+child from the container by itself. When that child is a text node the engine
+reparented, `removeChild` throws. Three interactions on a translated page threw:
+picking a different value, picking a first value over a placeholder, and
+unmounting the select on navigation. ngrok-private/frontend#3757 worked around
+the first two by wrapping every item label in a `<span>` at the call site.
+
+`Select.Item` now wraps `children` in a `<span data-slot="select-item-label">`,
+which is the node Radix portals. `Select.Value` wraps `placeholder` in a
+`<span data-slot="select-placeholder">` and a consumer's own `children` in a
+`<span data-slot="select-value-label">`. The last one also moves a lone string
+child onto React's `textContent` path, so a swap between text and an element
+there wipes the `<font>` instead of removing a node React no longer owns.
+
+All three spans are `display: contents`, for the reason the first amendment gives.
+Product code restyles the value node through the trigger, with
+`[&>span]:flex-1` and `[&>span]:line-clamp-none`, and puts flex rows in its
+items; a span that generated a box would make the row one flex item and take the
+consumer's layout away. `asChild` on `Select.Value` skips the wrapper, because the
+consumer's element is then the node React removes.
+
+The mechanism table gains a row:
+
+| Update                            | Result                                                                            |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| Remove a portal's bare text child | Throws. A portal has no node of its own, so its children are the outermost nodes. |
+
+The rule in Consequences gains a second clause: **never portal bare text.**
 
 ## Consequences
 

--- a/packages/mantle/src/components/select/select.browser.test.tsx
+++ b/packages/mantle/src/components/select/select.browser.test.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Select } from "./select.js";
+
+/**
+ * Mirrors the CSS Tailwind 4 emits for the one utility the wrapper spans carry,
+ * plus a consumer override in the shape product code uses on the trigger
+ * (`[&>span]:flex [&>span]:gap-2`) to lay the value out as a row. Inlined so
+ * the test stays hermetic and needs no Tailwind build step.
+ */
+const STYLE = `
+@layer utilities {
+	.contents { display: contents; }
+}
+[data-slot~="select-value"] { display: flex; align-items: center; gap: 8px; }
+`;
+
+const GAP = 8;
+
+let styleElement: HTMLStyleElement;
+
+beforeAll(() => {
+	styleElement = document.createElement("style");
+	styleElement.textContent = STYLE;
+	document.head.appendChild(styleElement);
+});
+
+afterAll(() => {
+	styleElement.remove();
+});
+
+/** The horizontal distance between two elements laid out in a row. */
+function horizontalDistance(left: Element, right: Element) {
+	return right.getBoundingClientRect().left - left.getBoundingClientRect().right;
+}
+
+/** The wrapper span the test is about, found by its slot inside the trigger. */
+function wrapper(slot: string) {
+	const element = screen.getByRole("combobox").querySelector(`[data-slot="${slot}"]`);
+	if (element == null) {
+		throw new Error(`No element carries data-slot="${slot}".`);
+	}
+	return element;
+}
+
+describe("Select wrapper span layout", () => {
+	test("a consumer's children inside Select.Value stay flex items of the value node", async () => {
+		render(
+			<Select.Root value="apple">
+				<Select.Trigger>
+					<Select.Value placeholder="Select a fruit">
+						<span data-testid="name">Apple</span>
+						<span data-testid="hint">fruit</span>
+					</Select.Value>
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="apple">Apple</Select.Item>
+				</Select.Content>
+			</Select.Root>,
+		);
+
+		// The proof that the label span generates no box: both children are flex
+		// items of the value node, so its `gap` separates them. With a box on the
+		// span they would be one inline run, laid out flush at 0px.
+		expect(
+			horizontalDistance(await screen.findByTestId("name"), screen.getByTestId("hint")),
+		).toBeCloseTo(GAP, 0);
+		expect(wrapper("select-value-label").getClientRects()).toHaveLength(0);
+		expect(getComputedStyle(wrapper("select-value-label")).display).toBe("contents");
+	});
+
+	test("the portaled item label keeps the item's children as flex items of the value node", async () => {
+		render(
+			<Select.Root defaultValue="apple">
+				<Select.Trigger>
+					<Select.Value placeholder="Select a fruit" />
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="apple">
+						<span data-testid="name">Apple</span>
+						<span data-testid="hint">fruit</span>
+					</Select.Item>
+				</Select.Content>
+			</Select.Root>,
+		);
+
+		// Radix portals the label span into the value node, so the same contract
+		// holds for the copy the trigger shows.
+		const name = await screen.findByTestId("name");
+		expect(horizontalDistance(name, screen.getByTestId("hint"))).toBeCloseTo(GAP, 0);
+		expect(wrapper("select-item-label").getClientRects()).toHaveLength(0);
+		expect(getComputedStyle(wrapper("select-item-label")).display).toBe("contents");
+	});
+
+	test("the placeholder span generates no box", () => {
+		render(
+			<Select.Root>
+				<Select.Trigger>
+					<Select.Value placeholder="Select a fruit" />
+				</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="apple">Apple</Select.Item>
+				</Select.Content>
+			</Select.Root>,
+		);
+
+		expect(wrapper("select-placeholder").getClientRects()).toHaveLength(0);
+		expect(getComputedStyle(wrapper("select-placeholder")).display).toBe("contents");
+	});
+});

--- a/packages/mantle/src/components/select/select.test.tsx
+++ b/packages/mantle/src/components/select/select.test.tsx
@@ -331,6 +331,27 @@ describe("Select", () => {
 			expect(trigger.querySelector('[data-slot="select-item-label"]')).not.toBeInTheDocument();
 		});
 
+		test("a consumer data-slot joins ahead of the part's own slot on Select.Value and Select.Item", () => {
+			render(
+				<Select.Root defaultValue="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" data-slot="app-value" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple" data-slot="app-item">
+							Apple
+						</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const trigger = screen.getByRole("combobox");
+			expect(trigger.querySelector('[data-slot="app-value select-value"]')).toBeInstanceOf(
+				HTMLSpanElement,
+			);
+			expect(trigger.querySelector('[data-slot="select-value"]')).not.toBeInTheDocument();
+		});
+
 		test("Select.Value asChild renders the child as-is and skips the label span", () => {
 			render(
 				<Select.Root value="apple">
@@ -345,10 +366,13 @@ describe("Select", () => {
 				</Select.Root>,
 			);
 
-			// Why no `data-slot` assertion: Radix 2.3.7 hands `Slot` a keyed Fragment,
-			// so an `asChild` child receives none of the value's props. The child is
-			// still the node React removes, which is what this test pins.
+			// Why this pins a missing attribute: Radix 2.3.7 hands `Slot` a keyed
+			// Fragment, so an `asChild` child receives none of the value's props, and
+			// the docs page marks the path unsupported. When this assertion fails,
+			// Radix fixed the Fragment wrap: drop the warning from the docs page and
+			// the JSDoc, and assert the joined slot here instead.
 			const value = screen.getByTestId("value");
+			expect(value).not.toHaveAttribute("data-slot");
 			expect(value.parentElement).toBe(screen.getByRole("combobox"));
 			expect(value.querySelector('[data-slot="select-value-label"]')).not.toBeInTheDocument();
 			expect(

--- a/packages/mantle/src/components/select/select.test.tsx
+++ b/packages/mantle/src/components/select/select.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { useState } from "react";
 import { describe, expect, test, vi } from "vitest";
+import { translateTextNodes } from "../../test-utils/translate-text-nodes.js";
 import { Field } from "../field/field.js";
 import { Select } from "./select.js";
 
@@ -242,5 +244,335 @@ describe("Select", () => {
 
 		expect(screen.getByRole("combobox")).toHaveAttribute("aria-invalid", "true");
 		expect(screen.getByRole("combobox")).toHaveAttribute("data-validation", "error");
+	});
+
+	describe("data-slot", () => {
+		test("every part carries its slot, and the selected label reaches the trigger", async () => {
+			const user = userEvent.setup();
+			render(
+				<Select.Root defaultValue="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Group>
+							<Select.Label>Fruits</Select.Label>
+							<Select.Item value="apple">Apple</Select.Item>
+						</Select.Group>
+						<Select.Separator />
+						<Select.Group>
+							<Select.Label>Veggies</Select.Label>
+							<Select.Item value="carrot">Carrot</Select.Item>
+						</Select.Group>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const trigger = screen.getByRole("combobox");
+			expect(trigger).toHaveAttribute("data-slot", "select-trigger");
+			const value = trigger.querySelector('[data-slot="select-value"]');
+			expect(value).toBeInstanceOf(HTMLSpanElement);
+			// Radix portals the selected item's children into the value node, so
+			// the label span is the node it later removes.
+			expect(value?.querySelector('[data-slot="select-item-label"]')).toHaveTextContent("Apple");
+
+			await user.click(trigger);
+
+			const listbox = await screen.findByRole("listbox");
+			const option = screen.getByRole("option", { name: "Apple" });
+			expect(listbox).toHaveAttribute("data-slot", "select-content");
+			expect(screen.getByRole("group", { name: "Fruits" })).toHaveAttribute(
+				"data-slot",
+				"select-group",
+			);
+			expect(screen.getByText("Fruits")).toHaveAttribute("data-slot", "select-label");
+			expect(option).toHaveAttribute("data-slot", "select-item");
+			expect(listbox.querySelector('[data-slot="select-separator"]')).toBeInTheDocument();
+			expect(option.querySelector('[data-slot="select-item-label"]')).toHaveTextContent("Apple");
+		});
+
+		test("the placeholder renders inside its own slot until a value is picked", () => {
+			render(
+				<Select.Root>
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const trigger = screen.getByRole("combobox");
+			expect(trigger.querySelector('[data-slot="select-placeholder"]')).toHaveTextContent(
+				"Select a fruit",
+			);
+			expect(trigger.querySelector('[data-slot="select-item-label"]')).not.toBeInTheDocument();
+		});
+
+		test("Select.Value with children renders them and no placeholder slot", () => {
+			render(
+				<Select.Root value="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit">Custom apple</Select.Value>
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const trigger = screen.getByRole("combobox");
+			expect(trigger.querySelector('[data-slot="select-value"]')).toHaveTextContent("Custom apple");
+			expect(trigger.querySelector('[data-slot="select-value-label"]')).toHaveTextContent(
+				"Custom apple",
+			);
+			expect(trigger.querySelector('[data-slot="select-placeholder"]')).not.toBeInTheDocument();
+			expect(trigger.querySelector('[data-slot="select-item-label"]')).not.toBeInTheDocument();
+		});
+
+		test("Select.Value asChild renders the child as-is and skips the label span", () => {
+			render(
+				<Select.Root value="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" asChild>
+							<output data-testid="value">Custom apple</output>
+						</Select.Value>
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			// Why no `data-slot` assertion: Radix 2.3.7 hands `Slot` a keyed Fragment,
+			// so an `asChild` child receives none of the value's props. The child is
+			// still the node React removes, which is what this test pins.
+			const value = screen.getByTestId("value");
+			expect(value.parentElement).toBe(screen.getByRole("combobox"));
+			expect(value.querySelector('[data-slot="select-value-label"]')).not.toBeInTheDocument();
+			expect(
+				screen.getByRole("combobox").querySelector('[data-slot="select-value-label"]'),
+			).not.toBeInTheDocument();
+		});
+
+		// Why this pins a class: `display: contents` is the only observable
+		// implementation of "the wrapper adds no box", and happy-dom has no layout.
+		// A consumer's `[&>span]:flex-1` on the trigger reaches the value span, and
+		// their own item content must stay its direct layout child.
+		test("lays out the wrapper spans as contents so they add no box of their own", () => {
+			render(
+				<Select.Root defaultValue="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			const trigger = screen.getByRole("combobox");
+			expect(trigger.querySelector('[data-slot="select-item-label"]')).toHaveClass("contents");
+
+			render(
+				<Select.Root value="">
+					<Select.Trigger data-testid="empty">
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			expect(
+				screen.getByTestId("empty").querySelector('[data-slot="select-placeholder"]'),
+			).toHaveClass("contents");
+
+			render(
+				<Select.Root value="apple">
+					<Select.Trigger data-testid="custom">
+						<Select.Value>Custom apple</Select.Value>
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			expect(
+				screen.getByTestId("custom").querySelector('[data-slot="select-value-label"]'),
+			).toHaveClass("contents");
+		});
+	});
+
+	// Why these tests: decisions/2026-08-04-translation-safe-label-wrappers.md.
+	// Radix portals the selected item's children into `Select.Value` and keys
+	// the placeholder, so a bare text node in either spot is one React removes
+	// by itself. A translation engine reparents that node first, and the
+	// `removeChild` throws.
+	describe("after browser translation", () => {
+		test("changes a translated selection and reports the new value", async () => {
+			const user = userEvent.setup();
+			const onValueChange = vi.fn<(value: string) => void>();
+			render(
+				<Select.Root defaultValue="apple" onValueChange={onValueChange}>
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+						<Select.Item value="banana">Banana</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			const trigger = screen.getByRole("combobox");
+			translateTextNodes(trigger);
+			expect(trigger).toHaveTextContent("[Apple-es]");
+
+			await user.click(trigger);
+			await user.click(await screen.findByRole("option", { name: "Banana" }));
+
+			expect(onValueChange).toHaveBeenCalledTimes(1);
+			expect(onValueChange).toHaveBeenLastCalledWith("banana");
+			expect(trigger).toHaveTextContent("Banana");
+		});
+
+		test("picks a first value over a translated placeholder", async () => {
+			const user = userEvent.setup();
+			const onValueChange = vi.fn<(value: string) => void>();
+			render(
+				<Select.Root onValueChange={onValueChange}>
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+						<Select.Item value="banana">Banana</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			const trigger = screen.getByRole("combobox");
+			translateTextNodes(trigger);
+			expect(trigger).toHaveTextContent("[Select a fruit-es]");
+
+			await user.click(trigger);
+			await user.click(await screen.findByRole("option", { name: "Apple" }));
+
+			expect(onValueChange).toHaveBeenCalledTimes(1);
+			expect(onValueChange).toHaveBeenLastCalledWith("apple");
+			expect(trigger).toHaveTextContent("Apple");
+			expect(trigger.querySelector('[data-slot="select-placeholder"]')).not.toBeInTheDocument();
+		});
+
+		test("clears a translated custom value back to the placeholder", async () => {
+			const user = userEvent.setup();
+			function Page() {
+				const [value, setValue] = useState("apple");
+				return (
+					<>
+						<Select.Root value={value} onValueChange={setValue}>
+							<Select.Trigger>
+								<Select.Value placeholder="Select a fruit">{value.toUpperCase()}</Select.Value>
+							</Select.Trigger>
+							<Select.Content>
+								<Select.Item value="apple">Apple</Select.Item>
+							</Select.Content>
+						</Select.Root>
+						<button type="button" onClick={() => setValue("")}>
+							Clear
+						</button>
+					</>
+				);
+			}
+			render(<Page />);
+			const trigger = screen.getByRole("combobox");
+			translateTextNodes(trigger);
+			expect(trigger).toHaveTextContent("[APPLE-es]");
+
+			await user.click(screen.getByRole("button", { name: "Clear" }));
+
+			expect(trigger).toHaveTextContent("Select a fruit");
+			expect(trigger.querySelector('[data-slot="select-value-label"]')).not.toBeInTheDocument();
+		});
+
+		test("swaps a translated custom value between text and an element", async () => {
+			const user = userEvent.setup();
+			function Page() {
+				const [paused, setPaused] = useState(true);
+				return (
+					<>
+						<Select.Root value="past-3d">
+							<Select.Trigger>
+								<Select.Value>{paused ? "Paused" : <time>Past 3 days</time>}</Select.Value>
+							</Select.Trigger>
+							<Select.Content>
+								<Select.Item value="past-3d">Past 3 days</Select.Item>
+							</Select.Content>
+						</Select.Root>
+						<button type="button" onClick={() => setPaused(false)}>
+							Resume
+						</button>
+					</>
+				);
+			}
+			render(<Page />);
+			const trigger = screen.getByRole("combobox");
+			translateTextNodes(trigger);
+			expect(trigger).toHaveTextContent("[Paused-es]");
+
+			await user.click(screen.getByRole("button", { name: "Resume" }));
+
+			// The lone string child took the `textContent` path, so the swap wiped
+			// the `<font>` wrapper instead of removing a node it no longer owned.
+			expect(trigger.querySelector("time")).toHaveTextContent("Past 3 days");
+			expect(trigger).not.toHaveTextContent("Paused");
+		});
+
+		test('translate="no" on an item rides on the label copy the trigger shows', async () => {
+			const user = userEvent.setup();
+			render(
+				<Select.Root defaultValue="us-east-1">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a region" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="us-east-1" translate="no">
+							us-east-1
+						</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			const trigger = screen.getByRole("combobox");
+			expect(trigger.querySelector('[data-slot="select-item-label"]')).toHaveAttribute(
+				"translate",
+				"no",
+			);
+
+			translateTextNodes(trigger);
+
+			expect(trigger).toHaveTextContent("us-east-1");
+			expect(trigger).not.toHaveTextContent("-es]");
+
+			await user.click(trigger);
+			const option = await screen.findByRole("option", { name: "us-east-1" });
+			expect(option).toHaveAttribute("translate", "no");
+		});
+
+		test("unmounts a translated selection", () => {
+			const { unmount } = render(
+				<Select.Root defaultValue="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			translateTextNodes(screen.getByRole("combobox"));
+
+			unmount();
+
+			expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+		});
 	});
 });

--- a/packages/mantle/src/components/select/select.test.tsx
+++ b/packages/mantle/src/components/select/select.test.tsx
@@ -360,6 +360,137 @@ describe("Select", () => {
 			);
 		});
 
+		test("every part joins a consumer data-slot ahead of its own", async () => {
+			const user = userEvent.setup();
+			render(
+				<Select.Root defaultValue="apple">
+					<Select.Trigger data-slot="app-trigger">
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content data-slot="app-content">
+						<Select.Group data-slot="app-group">
+							<Select.Label data-slot="app-label">Fruits</Select.Label>
+							<Select.Item value="apple">Apple</Select.Item>
+						</Select.Group>
+						<Select.Separator data-slot="app-separator" />
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const trigger = screen.getByRole("combobox");
+			expect(trigger).toHaveAttribute("data-slot", "app-trigger select-trigger");
+
+			await user.click(trigger);
+
+			const listbox = await screen.findByRole("listbox");
+			expect(listbox).toHaveAttribute("data-slot", "app-content select-content");
+			expect(screen.getByRole("group", { name: "Fruits" })).toHaveAttribute(
+				"data-slot",
+				"app-group select-group",
+			);
+			expect(screen.getByText("Fruits")).toHaveAttribute("data-slot", "app-label select-label");
+			expect(
+				listbox.querySelector('[data-slot="app-separator select-separator"]'),
+			).toBeInTheDocument();
+		});
+
+		test("className and arbitrary data attributes reach each part's root", () => {
+			render(
+				<Select.Root defaultValue="apple" defaultOpen>
+					<Select.Trigger className="app-trigger" data-testid="trigger">
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content className="app-content" data-testid="content">
+						<Select.Group className="app-group" data-testid="group">
+							<Select.Label className="app-label" data-testid="label">
+								Fruits
+							</Select.Label>
+							<Select.Item value="apple" className="app-item" data-testid="item">
+								Apple
+							</Select.Item>
+						</Select.Group>
+						<Select.Separator className="app-separator" data-testid="separator" />
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			for (const part of ["trigger", "content", "group", "label", "item", "separator"]) {
+				const element = screen.getByTestId(part);
+				expect(element).toHaveClass(`app-${part}`);
+				expect(element).toHaveAttribute("data-slot", `select-${part}`);
+			}
+		});
+
+		test("Select.Label asChild renders the child and merges class, data attributes, and ref", () => {
+			const refSpy = vi.fn<(node: HTMLDivElement | null) => void>();
+			render(
+				<Select.Root defaultValue="apple" defaultOpen>
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Group>
+							<Select.Label asChild className="app-label" data-testid="label" ref={refSpy}>
+								<h3>Fruits</h3>
+							</Select.Label>
+							<Select.Item value="apple">Apple</Select.Item>
+						</Select.Group>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const heading = screen.getByRole("heading", { name: "Fruits" });
+			expect(heading).toBe(screen.getByTestId("label"));
+			expect(heading).toHaveClass("app-label");
+			expect(heading).toHaveAttribute("data-slot", "select-label");
+			expect(refSpy).toHaveBeenCalledTimes(1);
+			expect(refSpy).toHaveBeenLastCalledWith(heading);
+		});
+
+		test("the trigger and content stamp their documented state attributes across open, pick, and disabled", async () => {
+			const user = userEvent.setup();
+			render(
+				<Select.Root>
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			const trigger = screen.getByRole("combobox");
+			expect(trigger).toHaveAttribute("data-placeholder", "");
+			expect(trigger).toHaveAttribute("data-state", "closed");
+			expect(trigger).not.toHaveAttribute("data-disabled");
+
+			await user.click(trigger);
+
+			expect(trigger).toHaveAttribute("data-state", "open");
+			const listbox = await screen.findByRole("listbox");
+			expect(listbox).toHaveAttribute("data-state", "open");
+			expect(listbox).toHaveAttribute("data-side", "bottom");
+			expect(listbox).toHaveAttribute("data-align", "start");
+
+			await user.click(screen.getByRole("option", { name: "Apple" }));
+
+			expect(trigger).not.toHaveAttribute("data-placeholder");
+			expect(trigger).toHaveAttribute("data-state", "closed");
+
+			render(
+				<Select.Root disabled>
+					<Select.Trigger data-testid="disabled">
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+			expect(screen.getByTestId("disabled")).toHaveAttribute("data-disabled", "");
+		});
+
 		test("documented item data attributes follow selection, keyboard highlight, and disabled", async () => {
 			const user = userEvent.setup();
 			render(

--- a/packages/mantle/src/components/select/select.test.tsx
+++ b/packages/mantle/src/components/select/select.test.tsx
@@ -331,7 +331,8 @@ describe("Select", () => {
 			expect(trigger.querySelector('[data-slot="select-item-label"]')).not.toBeInTheDocument();
 		});
 
-		test("a consumer data-slot joins ahead of the part's own slot on Select.Value and Select.Item", () => {
+		test("a consumer data-slot joins ahead of the part's own slot on Select.Value and Select.Item", async () => {
+			const user = userEvent.setup();
 			render(
 				<Select.Root defaultValue="apple">
 					<Select.Trigger>
@@ -350,6 +351,53 @@ describe("Select", () => {
 				HTMLSpanElement,
 			);
 			expect(trigger.querySelector('[data-slot="select-value"]')).not.toBeInTheDocument();
+
+			await user.click(trigger);
+
+			expect(await screen.findByRole("option", { name: "Apple" })).toHaveAttribute(
+				"data-slot",
+				"app-item select-item",
+			);
+		});
+
+		test("documented item data attributes follow selection, keyboard highlight, and disabled", async () => {
+			const user = userEvent.setup();
+			render(
+				<Select.Root defaultValue="apple">
+					<Select.Trigger>
+						<Select.Value placeholder="Select a fruit" />
+					</Select.Trigger>
+					<Select.Content>
+						<Select.Item value="apple">Apple</Select.Item>
+						<Select.Item value="banana">Banana</Select.Item>
+						<Select.Item value="cherry" disabled>
+							Cherry
+						</Select.Item>
+					</Select.Content>
+				</Select.Root>,
+			);
+
+			await user.click(screen.getByRole("combobox"));
+
+			const apple = await screen.findByRole("option", { name: "Apple" });
+			const banana = screen.getByRole("option", { name: "Banana" });
+			const cherry = screen.getByRole("option", { name: "Cherry" });
+			expect(apple).toHaveAttribute("data-state", "checked");
+			expect(banana).toHaveAttribute("data-state", "unchecked");
+			expect(cherry).toHaveAttribute("data-disabled", "");
+			expect(banana).not.toHaveAttribute("data-disabled");
+			// Radix focuses the selected item when the list opens, so it is highlighted.
+			expect(apple).toHaveAttribute("data-highlighted", "");
+			expect(banana).not.toHaveAttribute("data-highlighted");
+
+			await user.keyboard("{ArrowDown}");
+
+			expect(banana).toHaveAttribute("data-highlighted", "");
+			expect(apple).not.toHaveAttribute("data-highlighted");
+
+			await user.keyboard("{Enter}");
+
+			expect(screen.getByRole("combobox")).toHaveTextContent("Banana");
 		});
 
 		test("Select.Value asChild renders the child as-is and skips the label span", () => {
@@ -379,60 +427,8 @@ describe("Select", () => {
 				screen.getByRole("combobox").querySelector('[data-slot="select-value-label"]'),
 			).not.toBeInTheDocument();
 		});
-
-		// Why this pins a class: `display: contents` is the only observable
-		// implementation of "the wrapper adds no box", and happy-dom has no layout.
-		// A consumer's `[&>span]:flex-1` on the trigger reaches the value span, and
-		// their own item content must stay its direct layout child.
-		test("lays out the wrapper spans as contents so they add no box of their own", () => {
-			render(
-				<Select.Root defaultValue="apple">
-					<Select.Trigger>
-						<Select.Value placeholder="Select a fruit" />
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Item value="apple">Apple</Select.Item>
-					</Select.Content>
-				</Select.Root>,
-			);
-			const trigger = screen.getByRole("combobox");
-			expect(trigger.querySelector('[data-slot="select-item-label"]')).toHaveClass("contents");
-
-			render(
-				<Select.Root value="">
-					<Select.Trigger data-testid="empty">
-						<Select.Value placeholder="Select a fruit" />
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Item value="apple">Apple</Select.Item>
-					</Select.Content>
-				</Select.Root>,
-			);
-			expect(
-				screen.getByTestId("empty").querySelector('[data-slot="select-placeholder"]'),
-			).toHaveClass("contents");
-
-			render(
-				<Select.Root value="apple">
-					<Select.Trigger data-testid="custom">
-						<Select.Value>Custom apple</Select.Value>
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Item value="apple">Apple</Select.Item>
-					</Select.Content>
-				</Select.Root>,
-			);
-			expect(
-				screen.getByTestId("custom").querySelector('[data-slot="select-value-label"]'),
-			).toHaveClass("contents");
-		});
 	});
 
-	// Why these tests: decisions/2026-08-04-translation-safe-label-wrappers.md.
-	// Radix portals the selected item's children into `Select.Value` and keys
-	// the placeholder, so a bare text node in either spot is one React removes
-	// by itself. A translation engine reparents that node first, and the
-	// `removeChild` throws.
 	describe("after browser translation", () => {
 		test("changes a translated selection and reports the new value", async () => {
 			const user = userEvent.setup();

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -40,13 +40,40 @@ type SelectContextType = WithValidation &
 const SelectContext = createContext<SelectContextType>({});
 
 type SelectProps = PropsWithChildren & {
+	/**
+	 * The `autocomplete` attribute of the hidden native select.
+	 */
 	autoComplete?: string;
+	/**
+	 * Whether the list is open on first render. Use for an uncontrolled open state.
+	 * @default false
+	 */
 	defaultOpen?: boolean;
+	/**
+	 * The value on first render. Use for an uncontrolled value.
+	 */
 	defaultValue?: string;
+	/**
+	 * The reading direction. When omitted, inherits from `DirectionProvider`.
+	 */
 	dir?: "ltr" | "rtl";
+	/**
+	 * Whether the whole select is inert. The trigger stamps `data-disabled`.
+	 * @default false
+	 */
 	disabled?: boolean;
+	/**
+	 * The `id` of the form the hidden native select belongs to, when it sits
+	 * outside that form.
+	 */
 	form?: string;
+	/**
+	 * The `id` of the trigger button. `Field.Control` sets it for you.
+	 */
 	id?: string;
+	/**
+	 * The name of the hidden native select, submitted with its owning form.
+	 */
 	name?: string;
 	/**
 	 * Event handler called when the trigger button blurs. Runs after any
@@ -58,14 +85,30 @@ type SelectProps = PropsWithChildren & {
 	 * @deprecated Use `onValueChange` instead.
 	 */
 	onChange?: (value: string) => void;
+	/**
+	 * Event handler called when the open state changes.
+	 */
 	onOpenChange?(open: boolean): void;
+	/**
+	 * Event handler called when the value changes.
+	 */
 	onValueChange?(value: string): void;
+	/**
+	 * The controlled open state. Pair with `onOpenChange`.
+	 */
 	open?: boolean;
 	/**
 	 * Ref for the trigger button.
 	 */
 	ref?: Ref<HTMLButtonElement>;
+	/**
+	 * Whether a value is required before the owning form submits.
+	 * @default false
+	 */
 	required?: boolean;
+	/**
+	 * The controlled value. Pair with `onValueChange`.
+	 */
 	value?: string;
 } & WithValidation &
 	WithAriaInvalid;
@@ -155,6 +198,10 @@ const Root = ({
  * A group of related options within a select menu. Similar to an html `<optgroup>` element.
  * Pair it with `Select.Label`, which gives the group its accessible name.
  *
+ * | Data Attribute | Value            | Description           |
+ * | -------------- | ---------------- | --------------------- |
+ * | `data-slot`    | `"select-group"` | On the group element. |
+ *
  * @see https://mantle.ngrok.com/components/forms/select#selectgroup
  *
  * @example
@@ -180,10 +227,15 @@ const Root = ({
  * </Select.Root>
  * ```
  */
-const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimitive.Group>) => (
+const Group = ({
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<typeof SelectPrimitive.Group> & WithDataSlot) => (
 	<SelectPrimitive.Group
 		ref={ref}
-		data-slot="select-group"
+		data-slot={joinDataSlot(dataSlot, "select-group")}
 		className={cx("space-y-px", className)}
 		{...props}
 	/>
@@ -277,14 +329,23 @@ const Value = ({
 
 type SelectTriggerProps = ComponentProps<typeof SelectPrimitive.Trigger> &
 	WithAriaInvalid &
+	WithDataSlot &
 	WithValidation;
 
 /**
  * The button that toggles the select. The Select.Content will position itself adjacent to the trigger.
- * When composing with `Field.Item`, wrap `Select.Root` in `Field.Control` —
+ * When composing with `Field.Item`, wrap `Select.Root` in `Field.Control`:
  * the generated `id`, `name`, and `aria-invalid` flow onto `Select.Root` (so
  * the hidden form input gets the field name), and the trigger reads
  * `aria-describedby` / `aria-errormessage` from `FieldControlContext`.
+ *
+ * | Data Attribute     | Value                                   | Description                                                          |
+ * | ------------------ | --------------------------------------- | -------------------------------------------------------------------- |
+ * | `data-slot`        | `"select-trigger"`                      | On the trigger button.                                               |
+ * | `data-state`       | `"open"` \| `"closed"`                  | Whether the list is open.                                            |
+ * | `data-placeholder` | present when there is no value          | Presence-only. Style the placeholder text with `data-placeholder:`.  |
+ * | `data-disabled`    | present when disabled                   | Presence-only. The `disabled` prop on `Select.Root`.                 |
+ * | `data-validation`  | `"success"` \| `"warning"` \| `"error"` | The resolved `validation` state. Omitted when there is none.         |
  *
  * @see https://mantle.ngrok.com/components/forms/select#selecttrigger
  *
@@ -315,6 +376,7 @@ const Trigger = ({
 	"aria-invalid": ariaInValidProp,
 	className,
 	children,
+	"data-slot": dataSlot,
 	id: propId,
 	onBlur,
 	ref,
@@ -340,7 +402,7 @@ const Trigger = ({
 
 	return (
 		<SelectPrimitive.Trigger
-			data-slot="select-trigger"
+			data-slot={joinDataSlot(dataSlot, "select-trigger")}
 			className={cx(
 				"h-9 text-sm",
 				"border-form bg-form text-strong font-sans placeholder:text-placeholder hover:bg-form-hover hover:text-strong flex w-full items-center justify-between gap-1.5 rounded-md border px-3 py-2 disabled:pointer-events-none disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left",
@@ -412,14 +474,15 @@ const SelectScrollDownButton = ({
 	</SelectPrimitive.ScrollDownButton>
 );
 
-type SelectContentProps = ComponentProps<typeof SelectPrimitive.Content> & {
-	/**
-	 * The width of the content. Defaults to the width of the trigger.
-	 * If set to "content", the content takes its intrinsic width — the width of the widest item.
-	 * @default "trigger"
-	 */
-	width?: "trigger" | "content";
-};
+type SelectContentProps = ComponentProps<typeof SelectPrimitive.Content> &
+	WithDataSlot & {
+		/**
+		 * The width of the content. Defaults to the width of the trigger.
+		 * If set to "content", the content takes its intrinsic width: the width of the widest item.
+		 * @default "trigger"
+		 */
+		width?: "trigger" | "content";
+	};
 
 /**
  * The component that pops out when the select is open as a portal adjacent to the trigger button.
@@ -433,6 +496,13 @@ type SelectContentProps = ComponentProps<typeof SelectPrimitive.Content> & {
  * every overlay, it portals to `document.body`, below the overlay tier
  * (`z-60`). When sibling floats share a container, the most recently mounted
  * float paints on top.
+ *
+ * | Data Attribute | Value                                          | Description                                                            |
+ * | -------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
+ * | `data-slot`    | `"select-content"`                             | On the content element.                                                |
+ * | `data-state`   | `"open"` \| `"closed"`                         | Drives the open and close animations.                                  |
+ * | `data-side`    | `"top"` \| `"right"` \| `"bottom"` \| `"left"` | The side of the trigger the list opened on. `position="popper"` only.  |
+ * | `data-align`   | `"start"` \| `"center"` \| `"end"`             | The alignment against the trigger. `position="popper"` only.           |
  *
  * @see https://mantle.ngrok.com/components/forms/select#selectcontent
  *
@@ -462,6 +532,7 @@ type SelectContentProps = ComponentProps<typeof SelectPrimitive.Content> & {
 const Content = ({
 	className,
 	children,
+	"data-slot": dataSlot,
 	position = "popper",
 	ref,
 	width = "trigger",
@@ -473,9 +544,9 @@ const Content = ({
 		<SelectPrimitive.Portal container={layerContainer}>
 			<SelectPrimitive.Content
 				ref={ref}
-				data-slot="select-content"
+				data-slot={joinDataSlot(dataSlot, "select-content")}
 				className={cx(
-					"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
+					"border-popover data-side-bottom:slide-in-from-top-2 data-side-left:slide-in-from-right-2 data-side-right:slide-in-from-left-2 data-side-top:slide-in-from-bottom-2 data-state-closed:animate-out data-state-closed:fade-out-0 data-state-closed:zoom-out-95 data-state-open:animate-in data-state-open:fade-in-0 data-state-open:zoom-in-95 motion-reduce:animate-none relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md",
 					"bg-popover font-sans",
 					position === "popper" &&
 						"data-side-bottom:translate-y-2 data-side-left:-translate-x-2 data-side-right:translate-x-2 data-side-top:-translate-y-2 max-h-(--radix-select-content-available-height)",
@@ -503,6 +574,10 @@ const Content = ({
 /**
  * Used to render the label of a group. It won't be focusable using arrow keys.
  *
+ * | Data Attribute | Value            | Description                 |
+ * | -------------- | ---------------- | --------------------------- |
+ * | `data-slot`    | `"select-label"` | On the group label element. |
+ *
  * @see https://mantle.ngrok.com/components/forms/select#selectlabel
  *
  * @example
@@ -528,10 +603,15 @@ const Content = ({
  * </Select.Root>
  * ```
  */
-const Label = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimitive.Label>) => (
+const Label = ({
+	className,
+	"data-slot": dataSlot,
+	ref,
+	...props
+}: ComponentProps<typeof SelectPrimitive.Label> & WithDataSlot) => (
 	<SelectPrimitive.Label
 		ref={ref}
-		data-slot="select-label"
+		data-slot={joinDataSlot(dataSlot, "select-label")}
 		className={cx("px-2 py-1.5 text-sm font-medium", className)}
 		{...props}
 	/>
@@ -637,6 +717,10 @@ const Item = ({
 /**
  * Used to visually separate items or groups of items in the select content.
  *
+ * | Data Attribute | Value                | Description               |
+ * | -------------- | -------------------- | ------------------------- |
+ * | `data-slot`    | `"select-separator"` | On the separator element. |
+ *
  * @see https://mantle.ngrok.com/components/forms/select#selectseparator
  *
  * @example
@@ -664,12 +748,13 @@ const Item = ({
  */
 const SelectSeparatorComponent = ({
 	className,
+	"data-slot": dataSlot,
 	ref,
 	...props
-}: ComponentProps<typeof Separator>) => (
+}: ComponentProps<typeof Separator> & WithDataSlot) => (
 	<Separator
 		ref={ref}
-		data-slot="select-separator"
+		data-slot={joinDataSlot(dataSlot, "select-separator")}
 		className={cx("-mx-1 my-1 h-px w-auto", className)}
 		{...props}
 	/>
@@ -789,6 +874,13 @@ const Select = {
 	 * (`z-60`). When sibling floats share a container, the most recently mounted
 	 * float paints on top.
 	 *
+	 * | Data Attribute | Value                                          | Description                                                            |
+	 * | -------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
+	 * | `data-slot`    | `"select-content"`                             | On the content element.                                                |
+	 * | `data-state`   | `"open"` \| `"closed"`                         | Drives the open and close animations.                                  |
+	 * | `data-side`    | `"top"` \| `"right"` \| `"bottom"` \| `"left"` | The side of the trigger the list opened on. `position="popper"` only.  |
+	 * | `data-align`   | `"start"` \| `"center"` \| `"end"`             | The alignment against the trigger. `position="popper"` only.           |
+	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectcontent
 	 *
 	 * @example
@@ -818,6 +910,10 @@ const Select = {
 	/**
 	 * A group of related options within a select menu. Similar to an html `<optgroup>` element.
 	 * Pair it with `Select.Label`, which gives the group its accessible name.
+	 *
+	 * | Data Attribute | Value            | Description           |
+	 * | -------------- | ---------------- | --------------------- |
+	 * | `data-slot`    | `"select-group"` | On the group element. |
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectgroup
 	 *
@@ -901,6 +997,10 @@ const Select = {
 	/**
 	 * Used to render the label of a group. It won't be focusable using arrow keys.
 	 *
+	 * | Data Attribute | Value            | Description                 |
+	 * | -------------- | ---------------- | --------------------------- |
+	 * | `data-slot`    | `"select-label"` | On the group label element. |
+	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectlabel
 	 *
 	 * @example
@@ -929,6 +1029,10 @@ const Select = {
 	Label,
 	/**
 	 * Used to visually separate items or groups of items in the select content.
+	 *
+	 * | Data Attribute | Value                | Description               |
+	 * | -------------- | -------------------- | ------------------------- |
+	 * | `data-slot`    | `"select-separator"` | On the separator element. |
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectseparator
 	 *
@@ -962,6 +1066,14 @@ const Select = {
 	 * the generated `id`, `name`, and `aria-invalid` flow onto `Select.Root` (so
 	 * the hidden form input gets the field name), and the trigger reads
 	 * `aria-describedby` / `aria-errormessage` from `FieldControlContext`.
+	 *
+	 * | Data Attribute     | Value                                   | Description                                                          |
+	 * | ------------------ | --------------------------------------- | -------------------------------------------------------------------- |
+	 * | `data-slot`        | `"select-trigger"`                      | On the trigger button.                                               |
+	 * | `data-state`       | `"open"` \| `"closed"`                  | Whether the list is open.                                            |
+	 * | `data-placeholder` | present when there is no value          | Presence-only. Style the placeholder text with `data-placeholder:`.  |
+	 * | `data-disabled`    | present when disabled                   | Presence-only. The `disabled` prop on `Select.Root`.                 |
+	 * | `data-validation`  | `"success"` \| `"warning"` \| `"error"` | The resolved `validation` state. Omitted when there is none.         |
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selecttrigger
 	 *

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -15,6 +15,8 @@ import type {
 import { createContext, useContext, useMemo } from "react";
 import { useComposedRefs } from "../../utils/compose-refs/compose-refs.js";
 import { cx } from "../../utils/cx/cx.js";
+import { joinDataSlot } from "../../utils/data-slot.js";
+import type { WithDataSlot } from "../../utils/data-slot.js";
 import { useLayerContainer } from "../../utils/layer-container/layer-container.js";
 import { FieldControlContext } from "../field/field-context.js";
 import { parseValidation, useFieldValidation } from "../field/validation.js";
@@ -187,6 +189,8 @@ const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
 	/>
 );
 
+type SelectValueProps = ComponentProps<typeof SelectPrimitive.Value> & WithDataSlot;
+
 /**
  * The part that reflects the selected value. Renders the selected item's text
  * by default. For more control, control the select and pass your own children.
@@ -201,7 +205,11 @@ const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
  * `display: contents`, so it lays out nothing of its own. React removes one of
  * those spans whenever the value changes, and an element removal cannot throw:
  * a browser translation engine reparents text nodes, and a removal aimed at a
- * reparented text node does. Under `asChild`, your element is the wrapper.
+ * reparented text node does.
+ *
+ * **`asChild` is not supported.** Radix hands its `Slot` a keyed Fragment, so
+ * your element receives none of the value's props and React warns. Pass
+ * `children` instead.
  *
  * | Data Attribute | Value                  | Description                                                                   |
  * | -------------- | ---------------------- | ----------------------------------------------------------------------------- |
@@ -237,14 +245,15 @@ const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
 const Value = ({
 	asChild,
 	children,
+	"data-slot": dataSlot,
 	placeholder,
 	ref,
 	...props
-}: ComponentProps<typeof SelectPrimitive.Value>) => (
+}: SelectValueProps) => (
 	<SelectPrimitive.Value
 		ref={ref}
 		asChild={asChild}
-		data-slot="select-value"
+		data-slot={joinDataSlot(dataSlot, "select-value")}
 		// Why the spans: decisions/2026-08-04-translation-safe-label-wrappers.md
 		placeholder={
 			placeholder != null && (
@@ -528,12 +537,13 @@ const Label = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
 	/>
 );
 
-type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> & {
-	/**
-	 * An optional icon rendered before the item text.
-	 */
-	icon?: ReactNode;
-};
+type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> &
+	WithDataSlot & {
+		/**
+		 * An optional icon rendered before the item text.
+		 */
+		icon?: ReactNode;
+	};
 
 /**
  * An option within a select menu. Similar to an html `<option>` element.
@@ -587,10 +597,18 @@ type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> & {
  * </Select.Root>
  * ```
  */
-const Item = ({ className, children, icon, ref, translate, ...props }: SelectItemProps) => (
+const Item = ({
+	className,
+	children,
+	"data-slot": dataSlot,
+	icon,
+	ref,
+	translate,
+	...props
+}: SelectItemProps) => (
 	<SelectPrimitive.Item
 		ref={ref}
-		data-slot="select-item"
+		data-slot={joinDataSlot(dataSlot, "select-item")}
 		translate={translate}
 		className={cx(
 			"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden",
@@ -985,7 +1003,11 @@ const Select = {
 	 * `display: contents`, so it lays out nothing of its own. React removes one of
 	 * those spans whenever the value changes, and an element removal cannot throw:
 	 * a browser translation engine reparents text nodes, and a removal aimed at a
-	 * reparented text node does. Under `asChild`, your element is the wrapper.
+	 * reparented text node does.
+	 *
+	 * **`asChild` is not supported.** Radix hands its `Slot` a keyed Fragment, so
+	 * your element receives none of the value's props and React warns. Pass
+	 * `children` instead.
 	 *
 	 * | Data Attribute | Value                  | Description                                                                   |
 	 * | -------------- | ---------------------- | ----------------------------------------------------------------------------- |

--- a/packages/mantle/src/components/select/select.tsx
+++ b/packages/mantle/src/components/select/select.tsx
@@ -190,9 +190,24 @@ const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
 /**
  * The part that reflects the selected value. Renders the selected item's text
  * by default. For more control, control the select and pass your own children.
- * Do not style this part — under `Select.Content position="item-aligned"`, Radix
+ * Do not style this part: under `Select.Content position="item-aligned"`, Radix
  * measures its box to align the open list over the selected item. Pass
  * `placeholder` for the text to show when the select has no value.
+ *
+ * **Structure.** `placeholder` renders inside a
+ * `<span data-slot="select-placeholder">`, your own `children` inside a
+ * `<span data-slot="select-value-label">`, and the selected item's text arrives
+ * inside the `select-item-label` span that `Select.Item` renders. Each span is
+ * `display: contents`, so it lays out nothing of its own. React removes one of
+ * those spans whenever the value changes, and an element removal cannot throw:
+ * a browser translation engine reparents text nodes, and a removal aimed at a
+ * reparented text node does. Under `asChild`, your element is the wrapper.
+ *
+ * | Data Attribute | Value                  | Description                                                                   |
+ * | -------------- | ---------------------- | ----------------------------------------------------------------------------- |
+ * | `data-slot`    | `"select-value"`       | On the value element.                                                         |
+ * | `data-slot`    | `"select-placeholder"` | On the `<span>` wrapping `placeholder`. Present only while there is no value. |
+ * | `data-slot`    | `"select-value-label"` | On the `<span>` wrapping your `children`. Absent under `asChild`.             |
  *
  * @see https://mantle.ngrok.com/components/forms/select#selectvalue
  *
@@ -219,7 +234,37 @@ const Group = ({ className, ref, ...props }: ComponentProps<typeof SelectPrimiti
  * </Select.Root>
  * ```
  */
-const Value = SelectPrimitive.Value;
+const Value = ({
+	asChild,
+	children,
+	placeholder,
+	ref,
+	...props
+}: ComponentProps<typeof SelectPrimitive.Value>) => (
+	<SelectPrimitive.Value
+		ref={ref}
+		asChild={asChild}
+		data-slot="select-value"
+		// Why the spans: decisions/2026-08-04-translation-safe-label-wrappers.md
+		placeholder={
+			placeholder != null && (
+				<span data-slot="select-placeholder" className="contents">
+					{placeholder}
+				</span>
+			)
+		}
+		{...props}
+	>
+		{/* Why `== null` passes through: Radix reads `children !== undefined` to decide whether to portal the item text, so `undefined` must stay `undefined`. */}
+		{asChild || children == null ? (
+			children
+		) : (
+			<span data-slot="select-value-label" className="contents">
+				{children}
+			</span>
+		)}
+	</SelectPrimitive.Value>
+);
 
 type SelectTriggerProps = ComponentProps<typeof SelectPrimitive.Trigger> &
 	WithAriaInvalid &
@@ -497,6 +542,26 @@ type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> & {
  * Displays the children as the option's text. Pass `icon` to render an icon
  * before the text.
  *
+ * **Structure.** `children` render inside a `<span data-slot="select-item-label">`.
+ * Radix portals that span into `Select.Value` while the item is selected and
+ * removes it when the selection changes. The span exists so the node React
+ * removes is an element: a browser translation engine reparents text nodes,
+ * and a removal aimed at one throws. The span is `display: contents`, so it
+ * lays out nothing of its own in the list or in the trigger. To style it as a
+ * box, set a display of your own on it first.
+ *
+ * **Untranslatable labels.** When the label is an ID, a path, a filename, or a
+ * key, set `translate="no"` on the item. The attribute also rides on the label
+ * span, so the copy the trigger shows stays untranslated too.
+ *
+ * | Data Attribute     | Value                        | Description                                                          |
+ * | ------------------ | ---------------------------- | -------------------------------------------------------------------- |
+ * | `data-slot`        | `"select-item"`              | On the option element.                                               |
+ * | `data-slot`        | `"select-item-label"`        | On the `<span>` wrapping `children`, in the list and in the trigger. |
+ * | `data-state`       | `"checked"` \| `"unchecked"` | Whether this item is the selected value.                             |
+ * | `data-highlighted` | present when highlighted     | Presence-only. The item under the pointer or the keyboard focus.     |
+ * | `data-disabled`    | present when disabled        | Presence-only. The `disabled` prop.                                  |
+ *
  * @see https://mantle.ngrok.com/components/forms/select#selectitem
  *
  * @example
@@ -522,10 +587,11 @@ type SelectItemProps = ComponentProps<typeof SelectPrimitive.Item> & {
  * </Select.Root>
  * ```
  */
-const Item = ({ className, children, icon, ref, ...props }: SelectItemProps) => (
+const Item = ({ className, children, icon, ref, translate, ...props }: SelectItemProps) => (
 	<SelectPrimitive.Item
 		ref={ref}
 		data-slot="select-item"
+		translate={translate}
 		className={cx(
 			"relative flex gap-2 w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-8 text-strong text-sm outline-hidden",
 			"focus:bg-active-menu-item",
@@ -537,7 +603,13 @@ const Item = ({ className, children, icon, ref, ...props }: SelectItemProps) => 
 		{...props}
 	>
 		{icon && <Icon svg={icon} />}
-		<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		<SelectPrimitive.ItemText>
+			{/* Why the label span: decisions/2026-08-04-translation-safe-label-wrappers.md */}
+			{/* Why `translate` repeats: Radix portals this span into the trigger, out of the item's subtree, so the item's attribute never reaches that copy. */}
+			<span data-slot="select-item-label" className="contents" translate={translate}>
+				{children}
+			</span>
+		</SelectPrimitive.ItemText>
 		<SelectPrimitive.ItemIndicator className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
 			<Icon svg={<CheckIcon weight="bold" />} className="size-4 text-accent-600" />
 		</SelectPrimitive.ItemIndicator>
@@ -762,6 +834,26 @@ const Select = {
 	 * Displays the children as the option's text. Pass `icon` to render an icon
 	 * before the text.
 	 *
+	 * **Structure.** `children` render inside a `<span data-slot="select-item-label">`.
+	 * Radix portals that span into `Select.Value` while the item is selected and
+	 * removes it when the selection changes. The span exists so the node React
+	 * removes is an element: a browser translation engine reparents text nodes,
+	 * and a removal aimed at one throws. The span is `display: contents`, so it
+	 * lays out nothing of its own in the list or in the trigger. To style it as a
+	 * box, set a display of your own on it first.
+	 *
+	 * **Untranslatable labels.** When the label is an ID, a path, a filename, or a
+	 * key, set `translate="no"` on the item. The attribute also rides on the label
+	 * span, so the copy the trigger shows stays untranslated too.
+	 *
+	 * | Data Attribute     | Value                        | Description                                                          |
+	 * | ------------------ | ---------------------------- | -------------------------------------------------------------------- |
+	 * | `data-slot`        | `"select-item"`              | On the option element.                                               |
+	 * | `data-slot`        | `"select-item-label"`        | On the `<span>` wrapping `children`, in the list and in the trigger. |
+	 * | `data-state`       | `"checked"` \| `"unchecked"` | Whether this item is the selected value.                             |
+	 * | `data-highlighted` | present when highlighted     | Presence-only. The item under the pointer or the keyboard focus.     |
+	 * | `data-disabled`    | present when disabled        | Presence-only. The `disabled` prop.                                  |
+	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectitem
 	 *
 	 * @example
@@ -882,9 +974,24 @@ const Select = {
 	/**
 	 * The part that reflects the selected value. Renders the selected item's text
 	 * by default. For more control, control the select and pass your own children.
-	 * Do not style this part — under `Select.Content position="item-aligned"`, Radix
+	 * Do not style this part: under `Select.Content position="item-aligned"`, Radix
 	 * measures its box to align the open list over the selected item. Pass
 	 * `placeholder` for the text to show when the select has no value.
+	 *
+	 * **Structure.** `placeholder` renders inside a
+	 * `<span data-slot="select-placeholder">`, your own `children` inside a
+	 * `<span data-slot="select-value-label">`, and the selected item's text arrives
+	 * inside the `select-item-label` span that `Select.Item` renders. Each span is
+	 * `display: contents`, so it lays out nothing of its own. React removes one of
+	 * those spans whenever the value changes, and an element removal cannot throw:
+	 * a browser translation engine reparents text nodes, and a removal aimed at a
+	 * reparented text node does. Under `asChild`, your element is the wrapper.
+	 *
+	 * | Data Attribute | Value                  | Description                                                                   |
+	 * | -------------- | ---------------------- | ----------------------------------------------------------------------------- |
+	 * | `data-slot`    | `"select-value"`       | On the value element.                                                         |
+	 * | `data-slot`    | `"select-placeholder"` | On the `<span>` wrapping `placeholder`. Present only while there is no value. |
+	 * | `data-slot`    | `"select-value-label"` | On the `<span>` wrapping your `children`. Absent under `asChild`.             |
 	 *
 	 * @see https://mantle.ngrok.com/components/forms/select#selectvalue
 	 *


### PR DESCRIPTION
## Why

ngrok-private/frontend#3757 wrapped every `Select.Item` label in a `<span>` at three call sites. On a translated page, a selection change or a page unmount threw `NotFoundError` and blanked the page. That is a `Select` defect, not an app one. In `local/frontend`, fourteen custom `Select.Value` renders and twenty-five multi-line items share the shape, so the fix belongs in mantle. Frontend can drop its wrappers once this ships.

## What

Radix portals the selected item's raw `children` into the `Select.Value` node and keys the placeholder fragment. A portal has no node of its own, so React removes a bare text node from the trigger by itself. Google Translate reparents that node first, and `removeChild` throws.

- `Select.Item` renders `children` inside `<span data-slot="select-item-label">`, which is the node Radix portals and later removes.
- `Select.Value` renders `placeholder` inside `<span data-slot="select-placeholder">` and your own `children` inside `<span data-slot="select-value-label">`. A lone string child now takes React's `textContent` path, so a swap between text and an element there is safe too.
- All three spans are `display: contents`. Frontend restyles the value node through the trigger with `[&>span]:flex-1` and puts flex rows in items, so a span with a box would take that layout away.
- `translate="no"` on a `Select.Item` rides on the label span, so an ID or a path stays untranslated in the trigger.
- `Select.Value` carries `data-slot="select-value"`. The decision doc gains an amendment, and CONVENTIONS and COMPONENT_SPEC name the portal case.
- An audit against COMPONENT_SPEC.md: every part joins a consumer `data-slot` instead of replacing it, the API reference and JSDoc list the data attributes each part stamps, `Select.Root` props carry descriptions, `Select.Content` honors `prefers-reduced-motion`, and the docs page puts `Composition` and `Polymorphism` before the examples.
- The docs page gains two live examples: a two-line item with an icon beside a compact `Select.Value` render, and an item with `translate="no"` whose label the trigger keeps untranslated.

## Validation

- The six regression tests fail on `main` with `DOMException: Failed to execute 'removeChild'` and pass here.
- `local/frontend` audit: no `Select.Value asChild`, no direct Radix Select import, and no selector that depends on the trigger's inner DOM.

## Limitations

Radix 2.3.7 hands `Slot` a keyed Fragment under `Select.Value asChild`, so the child receives no props and React warns. That is upstream and pre-existing. The docs page still says `asChild` works there.
