### PR TITLE
docs(www): add source-all.css to the setup guide

### DIFF
--- a/apps/www/app/docs/for-ai-agents.mdx
+++ b/apps/www/app/docs/for-ai-agents.mdx
@@ -68,7 +68,7 @@ design system. Conventions:
 - The app's CSS entry must `@import "@ngrok/mantle/mantle.css"` and then
   `@import "@ngrok/mantle/source-all.css"`. Keep both in one CSS file.
   Without the second import Tailwind generates none of the classes
-  mantle's components use, and they render unstyled.
+  mantle's components use. The components render unstyled.
 - Color scales use Tailwind's 50-950 steps (`text-accent-600`). There is
   no 1-12 scale, so `text-accent-11` matches nothing. Text color tokens
   are `text-strong`, `text-body`, `text-muted`, and `text-placeholder`.
@@ -88,7 +88,7 @@ design system. Conventions:
 - **`cx` over string interpolation.** Compose class names with [`cx`](/utils/cx). It merges Tailwind classes and de-duplicates conflicts.
 - **Nullish checks use `== null` / `!= null`.** The codebase prefers these over `=== undefined` / `!== undefined`, since `== null` covers both `null` and `undefined`.
 - **Theme + provider setup.** Apps must mount [`ThemeProvider`](/components/primitives/theme) and [`Toaster`](/components/feedback/toast) at the root. Add [`TooltipProvider`](/components/overlays/tooltip) once when using shared tooltip delay or hover settings. Without `ThemeProvider`, theme tokens are unstyled and there's a flash of unstyled content.
-- **Stylesheet setup.** The app's CSS entry imports `@ngrok/mantle/mantle.css` and then `@ngrok/mantle/source-all.css` (see [Stylesheet](/#stylesheet)). `mantle.css` declares no `@source`, and Tailwind 4 skips `node_modules` when it scans for class names, so without `source-all.css` Tailwind generates none of the classes mantle's components use. The components render without their styles, and an open `Dialog` shows its content in the page flow with no backdrop. Import both from the same CSS file: Tailwind compiles each CSS entry on its own, so an `@source` in a separate file adds nothing.
+- **Stylesheet setup.** The app's CSS entry imports `@ngrok/mantle/mantle.css` and then `@ngrok/mantle/source-all.css` (see [Stylesheet](/#stylesheet)). `mantle.css` declares no `@source`, and Tailwind 4 skips `node_modules` when it scans for class names, so without `source-all.css` Tailwind generates none of the classes mantle's components use. The components render without their styles. An open `Dialog` shows its content in the page flow with no backdrop. Import both from the same CSS file: Tailwind compiles each CSS entry on its own, so an `@source` in a separate file adds nothing.
 - **Phosphor icons by default.** Import icons from `@phosphor-icons/react/<IconName>` (e.g. `@phosphor-icons/react/Fire`). Custom ngrok icons live at [`@ngrok/mantle/icons`](/components/data-display/icons).
 - **No `as` casts in app code.** Use proper null checks and type narrowing. Type assertions are restricted to `as const` and dedicated type guards (see [Conventions](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md)).
 - **Translation-safe markup.** Google Translate reparents every text node, so React throws `NotFoundError` and the page goes blank when it inserts an element before one. Never render a conditional element immediately before bare text children: wrap the text in a `<span>`, move the element after it, or mount it unconditionally. Pass a `Button` or `Badge` icon through the `icon` prop, never as a child. Mark code, keys, filenames, IDs, and passcodes `translate="no"`; [`Code`](/components/data-display/code), [`Kbd`](/components/data-display/kbd), `CodeBlock.Code`, and `OtpInput.Slot` already do.

--- a/apps/www/app/docs/for-ai-agents.mdx
+++ b/apps/www/app/docs/for-ai-agents.mdx
@@ -65,6 +65,13 @@ design system. Conventions:
 - The app must wrap children in <ThemeProvider> and <Toaster> at the root
   (see /). Add <TooltipProvider> once at the root when using shared tooltip
   delay or hover settings.
+- The app's CSS entry must `@import "@ngrok/mantle/mantle.css"` and then
+  `@import "@ngrok/mantle/source-all.css"`. Keep both in one CSS file.
+  Without the second import Tailwind generates none of the classes
+  mantle's components use, and they render unstyled.
+- Color scales use Tailwind's 50-950 steps (`text-accent-600`). There is
+  no 1-12 scale, so `text-accent-11` matches nothing. Text color tokens
+  are `text-strong`, `text-body`, `text-muted`, and `text-placeholder`.
 - All external dependencies must be exact-pinned (no `^` or `~`).
 - Reference the canonical docs at https://mantle.ngrok.com or fetch
   https://mantle.ngrok.com/llms.txt for the full index. When building an
@@ -81,11 +88,12 @@ design system. Conventions:
 - **`cx` over string interpolation.** Compose class names with [`cx`](/utils/cx). It merges Tailwind classes and de-duplicates conflicts.
 - **Nullish checks use `== null` / `!= null`.** The codebase prefers these over `=== undefined` / `!== undefined`, since `== null` covers both `null` and `undefined`.
 - **Theme + provider setup.** Apps must mount [`ThemeProvider`](/components/primitives/theme) and [`Toaster`](/components/feedback/toast) at the root. Add [`TooltipProvider`](/components/overlays/tooltip) once when using shared tooltip delay or hover settings. Without `ThemeProvider`, theme tokens are unstyled and there's a flash of unstyled content.
+- **Stylesheet setup.** The app's CSS entry imports `@ngrok/mantle/mantle.css` and then `@ngrok/mantle/source-all.css` (see [Stylesheet](/#stylesheet)). `mantle.css` declares no `@source`, and Tailwind 4 skips `node_modules` when it scans for class names, so without `source-all.css` Tailwind generates none of the classes mantle's components use. The components render without their styles, and an open `Dialog` shows its content in the page flow with no backdrop. Import both from the same CSS file: Tailwind compiles each CSS entry on its own, so an `@source` in a separate file adds nothing.
 - **Phosphor icons by default.** Import icons from `@phosphor-icons/react/<IconName>` (e.g. `@phosphor-icons/react/Fire`). Custom ngrok icons live at [`@ngrok/mantle/icons`](/components/data-display/icons).
 - **No `as` casts in app code.** Use proper null checks and type narrowing. Type assertions are restricted to `as const` and dedicated type guards (see [Conventions](https://github.com/ngrok/mantle/blob/main/CONVENTIONS.md)).
 - **Translation-safe markup.** Google Translate reparents every text node, so React throws `NotFoundError` and the page goes blank when it inserts an element before one. Never render a conditional element immediately before bare text children: wrap the text in a `<span>`, move the element after it, or mount it unconditionally. Pass a `Button` or `Badge` icon through the `icon` prop, never as a child. Mark code, keys, filenames, IDs, and passcodes `translate="no"`; [`Code`](/components/data-display/code), [`Kbd`](/components/data-display/kbd), `CodeBlock.Code`, and `OtpInput.Slot` already do.
 - **Exact-pinned versions.** When adding a dependency, pin it. No `^` or `~` ranges.
-- **Tailwind 4.** Custom classes use the design tokens defined in `mantle.css`. Prefer semantic tokens (`text-strong`, `bg-form`, `border-accent-600`) over raw color names where they exist.
+- **Tailwind 4.** Custom classes use the design tokens defined in `mantle.css`. Prefer semantic tokens (`text-strong`, `bg-form`, `border-accent-600`) over raw color names where they exist. Color scales use Tailwind's `50`–`950` steps (`text-accent-600`, `bg-neutral-100`); there is no `1`–`12` scale, so `text-accent-11` matches nothing. The text color tokens are on [Typography](/base/typography#colors) and the palettes on [Colors](/base/colors).
 
 ## Composition patterns
 

--- a/apps/www/app/docs/index.mdx
+++ b/apps/www/app/docs/index.mdx
@@ -75,6 +75,30 @@ pnpm add -DE tailwindcss
 bun add -DE tailwindcss
 ```
 
+### Stylesheet
+
+Create one CSS entry file for your app and import both mantle stylesheets from it:
+
+```css
+/* app/app.css */
+@import "@ngrok/mantle/mantle.css";
+@import "@ngrok/mantle/source-all.css";
+```
+
+`mantle.css` imports Tailwind, the theme tokens, and the light theme. `source-all.css` holds one
+`@source` directive that points Tailwind at mantle's `dist/` directory. Tailwind 4 skips
+`node_modules` when it scans for class names, so without that directive it generates none of the
+classes mantle's components use. The components then render without their styles: an open
+`Dialog`, for example, shows its content in the page flow with no backdrop.
+
+> [!WARNING]
+> Import `source-all.css` from the same CSS file as `mantle.css`, not from JavaScript. Tailwind
+> compiles each CSS entry on its own, so an `@source` in a separate file adds nothing to the
+> stylesheet that holds `mantle.css`.
+
+Add your own `@source` directives to the same file when you keep components in a workspace
+package that Tailwind's automatic detection can't see.
+
 ### React Router
 
 Install the additional dev dependencies for the Tailwind Vite plugin:
@@ -104,7 +128,7 @@ export default defineConfig({
 });
 ```
 
-In your app's `app/root.tsx`, import `mantle.css` and set up the
+In your app's `app/root.tsx`, import `app.css` and set up the
 [Theme Provider](/components/primitives/theme), [Toaster](/components/feedback/toast), and
 [Tooltip Provider](/components/overlays/tooltip).
 
@@ -149,7 +173,7 @@ import {
 } from "react-router";
 
 import type { Route } from "./+types/root";
-import "@ngrok/mantle/mantle.css";
+import "./app.css";
 
 export function Layout({ children }: PropsWithChildren) {
 	const initialHtmlThemeProps = useInitialHtmlThemeProps({
@@ -278,9 +302,9 @@ export default defineConfig({
 });
 ```
 
-In your app's `src/main.tsx`, import `mantle.css` and set up the
-[Theme Provider](/components/primitives/theme), [Toaster](/components/feedback/toast), and
-[Tooltip Provider](/components/overlays/tooltip):
+In your app's `src/main.tsx`, import `app.css` (created in [Stylesheet](#stylesheet), here at
+`src/app.css`) and set up the [Theme Provider](/components/primitives/theme),
+[Toaster](/components/feedback/toast), and [Tooltip Provider](/components/overlays/tooltip):
 
 ```tsx
 // src/main.tsx
@@ -289,7 +313,7 @@ import { createRoot } from "react-dom/client";
 import { ThemeProvider } from "@ngrok/mantle/theme";
 import { Toaster } from "@ngrok/mantle/toast";
 import { TooltipProvider } from "@ngrok/mantle/tooltip";
-import "@ngrok/mantle/mantle.css";
+import "./app.css";
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(
@@ -347,8 +371,8 @@ You are now ready to use mantle components in your application! Start with the
 
 ### React SPA
 
-In your app's entry/root file, import `mantle.css` and set up the
-[Theme Provider](/components/primitives/theme), [Toaster](/components/feedback/toast), and
+In your app's entry/root file, import `app.css` (created in [Stylesheet](#stylesheet)) and set
+up the [Theme Provider](/components/primitives/theme), [Toaster](/components/feedback/toast), and
 [Tooltip Provider](/components/overlays/tooltip):
 
 ```tsx
@@ -358,7 +382,7 @@ import { createRoot } from "react-dom/client";
 import { ThemeProvider } from "@ngrok/mantle/theme";
 import { Toaster } from "@ngrok/mantle/toast";
 import { TooltipProvider } from "@ngrok/mantle/tooltip";
-import "@ngrok/mantle/mantle.css";
+import "./app.css";
 import App from "./App.tsx";
 
 const container = window.document.getElementById("app");

--- a/apps/www/app/docs/index.mdx
+++ b/apps/www/app/docs/index.mdx
@@ -77,10 +77,11 @@ bun add -DE tailwindcss
 
 ### Stylesheet
 
-Create one CSS entry file for your app and import both mantle stylesheets from it:
+Create one CSS entry file, `app.css`, and import both mantle stylesheets from it. Each framework
+section below says where the file lives.
 
 ```css
-/* app/app.css */
+/* app.css */
 @import "@ngrok/mantle/mantle.css";
 @import "@ngrok/mantle/source-all.css";
 ```
@@ -128,9 +129,9 @@ export default defineConfig({
 });
 ```
 
-In your app's `app/root.tsx`, import `app.css` and set up the
-[Theme Provider](/components/primitives/theme), [Toaster](/components/feedback/toast), and
-[Tooltip Provider](/components/overlays/tooltip).
+In your app's `app/root.tsx`, import `app.css` (created in [Stylesheet](#stylesheet), here at
+`app/app.css`) and set up the [Theme Provider](/components/primitives/theme),
+[Toaster](/components/feedback/toast), and [Tooltip Provider](/components/overlays/tooltip).
 
 > [!WARNING]
 > It is critical to include `PreventWrongThemeFlashScript` early in the `<head>` of your app to


### PR DESCRIPTION
## Why

The setup guide tells a consumer to `import "@ngrok/mantle/mantle.css"` from JavaScript and never mentions `source-all.css`. Since #1036, `mantle.css` declares no `@source`, and Tailwind 4 skips `node_modules` when it scans for class names. A consumer who follows the guide gets components with none of their classes generated, so an open `Dialog` renders in the page flow with no backdrop.

An agent that ported an internal app to mantle hit this gap, and it also guessed a Radix-style `text-accent-11` token that does not exist.

## What

- Add a Stylesheet step to the setup guide: one CSS entry that imports `mantle.css` and then `source-all.css`, with the reason the second import matters and a warning to keep both in one CSS file.
- Point the React Router, Vite, and React SPA examples at that `app.css`.
- Add the same stylesheet rule to the For AI Agents page, in both the system-prompt snippet and the conventions list.
- Note on the same page that color scales use Tailwind's `50`–`950` steps, and link the text color tokens and palettes.
