### PR TITLE
docs(www): add the list page loading states recipe

### DIFF
--- a/apps/www/app/components/navigation-data.ts
+++ b/apps/www/app/components/navigation-data.ts
@@ -332,6 +332,7 @@ export const layoutDescriptions = {
 export const recipePages = [
 	//,
 	"Breadcrumbs from Routes",
+	"List Page Loading States",
 	"Overlays + Async Data",
 	"Route Announcer",
 ] as const;
@@ -339,6 +340,7 @@ export const recipePages = [
 /** Route lookup for recipe pages. */
 export const recipeRoutes = {
 	"Breadcrumbs from Routes": "/recipes/breadcrumbs-from-routes",
+	"List Page Loading States": "/recipes/list-page-loading-states",
 	"Overlays + Async Data": "/recipes/overlay-async",
 	"Route Announcer": "/recipes/route-announcer",
 } as const satisfies Record<(typeof recipePages)[number], Route>;
@@ -347,6 +349,8 @@ export const recipeRoutes = {
 export const recipeDescriptions = {
 	"Breadcrumbs from Routes":
 		"Derive a breadcrumb trail from the matched route chain with React Router route handles \u2014 derived state, so it is correct on the server and on the first frame, with no context and no effects.",
+	"List Page Loading States":
+		"Render a list page's header, filters, and column headers on the first frame, then fill the table with skeleton rows that match the loaded rows, so nothing shifts when the data lands.",
 	"Overlays + Async Data":
 		"Open a Sheet, Dialog, or Alert Dialog immediately, then swap the body between pending, loaded, 404, and 500 states with TanStack Query.",
 	"Route Announcer":

--- a/apps/www/app/docs/components/data-display/data-table.mdx
+++ b/apps/www/app/docs/components/data-display/data-table.mdx
@@ -416,7 +416,7 @@ A list has **two** distinct empty states, and they need different copy and actio
 1. **No data**: nothing exists yet. Informational, optionally a primary "create" action.
 2. **No results for the active filter/search**: the user filtered to nothing and needs a way out (a **Clear filters** button).
 
-Branch on `rows.length`, then on whether a filter is active, and host an [`Empty`](/components/feedback/empty) inside `DataTable.EmptyRow` for each branch. `EmptyRow` already spans every column (auto `colSpan`) and `Empty.Root` centers itself. Drop a single `Empty.Root` in as the child; don't hand-roll a `<td>` or any centering. Type into the filter below to see the "no results" branch and its working `Clear filters` reset:
+Branch on `rows.length`, then on whether a filter is active, and host an [`Empty`](/components/feedback/empty) inside `DataTable.EmptyRow` for each branch. A pending query is a third state that comes before both: the [List Page Loading States](/recipes/list-page-loading-states) recipe wires all three, with skeleton rows that match the loaded rows. `EmptyRow` already spans every column (auto `colSpan`) and `Empty.Root` centers itself. Drop a single `Empty.Root` in as the child; don't hand-roll a `<td>` or any centering. Type into the filter below to see the "no results" branch and its working `Clear filters` reset:
 
 <Example>
 	<FilteredEmptyStateDemo />

--- a/apps/www/app/docs/components/feedback/skeleton.mdx
+++ b/apps/www/app/docs/components/feedback/skeleton.mdx
@@ -16,6 +16,8 @@ A skeleton is a placeholder for content that is loading. By rendering a neutral 
 - Async-loaded content where the eventual shape is predictable (lists, cards, tables, avatars).
 - On initial page load, before data has resolved.
 
+For a whole list page, the [List Page Loading States](/recipes/list-page-loading-states) recipe shows where the skeleton belongs and what renders around it.
+
 ## When not to use
 
 - For very short fetches (under ~200&thinsp;ms) — a flash of skeleton is more distracting than helpful.

--- a/apps/www/app/docs/recipes/list-page-loading-states.mdx
+++ b/apps/www/app/docs/recipes/list-page-loading-states.mdx
@@ -1,0 +1,911 @@
+---
+title: List Page Loading States
+description: Render a list page's header, filters, and column headers on the first frame, then fill the table with skeleton rows that match the loaded rows, so nothing shifts when the data lands.
+---
+
+import { CodeExample } from "~/components/code-example";
+
+# List Page Loading States
+
+A list page has one job before its data arrives: look like itself. The heading, the description, the primary action, the filters, and the column headers depend on nothing the server sends, so they can paint on the first frame. Only the count and the rows wait. This recipe wires a [Data Table](/components/data-display/data-table), [Skeleton](/components/feedback/skeleton) rows, [Empty](/components/feedback/empty) states, and a [Live Region](/components/primitives/live-region) into a page that paints fast, fills in without moving, and tells screen readers what it is doing.
+
+The failure modes it removes are ones you have seen: a spinner where the page should be, a "No results" that flashes before the real rows, columns that slide sideways when text arrives, a pagination bar that pushes the page down once it mounts, and a count that reads `0` for a second.
+
+> [!IMPORTANT]
+> Don't copy this UI verbatim. The recipe teaches the **state structure**: the shell renders on the first frame, exactly one region of the table body branches, the skeleton derives from the real columns, and a refetch keeps the loaded rows. The domains table, its copy, and the toolbar controls are stand-ins. Swap them for your product's content and keep the structure.
+
+<CodeExample.Root>
+	<CodeExample.PreviewFrame example="list-page-loading" title="List page loading demo" />
+	<CodeExample.Code>
+
+```tsx
+import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { cx } from "@ngrok/mantle/cx";
+import {
+	DataTable,
+	type Row,
+	createColumnHelper,
+	tableFeatures,
+	useTable,
+} from "@ngrok/mantle/data-table";
+import { Empty } from "@ngrok/mantle/empty";
+import { Input } from "@ngrok/mantle/input";
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { Main } from "@ngrok/mantle/main";
+import { Select } from "@ngrok/mantle/select";
+import { Skeleton } from "@ngrok/mantle/skeleton";
+import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
+import { Table } from "@ngrok/mantle/table";
+import { GlobeHemisphereWestIcon } from "@phosphor-icons/react/GlobeHemisphereWest";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react/MagnifyingGlass";
+import { WarningCircleIcon } from "@phosphor-icons/react/WarningCircle";
+import {
+	keepPreviousData,
+	useQuery,
+	useQueryClient,
+	type UseQueryResult,
+} from "@tanstack/react-query";
+import { useDeferredValue, useState } from "react";
+
+const SIMULATED_API_LATENCY_MS = 1_500;
+const PAGE_SIZE = 8;
+const DEMO_DOMAIN_COUNT = 1_284;
+const DOMAINS_QUERY_KEY_ROOT = ["list-page-loading-domains"];
+
+const regions = ["us", "eu", "ap", "au", "jp", "in", "sa"] as const;
+
+/** An ngrok region code. */
+type Region = (typeof regions)[number];
+
+const certificateKinds = ["managed", "custom"] as const;
+
+/** Who issues and renews the domain's TLS certificate. */
+type CertificateKind = (typeof certificateKinds)[number];
+
+const certificateLabels: Record<CertificateKind, string> = {
+	managed: "Managed",
+	custom: "Custom",
+};
+
+/** One reserved domain, as the demo API returns it. */
+type Domain = {
+	/** Stable identifier from the backend. */
+	id: string;
+	/** The fully qualified domain name. */
+	name: string;
+	/** The region the domain is reserved in. */
+	region: Region;
+	/** Who manages the certificate. */
+	certificate: CertificateKind;
+	/** How many endpoints are online on the domain right now. */
+	endpointCount: number;
+	/** ISO date string for when the domain was reserved. */
+	createdAt: string;
+};
+
+/** The active list filters. `"any"` leaves that dimension unfiltered. */
+type DomainFilters = {
+	region: Region | "any";
+	certificate: CertificateKind | "any";
+	search: string;
+};
+
+const defaultFilters: DomainFilters = { region: "any", certificate: "any", search: "" };
+
+/** One page of the list, plus the total the filters match. */
+type DomainsPage = {
+	items: Domain[];
+	total: number;
+};
+
+/** Which response the demo API returns. */
+type DomainsScenario = "success" | "no-domains" | "server-error";
+
+const domainsScenarios = [
+	"success",
+	"no-domains",
+	"server-error",
+] as const satisfies ReadonlyArray<DomainsScenario>;
+
+const scenarioLabels: Record<DomainsScenario, string> = {
+	success: "Scenario: loaded",
+	"no-domains": "Scenario: no domains",
+	"server-error": "Scenario: request fails",
+};
+
+/** Narrows a raw select value to a known demo scenario. */
+function isDomainsScenario(value: string): value is DomainsScenario {
+	return domainsScenarios.some((scenario) => scenario === value);
+}
+
+/** Narrows a raw select value to a region filter. */
+function isRegionFilter(value: string): value is DomainFilters["region"] {
+	return value === "any" || regions.some((region) => region === value);
+}
+
+/** Narrows a raw select value to a certificate filter. */
+function isCertificateFilter(value: string): value is DomainFilters["certificate"] {
+	return value === "any" || certificateKinds.some((kind) => kind === value);
+}
+
+/** Whether any filter narrows the list, so an empty page reads as "no results" and not "no data". */
+function hasActiveFilter(filters: DomainFilters): boolean {
+	return filters.region !== "any" || filters.certificate !== "any" || filters.search.trim() !== "";
+}
+
+// The mock API below stands in for your API client. Keep the shape it returns
+// (a page plus a total) and the `signal` it accepts; replace everything else.
+
+const nameStems = [
+	"api",
+	"app",
+	"shop",
+	"auth",
+	"billing",
+	"docs",
+	"webhooks",
+	"staging",
+	"preview",
+	"admin",
+] as const;
+const nameSuffixes = ["ngrok.app", "ngrok.dev", "acme-labs.example", "example.com"] as const;
+const NEWEST_CREATED_AT = Date.UTC(2026, 8, 11);
+const DAY_MS = 86_400_000;
+
+/** Reads `items[index]` with wraparound. Throws on an empty list, because a demo with no data to cycle through is a bug. */
+function cycle<T>(items: ReadonlyArray<T>, index: number): T {
+	const item = items[index % items.length];
+	if (item == null) {
+		throw new Error("cycle() needs a non-empty list");
+	}
+	return item;
+}
+
+/** Builds the fixed dataset once. Every field derives from the index, so the list is the same on every load. */
+function createDemoDomains(): Domain[] {
+	return Array.from({ length: DEMO_DOMAIN_COUNT }, (_, index) => {
+		const stem = cycle(nameStems, index);
+		const suffix = cycle(nameSuffixes, Math.floor(index / nameStems.length));
+		return {
+			id: `rd_${(index + 1).toString().padStart(4, "0")}`,
+			name: `${stem}-${index + 1}.${suffix}`,
+			region: cycle(regions, index * 3),
+			certificate: index % 5 === 0 ? "custom" : "managed",
+			endpointCount: (index * 7) % 4,
+			createdAt: new Date(NEWEST_CREATED_AT - index * DAY_MS).toISOString(),
+		};
+	});
+}
+
+const demoDomains = createDemoDomains();
+
+/** Whether a domain passes every active filter. */
+function matchesFilters(domain: Domain, filters: DomainFilters): boolean {
+	if (filters.region !== "any" && domain.region !== filters.region) {
+		return false;
+	}
+	if (filters.certificate !== "any" && domain.certificate !== filters.certificate) {
+		return false;
+	}
+	const search = filters.search.trim().toLowerCase();
+	return search === "" || domain.name.includes(search);
+}
+
+/** Waits for the simulated network, and rejects when TanStack Query aborts the request. */
+function waitForDemoApi(signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("The domains request was aborted.", "AbortError"));
+			return;
+		}
+
+		const timeoutId = setTimeout(() => {
+			signal?.removeEventListener("abort", handleAbort);
+			resolve();
+		}, SIMULATED_API_LATENCY_MS);
+
+		/** Cancels the simulated delay when the query unmounts or its key changes. */
+		function handleAbort() {
+			clearTimeout(timeoutId);
+			reject(new DOMException("The domains request was aborted.", "AbortError"));
+		}
+
+		signal?.addEventListener("abort", handleAbort, { once: true });
+	});
+}
+
+/** Options accepted by the simulated domains fetcher. */
+type FetchDomainsOptions = {
+	/** The filters to apply server-side. */
+	filters: DomainFilters;
+	/** Which response to simulate. */
+	scenario: DomainsScenario;
+	/** Abort signal passed by TanStack Query. */
+	signal?: AbortSignal;
+};
+
+/** Simulates a paged list endpoint: latency, server-side filters, a total, and a failure mode. */
+async function fetchDomains({
+	filters,
+	scenario,
+	signal,
+}: FetchDomainsOptions): Promise<DomainsPage> {
+	await waitForDemoApi(signal);
+
+	if (scenario === "server-error") {
+		throw new Error("The domains service returned 503 Service Unavailable.");
+	}
+
+	if (scenario === "no-domains") {
+		return { items: [], total: 0 };
+	}
+
+	const matches = demoDomains.filter((domain) => matchesFilters(domain, filters));
+	return { items: matches.slice(0, PAGE_SIZE), total: matches.length };
+}
+
+/** Options for the domains list query. */
+type UseDomainsQueryOptions = {
+	/** The filters the server applies. Each distinct set is its own cache entry. */
+	filters: DomainFilters;
+	/** Demo scenario selected in the toolbar. */
+	scenario: DomainsScenario;
+};
+
+/** Owns fetching, caching, and the previous-page policy for the domains list. */
+function useDomainsQuery({
+	filters,
+	scenario,
+}: UseDomainsQueryOptions): UseQueryResult<DomainsPage, Error> {
+	return useQuery({
+		queryKey: [...DOMAINS_QUERY_KEY_ROOT, scenario, filters],
+		queryFn: ({ signal }) => fetchDomains({ filters, scenario, signal }),
+		// Why keepPreviousData: a filter change swaps the query key. Without it
+		// the table falls back to skeleton rows on every keystroke. With it the
+		// loaded rows stay on screen, dimmed, until the next page lands.
+		placeholderData: keepPreviousData,
+		// Why no retry: the demo's failure is deterministic, so a retry only adds
+		// latency. A real list encodes its retry policy here, as the
+		// overlay-async recipe does.
+		retry: false,
+		// Why staleTime: a return visit within 30 seconds renders from the cache,
+		// so the reader never sees the skeleton twice.
+		staleTime: 30_000,
+	});
+}
+
+/** The one region of the table body that renders. */
+type ListBodyState =
+	| { kind: "pending" }
+	| { kind: "error"; error: Error }
+	| { kind: "no-data" }
+	| { kind: "no-results" }
+	| { kind: "rows"; items: Domain[]; total: number };
+
+/** Options for deriving the table body state. */
+type ResolveListBodyStateOptions = {
+	/** The domains list query. */
+	query: UseQueryResult<DomainsPage, Error>;
+	/** Whether a filter narrows the list. */
+	isFiltered: boolean;
+};
+
+/**
+ * Derives the table body state from the query. Pending wins over empty, so
+ * "no results" never flashes before the first response lands.
+ */
+function resolveListBodyState({ query, isFiltered }: ResolveListBodyStateOptions): ListBodyState {
+	switch (query.status) {
+		case "pending": {
+			return { kind: "pending" };
+		}
+		case "error": {
+			return { kind: "error", error: query.error };
+		}
+		case "success": {
+			const { items, total } = query.data;
+			if (items.length > 0) {
+				return { kind: "rows", items, total };
+			}
+			return { kind: isFiltered ? "no-results" : "no-data" };
+		}
+	}
+}
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+/** Options for the count line. */
+type FormatDomainCountOptions = {
+	/** How many rows the page shows. */
+	shown: number;
+	/** How many domains match the filters. */
+	total: number;
+};
+
+/** Formats the count line: `Showing 8 of 1,284 domains`. */
+function formatDomainCount({ shown, total }: FormatDomainCountOptions): string {
+	return `Showing ${numberFormat.format(shown)} of ${numberFormat.format(total)} domains`;
+}
+
+/** Options for the live-region message. */
+type DescribeListStateOptions = {
+	/** The table body state. */
+	state: ListBodyState;
+	/** Whether a refetch is in flight behind loaded rows. */
+	isRefetching: boolean;
+};
+
+/**
+ * The live-region message for a list state. The skeleton rows are
+ * `aria-hidden`, so this message is the only loading signal a screen reader
+ * gets.
+ */
+function describeListState({ state, isRefetching }: DescribeListStateOptions): string {
+	if (isRefetching) {
+		return "Updating domains";
+	}
+	switch (state.kind) {
+		case "pending": {
+			return "Loading domains";
+		}
+		case "error": {
+			return "Domains failed to load";
+		}
+		case "no-data": {
+			return "No domains yet";
+		}
+		case "no-results": {
+			return "No domains match the filters";
+		}
+		case "rows": {
+			return formatDomainCount({ shown: state.items.length, total: state.total });
+		}
+	}
+}
+
+const dateFormat = new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeZone: "UTC" });
+
+// The list is sorted and filtered on the server, so the table registers no
+// client-side features.
+const features = tableFeatures({});
+const columnHelper = createColumnHelper<typeof features, Domain>();
+
+// Every column but the first names its width. With `table-fixed` on the
+// table, those widths hold from the skeleton rows through the loaded rows, and
+// the first column absorbs whatever is left.
+const columns = columnHelper.columns([
+	columnHelper.accessor("name", {
+		id: "name",
+		header: () => <DataTable.Header>Domain</DataTable.Header>,
+		cell: (props) => (
+			<DataTable.Cell className="text-strong truncate">{props.getValue()}</DataTable.Cell>
+		),
+	}),
+	columnHelper.accessor("region", {
+		id: "region",
+		header: () => <DataTable.Header className="w-24">Region</DataTable.Header>,
+		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	}),
+	columnHelper.accessor("certificate", {
+		id: "certificate",
+		header: () => <DataTable.Header className="w-36">Certificate</DataTable.Header>,
+		cell: (props) => (
+			<DataTable.Cell>
+				<Badge appearance="muted" color={props.getValue() === "managed" ? "success" : "neutral"}>
+					{certificateLabels[props.getValue()]}
+				</Badge>
+			</DataTable.Cell>
+		),
+	}),
+	columnHelper.accessor("endpointCount", {
+		id: "endpointCount",
+		header: () => <DataTable.Header className="w-28 text-right">Endpoints</DataTable.Header>,
+		cell: (props) => <DataTable.Cell className="text-right">{props.getValue()}</DataTable.Cell>,
+	}),
+	columnHelper.accessor("createdAt", {
+		id: "createdAt",
+		header: () => <DataTable.Header className="w-36">Created</DataTable.Header>,
+		cell: (props) => (
+			<DataTable.Cell>{dateFormat.format(new Date(props.getValue()))}</DataTable.Cell>
+		),
+	}),
+]);
+
+/**
+ * The skeleton bar for each column id, sized to the content it stands in for.
+ * A bar near the real content's width keeps the row height and the column
+ * widths still when the rows swap in.
+ */
+const skeletonCellClassNames: Record<string, string> = {
+	name: "w-3/4",
+	region: "w-6",
+	certificate: "h-5 w-20 rounded-full",
+	endpointCount: "ml-auto w-6",
+	createdAt: "w-28",
+};
+
+/** Why a module constant: `useTable` compares `data` by reference, so a fresh `[]` per render would reset the row model. */
+const noDomains: Domain[] = [];
+
+/** Props for the skeleton rows. */
+type SkeletonRowsProps = {
+	/** The table's leaf columns, so the skeleton has one cell per real column. */
+	columns: ReadonlyArray<{ id: string }>;
+	/** How many rows to render. Match it to the page size. */
+	count: number;
+};
+
+/**
+ * Placeholder rows with one skeleton per column. They use the same cell part
+ * as the loaded rows, so padding and row height match, and they derive from
+ * the same column list, so the column count cannot drift.
+ */
+function SkeletonRows({ columns, count }: SkeletonRowsProps) {
+	return Array.from({ length: count }, (_, index) => (
+		// Why aria-hidden: the rows carry no information. The page's LiveRegion
+		// announces the loading state instead.
+		<Table.Row key={index} aria-hidden>
+			{columns.map((column) => (
+				<DataTable.Cell key={column.id}>
+					<Skeleton className={cx("h-4", skeletonCellClassNames[column.id] ?? "w-24")} />
+				</DataTable.Cell>
+			))}
+		</Table.Row>
+	));
+}
+
+/** Props for the table body. */
+type DomainsTableBodyProps = {
+	/** The derived body state. */
+	state: ListBodyState;
+	/** The rows TanStack Table built from the loaded page. */
+	rows: ReadonlyArray<Row<typeof features, Domain>>;
+	/** The table's leaf columns, for the skeleton rows. */
+	columns: ReadonlyArray<{ id: string }>;
+	/** Whether the retry request is in flight. */
+	isRetrying: boolean;
+	/** Refetches the current page after an error. */
+	onRetry: () => void;
+	/** Resets every filter to its default. */
+	onClearFilters: () => void;
+};
+
+/** Renders exactly one of the five body states inside the table frame. */
+function DomainsTableBody({
+	state,
+	rows,
+	columns,
+	isRetrying,
+	onRetry,
+	onClearFilters,
+}: DomainsTableBodyProps) {
+	switch (state.kind) {
+		case "pending": {
+			return <SkeletonRows columns={columns} count={PAGE_SIZE} />;
+		}
+		case "rows": {
+			return rows.map((row) => <DataTable.Row key={row.id} row={row} />);
+		}
+		case "error": {
+			return (
+				<DataTable.EmptyRow>
+					<Empty.Root>
+						<Empty.Icon svg={<WarningCircleIcon />} />
+						<Empty.Title>Domains failed to load</Empty.Title>
+						<Empty.Description>
+							<p>{state.error.message}</p>
+						</Empty.Description>
+						<Empty.Actions>
+							<Button
+								type="button"
+								appearance="outlined"
+								intent="neutral"
+								isLoading={isRetrying}
+								onClick={onRetry}
+							>
+								Retry
+							</Button>
+						</Empty.Actions>
+					</Empty.Root>
+				</DataTable.EmptyRow>
+			);
+		}
+		case "no-results": {
+			return (
+				<DataTable.EmptyRow>
+					<Empty.Root>
+						<Empty.Icon svg={<MagnifyingGlassIcon />} />
+						<Empty.Title>No domains match the filters</Empty.Title>
+						<Empty.Description>
+							<p>Try a different search, or clear the filters to see every domain.</p>
+						</Empty.Description>
+						<Empty.Actions>
+							<Button type="button" appearance="outlined" intent="neutral" onClick={onClearFilters}>
+								Clear filters
+							</Button>
+						</Empty.Actions>
+					</Empty.Root>
+				</DataTable.EmptyRow>
+			);
+		}
+		case "no-data": {
+			return (
+				<DataTable.EmptyRow>
+					<Empty.Root>
+						<Empty.Icon svg={<GlobeHemisphereWestIcon />} />
+						<Empty.Title>No domains yet</Empty.Title>
+						<Empty.Description>
+							<p>Reserve a domain to route public traffic to an endpoint.</p>
+						</Empty.Description>
+						<Empty.Actions>
+							<Button type="button" appearance="outlined" intent="neutral">
+								New domain
+							</Button>
+						</Empty.Actions>
+					</Empty.Root>
+				</DataTable.EmptyRow>
+			);
+		}
+	}
+}
+
+/** Props for the count line. */
+type DomainCountProps = {
+	/** The derived body state. */
+	state: ListBodyState;
+};
+
+/** The text of the count line, or a skeleton while the first page loads. */
+function DomainCountText({ state }: DomainCountProps) {
+	switch (state.kind) {
+		case "pending": {
+			// Why asChild: a `<div>` inside a `<p>` splits the paragraph in the
+			// server-rendered HTML, and the table below moves on hydration.
+			return (
+				<Skeleton asChild className="h-3 w-44">
+					<span />
+				</Skeleton>
+			);
+		}
+		case "error": {
+			return null;
+		}
+		case "no-data":
+		case "no-results": {
+			return formatDomainCount({ shown: 0, total: 0 });
+		}
+		case "rows": {
+			return formatDomainCount({ shown: state.items.length, total: state.total });
+		}
+	}
+}
+
+/**
+ * The count line above the table. It is mounted in every state at a fixed
+ * height and aligned to the right edge, so the table never moves when the
+ * count arrives and a wider number moves nothing beside it. It never reads
+ * `0` while the first page is still loading.
+ */
+function DomainCount({ state }: DomainCountProps) {
+	return (
+		<p className="text-muted flex h-5 items-center justify-end text-sm">
+			<DomainCountText state={state} />
+		</p>
+	);
+}
+
+/** Props for the domains table. */
+type DomainsTableProps = {
+	/** The domains list query. */
+	query: UseQueryResult<DomainsPage, Error>;
+	/** Whether a filter narrows the list. */
+	isFiltered: boolean;
+	/** Resets every filter to its default. */
+	onClearFilters: () => void;
+};
+
+/** The table frame: the header renders from the column list on the first frame, and only the body branches. */
+function DomainsTable({ query, isFiltered, onClearFilters }: DomainsTableProps) {
+	const table = useTable({ features, data: query.data?.items ?? noDomains, columns });
+	const state = resolveListBodyState({ query, isFiltered });
+	const isRefetching = query.isFetching && !query.isPending;
+
+	return (
+		<div className="flex flex-col gap-2">
+			<DomainCount state={state} />
+			{/* Why aria-busy: a refetch behind loaded rows dims the table instead of
+			    replacing it, and the attribute tells assistive tech the region is
+			    updating. */}
+			<div aria-busy={isRefetching} className="transition-opacity aria-busy:opacity-60">
+				<DataTable.Root table={table} className="[&_table]:table-fixed">
+					<DataTable.Head />
+					<DataTable.Body>
+						<DomainsTableBody
+							state={state}
+							rows={table.getRowModel().rows}
+							columns={table.getAllLeafColumns()}
+							isRetrying={query.isFetching}
+							onRetry={() => {
+								void query.refetch();
+							}}
+							onClearFilters={onClearFilters}
+						/>
+					</DataTable.Body>
+				</DataTable.Root>
+			</div>
+		</div>
+	);
+}
+
+/** Props for a filter select. */
+type FilterSelectProps = {
+	/** The dimension the select filters, used as the accessible name and the option prefix. */
+	label: string;
+	/** The selected option value. */
+	value: string;
+	/** The options, including the `"any"` option first. */
+	options: ReadonlyArray<{ value: string; label: string }>;
+	/** Called with the raw option value; the caller narrows it. */
+	onValueChange: (value: string) => void;
+};
+
+/** A fixed-width filter, so a label change (`Region: any` to `Region: eu`) moves no sibling. */
+function FilterSelect({ label, value, options, onValueChange }: FilterSelectProps) {
+	const selected = options.find((option) => option.value === value);
+
+	return (
+		<Select.Root value={value} onValueChange={onValueChange}>
+			<Select.Trigger className="w-44" aria-label={label}>
+				{/* Why children: Radix fills an empty `Select.Value` from the mounted
+				    items, which the server never renders. Explicit text puts the
+				    label in the server HTML, so the trigger is not blank on the
+				    first frame. */}
+				<Select.Value>
+					{label}: {selected?.label}
+				</Select.Value>
+			</Select.Trigger>
+			<Select.Content width="trigger">
+				{options.map((option) => (
+					<Select.Item key={option.value} value={option.value}>
+						{label}: {option.label}
+					</Select.Item>
+				))}
+			</Select.Content>
+		</Select.Root>
+	);
+}
+
+const regionOptions = [
+	{ value: "any", label: "any" },
+	...regions.map((region) => ({ value: region, label: region })),
+];
+
+const certificateOptions = [
+	{ value: "any", label: "any" },
+	...certificateKinds.map((kind) => ({ value: kind, label: certificateLabels[kind] })),
+];
+
+/** Props for the list page. */
+type DomainsListPageProps = {
+	/** Demo scenario selected in the toolbar. */
+	scenario: DomainsScenario;
+};
+
+/**
+ * The recipe. The heading, description, primary action, filters, and column
+ * headers render on the first frame. Only the count line and the table body
+ * read the query.
+ */
+export function DomainsListPage({ scenario }: DomainsListPageProps) {
+	const [filters, setFilters] = useState(defaultFilters);
+	// Why useDeferredValue: the search box updates on every keystroke, and the
+	// query key follows one frame behind, so typing never waits on a render of
+	// the table.
+	const deferredSearch = useDeferredValue(filters.search);
+	const query = useDomainsQuery({ filters: { ...filters, search: deferredSearch }, scenario });
+	const state = resolveListBodyState({ query, isFiltered: hasActiveFilter(filters) });
+
+	return (
+		<div className="mx-auto flex w-full max-w-6xl flex-col gap-4 p-6">
+			<LiveRegion>
+				{describeListState({ state, isRefetching: query.isFetching && !query.isPending })}
+			</LiveRegion>
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<h1 className="text-strong text-2xl font-medium">Domains</h1>
+					<p className="text-muted text-sm">
+						Reserved domains route public traffic to your endpoints. Reserve one per region you
+						serve from.
+					</p>
+				</div>
+				<Button type="button" appearance="filled" intent="accent">
+					New domain
+				</Button>
+			</div>
+			<div className="flex flex-wrap items-center gap-2">
+				<FilterSelect
+					label="Region"
+					value={filters.region}
+					options={regionOptions}
+					onValueChange={(value) => {
+						if (isRegionFilter(value)) {
+							setFilters((current) => ({ ...current, region: value }));
+						}
+					}}
+				/>
+				<FilterSelect
+					label="Certificate"
+					value={filters.certificate}
+					options={certificateOptions}
+					onValueChange={(value) => {
+						if (isCertificateFilter(value)) {
+							setFilters((current) => ({ ...current, certificate: value }));
+						}
+					}}
+				/>
+				<Input
+					type="search"
+					aria-label="Search domains"
+					placeholder="Search domains…"
+					className="min-w-64 flex-1"
+					value={filters.search}
+					onChange={(event) => {
+						const search = event.target.value;
+						setFilters((current) => ({ ...current, search }));
+					}}
+				/>
+			</div>
+			<DomainsTable
+				query={query}
+				isFiltered={hasActiveFilter(filters)}
+				onClearFilters={() => {
+					setFilters(defaultFilters);
+				}}
+			/>
+		</div>
+	);
+}
+
+/**
+ * The framed preview: the domains list page inside an app shell, with
+ * demo-only controls in the toolbar to pick the response and replay the
+ * cold load. Renders as an entire framed-preview document (see
+ * preview-registry.ts), so it pins itself with `fixed inset-0` and owns the
+ * `Main` landmark.
+ */
+export function ListPageLoadingDemo() {
+	const [scenario, setScenario] = useState<DomainsScenario>("success");
+	const queryClient = useQueryClient();
+
+	/** Demo-only: resets every cached page, so the next render shows the cold load again. */
+	const replay = () => {
+		void queryClient.resetQueries({ queryKey: DOMAINS_QUERY_KEY_ROOT });
+	};
+
+	return (
+		<AppLayout.Root className="fixed inset-0">
+			<SkipToMainLink />
+			<AppLayout.Workspace>
+				<AppLayout.Content>
+					<AppLayout.Header>
+						<p className="text-strong text-sm font-medium">Domains</p>
+						<div className="ml-auto flex items-center gap-2">
+							<Select.Root
+								value={scenario}
+								onValueChange={(value) => {
+									if (isDomainsScenario(value)) {
+										setScenario(value);
+									}
+								}}
+							>
+								<Select.Trigger className="w-52" aria-label="Demo scenario">
+									<Select.Value>{scenarioLabels[scenario]}</Select.Value>
+								</Select.Trigger>
+								<Select.Content width="trigger">
+									{domainsScenarios.map((value) => (
+										<Select.Item key={value} value={value}>
+											{scenarioLabels[value]}
+										</Select.Item>
+									))}
+								</Select.Content>
+							</Select.Root>
+							<Button
+								type="button"
+								appearance="outlined"
+								intent="neutral"
+								size="sm"
+								onClick={replay}
+							>
+								Replay load
+							</Button>
+						</div>
+					</AppLayout.Header>
+					<AppLayout.Body asChild>
+						<Main>
+							<DomainsListPage scenario={scenario} />
+						</Main>
+					</AppLayout.Body>
+				</AppLayout.Content>
+			</AppLayout.Workspace>
+		</AppLayout.Root>
+	);
+}
+```
+
+    </CodeExample.Code>
+
+</CodeExample.Root>
+
+Pick a scenario in the toolbar, then click **Replay load** to watch it from a cold start. After the rows land, type in the search box: the rows dim while the next page loads, and the skeleton never comes back.
+
+## Why the shell first
+
+- **The first frame is the layout.** Everything above the rows is static markup. Paint it before the request resolves, and the reader gets the page's shape at once. The browser gets its largest paint without a round trip to the server.
+- **A skeleton that matches the rows moves nothing.** Cumulative Layout Shift (CLS) counts every element that moves after it paints. Skeleton rows with the same cell padding, the same row count, and bars near the real content's width mean the swap to real rows changes pixels, not positions.
+- **Fixed column widths hold from skeleton to rows.** The default `table-layout: auto` sizes every column by its content, so the header columns slide sideways the moment real text arrives. `table-fixed` plus a width on each header pins them.
+- **A refetch is not a cold load.** The reader already has rows on screen. Replacing them with skeletons throws away a working page for the length of a request. Keep them, dim them, and swap when the next page lands.
+- **Screen readers can't see a skeleton.** `Skeleton` renders `aria-hidden`, which is right: the bars carry no information. The page still has to say that it is loading, and later how many rows it shows, so a `LiveRegion` mounted from the first frame announces each state.
+
+## What this covers
+
+| State         | What renders                                                                                     |
+| :------------ | :----------------------------------------------------------------------------------------------- |
+| Cold load     | The header, the filters, the column headers, eight skeleton rows, and a skeleton count.          |
+| Loaded        | Eight rows and `Showing 8 of 1,284 domains`.                                                     |
+| Filter change | The loaded rows stay on screen, dimmed and `aria-busy`, until the filtered page lands.           |
+| No results    | An `Empty` inside the table frame with a **Clear filters** action.                               |
+| No data       | An `Empty` inside the table frame with the create action.                                        |
+| Request fails | An `Empty` inside the table frame with a **Retry** action. The header and filters stay in place. |
+
+The demo waits 1.5 seconds per request so every state is visible. The route is also available as plain markdown at [`/recipes/list-page-loading-states.md`](/recipes/list-page-loading-states.md), so humans and LLM tools can fetch the same recipe without scraping the rendered page.
+
+## Anatomy
+
+```text showLineNumbers=false
+DomainsListPage                              renders on the first frame
+├── LiveRegion                               mounted once; its text changes per state
+├── Heading, description, primary action     static
+├── Filters: Select, Select, Input           static; fixed widths
+└── DomainsTable
+    ├── DomainCount                          fixed height; skeleton | text
+    └── DataTable.Root                       [&_table]:table-fixed
+        ├── DataTable.Head                   built from the column list; never waits
+        └── DataTable.Body                   pending | rows | no-results | no-data | error   ← the only region that branches
+```
+
+## Implementation
+
+The rules below keep the code consistent with the intent above.
+
+1. **Render everything that does not read the query outside the branch.** The heading, description, primary action, filters, and `DataTable.Head` take no data. In the demo, only `DomainCount` and `DomainsTableBody` read `state`. Give each `Select.Value` its text as children: Radix fills an empty one from the mounted items, which the server never renders, so the trigger is blank until hydration.
+2. **Derive one body state, and check pending first.** `resolveListBodyState` returns exactly one of `pending`, `rows`, `no-results`, `no-data`, and `error`. Pending comes first, so an empty state can't render before the first response. A `switch` on the state renders exactly one region.
+3. **Build the skeleton from the real table.** `SkeletonRows` takes `table.getAllLeafColumns()` and renders one `DataTable.Cell` per column, so the skeleton can't have more or fewer columns than the loaded rows. A second column list, or a copy of the real one with different flags, drifts.
+4. **Match the row count to the page size.** Eight skeleton rows for a page of eight. Three skeleton rows for a page of twenty guarantee seventeen rows of shift. If the table registers `rowPaginationFeature`, pass `manualPagination: true` to the skeleton's table, or the row model caps the placeholder at the default page size.
+5. **Size each bar to its column.** A `Record` keyed by column id holds one class per column: a wide bar for the domain name, a pill for the badge, a right-aligned bar for the number. Bars that match the content's shape keep the row height still.
+6. **Pin the column widths.** Set `[&_table]:table-fixed` on `DataTable.Root` and a width class on every `DataTable.Header` but one. The unsized column absorbs the remaining width, and `truncate` on its cells keeps a long value on one line.
+7. **Mount the count line in every state.** `DomainCount` is a fixed-height `<p>` aligned to the right edge, so a wider number moves nothing beside it. It shows a skeleton while pending and the count when loaded. It never shows `0` before the first response, because a count that appears with the data pushes the table down.
+8. **Keep the loaded rows through a refetch.** `placeholderData: keepPreviousData` keeps the previous page while a new key loads. The wrapper sets `aria-busy` and dims, and `isRefetching` (fetching with data present) drives both. If your list filters on the client instead, run the filter in the query's `select` and pass the filter value through `useDeferredValue`. The query never re-enters pending.
+9. **Announce every state once.** One `LiveRegion` renders from the first frame and swaps its text: `Loading domains`, `Updating domains`, `Showing 8 of 1,284 domains`, and the empty and error messages. Skeleton rows are `aria-hidden`, so the region is the loading signal.
+10. **Keep errors inside the frame.** An error renders an `Empty` in `DataTable.EmptyRow` with a **Retry** button that calls `query.refetch()`. The frame, the header, and the filters stay where they are. Put the retry policy in the hook, as the [Overlays + Async Data](/recipes/overlay-async) recipe does.
+11. **Cache the page for the return trip.** A `staleTime` long enough to cover a detail-and-back navigation renders the list from cache, so the reader sees the skeleton once per session instead of once per visit.
+
+## Anti-patterns
+
+The left column is what not to do. The right column is the fix.
+
+| Don't                                                                                                                    | Do                                                                                                                                                             |
+| :----------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Return a full-page spinner while an existence check resolves. The heading and toolbar wait on a request they don't need. | Render the heading, description, and toolbar, and gate only the region below them. If a zero state replaces the whole page, gate below the heading they share. |
+| Render three skeleton rows for a twenty-row page.                                                                        | Render one skeleton row per row of the page size.                                                                                                              |
+| Mount pagination only with the loaded table.                                                                             | Render the pagination controls in every state and disable them while pending.                                                                                  |
+| Show `0 results` while the first page loads.                                                                             | Show a skeleton, or nothing, until the first response.                                                                                                         |
+| Build the skeleton from a second column list with hard-coded flags.                                                      | Pass the real table's leaf columns to the skeleton.                                                                                                            |
+| Leave the default `table-auto` layout, so columns move when text arrives.                                                | Set `table-fixed` and a width on every header but one.                                                                                                         |
+| Replace loaded rows with skeletons on a filter change.                                                                   | Keep the rows with `keepPreviousData`, or filter on the client in `select`.                                                                                    |
+| Say nothing to screen readers while the rows load.                                                                       | Mount a `LiveRegion` on the first frame and change its text per state.                                                                                         |
+
+## Other data layers
+
+The rules don't depend on TanStack Query. With React Router loaders, render the same shell with skeleton rows as the route's `HydrateFallback`, and read `useNavigation().state` for the pending state of a filter change. Never gate an `<Outlet />` on a pending request: every child route waits behind it. For a page-level loading indicator, a fixed, zero-height progress bar at the top of the viewport costs no layout at all.

--- a/apps/www/app/docs/recipes/list-page-loading-states.mdx
+++ b/apps/www/app/docs/recipes/list-page-loading-states.mdx
@@ -47,7 +47,7 @@ import {
 	useQueryClient,
 	type UseQueryResult,
 } from "@tanstack/react-query";
-import { useDeferredValue, useState } from "react";
+import { type ReactNode, useDeferredValue, useEffect, useState } from "react";
 
 const SIMULATED_API_LATENCY_MS = 1_500;
 const PAGE_SIZE = 8;
@@ -380,13 +380,15 @@ const columns = columnHelper.columns([
 		id: "name",
 		header: () => <DataTable.Header>Domain</DataTable.Header>,
 		cell: (props) => (
-			<DataTable.Cell className="text-strong truncate">{props.getValue()}</DataTable.Cell>
+			<DataTable.Cell className="text-strong truncate" translate="no">
+				{props.getValue()}
+			</DataTable.Cell>
 		),
 	}),
 	columnHelper.accessor("region", {
 		id: "region",
 		header: () => <DataTable.Header className="w-24">Region</DataTable.Header>,
-		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+		cell: (props) => <DataTable.Cell translate="no">{props.getValue()}</DataTable.Cell>,
 	}),
 	columnHelper.accessor("certificate", {
 		id: "certificate",
@@ -646,7 +648,7 @@ type FilterSelectProps = {
 	/** The selected option value. */
 	value: string;
 	/** The options, including the `"any"` option first. */
-	options: ReadonlyArray<{ value: string; label: string }>;
+	options: ReadonlyArray<{ value: string; label: ReactNode }>;
 	/** Called with the raw option value; the caller narrows it. */
 	onValueChange: (value: string) => void;
 };
@@ -677,9 +679,11 @@ function FilterSelect({ label, value, options, onValueChange }: FilterSelectProp
 	);
 }
 
+// Why translate="no": a region code is copied into a CLI flag, and a translated
+// one names the wrong region. The domain and region cells above lock it too.
 const regionOptions = [
 	{ value: "any", label: "any" },
-	...regions.map((region) => ({ value: region, label: region })),
+	...regions.map((region) => ({ value: region, label: <span translate="no">{region}</span> })),
 ];
 
 const certificateOptions = [
@@ -704,14 +708,27 @@ export function DomainsListPage({ scenario }: DomainsListPageProps) {
 	// query key follows one frame behind, so typing never waits on a render of
 	// the table.
 	const deferredSearch = useDeferredValue(filters.search);
-	const query = useDomainsQuery({ filters: { ...filters, search: deferredSearch }, scenario });
-	const state = resolveListBodyState({ query, isFiltered: hasActiveFilter(filters) });
+	// Why one filters value for the query and the empty check: the eager
+	// `filters` run a frame ahead of the deferred search. If the empty check
+	// read them, clearing a no-result search would show "No domains yet" for
+	// the frame in which the query still holds the old search.
+	const queryFilters: DomainFilters = { ...filters, search: deferredSearch };
+	const query = useDomainsQuery({ filters: queryFilters, scenario });
+	const isFiltered = hasActiveFilter(queryFilters);
+	const state = resolveListBodyState({ query, isFiltered });
+	const message = describeListState({ state, isRefetching: query.isFetching && !query.isPending });
+
+	// Why an effect: a live region announces changes, not the text it mounts
+	// with. The region mounts empty, in the server HTML too, and the first
+	// message is published after mount so a screen reader hears it.
+	const [announcement, setAnnouncement] = useState("");
+	useEffect(() => {
+		setAnnouncement(message);
+	}, [message]);
 
 	return (
 		<div className="mx-auto flex w-full max-w-6xl flex-col gap-4 p-6">
-			<LiveRegion>
-				{describeListState({ state, isRefetching: query.isFetching && !query.isPending })}
-			</LiveRegion>
+			<LiveRegion>{announcement}</LiveRegion>
 			<div className="flex flex-wrap items-start justify-between gap-4">
 				<div className="flex flex-col gap-1">
 					<h1 className="text-strong text-2xl font-medium">Domains</h1>
@@ -759,7 +776,7 @@ export function DomainsListPage({ scenario }: DomainsListPageProps) {
 			</div>
 			<DomainsTable
 				query={query}
-				isFiltered={hasActiveFilter(filters)}
+				isFiltered={isFiltered}
 				onClearFilters={() => {
 					setFilters(defaultFilters);
 				}}
@@ -844,7 +861,7 @@ Pick a scenario in the toolbar, then click **Replay load** to watch it from a co
 
 - **The first frame is the layout.** Everything above the rows is static markup. Paint it before the request resolves, and the reader gets the page's shape at once. The browser gets its largest paint without a round trip to the server.
 - **A skeleton that matches the rows moves nothing.** Cumulative Layout Shift (CLS) counts every element that moves after it paints. Skeleton rows with the same cell padding, the same row count, and bars near the real content's width mean the swap to real rows changes pixels, not positions.
-- **Fixed column widths hold from skeleton to rows.** The default `table-layout: auto` sizes every column by its content, so the header columns slide sideways the moment real text arrives. `table-fixed` plus a width on each header pins them.
+- **Column widths come from the headers, not the data.** The default `table-layout: auto` sizes every column by its widest cell. With no header widths, the columns slide sideways the moment real text arrives, and a long value on page two widens its column, moves every header after it, and pushes the table into a horizontal scroll. A width on each header holds the columns through the skeleton swap. `table-fixed` makes those widths final, so a long value truncates instead of moving the table.
 - **A refetch is not a cold load.** The reader already has rows on screen. Replacing them with skeletons throws away a working page for the length of a request. Keep them, dim them, and swap when the next page lands.
 - **Screen readers can't see a skeleton.** `Skeleton` renders `aria-hidden`, which is right: the bars carry no information. The page still has to say that it is loading, and later how many rows it shows, so a `LiveRegion` mounted from the first frame announces each state.
 
@@ -884,10 +901,10 @@ The rules below keep the code consistent with the intent above.
 3. **Build the skeleton from the real table.** `SkeletonRows` takes `table.getAllLeafColumns()` and renders one `DataTable.Cell` per column, so the skeleton can't have more or fewer columns than the loaded rows. A second column list, or a copy of the real one with different flags, drifts.
 4. **Match the row count to the page size.** Eight skeleton rows for a page of eight. Three skeleton rows for a page of twenty guarantee seventeen rows of shift. If the table registers `rowPaginationFeature`, pass `manualPagination: true` to the skeleton's table, or the row model caps the placeholder at the default page size.
 5. **Size each bar to its column.** A `Record` keyed by column id holds one class per column: a wide bar for the domain name, a pill for the badge, a right-aligned bar for the number. Bars that match the content's shape keep the row height still.
-6. **Pin the column widths.** Set `[&_table]:table-fixed` on `DataTable.Root` and a width class on every `DataTable.Header` but one. The unsized column absorbs the remaining width, and `truncate` on its cells keeps a long value on one line.
+6. **Pin the column widths.** Set a width class on every `DataTable.Header` but one, and `[&_table]:table-fixed` on `DataTable.Root`. The header widths hold from skeleton to rows on their own, as long as no cell is wider than its column. `table-fixed` covers the case where one is: under auto layout that column grows and every header after it moves, and `truncate` only clips text under fixed layout. The unsized column absorbs the remaining width.
 7. **Mount the count line in every state.** `DomainCount` is a fixed-height `<p>` aligned to the right edge, so a wider number moves nothing beside it. It shows a skeleton while pending and the count when loaded. It never shows `0` before the first response, because a count that appears with the data pushes the table down.
 8. **Keep the loaded rows through a refetch.** `placeholderData: keepPreviousData` keeps the previous page while a new key loads. The wrapper sets `aria-busy` and dims, and `isRefetching` (fetching with data present) drives both. If your list filters on the client instead, run the filter in the query's `select` and pass the filter value through `useDeferredValue`. The query never re-enters pending.
-9. **Announce every state once.** One `LiveRegion` renders from the first frame and swaps its text: `Loading domains`, `Updating domains`, `Showing 8 of 1,284 domains`, and the empty and error messages. Skeleton rows are `aria-hidden`, so the region is the loading signal.
+9. **Announce every state once.** One `LiveRegion` renders from the first frame, empty, and an effect publishes the message after mount: `Loading domains`, `Updating domains`, `Showing 8 of 1,284 domains`, and the empty and error messages. A live region announces changes, not the text it mounts with, so an empty mount is what makes the first message audible. Skeleton rows are `aria-hidden`, so the region is the loading signal.
 10. **Keep errors inside the frame.** An error renders an `Empty` in `DataTable.EmptyRow` with a **Retry** button that calls `query.refetch()`. The frame, the header, and the filters stay where they are. Put the retry policy in the hook, as the [Overlays + Async Data](/recipes/overlay-async) recipe does.
 11. **Cache the page for the return trip.** A `staleTime` long enough to cover a detail-and-back navigation renders the list from cache, so the reader sees the skeleton once per session instead of once per visit.
 
@@ -895,17 +912,17 @@ The rules below keep the code consistent with the intent above.
 
 The left column is what not to do. The right column is the fix.
 
-| Don't                                                                                                                    | Do                                                                                                                                                             |
-| :----------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Return a full-page spinner while an existence check resolves. The heading and toolbar wait on a request they don't need. | Render the heading, description, and toolbar, and gate only the region below them. If a zero state replaces the whole page, gate below the heading they share. |
-| Render three skeleton rows for a twenty-row page.                                                                        | Render one skeleton row per row of the page size.                                                                                                              |
-| Mount pagination only with the loaded table.                                                                             | Render the pagination controls in every state and disable them while pending.                                                                                  |
-| Show `0 results` while the first page loads.                                                                             | Show a skeleton, or nothing, until the first response.                                                                                                         |
-| Build the skeleton from a second column list with hard-coded flags.                                                      | Pass the real table's leaf columns to the skeleton.                                                                                                            |
-| Leave the default `table-auto` layout, so columns move when text arrives.                                                | Set `table-fixed` and a width on every header but one.                                                                                                         |
-| Replace loaded rows with skeletons on a filter change.                                                                   | Keep the rows with `keepPreviousData`, or filter on the client in `select`.                                                                                    |
-| Say nothing to screen readers while the rows load.                                                                       | Mount a `LiveRegion` on the first frame and change its text per state.                                                                                         |
+| Don't                                                                                                                     | Do                                                                                                                                                             |
+| :------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Return a full-page spinner while an existence check resolves. The heading and toolbar wait on a request they don't need.  | Render the heading, description, and toolbar, and gate only the region below them. If a zero state replaces the whole page, gate below the heading they share. |
+| Render three skeleton rows for a twenty-row page.                                                                         | Render one skeleton row per row of the page size.                                                                                                              |
+| Mount pagination only with the loaded table.                                                                              | Render the pagination controls in every state and disable them while pending.                                                                                  |
+| Show `0 results` while the first page loads.                                                                              | Show a skeleton, or nothing, until the first response.                                                                                                         |
+| Build the skeleton from a second column list with hard-coded flags.                                                       | Pass the real table's leaf columns to the skeleton.                                                                                                            |
+| Leave the default `table-auto` layout with no header widths, so the columns move when text arrives or a long value lands. | Set a width on every header but one, and `table-fixed` so a long value truncates instead of widening its column.                                               |
+| Replace loaded rows with skeletons on a filter change.                                                                    | Keep the rows with `keepPreviousData`, or filter on the client in `select`.                                                                                    |
+| Say nothing to screen readers while the rows load.                                                                        | Mount a `LiveRegion` on the first frame and change its text per state.                                                                                         |
 
 ## Other data layers
 
-The rules don't depend on TanStack Query. With React Router loaders, render the same shell with skeleton rows as the route's `HydrateFallback`, and read `useNavigation().state` for the pending state of a filter change. Never gate an `<Outlet />` on a pending request: every child route waits behind it. For a page-level loading indicator, a fixed, zero-height progress bar at the top of the viewport costs no layout at all.
+The rules don't depend on TanStack Query. With React Router, a server `loader` blocks the document until the list resolves, so the first paint has rows and no skeleton, at the cost of a slower document. To paint the shell first, keep the list out of the loader and fetch it from the component, or return the promise from the loader and render the skeleton rows as the `Suspense` fallback around `Await`. `HydrateFallback` applies only when a `clientLoader` runs during hydration; if you have one, make it the same shell with skeleton rows, never a spinner. For later navigations, read `useNavigation().state`. Never gate an `<Outlet />` on a pending request: every child route waits behind it. For a page-level loading indicator, a fixed, zero-height progress bar at the top of the viewport costs no layout at all.

--- a/apps/www/app/features/list-page-loading-demo.test.tsx
+++ b/apps/www/app/features/list-page-loading-demo.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DomainsListPage, ListPageLoadingDemo } from "./list-page-loading-demo";
 
@@ -9,11 +11,16 @@ const PAST_THE_MOCK_LATENCY_MS = 2_000;
 
 const columnHeaders = ["Domain", "Region", "Certificate", "Endpoints", "Created"];
 
+type Scenario = "success" | "no-domains" | "server-error";
+
+function createQueryClient() {
+	return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
 /** Renders the recipe page inside the QueryClientProvider it expects from the app root. */
-function renderPage(scenario: "success" | "no-domains" | "server-error" = "success") {
-	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function renderPage(scenario: Scenario = "success") {
 	return render(
-		<QueryClientProvider client={queryClient}>
+		<QueryClientProvider client={createQueryClient()}>
 			<DomainsListPage scenario={scenario} />
 		</QueryClientProvider>,
 	);
@@ -21,12 +28,16 @@ function renderPage(scenario: "success" | "no-domains" | "server-error" = "succe
 
 /** Renders the framed demo document, toolbar controls included. */
 function renderDemo() {
-	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	return render(
-		<QueryClientProvider client={queryClient}>
+		<QueryClientProvider client={createQueryClient()}>
 			<ListPageLoadingDemo />
 		</QueryClientProvider>,
 	);
+}
+
+/** A user whose inter-action waits run on the fake clock. */
+function setupUser() {
+	return userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 }
 
 /** Lets the simulated request resolve and TanStack Query publish the result. */
@@ -54,7 +65,10 @@ function countSkeletons(): number {
 }
 
 beforeEach(() => {
-	vi.useFakeTimers();
+	// Why shouldAdvanceTime: Testing Library drains user-event actions with a
+	// `setTimeout(0)` that it only advances for jest's fake timers. Under a
+	// frozen vitest clock that timer never fires, and every `user.*` call hangs.
+	vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
 afterEach(() => {
@@ -86,6 +100,30 @@ describe("DomainsListPage", () => {
 		expect(screen.getByRole("status").textContent).toBe("Loading domains");
 	});
 
+	it("serves the shell with the count skeleton inside its paragraph and an empty live region", () => {
+		const html = renderToString(
+			<QueryClientProvider client={createQueryClient()}>
+				<DomainsListPage scenario="success" />
+			</QueryClientProvider>,
+		);
+		const document = new DOMParser().parseFromString(html, "text/html");
+
+		// A `<div>` skeleton would end the paragraph in the parsed HTML, and the
+		// table below would move on hydration.
+		const countSkeleton = document.querySelector('p [data-slot="skeleton"]');
+		expect(countSkeleton?.tagName).toBe("SPAN");
+		expect(countSkeleton?.parentElement?.tagName).toBe("P");
+
+		expect(document.querySelectorAll("tbody tr")).toHaveLength(8);
+		// The region publishes its first message after mount, so the server sends it empty.
+		expect(document.querySelector('[role="status"]')?.textContent).toBe("");
+		// Radix fills an empty `Select.Value` only on the client; the text has to ship in the HTML.
+		expect(document.querySelector('[aria-label="Region"]')?.textContent).toContain("Region: any");
+		expect(document.querySelector('[aria-label="Certificate"]')?.textContent).toContain(
+			"Certificate: any",
+		);
+	});
+
 	it("swaps the skeleton rows for data rows without changing the row count", async () => {
 		renderPage();
 		await settleRequests();
@@ -105,12 +143,11 @@ describe("DomainsListPage", () => {
 	});
 
 	it("keeps the loaded rows, marked busy, while a search refetches", async () => {
+		const user = setupUser();
 		renderPage();
 		await settleRequests();
 
-		fireEvent.change(screen.getByRole("searchbox", { name: "Search domains" }), {
-			target: { value: "no-such-domain" },
-		});
+		await user.type(screen.getByRole("searchbox", { name: "Search domains" }), "no-such-domain");
 		await flushRenders();
 
 		// keepPreviousData: the rows stay, the wrapper reports busy, and no skeleton returns.
@@ -128,12 +165,50 @@ describe("DomainsListPage", () => {
 
 		// The unfiltered page is still fresh in the cache, so clearing renders it
 		// with no request and no skeleton.
-		fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+		await user.click(screen.getByRole("button", { name: "Clear filters" }));
 		await flushRenders();
 
 		expect(getBodyRows()).toHaveLength(8);
 		expect(countSkeletons()).toBe(0);
 		expect(document.querySelector('[aria-busy="true"]')).toBeNull();
+	});
+
+	// Regression: the empty check once read the eager filters while the query
+	// key followed the deferred search. Clearing a no-result search rendered a
+	// frame with no filter and the old empty page, which announced "No domains yet".
+	it("never announces the no-data state while a cleared search catches up", async () => {
+		const user = setupUser();
+		renderPage();
+		await settleRequests();
+		await user.type(screen.getByRole("searchbox", { name: "Search domains" }), "no-such-domain");
+		await settleRequests();
+
+		const status = screen.getByRole("status");
+		// Why the records, not `status.textContent`: React commits the stale frame
+		// and the corrected one inside one act() flush, so the callback runs once,
+		// after both. Each record still carries the text a commit wrote.
+		const announcements: string[] = [];
+		const observer = new MutationObserver((records) => {
+			for (const record of records) {
+				announcements.push(
+					record.oldValue ?? "",
+					...Array.from(record.addedNodes, (node) => node.textContent ?? ""),
+				);
+			}
+		});
+		observer.observe(status, {
+			childList: true,
+			characterData: true,
+			characterDataOldValue: true,
+			subtree: true,
+		});
+
+		await user.click(screen.getByRole("button", { name: "Clear filters" }));
+		await flushRenders();
+		observer.disconnect();
+
+		expect(announcements).not.toContain("No domains yet");
+		expect(status.textContent).toBe("Showing 8 of 1,284 domains");
 	});
 
 	it("shows the no-data state only after the response", async () => {
@@ -173,6 +248,7 @@ describe("DomainsListPage", () => {
 
 describe("ListPageLoadingDemo", () => {
 	it("owns the main landmark and replays the cold load from the toolbar", async () => {
+		const user = setupUser();
 		renderDemo();
 		await settleRequests();
 
@@ -180,7 +256,7 @@ describe("ListPageLoadingDemo", () => {
 		expect(screen.getByRole("combobox", { name: "Demo scenario" })).not.toBeNull();
 		expect(countSkeletons()).toBe(0);
 
-		fireEvent.click(screen.getByRole("button", { name: "Replay load" }));
+		await user.click(screen.getByRole("button", { name: "Replay load" }));
 		await flushRenders();
 
 		// resetQueries drops the cached page, so the skeleton rows return.

--- a/apps/www/app/features/list-page-loading-demo.test.tsx
+++ b/apps/www/app/features/list-page-loading-demo.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DomainsListPage, ListPageLoadingDemo } from "./list-page-loading-demo";
+
+/** Past the demo API's 1.5 second latency, so the pending request settles. */
+const PAST_THE_MOCK_LATENCY_MS = 2_000;
+
+const columnHeaders = ["Domain", "Region", "Certificate", "Endpoints", "Created"];
+
+/** Renders the recipe page inside the QueryClientProvider it expects from the app root. */
+function renderPage(scenario: "success" | "no-domains" | "server-error" = "success") {
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<DomainsListPage scenario={scenario} />
+		</QueryClientProvider>,
+	);
+}
+
+/** Renders the framed demo document, toolbar controls included. */
+function renderDemo() {
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<ListPageLoadingDemo />
+		</QueryClientProvider>,
+	);
+}
+
+/** Lets the simulated request resolve and TanStack Query publish the result. */
+async function settleRequests() {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(PAST_THE_MOCK_LATENCY_MS);
+	});
+}
+
+/** Flushes deferred renders and query notifications without reaching the response. */
+async function flushRenders() {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(0);
+	});
+}
+
+function getBodyRows(): HTMLElement[] {
+	return Array.from(document.querySelectorAll("tbody tr")).filter(
+		(row): row is HTMLElement => row instanceof HTMLElement,
+	);
+}
+
+function countSkeletons(): number {
+	return document.querySelectorAll('[data-slot="skeleton"]').length;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+});
+
+describe("DomainsListPage", () => {
+	it("renders the shell and one skeleton row per page row before the first response", () => {
+		renderPage();
+
+		expect(screen.getByRole("heading", { level: 1, name: "Domains" })).not.toBeNull();
+		expect(screen.getByRole("button", { name: "New domain" })).not.toBeNull();
+		expect(screen.getByRole("combobox", { name: "Region" })).not.toBeNull();
+		expect(screen.getByRole("combobox", { name: "Certificate" })).not.toBeNull();
+		expect(screen.getByRole("searchbox", { name: "Search domains" })).not.toBeNull();
+		for (const header of columnHeaders) {
+			expect(screen.getByRole("columnheader", { name: header })).not.toBeNull();
+		}
+
+		// Eight skeleton rows for a page of eight, one skeleton per column, plus
+		// the skeleton standing in for the count line.
+		expect(getBodyRows()).toHaveLength(8);
+		expect(countSkeletons()).toBe(8 * columnHeaders.length + 1);
+
+		// Pending wins over empty: no empty state and no `0` count before the response.
+		expect(screen.queryByText("No domains yet")).toBeNull();
+		expect(screen.queryByText(/Showing 0 of 0/)).toBeNull();
+		expect(screen.getByRole("status").textContent).toBe("Loading domains");
+	});
+
+	it("swaps the skeleton rows for data rows without changing the row count", async () => {
+		renderPage();
+		await settleRequests();
+
+		const rows = getBodyRows();
+		expect(rows).toHaveLength(8);
+		expect(countSkeletons()).toBe(0);
+		const [firstRow] = rows;
+		if (firstRow == null) {
+			throw new Error("expected a first data row");
+		}
+		expect(within(firstRow).getByText("api-1.ngrok.app")).not.toBeNull();
+
+		// The count line and the live region both carry the count.
+		expect(screen.getAllByText("Showing 8 of 1,284 domains")).toHaveLength(2);
+		expect(screen.getByRole("status").textContent).toBe("Showing 8 of 1,284 domains");
+	});
+
+	it("keeps the loaded rows, marked busy, while a search refetches", async () => {
+		renderPage();
+		await settleRequests();
+
+		fireEvent.change(screen.getByRole("searchbox", { name: "Search domains" }), {
+			target: { value: "no-such-domain" },
+		});
+		await flushRenders();
+
+		// keepPreviousData: the rows stay, the wrapper reports busy, and no skeleton returns.
+		expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+		expect(getBodyRows()).toHaveLength(8);
+		expect(countSkeletons()).toBe(0);
+		expect(screen.getByRole("status").textContent).toBe("Updating domains");
+
+		await settleRequests();
+
+		const table = screen.getByRole("table");
+		expect(within(table).getByText("No domains match the filters")).not.toBeNull();
+		expect(document.querySelector('[aria-busy="true"]')).toBeNull();
+		expect(screen.getByRole("status").textContent).toBe("No domains match the filters");
+
+		// The unfiltered page is still fresh in the cache, so clearing renders it
+		// with no request and no skeleton.
+		fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+		await flushRenders();
+
+		expect(getBodyRows()).toHaveLength(8);
+		expect(countSkeletons()).toBe(0);
+		expect(document.querySelector('[aria-busy="true"]')).toBeNull();
+	});
+
+	it("shows the no-data state only after the response", async () => {
+		renderPage("no-domains");
+
+		expect(screen.queryByText("No domains yet")).toBeNull();
+		expect(getBodyRows()).toHaveLength(8);
+
+		await settleRequests();
+
+		const table = screen.getByRole("table");
+		expect(within(table).getByText("No domains yet")).not.toBeNull();
+		expect(within(table).getByRole("button", { name: "New domain" })).not.toBeNull();
+		expect(screen.getByRole("status").textContent).toBe("No domains yet");
+		expect(screen.getAllByText("Showing 0 of 0 domains")).toHaveLength(1);
+	});
+
+	it("renders the request failure inside the table frame with a retry action", async () => {
+		renderPage("server-error");
+		await settleRequests();
+
+		const table = screen.getByRole("table");
+		expect(within(table).getByText("Domains failed to load")).not.toBeNull();
+		expect(
+			within(table).getByText("The domains service returned 503 Service Unavailable."),
+		).not.toBeNull();
+		expect(within(table).getByRole("button", { name: "Retry" })).not.toBeNull();
+		expect(screen.getByRole("status").textContent).toBe("Domains failed to load");
+
+		// The shell never left: the column headers and the filters are still in place.
+		for (const header of columnHeaders) {
+			expect(screen.getByRole("columnheader", { name: header })).not.toBeNull();
+		}
+		expect(screen.getByRole("combobox", { name: "Region" })).not.toBeNull();
+	});
+});
+
+describe("ListPageLoadingDemo", () => {
+	it("owns the main landmark and replays the cold load from the toolbar", async () => {
+		renderDemo();
+		await settleRequests();
+
+		expect(screen.getByRole("main")).not.toBeNull();
+		expect(screen.getByRole("combobox", { name: "Demo scenario" })).not.toBeNull();
+		expect(countSkeletons()).toBe(0);
+
+		fireEvent.click(screen.getByRole("button", { name: "Replay load" }));
+		await flushRenders();
+
+		// resetQueries drops the cached page, so the skeleton rows return.
+		expect(countSkeletons()).toBe(8 * columnHeaders.length + 1);
+		expect(screen.getByRole("status").textContent).toBe("Loading domains");
+	});
+});

--- a/apps/www/app/features/list-page-loading-demo.tsx
+++ b/apps/www/app/features/list-page-loading-demo.tsx
@@ -26,7 +26,7 @@ import {
 	useQueryClient,
 	type UseQueryResult,
 } from "@tanstack/react-query";
-import { useDeferredValue, useState } from "react";
+import { type ReactNode, useDeferredValue, useEffect, useState } from "react";
 
 const SIMULATED_API_LATENCY_MS = 1_500;
 const PAGE_SIZE = 8;
@@ -359,13 +359,15 @@ const columns = columnHelper.columns([
 		id: "name",
 		header: () => <DataTable.Header>Domain</DataTable.Header>,
 		cell: (props) => (
-			<DataTable.Cell className="text-strong truncate">{props.getValue()}</DataTable.Cell>
+			<DataTable.Cell className="text-strong truncate" translate="no">
+				{props.getValue()}
+			</DataTable.Cell>
 		),
 	}),
 	columnHelper.accessor("region", {
 		id: "region",
 		header: () => <DataTable.Header className="w-24">Region</DataTable.Header>,
-		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+		cell: (props) => <DataTable.Cell translate="no">{props.getValue()}</DataTable.Cell>,
 	}),
 	columnHelper.accessor("certificate", {
 		id: "certificate",
@@ -625,7 +627,7 @@ type FilterSelectProps = {
 	/** The selected option value. */
 	value: string;
 	/** The options, including the `"any"` option first. */
-	options: ReadonlyArray<{ value: string; label: string }>;
+	options: ReadonlyArray<{ value: string; label: ReactNode }>;
 	/** Called with the raw option value; the caller narrows it. */
 	onValueChange: (value: string) => void;
 };
@@ -656,9 +658,11 @@ function FilterSelect({ label, value, options, onValueChange }: FilterSelectProp
 	);
 }
 
+// Why translate="no": a region code is copied into a CLI flag, and a translated
+// one names the wrong region. The domain and region cells above lock it too.
 const regionOptions = [
 	{ value: "any", label: "any" },
-	...regions.map((region) => ({ value: region, label: region })),
+	...regions.map((region) => ({ value: region, label: <span translate="no">{region}</span> })),
 ];
 
 const certificateOptions = [
@@ -683,14 +687,27 @@ export function DomainsListPage({ scenario }: DomainsListPageProps) {
 	// query key follows one frame behind, so typing never waits on a render of
 	// the table.
 	const deferredSearch = useDeferredValue(filters.search);
-	const query = useDomainsQuery({ filters: { ...filters, search: deferredSearch }, scenario });
-	const state = resolveListBodyState({ query, isFiltered: hasActiveFilter(filters) });
+	// Why one filters value for the query and the empty check: the eager
+	// `filters` run a frame ahead of the deferred search. If the empty check
+	// read them, clearing a no-result search would show "No domains yet" for
+	// the frame in which the query still holds the old search.
+	const queryFilters: DomainFilters = { ...filters, search: deferredSearch };
+	const query = useDomainsQuery({ filters: queryFilters, scenario });
+	const isFiltered = hasActiveFilter(queryFilters);
+	const state = resolveListBodyState({ query, isFiltered });
+	const message = describeListState({ state, isRefetching: query.isFetching && !query.isPending });
+
+	// Why an effect: a live region announces changes, not the text it mounts
+	// with. The region mounts empty, in the server HTML too, and the first
+	// message is published after mount so a screen reader hears it.
+	const [announcement, setAnnouncement] = useState("");
+	useEffect(() => {
+		setAnnouncement(message);
+	}, [message]);
 
 	return (
 		<div className="mx-auto flex w-full max-w-6xl flex-col gap-4 p-6">
-			<LiveRegion>
-				{describeListState({ state, isRefetching: query.isFetching && !query.isPending })}
-			</LiveRegion>
+			<LiveRegion>{announcement}</LiveRegion>
 			<div className="flex flex-wrap items-start justify-between gap-4">
 				<div className="flex flex-col gap-1">
 					<h1 className="text-strong text-2xl font-medium">Domains</h1>
@@ -738,7 +755,7 @@ export function DomainsListPage({ scenario }: DomainsListPageProps) {
 			</div>
 			<DomainsTable
 				query={query}
-				isFiltered={hasActiveFilter(filters)}
+				isFiltered={isFiltered}
 				onClearFilters={() => {
 					setFilters(defaultFilters);
 				}}

--- a/apps/www/app/features/list-page-loading-demo.tsx
+++ b/apps/www/app/features/list-page-loading-demo.tsx
@@ -1,0 +1,813 @@
+import { AppLayout } from "@ngrok/mantle/app-layout";
+import { Badge } from "@ngrok/mantle/badge";
+import { Button } from "@ngrok/mantle/button";
+import { cx } from "@ngrok/mantle/cx";
+import {
+	DataTable,
+	type Row,
+	createColumnHelper,
+	tableFeatures,
+	useTable,
+} from "@ngrok/mantle/data-table";
+import { Empty } from "@ngrok/mantle/empty";
+import { Input } from "@ngrok/mantle/input";
+import { LiveRegion } from "@ngrok/mantle/live-region";
+import { Main } from "@ngrok/mantle/main";
+import { Select } from "@ngrok/mantle/select";
+import { Skeleton } from "@ngrok/mantle/skeleton";
+import { SkipToMainLink } from "@ngrok/mantle/skip-to-main-link";
+import { Table } from "@ngrok/mantle/table";
+import { GlobeHemisphereWestIcon } from "@phosphor-icons/react/GlobeHemisphereWest";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react/MagnifyingGlass";
+import { WarningCircleIcon } from "@phosphor-icons/react/WarningCircle";
+import {
+	keepPreviousData,
+	useQuery,
+	useQueryClient,
+	type UseQueryResult,
+} from "@tanstack/react-query";
+import { useDeferredValue, useState } from "react";
+
+const SIMULATED_API_LATENCY_MS = 1_500;
+const PAGE_SIZE = 8;
+const DEMO_DOMAIN_COUNT = 1_284;
+const DOMAINS_QUERY_KEY_ROOT = ["list-page-loading-domains"];
+
+const regions = ["us", "eu", "ap", "au", "jp", "in", "sa"] as const;
+
+/** An ngrok region code. */
+type Region = (typeof regions)[number];
+
+const certificateKinds = ["managed", "custom"] as const;
+
+/** Who issues and renews the domain's TLS certificate. */
+type CertificateKind = (typeof certificateKinds)[number];
+
+const certificateLabels: Record<CertificateKind, string> = {
+	managed: "Managed",
+	custom: "Custom",
+};
+
+/** One reserved domain, as the demo API returns it. */
+type Domain = {
+	/** Stable identifier from the backend. */
+	id: string;
+	/** The fully qualified domain name. */
+	name: string;
+	/** The region the domain is reserved in. */
+	region: Region;
+	/** Who manages the certificate. */
+	certificate: CertificateKind;
+	/** How many endpoints are online on the domain right now. */
+	endpointCount: number;
+	/** ISO date string for when the domain was reserved. */
+	createdAt: string;
+};
+
+/** The active list filters. `"any"` leaves that dimension unfiltered. */
+type DomainFilters = {
+	region: Region | "any";
+	certificate: CertificateKind | "any";
+	search: string;
+};
+
+const defaultFilters: DomainFilters = { region: "any", certificate: "any", search: "" };
+
+/** One page of the list, plus the total the filters match. */
+type DomainsPage = {
+	items: Domain[];
+	total: number;
+};
+
+/** Which response the demo API returns. */
+type DomainsScenario = "success" | "no-domains" | "server-error";
+
+const domainsScenarios = [
+	"success",
+	"no-domains",
+	"server-error",
+] as const satisfies ReadonlyArray<DomainsScenario>;
+
+const scenarioLabels: Record<DomainsScenario, string> = {
+	success: "Scenario: loaded",
+	"no-domains": "Scenario: no domains",
+	"server-error": "Scenario: request fails",
+};
+
+/** Narrows a raw select value to a known demo scenario. */
+function isDomainsScenario(value: string): value is DomainsScenario {
+	return domainsScenarios.some((scenario) => scenario === value);
+}
+
+/** Narrows a raw select value to a region filter. */
+function isRegionFilter(value: string): value is DomainFilters["region"] {
+	return value === "any" || regions.some((region) => region === value);
+}
+
+/** Narrows a raw select value to a certificate filter. */
+function isCertificateFilter(value: string): value is DomainFilters["certificate"] {
+	return value === "any" || certificateKinds.some((kind) => kind === value);
+}
+
+/** Whether any filter narrows the list, so an empty page reads as "no results" and not "no data". */
+function hasActiveFilter(filters: DomainFilters): boolean {
+	return filters.region !== "any" || filters.certificate !== "any" || filters.search.trim() !== "";
+}
+
+// The mock API below stands in for your API client. Keep the shape it returns
+// (a page plus a total) and the `signal` it accepts; replace everything else.
+
+const nameStems = [
+	"api",
+	"app",
+	"shop",
+	"auth",
+	"billing",
+	"docs",
+	"webhooks",
+	"staging",
+	"preview",
+	"admin",
+] as const;
+const nameSuffixes = ["ngrok.app", "ngrok.dev", "acme-labs.example", "example.com"] as const;
+const NEWEST_CREATED_AT = Date.UTC(2026, 8, 11);
+const DAY_MS = 86_400_000;
+
+/** Reads `items[index]` with wraparound. Throws on an empty list, because a demo with no data to cycle through is a bug. */
+function cycle<T>(items: ReadonlyArray<T>, index: number): T {
+	const item = items[index % items.length];
+	if (item == null) {
+		throw new Error("cycle() needs a non-empty list");
+	}
+	return item;
+}
+
+/** Builds the fixed dataset once. Every field derives from the index, so the list is the same on every load. */
+function createDemoDomains(): Domain[] {
+	return Array.from({ length: DEMO_DOMAIN_COUNT }, (_, index) => {
+		const stem = cycle(nameStems, index);
+		const suffix = cycle(nameSuffixes, Math.floor(index / nameStems.length));
+		return {
+			id: `rd_${(index + 1).toString().padStart(4, "0")}`,
+			name: `${stem}-${index + 1}.${suffix}`,
+			region: cycle(regions, index * 3),
+			certificate: index % 5 === 0 ? "custom" : "managed",
+			endpointCount: (index * 7) % 4,
+			createdAt: new Date(NEWEST_CREATED_AT - index * DAY_MS).toISOString(),
+		};
+	});
+}
+
+const demoDomains = createDemoDomains();
+
+/** Whether a domain passes every active filter. */
+function matchesFilters(domain: Domain, filters: DomainFilters): boolean {
+	if (filters.region !== "any" && domain.region !== filters.region) {
+		return false;
+	}
+	if (filters.certificate !== "any" && domain.certificate !== filters.certificate) {
+		return false;
+	}
+	const search = filters.search.trim().toLowerCase();
+	return search === "" || domain.name.includes(search);
+}
+
+/** Waits for the simulated network, and rejects when TanStack Query aborts the request. */
+function waitForDemoApi(signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("The domains request was aborted.", "AbortError"));
+			return;
+		}
+
+		const timeoutId = setTimeout(() => {
+			signal?.removeEventListener("abort", handleAbort);
+			resolve();
+		}, SIMULATED_API_LATENCY_MS);
+
+		/** Cancels the simulated delay when the query unmounts or its key changes. */
+		function handleAbort() {
+			clearTimeout(timeoutId);
+			reject(new DOMException("The domains request was aborted.", "AbortError"));
+		}
+
+		signal?.addEventListener("abort", handleAbort, { once: true });
+	});
+}
+
+/** Options accepted by the simulated domains fetcher. */
+type FetchDomainsOptions = {
+	/** The filters to apply server-side. */
+	filters: DomainFilters;
+	/** Which response to simulate. */
+	scenario: DomainsScenario;
+	/** Abort signal passed by TanStack Query. */
+	signal?: AbortSignal;
+};
+
+/** Simulates a paged list endpoint: latency, server-side filters, a total, and a failure mode. */
+async function fetchDomains({
+	filters,
+	scenario,
+	signal,
+}: FetchDomainsOptions): Promise<DomainsPage> {
+	await waitForDemoApi(signal);
+
+	if (scenario === "server-error") {
+		throw new Error("The domains service returned 503 Service Unavailable.");
+	}
+
+	if (scenario === "no-domains") {
+		return { items: [], total: 0 };
+	}
+
+	const matches = demoDomains.filter((domain) => matchesFilters(domain, filters));
+	return { items: matches.slice(0, PAGE_SIZE), total: matches.length };
+}
+
+/** Options for the domains list query. */
+type UseDomainsQueryOptions = {
+	/** The filters the server applies. Each distinct set is its own cache entry. */
+	filters: DomainFilters;
+	/** Demo scenario selected in the toolbar. */
+	scenario: DomainsScenario;
+};
+
+/** Owns fetching, caching, and the previous-page policy for the domains list. */
+function useDomainsQuery({
+	filters,
+	scenario,
+}: UseDomainsQueryOptions): UseQueryResult<DomainsPage, Error> {
+	return useQuery({
+		queryKey: [...DOMAINS_QUERY_KEY_ROOT, scenario, filters],
+		queryFn: ({ signal }) => fetchDomains({ filters, scenario, signal }),
+		// Why keepPreviousData: a filter change swaps the query key. Without it
+		// the table falls back to skeleton rows on every keystroke. With it the
+		// loaded rows stay on screen, dimmed, until the next page lands.
+		placeholderData: keepPreviousData,
+		// Why no retry: the demo's failure is deterministic, so a retry only adds
+		// latency. A real list encodes its retry policy here, as the
+		// overlay-async recipe does.
+		retry: false,
+		// Why staleTime: a return visit within 30 seconds renders from the cache,
+		// so the reader never sees the skeleton twice.
+		staleTime: 30_000,
+	});
+}
+
+/** The one region of the table body that renders. */
+type ListBodyState =
+	| { kind: "pending" }
+	| { kind: "error"; error: Error }
+	| { kind: "no-data" }
+	| { kind: "no-results" }
+	| { kind: "rows"; items: Domain[]; total: number };
+
+/** Options for deriving the table body state. */
+type ResolveListBodyStateOptions = {
+	/** The domains list query. */
+	query: UseQueryResult<DomainsPage, Error>;
+	/** Whether a filter narrows the list. */
+	isFiltered: boolean;
+};
+
+/**
+ * Derives the table body state from the query. Pending wins over empty, so
+ * "no results" never flashes before the first response lands.
+ */
+function resolveListBodyState({ query, isFiltered }: ResolveListBodyStateOptions): ListBodyState {
+	switch (query.status) {
+		case "pending": {
+			return { kind: "pending" };
+		}
+		case "error": {
+			return { kind: "error", error: query.error };
+		}
+		case "success": {
+			const { items, total } = query.data;
+			if (items.length > 0) {
+				return { kind: "rows", items, total };
+			}
+			return { kind: isFiltered ? "no-results" : "no-data" };
+		}
+	}
+}
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+/** Options for the count line. */
+type FormatDomainCountOptions = {
+	/** How many rows the page shows. */
+	shown: number;
+	/** How many domains match the filters. */
+	total: number;
+};
+
+/** Formats the count line: `Showing 8 of 1,284 domains`. */
+function formatDomainCount({ shown, total }: FormatDomainCountOptions): string {
+	return `Showing ${numberFormat.format(shown)} of ${numberFormat.format(total)} domains`;
+}
+
+/** Options for the live-region message. */
+type DescribeListStateOptions = {
+	/** The table body state. */
+	state: ListBodyState;
+	/** Whether a refetch is in flight behind loaded rows. */
+	isRefetching: boolean;
+};
+
+/**
+ * The live-region message for a list state. The skeleton rows are
+ * `aria-hidden`, so this message is the only loading signal a screen reader
+ * gets.
+ */
+function describeListState({ state, isRefetching }: DescribeListStateOptions): string {
+	if (isRefetching) {
+		return "Updating domains";
+	}
+	switch (state.kind) {
+		case "pending": {
+			return "Loading domains";
+		}
+		case "error": {
+			return "Domains failed to load";
+		}
+		case "no-data": {
+			return "No domains yet";
+		}
+		case "no-results": {
+			return "No domains match the filters";
+		}
+		case "rows": {
+			return formatDomainCount({ shown: state.items.length, total: state.total });
+		}
+	}
+}
+
+const dateFormat = new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeZone: "UTC" });
+
+// The list is sorted and filtered on the server, so the table registers no
+// client-side features.
+const features = tableFeatures({});
+const columnHelper = createColumnHelper<typeof features, Domain>();
+
+// Every column but the first names its width. With `table-fixed` on the
+// table, those widths hold from the skeleton rows through the loaded rows, and
+// the first column absorbs whatever is left.
+const columns = columnHelper.columns([
+	columnHelper.accessor("name", {
+		id: "name",
+		header: () => <DataTable.Header>Domain</DataTable.Header>,
+		cell: (props) => (
+			<DataTable.Cell className="text-strong truncate">{props.getValue()}</DataTable.Cell>
+		),
+	}),
+	columnHelper.accessor("region", {
+		id: "region",
+		header: () => <DataTable.Header className="w-24">Region</DataTable.Header>,
+		cell: (props) => <DataTable.Cell>{props.getValue()}</DataTable.Cell>,
+	}),
+	columnHelper.accessor("certificate", {
+		id: "certificate",
+		header: () => <DataTable.Header className="w-36">Certificate</DataTable.Header>,
+		cell: (props) => (
+			<DataTable.Cell>
+				<Badge appearance="muted" color={props.getValue() === "managed" ? "success" : "neutral"}>
+					{certificateLabels[props.getValue()]}
+				</Badge>
+			</DataTable.Cell>
+		),
+	}),
+	columnHelper.accessor("endpointCount", {
+		id: "endpointCount",
+		header: () => <DataTable.Header className="w-28 text-right">Endpoints</DataTable.Header>,
+		cell: (props) => <DataTable.Cell className="text-right">{props.getValue()}</DataTable.Cell>,
+	}),
+	columnHelper.accessor("createdAt", {
+		id: "createdAt",
+		header: () => <DataTable.Header className="w-36">Created</DataTable.Header>,
+		cell: (props) => (
+			<DataTable.Cell>{dateFormat.format(new Date(props.getValue()))}</DataTable.Cell>
+		),
+	}),
+]);
+
+/**
+ * The skeleton bar for each column id, sized to the content it stands in for.
+ * A bar near the real content's width keeps the row height and the column
+ * widths still when the rows swap in.
+ */
+const skeletonCellClassNames: Record<string, string> = {
+	name: "w-3/4",
+	region: "w-6",
+	certificate: "h-5 w-20 rounded-full",
+	endpointCount: "ml-auto w-6",
+	createdAt: "w-28",
+};
+
+/** Why a module constant: `useTable` compares `data` by reference, so a fresh `[]` per render would reset the row model. */
+const noDomains: Domain[] = [];
+
+/** Props for the skeleton rows. */
+type SkeletonRowsProps = {
+	/** The table's leaf columns, so the skeleton has one cell per real column. */
+	columns: ReadonlyArray<{ id: string }>;
+	/** How many rows to render. Match it to the page size. */
+	count: number;
+};
+
+/**
+ * Placeholder rows with one skeleton per column. They use the same cell part
+ * as the loaded rows, so padding and row height match, and they derive from
+ * the same column list, so the column count cannot drift.
+ */
+function SkeletonRows({ columns, count }: SkeletonRowsProps) {
+	return Array.from({ length: count }, (_, index) => (
+		// Why aria-hidden: the rows carry no information. The page's LiveRegion
+		// announces the loading state instead.
+		<Table.Row key={index} aria-hidden>
+			{columns.map((column) => (
+				<DataTable.Cell key={column.id}>
+					<Skeleton className={cx("h-4", skeletonCellClassNames[column.id] ?? "w-24")} />
+				</DataTable.Cell>
+			))}
+		</Table.Row>
+	));
+}
+
+/** Props for the table body. */
+type DomainsTableBodyProps = {
+	/** The derived body state. */
+	state: ListBodyState;
+	/** The rows TanStack Table built from the loaded page. */
+	rows: ReadonlyArray<Row<typeof features, Domain>>;
+	/** The table's leaf columns, for the skeleton rows. */
+	columns: ReadonlyArray<{ id: string }>;
+	/** Whether the retry request is in flight. */
+	isRetrying: boolean;
+	/** Refetches the current page after an error. */
+	onRetry: () => void;
+	/** Resets every filter to its default. */
+	onClearFilters: () => void;
+};
+
+/** Renders exactly one of the five body states inside the table frame. */
+function DomainsTableBody({
+	state,
+	rows,
+	columns,
+	isRetrying,
+	onRetry,
+	onClearFilters,
+}: DomainsTableBodyProps) {
+	switch (state.kind) {
+		case "pending": {
+			return <SkeletonRows columns={columns} count={PAGE_SIZE} />;
+		}
+		case "rows": {
+			return rows.map((row) => <DataTable.Row key={row.id} row={row} />);
+		}
+		case "error": {
+			return (
+				<DataTable.EmptyRow>
+					<Empty.Root>
+						<Empty.Icon svg={<WarningCircleIcon />} />
+						<Empty.Title>Domains failed to load</Empty.Title>
+						<Empty.Description>
+							<p>{state.error.message}</p>
+						</Empty.Description>
+						<Empty.Actions>
+							<Button
+								type="button"
+								appearance="outlined"
+								intent="neutral"
+								isLoading={isRetrying}
+								onClick={onRetry}
+							>
+								Retry
+							</Button>
+						</Empty.Actions>
+					</Empty.Root>
+				</DataTable.EmptyRow>
+			);
+		}
+		case "no-results": {
+			return (
+				<DataTable.EmptyRow>
+					<Empty.Root>
+						<Empty.Icon svg={<MagnifyingGlassIcon />} />
+						<Empty.Title>No domains match the filters</Empty.Title>
+						<Empty.Description>
+							<p>Try a different search, or clear the filters to see every domain.</p>
+						</Empty.Description>
+						<Empty.Actions>
+							<Button type="button" appearance="outlined" intent="neutral" onClick={onClearFilters}>
+								Clear filters
+							</Button>
+						</Empty.Actions>
+					</Empty.Root>
+				</DataTable.EmptyRow>
+			);
+		}
+		case "no-data": {
+			return (
+				<DataTable.EmptyRow>
+					<Empty.Root>
+						<Empty.Icon svg={<GlobeHemisphereWestIcon />} />
+						<Empty.Title>No domains yet</Empty.Title>
+						<Empty.Description>
+							<p>Reserve a domain to route public traffic to an endpoint.</p>
+						</Empty.Description>
+						<Empty.Actions>
+							<Button type="button" appearance="outlined" intent="neutral">
+								New domain
+							</Button>
+						</Empty.Actions>
+					</Empty.Root>
+				</DataTable.EmptyRow>
+			);
+		}
+	}
+}
+
+/** Props for the count line. */
+type DomainCountProps = {
+	/** The derived body state. */
+	state: ListBodyState;
+};
+
+/** The text of the count line, or a skeleton while the first page loads. */
+function DomainCountText({ state }: DomainCountProps) {
+	switch (state.kind) {
+		case "pending": {
+			// Why asChild: a `<div>` inside a `<p>` splits the paragraph in the
+			// server-rendered HTML, and the table below moves on hydration.
+			return (
+				<Skeleton asChild className="h-3 w-44">
+					<span />
+				</Skeleton>
+			);
+		}
+		case "error": {
+			return null;
+		}
+		case "no-data":
+		case "no-results": {
+			return formatDomainCount({ shown: 0, total: 0 });
+		}
+		case "rows": {
+			return formatDomainCount({ shown: state.items.length, total: state.total });
+		}
+	}
+}
+
+/**
+ * The count line above the table. It is mounted in every state at a fixed
+ * height and aligned to the right edge, so the table never moves when the
+ * count arrives and a wider number moves nothing beside it. It never reads
+ * `0` while the first page is still loading.
+ */
+function DomainCount({ state }: DomainCountProps) {
+	return (
+		<p className="text-muted flex h-5 items-center justify-end text-sm">
+			<DomainCountText state={state} />
+		</p>
+	);
+}
+
+/** Props for the domains table. */
+type DomainsTableProps = {
+	/** The domains list query. */
+	query: UseQueryResult<DomainsPage, Error>;
+	/** Whether a filter narrows the list. */
+	isFiltered: boolean;
+	/** Resets every filter to its default. */
+	onClearFilters: () => void;
+};
+
+/** The table frame: the header renders from the column list on the first frame, and only the body branches. */
+function DomainsTable({ query, isFiltered, onClearFilters }: DomainsTableProps) {
+	const table = useTable({ features, data: query.data?.items ?? noDomains, columns });
+	const state = resolveListBodyState({ query, isFiltered });
+	const isRefetching = query.isFetching && !query.isPending;
+
+	return (
+		<div className="flex flex-col gap-2">
+			<DomainCount state={state} />
+			{/* Why aria-busy: a refetch behind loaded rows dims the table instead of
+			    replacing it, and the attribute tells assistive tech the region is
+			    updating. */}
+			<div aria-busy={isRefetching} className="transition-opacity aria-busy:opacity-60">
+				<DataTable.Root table={table} className="[&_table]:table-fixed">
+					<DataTable.Head />
+					<DataTable.Body>
+						<DomainsTableBody
+							state={state}
+							rows={table.getRowModel().rows}
+							columns={table.getAllLeafColumns()}
+							isRetrying={query.isFetching}
+							onRetry={() => {
+								void query.refetch();
+							}}
+							onClearFilters={onClearFilters}
+						/>
+					</DataTable.Body>
+				</DataTable.Root>
+			</div>
+		</div>
+	);
+}
+
+/** Props for a filter select. */
+type FilterSelectProps = {
+	/** The dimension the select filters, used as the accessible name and the option prefix. */
+	label: string;
+	/** The selected option value. */
+	value: string;
+	/** The options, including the `"any"` option first. */
+	options: ReadonlyArray<{ value: string; label: string }>;
+	/** Called with the raw option value; the caller narrows it. */
+	onValueChange: (value: string) => void;
+};
+
+/** A fixed-width filter, so a label change (`Region: any` to `Region: eu`) moves no sibling. */
+function FilterSelect({ label, value, options, onValueChange }: FilterSelectProps) {
+	const selected = options.find((option) => option.value === value);
+
+	return (
+		<Select.Root value={value} onValueChange={onValueChange}>
+			<Select.Trigger className="w-44" aria-label={label}>
+				{/* Why children: Radix fills an empty `Select.Value` from the mounted
+				    items, which the server never renders. Explicit text puts the
+				    label in the server HTML, so the trigger is not blank on the
+				    first frame. */}
+				<Select.Value>
+					{label}: {selected?.label}
+				</Select.Value>
+			</Select.Trigger>
+			<Select.Content width="trigger">
+				{options.map((option) => (
+					<Select.Item key={option.value} value={option.value}>
+						{label}: {option.label}
+					</Select.Item>
+				))}
+			</Select.Content>
+		</Select.Root>
+	);
+}
+
+const regionOptions = [
+	{ value: "any", label: "any" },
+	...regions.map((region) => ({ value: region, label: region })),
+];
+
+const certificateOptions = [
+	{ value: "any", label: "any" },
+	...certificateKinds.map((kind) => ({ value: kind, label: certificateLabels[kind] })),
+];
+
+/** Props for the list page. */
+type DomainsListPageProps = {
+	/** Demo scenario selected in the toolbar. */
+	scenario: DomainsScenario;
+};
+
+/**
+ * The recipe. The heading, description, primary action, filters, and column
+ * headers render on the first frame. Only the count line and the table body
+ * read the query.
+ */
+export function DomainsListPage({ scenario }: DomainsListPageProps) {
+	const [filters, setFilters] = useState(defaultFilters);
+	// Why useDeferredValue: the search box updates on every keystroke, and the
+	// query key follows one frame behind, so typing never waits on a render of
+	// the table.
+	const deferredSearch = useDeferredValue(filters.search);
+	const query = useDomainsQuery({ filters: { ...filters, search: deferredSearch }, scenario });
+	const state = resolveListBodyState({ query, isFiltered: hasActiveFilter(filters) });
+
+	return (
+		<div className="mx-auto flex w-full max-w-6xl flex-col gap-4 p-6">
+			<LiveRegion>
+				{describeListState({ state, isRefetching: query.isFetching && !query.isPending })}
+			</LiveRegion>
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<h1 className="text-strong text-2xl font-medium">Domains</h1>
+					<p className="text-muted text-sm">
+						Reserved domains route public traffic to your endpoints. Reserve one per region you
+						serve from.
+					</p>
+				</div>
+				<Button type="button" appearance="filled" intent="accent">
+					New domain
+				</Button>
+			</div>
+			<div className="flex flex-wrap items-center gap-2">
+				<FilterSelect
+					label="Region"
+					value={filters.region}
+					options={regionOptions}
+					onValueChange={(value) => {
+						if (isRegionFilter(value)) {
+							setFilters((current) => ({ ...current, region: value }));
+						}
+					}}
+				/>
+				<FilterSelect
+					label="Certificate"
+					value={filters.certificate}
+					options={certificateOptions}
+					onValueChange={(value) => {
+						if (isCertificateFilter(value)) {
+							setFilters((current) => ({ ...current, certificate: value }));
+						}
+					}}
+				/>
+				<Input
+					type="search"
+					aria-label="Search domains"
+					placeholder="Search domains…"
+					className="min-w-64 flex-1"
+					value={filters.search}
+					onChange={(event) => {
+						const search = event.target.value;
+						setFilters((current) => ({ ...current, search }));
+					}}
+				/>
+			</div>
+			<DomainsTable
+				query={query}
+				isFiltered={hasActiveFilter(filters)}
+				onClearFilters={() => {
+					setFilters(defaultFilters);
+				}}
+			/>
+		</div>
+	);
+}
+
+/**
+ * The framed preview: the domains list page inside an app shell, with
+ * demo-only controls in the toolbar to pick the response and replay the
+ * cold load. Renders as an entire framed-preview document (see
+ * preview-registry.ts), so it pins itself with `fixed inset-0` and owns the
+ * `Main` landmark.
+ */
+export function ListPageLoadingDemo() {
+	const [scenario, setScenario] = useState<DomainsScenario>("success");
+	const queryClient = useQueryClient();
+
+	/** Demo-only: resets every cached page, so the next render shows the cold load again. */
+	const replay = () => {
+		void queryClient.resetQueries({ queryKey: DOMAINS_QUERY_KEY_ROOT });
+	};
+
+	return (
+		<AppLayout.Root className="fixed inset-0">
+			<SkipToMainLink />
+			<AppLayout.Workspace>
+				<AppLayout.Content>
+					<AppLayout.Header>
+						<p className="text-strong text-sm font-medium">Domains</p>
+						<div className="ml-auto flex items-center gap-2">
+							<Select.Root
+								value={scenario}
+								onValueChange={(value) => {
+									if (isDomainsScenario(value)) {
+										setScenario(value);
+									}
+								}}
+							>
+								<Select.Trigger className="w-52" aria-label="Demo scenario">
+									<Select.Value>{scenarioLabels[scenario]}</Select.Value>
+								</Select.Trigger>
+								<Select.Content width="trigger">
+									{domainsScenarios.map((value) => (
+										<Select.Item key={value} value={value}>
+											{scenarioLabels[value]}
+										</Select.Item>
+									))}
+								</Select.Content>
+							</Select.Root>
+							<Button
+								type="button"
+								appearance="outlined"
+								intent="neutral"
+								size="sm"
+								onClick={replay}
+							>
+								Replay load
+							</Button>
+						</div>
+					</AppLayout.Header>
+					<AppLayout.Body asChild>
+						<Main>
+							<DomainsListPage scenario={scenario} />
+						</Main>
+					</AppLayout.Body>
+				</AppLayout.Content>
+			</AppLayout.Workspace>
+		</AppLayout.Root>
+	);
+}

--- a/apps/www/app/features/list-page-loading-fences.test.ts
+++ b/apps/www/app/features/list-page-loading-fences.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The recipe page promises its fence is drop-in: copy the file, it runs. That
+ * only stays true if the fence and the demo module cannot drift, so this
+ * asserts the fence is byte-identical to the file the framed preview renders.
+ *
+ * If this fails, the fix is to re-copy the file into the fence, never to loosen
+ * the assertion. A recipe whose code does not run is worse than no recipe.
+ */
+const RECIPE = "app/docs/recipes/list-page-loading-states.mdx";
+
+const FENCED_FILES = ["app/features/list-page-loading-demo.tsx"] as const;
+
+/** This file's own location, two directories below the app root. */
+const APP_ROOT = new URL("../../", import.meta.url);
+
+/**
+ * Reads a path written relative to the app root. The paths above stay
+ * app-relative because they are the names the recipe page itself uses and the
+ * names that read best in test output, but they are resolved against this
+ * module's own URL rather than the process's working directory, which is not
+ * the app root under every runner and IDE.
+ */
+function readFromAppRoot(path: string): string {
+	return readFileSync(fileURLToPath(new URL(path, APP_ROOT)), "utf8");
+}
+
+/**
+ * Extracts every fenced `ts`/`tsx` block, allowing any fence length: a block
+ * whose own content contains a ``` fence must be delimited by a longer run, and
+ * oxfmt normalizes those to four backticks.
+ */
+function fencedBlocks(markdown: string): ReadonlyArray<string> {
+	const blocks: Array<string> = [];
+	const pattern = /^(`{3,})(?:ts|tsx)\n([\s\S]*?)^\1$/gm;
+	let match = pattern.exec(markdown);
+	while (match != null) {
+		const [, , body] = match;
+		if (body != null) {
+			blocks.push(body.trimEnd());
+		}
+		match = pattern.exec(markdown);
+	}
+	return blocks;
+}
+
+describe("list page loading recipe fences", () => {
+	const markdown = readFromAppRoot(RECIPE);
+	const blocks = fencedBlocks(markdown);
+
+	it("finds fenced code on the recipe page", () => {
+		expect(blocks.length).toBeGreaterThan(0);
+	});
+
+	it.for(FENCED_FILES)("%s appears verbatim in the recipe", (path) => {
+		const source = readFromAppRoot(path).trimEnd();
+		expect(blocks).toContain(source);
+	});
+});

--- a/apps/www/app/features/preview-registry.ts
+++ b/apps/www/app/features/preview-registry.ts
@@ -4,6 +4,7 @@ import { AppLayoutDemo } from "~/features/app-layout-demos";
 import { AppLayoutEditorDemo, AppLayoutPinnedFooterDemo } from "~/features/app-layout-editor-demo";
 import { AppShellDemo } from "~/features/app-shell-demo";
 import { CommandSearchShellDemo } from "~/features/command-demos";
+import { ListPageLoadingDemo } from "~/features/list-page-loading-demo";
 import {
 	CenteredLayoutDemo,
 	CenteredLayoutHeaderDemo,
@@ -100,6 +101,11 @@ export const previewExamples = {
 		title: "Centered layout notice demo",
 		Component: CenteredLayoutNoticeDemo,
 		sourceFile: "centered-layout-demos.tsx",
+	},
+	"list-page-loading": {
+		title: "List page loading demo",
+		Component: ListPageLoadingDemo,
+		sourceFile: "list-page-loading-demo.tsx",
 	},
 	sandbar: {
 		title: "Sandbar demo",

--- a/apps/www/app/routes.ts
+++ b/apps/www/app/routes.ts
@@ -143,7 +143,12 @@ const docsPages = [
 const layoutsPages = ["app-layout", "centered-layout"];
 
 // recipes section: compositional how-tos spanning multiple primitives
-const recipesPages = ["breadcrumbs-from-routes", "overlay-async", "route-announcer"];
+const recipesPages = [
+	"breadcrumbs-from-routes",
+	"list-page-loading-states",
+	"overlay-async",
+	"route-announcer",
+];
 
 // migrations section, in publish order. The four-digit prefix is the
 // guide's number. A guide keeps its number forever, and no later guide takes


### PR DESCRIPTION
## Why

The dashboard's list pages (Domains, Traffic Inspector, Authtokens) each hand-roll a `TableSkeleton`, and the copies drift: 3, 5, or 10 skeleton rows for a 20-row page, pagination that mounts with the data, a `0 results` count that flashes over the skeleton, and skeletons that say nothing to screen readers. Domains also replaces the whole header with a delayed spinner while an existence check resolves. Mantle had no guidance on any of it: the Skeleton page covers one bar, and the Data Table page covers the two empty states but not the pending one.

## How

A new recipe at `/recipes/list-page-loading-states`, with a framed demo of a domains list page. The shell renders on the first frame. `resolveListBodyState` picks exactly one body region, with pending ahead of empty. `SkeletonRows` derives from the real table's leaf columns, one row per page row. `table-fixed` plus header widths pin the columns. The count line is mounted at a fixed height. `keepPreviousData` keeps the rows through a refetch, and a `LiveRegion` announces each state. The page lists the rules, an anti-pattern table, and a note on React Router loaders.

The demo file is the fence on the page, and `list-page-loading-fences.test.ts` keeps them byte-identical. The Data Table and Skeleton pages link to the recipe.

## Validation

- Measured the framed preview with Playwright: the column header positions and the table's top edge are identical across the cold, loaded, busy, and no-results states. The first draft shifted 28px because a `<div>` skeleton inside the count `<p>` split the paragraph in the server HTML; the fence now uses `asChild` on a `<span>`.

## Follow-ups

- Mantle's `Table.Element` is `table-auto`, so the recipe reaches for `[&_table]:table-fixed` on `DataTable.Root`. A `tableLayout` prop on `Table.Element`, passed through `DataTable.Root`, would remove the arbitrary variant.
- A `DataTable.Skeleton` part that takes the table and a row count would replace the per-page copies in the dashboard.
